### PR TITLE
Add support for SQLite Pre-Update Hooks (+ tests)

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1381,7 +1381,21 @@ extension Database {
                     savepointStack.clear()
                     for observer in transactionObservers.flatMap({ $0.observer }) {
                         for event in eventsBuffer {
-                            observer.databaseDidChangeWithEvent(event)
+                            if let event = event as? DatabaseEvent {
+                                observer.databaseDidChangeWithEvent(event)
+                            }
+                            else {
+                            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                                if let event = event as? DatabasePreUpdateEvent {
+                                    observer.databaseWillChangeWithEvent(event)
+                                }
+                                else {
+                                    fatalError("Unexpected event type")
+                                }
+                            #else
+                                fatalError("Unexpected event type")
+                            #endif
+                            }
                         }
                     }
                 }
@@ -1411,11 +1425,39 @@ extension Database {
         savepointStack.clear()
         for observer in transactionObservers.flatMap({ $0.observer }) {
             for event in eventsBuffer {
-                observer.databaseDidChangeWithEvent(event)
+                if let event = event as? DatabaseEvent {
+                    observer.databaseDidChangeWithEvent(event)
+                }
+                else {
+                #if SQLITE_ENABLE_PREUPDATE_HOOK
+                    if let event = event as? DatabasePreUpdateEvent {
+                        observer.databaseWillChangeWithEvent(event)
+                    }
+                    else {
+                        fatalError("Unexpected event type")
+                    }
+                #else
+                    fatalError("Unexpected event type")
+                #endif
+                }
             }
             try observer.databaseWillCommit()
         }
     }
+    
+#if SQLITE_ENABLE_PREUPDATE_HOOK
+    /// Transaction hook
+    private func willChangeWithEvent(event: DatabasePreUpdateEvent)
+    {
+        if savepointStack.isEmpty {
+            for observer in transactionObservers.flatMap({ $0.observer }) {
+                observer.databaseWillChangeWithEvent(event)
+            }
+        } else {
+            savepointStack.eventsBuffer.append(event.copy())
+        }
+    }
+#endif
     
     /// Transaction hook
     private func didChangeWithEvent(event: DatabaseEvent) {
@@ -1484,6 +1526,18 @@ extension Database {
                 // Next step: updateStatementDidExecute()
             }
             }, dbPointer)
+        
+        #if SQLITE_ENABLE_PREUPDATE_HOOK
+        sqlite3_preupdate_hook(sqliteConnection, { (dbPointer, databaseConnection, updateKind, databaseNameCString, tableNameCString, initialRowID, finalRowID) in
+            let db = unsafeBitCast(dbPointer, Database.self)
+            db.willChangeWithEvent(DatabasePreUpdateEvent(connection: databaseConnection,
+                kind: DatabasePreUpdateEvent.Kind(rawValue: updateKind)!,
+                initialRowID: initialRowID,
+                finalRowID: finalRowID,
+                databaseNameCString: databaseNameCString,
+                tableNameCString: tableNameCString))
+            }, dbPointer)
+        #endif
     }
     
     private func uninstallTransactionObserverHooks() {
@@ -1555,6 +1609,42 @@ public protocol TransactionObserverType : class {
     ///
     /// This method is called on the database queue. It can change the database.
     func databaseDidRollback(db: Database)
+    
+    #if SQLITE_ENABLE_PREUPDATE_HOOK
+    /// Notifies before a database change (insert, update, or delete)
+    /// with change information (initial / final values for the row's
+    /// columns). (Called *before* databaseDidChangeWithEvent.)
+    ///
+    /// The change is pending until the end of the current transaction,
+    /// and you always get a second chance to get basic event information in
+    /// the databaseDidChangeWithEvent callback.
+    ///
+    /// This callback is mostly useful for calculating detailed change
+    /// information for a row, and provides the initial / final values.
+    ///
+    /// This method is called on the database queue.
+    ///
+    /// The event is only valid for the duration of this method call. If you
+    /// need to keep it longer, store a copy of its properties.
+    ///
+    /// - warning: this method must not change the database.
+    ///
+    /// Availability Info:
+    ///
+    ///     Requires SQLite 3.13.0 +
+    ///     Compiled with option SQLITE_ENABLE_PREUPDATE_HOOK
+    ///
+    ///     As of OSX 10.11.5, and iOS 9.3.2, the built-in SQLite library
+    ///     does not have this enabled, so you'll need to compile your own
+    ///     copy using GRDBCustomSQLite. See the README.md in /SQLiteCustom/
+    ///
+    ///     The databaseDidChangeWithEvent callback is always available,
+    ///     and may provide most/all of what you need.
+    ///     (For example, FetchedRecordsController is built without using
+    ///     this functionality.)
+    ///
+    func databaseWillChangeWithEvent(event: DatabasePreUpdateEvent)
+    #endif
 }
 
 /// Database stores WeakTransactionObserver so that it does not retain its
@@ -1566,8 +1656,11 @@ class WeakTransactionObserver {
     }
 }
 
