### PR TITLE
Fixed Swift 2.2 compile error

### DIFF
--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -154,7 +154,13 @@ public class Record : RowConvertible, TableMapping, Persistable {
     ///
     /// See `hasPersistentChangedValues` for more information.
     public var persistentChangedValues: [String: DatabaseValue?] {
-        return Dictionary(generatePersistentChangedValues())
+        var persistentChangedValues: [String: DatabaseValue?] = [:]
+        
+        for (key, value) in generatePersistentChangedValues() {
+            persistentChangedValues[key] = value
+        }
+        
+        return persistentChangedValues
     }
     
     // A change generator that is used by both hasPersistentChangedValues and


### PR DESCRIPTION
Compiler error: Generic parameter 'Key' could not be inferred