+public protocol DatabaseEventType {
+}
+
 /// A database event, notified to TransactionObserverType.
-public struct DatabaseEvent {
+public struct DatabaseEvent : DatabaseEventType {
     
     /// An event kind
     public enum Kind: Int32 {
@@ -1647,6 +1740,257 @@ private struct CopiedDatabaseEventImpl : DatabaseEventImpl {
     }
 }
 
+#if SQLITE_ENABLE_PREUPDATE_HOOK
+
+    public struct DatabasePreUpdateEvent : DatabaseEventType {
+        
+        /// An event kind
+        public enum Kind: Int32 {
+            /// SQLITE_INSERT
+            case Insert = 18
+            
+            /// SQLITE_DELETE
+            case Delete = 9
+            
+            /// SQLITE_UPDATE
+            case Update = 23
+        }
+        
+        /// The event kind
+        public let kind: Kind
+        
+        /// The database name
+        public var databaseName: String { return impl.databaseName }
+        
+        /// The table name
+        public var tableName: String { return impl.tableName }
+        
+        /// The number of columns in the row that is being inserted, updated, or deleted.
+        public var count: Int { return Int(impl.columnsCount) }
+        
+        /// The triggering depth of the row update
+        /// Returns: 
+        ///     0  if the preupdate callback was invoked as a result of a direct insert,
+        //         update, or delete operation;
+        ///     1  for inserts, updates, or deletes invoked by top-level triggers;
+        ///     2  for changes resulting from triggers called by top-level triggers;
+        ///     ... and so forth
+        public var depth: CInt { return impl.depth }
+        
+        /// The initial rowID of the row being changed for .Update and .Delete changes,
+        /// and nil for .Insert changes.
+        public let initialRowID: Int64?
+        
+        /// The final rowID of the row being changed for .Update and .Insert changes,
+        /// and nil for .Delete changes.
+        public let finalRowID: Int64?
+        
+        /// The initial database values in the row.
+        ///
+        /// Values appear in the same order as the columns in the table.
+        ///
+        /// The result is nil if the event is an .Insert event.
+        public var initialDatabaseValues: [DatabaseValue]?
+        {
+            guard (kind == .Update || kind == .Delete) else { return nil }
+            return impl.initialDatabaseValues
+        }
+        
+        /// Returns the initial `DatabaseValue` at given index.
+        ///
+        /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
+        /// righmost column.
+        ///
+        /// The result is nil if the event is an .Insert event.
+        @warn_unused_result
+        public func initialDatabaseValue(atIndex index: Int) -> DatabaseValue?
+        {
+            GRDBPrecondition(index >= 0 && index < count, "row index out of range")
+            guard (kind == .Update || kind == .Delete) else { return nil }
+            return impl.initialDatabaseValue(atIndex: index)
+        }
+        
+        /// The final database values in the row.
+        ///
+        /// Values appear in the same order as the columns in the table.
+        ///
+        /// The result is nil if the event is a .Delete event.
+        public var finalDatabaseValues: [DatabaseValue]?
+        {
+            guard (kind == .Update || kind == .Insert) else { return nil }
+            return impl.finalDatabaseValues
+        }
+        
+        /// Returns the final `DatabaseValue` at given index.
+        ///
+        /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
+        /// righmost column.
+        ///
+        /// The result is nil if the event is a .Delete event.
+        @warn_unused_result
+        public func finalDatabaseValue(atIndex index: Int) -> DatabaseValue?
+        {
+            GRDBPrecondition(index >= 0 && index < count, "row index out of range")
+            guard (kind == .Update || kind == .Insert) else { return nil }
+            return impl.finalDatabaseValue(atIndex: index)
+        }
+        
+        /// Returns an event that can be stored:
+        ///
+        ///     class MyObserver: TransactionObserverType {
+        ///         var pre_events: [DatabasePreUpdateEvent]
+        ///         func databaseWillChangeWithEvent(event: DatabasePreUpdateEvent) {
+        ///             pre_events.append(event.copy())
+        ///         }
+        ///     }
+        public func copy() -> DatabasePreUpdateEvent {
+            return impl.copy(self)
+        }
+        
+        private init(kind: Kind, initialRowID: Int64?, finalRowID: Int64?, impl: DatabasePreUpdateEventImpl) {
+            self.kind = kind
+            self.initialRowID = (kind == .Update || kind == .Delete ) ? initialRowID : nil
+            self.finalRowID = (kind == .Update || kind == .Insert ) ? finalRowID : nil
+            self.impl = impl
+        }
+        
+        init(connection: SQLiteConnection, kind: Kind, initialRowID: Int64, finalRowID: Int64, databaseNameCString: UnsafePointer<Int8>, tableNameCString: UnsafePointer<Int8>) {
+            self.init(kind: kind,
+                      initialRowID: (kind == .Update || kind == .Delete ) ? finalRowID : nil,
+                      finalRowID: (kind == .Update || kind == .Insert ) ? finalRowID : nil,
+                      impl: MetalDatabasePreUpdateEventImpl(connection: connection, kind: kind, databaseNameCString: databaseNameCString, tableNameCString: tableNameCString))
+        }
+        
+        private let impl: DatabasePreUpdateEventImpl
+    }
+    
+    /// Protocol for internal implementation of DatabaseEvent
+    private protocol DatabasePreUpdateEventImpl {
+        var databaseName: String { get }
+        var tableName: String { get }
+        
+        var columnsCount: CInt { get }
+        var depth: CInt { get }
+        var initialDatabaseValues: [DatabaseValue]? { get }
+        var finalDatabaseValues: [DatabaseValue]? { get }
+        
+        func initialDatabaseValue(atIndex index: Int) -> DatabaseValue?
+        func finalDatabaseValue(atIndex index: Int) -> DatabaseValue?
+        
+        func copy(event: DatabasePreUpdateEvent) -> DatabasePreUpdateEvent
+    }
+    
+    /// Optimization: MetalDatabasePreUpdateEventImpl does not create Swift strings from raw
+    /// SQLite char* until actually asked for databaseName or tableName,
+    /// nor does it request other data via the sqlite3_preupdate_* APIs
+    /// until asked.
+    private struct MetalDatabasePreUpdateEventImpl : DatabasePreUpdateEventImpl {
+        private let connection: SQLiteConnection
+        private let kind: DatabasePreUpdateEvent.Kind
+        
+        private let databaseNameCString: UnsafePointer<Int8>
+        private let tableNameCString: UnsafePointer<Int8>
+        
+        var databaseName: String { return String.fromCString(databaseNameCString)! }
+        var tableName: String { return String.fromCString(tableNameCString)! }
+        
+        var columnsCount: CInt { return sqlite3_preupdate_count(connection) }
+        var depth: CInt { return sqlite3_preupdate_depth(connection) }
+        var initialDatabaseValues: [DatabaseValue]? {
+            guard (kind == .Update || kind == .Delete) else { return nil }
+            return preupdate_getValues_old(connection)
+        }
+        
+        var finalDatabaseValues: [DatabaseValue]? {
+            guard (kind == .Update || kind == .Insert) else { return nil }
+            return preupdate_getValues_new(connection)
+        }
+        
+        func initialDatabaseValue(atIndex index: Int) -> DatabaseValue?
+        {
+            let columnCount = columnsCount
+            precondition(index >= 0 && index < Int(columnCount), "row index out of range")
+            return getValue(connection, column: CInt(index), sqlite_func: { (connection: SQLiteConnection, column: CInt, inout value: SQLiteValue ) -> CInt in
+                return sqlite3_preupdate_old(connection, column, &value)
+            })
+        }
+        
+        func finalDatabaseValue(atIndex index: Int) -> DatabaseValue?
+        {
+            let columnCount = columnsCount
+            precondition(index >= 0 && index < Int(columnCount), "row index out of range")
+            return getValue(connection, column: CInt(index), sqlite_func: { (connection: SQLiteConnection, column: CInt, inout value: SQLiteValue ) -> CInt in
+                return sqlite3_preupdate_new(connection, column, &value)
+            })
+        }
+        
+        func copy(event: DatabasePreUpdateEvent) -> DatabasePreUpdateEvent {
+            return DatabasePreUpdateEvent(kind: event.kind, initialRowID: event.initialRowID, finalRowID: event.finalRowID, impl: CopiedDatabasePreUpdateEventImpl(
+                    databaseName: databaseName,
+                    tableName: tableName,
+                    columnsCount: columnsCount,
+                    depth: depth,
+                    initialDatabaseValues: initialDatabaseValues,
+                    finalDatabaseValues: finalDatabaseValues))
+        }
+    
+        private func preupdate_getValues(connection: SQLiteConnection, sqlite_func: (connection: SQLiteConnection, column: CInt, inout value: SQLiteValue ) -> CInt ) -> [DatabaseValue]?
+        {
+            let columnCount = sqlite3_preupdate_count(connection)
+            guard columnCount > 0 else { return nil }
+            
+            var columnValues = [DatabaseValue]()
+            
+            for i in 0..<columnCount {
+                let value = getValue(connection, column: i, sqlite_func: sqlite_func)!
+                columnValues.append(value)
+            }
+            
+            return columnValues
+        }
+        
+        private func getValue(connection: SQLiteConnection, column: CInt, sqlite_func: (connection: SQLiteConnection, column: CInt, inout value: SQLiteValue ) -> CInt ) -> DatabaseValue?
+        {
+            var value : SQLiteValue = nil
+            guard sqlite_func(connection: connection, column: column, value: &value) == SQLITE_OK else { return nil }
+            guard value != nil else { return nil }
+            return DatabaseValue(sqliteValue: value)
+        }
+        
+        private func preupdate_getValues_old(connection: SQLiteConnection) -> [DatabaseValue]?
+        {
+            return preupdate_getValues(connection, sqlite_func: { (connection: SQLiteConnection, column: CInt, inout value: SQLiteValue ) -> CInt in
+                return sqlite3_preupdate_old(connection, column, &value)
+            })
+        }
+        
+        private func preupdate_getValues_new(connection: SQLiteConnection) -> [DatabaseValue]?
+        {
+            return preupdate_getValues(connection, sqlite_func: { (connection: SQLiteConnection, column: CInt, inout value: SQLiteValue ) -> CInt in
+                return sqlite3_preupdate_new(connection, column, &value)
+            })
+        }
+    }
+    
+    /// Impl for DatabasePreUpdateEvent that contains copies of all event data.
+    private struct CopiedDatabasePreUpdateEventImpl : DatabasePreUpdateEventImpl {
+        private let databaseName: String
+        private let tableName: String
+        private let columnsCount: CInt
+        private let depth: CInt
+        private let initialDatabaseValues: [DatabaseValue]?
+        private let finalDatabaseValues: [DatabaseValue]?
+        
+        private func initialDatabaseValue(atIndex index: Int) -> DatabaseValue? { return initialDatabaseValues?[index] }
+        private func finalDatabaseValue(atIndex index: Int) -> DatabaseValue? { return finalDatabaseValues?[index] }
+        
+        private func copy(event: DatabasePreUpdateEvent) -> DatabasePreUpdateEvent {
+            return event
+        }
+    }
+
+#endif
+
 /// The SQLite savepoint stack is described at
 /// https://www.sqlite.org/lang_savepoint.html
 ///
@@ -1658,7 +2002,7 @@ private struct CopiedDatabaseEventImpl : DatabaseEventImpl {
 ///   rollbacked.
 class SavePointStack {
     /// The buffered events. See Database.didChangeWithEvent()
-    var eventsBuffer: [DatabaseEvent] = []
+    var eventsBuffer: [DatabaseEventType] = []
     
     /// The savepoint stack, as an array of tuples (savepointName, index in the eventsBuffer array).
     /// Indexes let us drop rollbacked events from the event buffer.

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -355,6 +355,11 @@ private final class FetchedRecordsObserver<Record: RowConvertible> : Transaction
         controller = nil
     }
     
+    #if SQLITE_ENABLE_PREUPDATE_HOOK
+    /// Part of the TransactionObserverType protocol
+    func databaseWillChangeWithEvent(event: DatabasePreUpdateEvent) { }
+    #endif
+    
     /// Part of the TransactionObserverType protocol
     func databaseDidChangeWithEvent(event: DatabaseEvent) {
         if !needsComputeChanges && observedTables.contains(event.tableName) {

--- a/Tests/Public/Core/Savepoint/SavepointTests.swift
+++ b/Tests/Public/Core/Savepoint/SavepointTests.swift
@@ -22,7 +22,17 @@ private class TransactionObserver : TransactionObserverType {
     
     func reset() {
         allRecordedEvents.removeAll()
+        #if SQLITE_ENABLE_PREUPDATE_HOOK
+            allRecordedPreUpdateEvents.removeAll()
+        #endif
     }
+    
+    #if SQLITE_ENABLE_PREUPDATE_HOOK
+    var allRecordedPreUpdateEvents: [DatabasePreUpdateEvent] = []
+    func databaseWillChangeWithEvent(event: DatabasePreUpdateEvent) {
+        allRecordedPreUpdateEvents.append(event.copy())
+    }
+    #endif
     
     func databaseDidChangeWithEvent(event: DatabaseEvent) {
         allRecordedEvents.append(event.copy())
@@ -73,6 +83,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item2", "item3"])
             XCTAssertEqual(observer.allRecordedEvents.count, 3)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 3)
+            #endif
         }
     }
     
@@ -102,6 +115,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item3"])
             XCTAssertEqual(observer.allRecordedEvents.count, 2)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 2)
+            #endif
         }
     }
     
@@ -142,6 +158,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item2", "item3", "item4", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 5)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 5)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
 
@@ -176,6 +195,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 2)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 2)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
             
@@ -211,6 +233,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item2", "item4", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 4)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 4)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
             
@@ -246,6 +271,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 2)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 2)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
         }
@@ -277,6 +305,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item2", "item3"])
             XCTAssertEqual(observer.allRecordedEvents.count, 3)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 3)
+            #endif
         }
     }
     
@@ -306,6 +337,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item3"])
             XCTAssertEqual(observer.allRecordedEvents.count, 3)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 3)
+            #endif
         }
     }
     
@@ -345,6 +379,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item2", "item3", "item4", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 5)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 5)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
             
@@ -379,6 +416,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 5)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 5)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
             
@@ -414,6 +454,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item2", "item4", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 4)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 4)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
             
@@ -449,6 +492,9 @@ class SavepointTests: GRDBTestCase {
                 ])
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item1", "item5"])
             XCTAssertEqual(observer.allRecordedEvents.count, 4)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 4)
+            #endif
             try! dbQueue.inDatabase { db in try db.execute("DELETE FROM items") }
             observer.reset()
         }
@@ -474,6 +520,9 @@ class SavepointTests: GRDBTestCase {
             }
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item2"])
             XCTAssertEqual(observer.allRecordedEvents.count, 1)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 1)
+            #endif
         }
     }
     
@@ -502,6 +551,9 @@ class SavepointTests: GRDBTestCase {
             }
             XCTAssertEqual(fetchAllItemNames(dbQueue), ["item2"])
             XCTAssertEqual(observer.allRecordedEvents.count, 1)
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.allRecordedPreUpdateEvents.count, 1)
+            #endif
         }
     }
 }

--- a/Tests/Public/Core/TransactionObserver/TransactionObserverSavepointsTests.swift
+++ b/Tests/Public/Core/TransactionObserver/TransactionObserverSavepointsTests.swift
@@ -11,6 +11,13 @@ private class TransactionObserver : TransactionObserverType {
     var lastCommittedEvents: [DatabaseEvent] = []
     var events: [DatabaseEvent] = []
     
+#if SQLITE_ENABLE_PREUPDATE_HOOK
+    var preUpdateEvents: [DatabasePreUpdateEvent] = []
+    func databaseWillChangeWithEvent(event: DatabasePreUpdateEvent) {
+        preUpdateEvents.append(event.copy())
+    }
+#endif
+    
     func databaseDidChangeWithEvent(event: DatabaseEvent) {
         events.append(event.copy())
     }
@@ -35,9 +42,38 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         return (event.tableName == tableName) && (event.rowID == rowId) && (event.kind == kind)
     }
     
+#if SQLITE_ENABLE_PREUPDATE_HOOK
+    
+    private func match(preUpdateEvent event: DatabasePreUpdateEvent, kind: DatabasePreUpdateEvent.Kind, tableName: String, initialRowID: Int64?, finalRowID: Int64?, initialValues: [DatabaseValue]?, finalValues: [DatabaseValue]?, depth: CInt = 0) -> Bool {
+        
+        func checkDatabaseValues(values: [DatabaseValue]?, expected: [DatabaseValue]?) -> Bool {
+            if let values = values {
+                guard let expected = expected else { return false }
+                return values == expected
+            }
+            else { return expected == nil }
+        }
+        
+        var count : Int = 0
+        if let initialValues = initialValues { count = initialValues.count }
+        if let finalValues = finalValues { count = max(count, finalValues.count) }
+        
+        guard (event.kind == kind) else { return false }
+        guard (event.tableName == tableName) else { return false }
+        guard (event.count == count) else { return false }
+        guard (event.depth == depth) else { return false }
+        guard (event.initialRowID == initialRowID) else { return false }
+        guard (event.finalRowID == finalRowID) else { return false }
+        guard checkDatabaseValues(event.initialDatabaseValues, expected: initialValues) else { return false }
+        guard checkDatabaseValues(event.finalDatabaseValues, expected: finalValues) else { return false }
+        
+        return true
+    }
+    
+#endif
+    
     
     // MARK: - Events
-    
     func testSavepointAsTransaction() {
         assertNoError {
             let dbQueue = try makeDatabaseQueue()
@@ -63,6 +99,12 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
             XCTAssertEqual(observer.lastCommittedEvents.count, 2)
             XCTAssertTrue(match(event: observer.lastCommittedEvents[0], kind: .Insert, tableName: "items1", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[1], kind: .Insert, tableName: "items2", rowId: 1))
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.preUpdateEvents.count, 2)
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[0], kind: .Insert, tableName: "items1", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[1], kind: .Insert, tableName: "items2", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+            #endif
         }
     }
     
@@ -90,6 +132,12 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
             XCTAssertEqual(observer.lastCommittedEvents.count, 2)
             XCTAssertTrue(match(event: observer.lastCommittedEvents[0], kind: .Insert, tableName: "items1", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[1], kind: .Insert, tableName: "items2", rowId: 1))
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.preUpdateEvents.count, 2)
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[0], kind: .Insert, tableName: "items1", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[1], kind: .Insert, tableName: "items2", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+            #endif
         }
     }
     
@@ -132,6 +180,14 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
             XCTAssertTrue(match(event: observer.lastCommittedEvents[1], kind: .Insert, tableName: "items2", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[2], kind: .Insert, tableName: "items3", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[3], kind: .Insert, tableName: "items4", rowId: 1))
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.preUpdateEvents.count, 4)
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[0], kind: .Insert, tableName: "items1", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[1], kind: .Insert, tableName: "items2", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[2], kind: .Insert, tableName: "items3", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[3], kind: .Insert, tableName: "items4", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+            #endif
         }
     }
     
@@ -171,6 +227,12 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
             XCTAssertEqual(observer.lastCommittedEvents.count, 2)
             XCTAssertTrue(match(event: observer.lastCommittedEvents[0], kind: .Insert, tableName: "items1", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[1], kind: .Insert, tableName: "items4", rowId: 1))
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.preUpdateEvents.count, 2)
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[0], kind: .Insert, tableName: "items1", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[1], kind: .Insert, tableName: "items4", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+            #endif
         }
     }
     
@@ -209,6 +271,14 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
             XCTAssertTrue(match(event: observer.lastCommittedEvents[1], kind: .Insert, tableName: "items2", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[2], kind: .Insert, tableName: "items3", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[3], kind: .Insert, tableName: "items4", rowId: 1))
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.preUpdateEvents.count, 4)
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[0], kind: .Insert, tableName: "items1", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[1], kind: .Insert, tableName: "items2", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[2], kind: .Insert, tableName: "items3", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[3], kind: .Insert, tableName: "items4", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+            #endif
         }
     }
     
@@ -249,6 +319,12 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
             XCTAssertEqual(observer.lastCommittedEvents.count, 2)
             XCTAssertTrue(match(event: observer.lastCommittedEvents[0], kind: .Insert, tableName: "items1", rowId: 1))
             XCTAssertTrue(match(event: observer.lastCommittedEvents[1], kind: .Insert, tableName: "items4", rowId: 1))
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+                XCTAssertEqual(observer.preUpdateEvents.count, 2)
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[0], kind: .Insert, tableName: "items1", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+                XCTAssertTrue(match(preUpdateEvent: observer.preUpdateEvents[1], kind: .Insert, tableName: "items4", initialRowID: nil, finalRowID: 1, initialValues: nil, finalValues: [Int(1).databaseValue]))
+            #endif
         }
     }
     


### PR DESCRIPTION
If SQLITE_ENABLE_PREUPDATE_HOOK is defined, and GRDB is built with a custom SQLite library with the functionality (see: GRDBCustomSQLite), enable support for SQLite Pre-Update Hooks and the new `willChangeWithEvent` callback on TransactionObservers.

`willChangeWithEvent` provides a **DatabasePreUpdateEvent**, which contains the same information as DatabaseUpdateEvent, plus:

- Pre-change/Post-change **rowID** (instead of just the final rowID in DatabaseEvent)
- The **triggering depth** of the row update
- Pre-change/Post-change **DatabaseValues** for the columns in the row

As mentioned in the comments, the requirements are:
SQLite 3.13.0+, built with SQLITE_ENABLE_PREUPDATE_HOOK (which can be accomplished using GRDBCustomSQLite).