### PR TITLE
Table Creation DSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,30 @@ Release Notes
 - Upgrade sqlcipher to v3.4.0 ([announcement](https://discuss.zetetic.net/t/sqlcipher-3-4-0-release/1273), [changelog](https://github.com/sqlcipher/sqlcipher/blob/master/CHANGELOG.md))
 
 - Row adopts DictionaryLiteralConvertible
-    
+
+- Database schema DSL (TODO: doc link):
+
+    ```swift
+    // CREATE TABLE pointOfInterests (
+    //   id INTEGER PRIMARY KEY,
+    //   title TEXT,
+    //   favorite BOOLEAN NOT NULL,
+    //   latitude DOUBLE NOT NULL,
+    //   longitude DOUBLE NOT NULL
+    // )
+    db.create(table: "pointOfInterests") { t in
+        t.column("id", .Integer).primaryKey()
+        t.column("title", .Text)
+        t.column("favorite", .Boolean).notNull()
+        t.column("longitude", .Double).notNull()
+        t.column("latitude", .Double).notNull()
+    }
+    ```
+
+**Breaking Changes**
+
+- Built-in SQLite collations used to be named by string: "NOCASE", etc. Now use the SQLCollation enum: `.Nocase`, etc.
+
 
 ## 0.77.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,6 @@ Release Notes
 - Database schema DSL (TODO: doc link):
 
     ```swift
-    // CREATE TABLE pointOfInterests (
-    //   id INTEGER PRIMARY KEY,
-    //   title TEXT,
-    //   favorite BOOLEAN NOT NULL,
-    //   latitude DOUBLE NOT NULL,
-    //   longitude DOUBLE NOT NULL
-    // )
     db.create(table: "pointOfInterests") { t in
         t.column("id", .Integer).primaryKey()
         t.column("title", .Text)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Release Notes
     let row: Row = ["name": "foo", "date": NSDate()]
     ```
 
-- Create, and alter tables ([documentation](https://github.com/groue/GRDB.swift#database-schema)):
+- DSL for table creation and updates (closes [#83](https://github.com/groue/GRDB.swift/issues/83), [documentation](https://github.com/groue/GRDB.swift#database-schema)):
 
     ```swift
     db.create(table: "pointOfInterests") { t in
@@ -38,7 +38,12 @@ Release Notes
 
 - Built-in SQLite collations used to be named by string: "NOCASE", etc. Now use the SQLCollation enum: `.Nocase`, etc.
 
-- PrimaryKey has been renamed PrimaryKeyInfo.
+- PrimaryKey has been renamed PrimaryKeyInfo:
+
+    ```swift
+    let pk = db.primaryKey("persons")
+    pk.columns  // ["id"]
+    ```
 
 
 ## 0.77.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Release Notes
     }
     ```
 
+- Support for the `length` SQLite built-in function.
+
 **Breaking Changes**
 
 - Built-in SQLite collations used to be named by string: "NOCASE", etc. Now use the SQLCollation enum: `.Nocase`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ Release Notes
 
 - Upgrade sqlcipher to v3.4.0 ([announcement](https://discuss.zetetic.net/t/sqlcipher-3-4-0-release/1273), [changelog](https://github.com/sqlcipher/sqlcipher/blob/master/CHANGELOG.md))
 
-- Row adopts DictionaryLiteralConvertible
+- Row adopts DictionaryLiteralConvertible:
 
-- Database schema DSL (TODO: doc link):
+    ```swift
+    let row: Row = ["name": "foo", "date": NSDate()]
+    ```
+
+- Create, and alter tables ([documentation](https://github.com/groue/GRDB.swift#database-schema)):
 
     ```swift
     db.create(table: "pointOfInterests") { t in
@@ -21,11 +25,20 @@ Release Notes
     }
     ```
 
-- Support for the `length` SQLite built-in function.
+- Support for the `length` SQLite built-in function:
+    
+    ```swift
+    db.create(table: "persons") { t in
+        t.column("name", .Text).check { length($0) > 0 }
+    }
+    ```
+
 
 **Breaking Changes**
 
 - Built-in SQLite collations used to be named by string: "NOCASE", etc. Now use the SQLCollation enum: `.Nocase`, etc.
+
+- PrimaryKey has been renamed PrimaryKeyInfo.
 
 
 ## 0.77.0

--- a/GRDB.swift.podspec
+++ b/GRDB.swift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 	s.name     = 'GRDB.swift'
 	s.version  = '0.77.0'
 	s.license  = { :type => 'MIT', :file => 'LICENSE' }
-	s.summary  = 'A versatile SQLite toolkit for Swift, with WAL mode support.'
+	s.summary  = 'A Swift application toolkit for SQLite databases.'
 	s.homepage = 'https://github.com/groue/GRDB.swift'
 	s.author   = { 'Gwendal Roué' => 'gr@pierlis.com' }
 	s.source   = { :git => 'https://github.com/groue/GRDB.swift.git', :tag => "v#{s.version}" }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -803,7 +803,7 @@ extension Database {
     /// primary key.
     ///
     /// - throws: A DatabaseError if table does not exist.
-    public func primaryKey(tableName: String) throws -> PrimaryKey? {
+    public func primaryKey(tableName: String) throws -> PrimaryKeyInfo? {
         SchedulingWatchdog.preconditionValidQueue(self)
         
         if let primaryKey = schemaCache.primaryKey(tableName: tableName) {
@@ -836,7 +836,7 @@ extension Database {
         
         let columns = try self.columns(in: tableName)
         
-        let primaryKey: PrimaryKey?
+        let primaryKey: PrimaryKeyInfo?
         let pkColumns = columns
             .filter { $0.primaryKeyIndex > 0 }
             .sort { $0.primaryKeyIndex < $1.primaryKeyIndex }
@@ -1059,7 +1059,7 @@ public struct IndexInfo {
 ///     let citizenshipsPk = db.primaryKey("citizenships")!
 ///     citizenshipsPk.columns     // ["personID", "countryIsoCode"]
 ///     citizenshipsPk.rowIDColumn // nil
-public struct PrimaryKey {
+public struct PrimaryKeyInfo {
     private enum Impl {
         /// An INTEGER PRIMARY KEY column that aliases the Row ID.
         /// Associated string is the column name.
@@ -1072,13 +1072,13 @@ public struct PrimaryKey {
     
     private let impl: Impl
     
-    static func rowID(column: String) -> PrimaryKey {
-        return PrimaryKey(impl: .RowID(column))
+    static func rowID(column: String) -> PrimaryKeyInfo {
+        return PrimaryKeyInfo(impl: .RowID(column))
     }
     
-    static func regular(columns: [String]) -> PrimaryKey {
+    static func regular(columns: [String]) -> PrimaryKeyInfo {
         assert(!columns.isEmpty)
-        return PrimaryKey(impl: .Regular(columns))
+        return PrimaryKeyInfo(impl: .Regular(columns))
     }
     
     /// The columns in the primary key; this array is never empty.

--- a/GRDB/Core/DatabaseSchemaCache.swift
+++ b/GRDB/Core/DatabaseSchemaCache.swift
@@ -7,8 +7,8 @@
 protocol DatabaseSchemaCacheType {
     mutating func clear()
     
-    func primaryKey(tableName tableName: String) -> PrimaryKey??
-    mutating func setPrimaryKey(primaryKey: PrimaryKey?, forTableName tableName: String)
+    func primaryKey(tableName tableName: String) -> PrimaryKeyInfo??
+    mutating func setPrimaryKey(primaryKey: PrimaryKeyInfo?, forTableName tableName: String)
     
     func columns(in tableName: String) -> [ColumnInfo]?
     mutating func setColumns(columns: [ColumnInfo], forTableName tableName: String)
@@ -19,7 +19,7 @@ protocol DatabaseSchemaCacheType {
 
 /// A thread-unsafe database schema cache
 final class DatabaseSchemaCache: DatabaseSchemaCacheType {
-    private var primaryKeys: [String: PrimaryKey?] = [:]
+    private var primaryKeys: [String: PrimaryKeyInfo?] = [:]
     private var columns: [String: [ColumnInfo]] = [:]
     private var indexes: [String: [IndexInfo]] = [:]
     
@@ -29,11 +29,11 @@ final class DatabaseSchemaCache: DatabaseSchemaCacheType {
         indexes = [:]
     }
     
-    func primaryKey(tableName tableName: String) -> PrimaryKey?? {
+    func primaryKey(tableName tableName: String) -> PrimaryKeyInfo?? {
         return primaryKeys[tableName]
     }
     
-    func setPrimaryKey(primaryKey: PrimaryKey?, forTableName tableName: String) {
+    func setPrimaryKey(primaryKey: PrimaryKeyInfo?, forTableName tableName: String) {
         primaryKeys[tableName] = primaryKey
     }
     
@@ -62,11 +62,11 @@ final class SharedDatabaseSchemaCache: DatabaseSchemaCacheType {
         cache.write { $0.clear() }
     }
     
-    func primaryKey(tableName tableName: String) -> PrimaryKey?? {
+    func primaryKey(tableName tableName: String) -> PrimaryKeyInfo?? {
         return cache.read { $0.primaryKey(tableName: tableName) }
     }
     
-    func setPrimaryKey(primaryKey: PrimaryKey?, forTableName tableName: String) {
+    func setPrimaryKey(primaryKey: PrimaryKeyInfo?, forTableName tableName: String) {
         cache.write { $0.setPrimaryKey(primaryKey, forTableName: tableName) }
     }
     

--- a/GRDB/QueryInterface/SQLCollation.swift
+++ b/GRDB/QueryInterface/SQLCollation.swift
@@ -53,12 +53,16 @@ extension _SQLCollatedExpression : _SQLOrdering {
 
 extension _SpecificSQLExpressible {
     
+    func collating(collationName: String) -> _SQLCollatedExpression {
+        return _SQLCollatedExpression(baseExpression: sqlExpression, collationName: collationName)
+    }
+    
     /// This method is an implementation detail of the query interface.
     /// Do not use it directly.
     ///
     /// See https://github.com/groue/GRDB.swift/#the-query-interface
-    public func collating(collationName: String) -> _SQLCollatedExpression {
-        return _SQLCollatedExpression(baseExpression: sqlExpression, collationName: collationName)
+    public func collating(collation: SQLCollation) -> _SQLCollatedExpression {
+        return collating(collation.rawValue)
     }
     
     /// This method is an implementation detail of the query interface.

--- a/GRDB/QueryInterface/SQLFunction.swift
+++ b/GRDB/QueryInterface/SQLFunction.swift
@@ -71,6 +71,16 @@ public func ?? (lhs: _SQLExpressible?, rhs: _SpecificSQLExpressible) -> _SQLExpr
 }
 
 
+// MARK: - LENGTH(...)
+
+/// Returns an SQL expression.
+///
+/// See https://github.com/groue/GRDB.swift/#sql-functions
+public func length(value: _SpecificSQLExpressible) -> _SQLExpression {
+    return .Function("LENGTH", [value.sqlExpression])
+}
+
+
 // MARK: - MAX(...)
 
 /// Returns an SQL expression.

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -1,8 +1,18 @@
 extension Database {
     // TODO: doc
-    // TODO: Don't expose withoutRowID if not available
-    public func create(table name: String, temporary: Bool = false, ifNotExists: Bool = false, withoutRowID: Bool = false, body: (SQLTableBuilder) -> Void) throws {
+    @available(iOS 8.2, OSX 10.10, *)
+    public func create(table name: String, temporary: Bool = false, ifNotExists: Bool = false, withoutRowID: Bool, body: (SQLTableBuilder) -> Void) throws {
+        // WITHOUT ROWID was added in SQLite 3.8.2 http://www.sqlite.org/changes.html#version_3_8_2
+        // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
         let builder = SQLTableBuilder(name: name, temporary: temporary, ifNotExists: ifNotExists, withoutRowID: withoutRowID)
+        body(builder)
+        let sql = try builder.sql(self)
+        try execute(sql)
+    }
+
+    // TODO: doc
+    public func create(table name: String, temporary: Bool = false, ifNotExists: Bool = false, body: (SQLTableBuilder) -> Void) throws {
+        let builder = SQLTableBuilder(name: name, temporary: temporary, ifNotExists: ifNotExists, withoutRowID: false)
         body(builder)
         let sql = try builder.sql(self)
         try execute(sql)

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -64,7 +64,7 @@ public final class SQLColumnBuilder {
     var notNullConflictResolution: SQLConflictResolution?
     var uniqueConflictResolution: SQLConflictResolution?
     var checkExpression: _SQLExpression?
-    var defaultExpression: _SQLExpression?
+    var defaultValue: DatabaseValueConvertible?
     var collationName: String?
     var reference: (table: String, column: String?, deleteAction: SQLForeignKeyAction?, updateAction: SQLForeignKeyAction?, deferred: Bool)?
     
@@ -95,9 +95,8 @@ public final class SQLColumnBuilder {
     
     // TODO: doc
     // TODO: defaults(sql: "CURRENT_TIMESTAMP")
-    // TODO: _SQLExpressible or DatabaseValueConvertible?
-    public func defaults(value: _SQLExpressible) {
-        defaultExpression = value.sqlExpression
+    public func defaults(value: DatabaseValueConvertible) {
+        defaultValue = value
     }
     
     // TODO: doc
@@ -282,10 +281,10 @@ extension SQLColumnBuilder {
             chunks.append("(" + checkExpression.sql(&arguments) + ")")
         }
         
-        if let defaultExpression = defaultExpression {
-            var arguments: StatementArguments? = nil // nil so that defaultExpression.sql(&arguments) embeds literals
+        if let defaultValue = defaultValue {
+            var arguments: StatementArguments? = nil // nil so that defaultValue.sqlExpression.sql(&arguments) embeds literals
             chunks.append("DEFAULT")
-            chunks.append("(" + defaultExpression.sql(&arguments) + ")")
+            chunks.append("(" + defaultValue.sqlExpression.sql(&arguments) + ")")
         }
         
         if let collationName = collationName {

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -1,4 +1,7 @@
 extension Database {
+    
+    // MARK: - Database Schema
+    
     /// Creates a database table.
     ///
     ///     try db.create(table: "pointOfInterests") { t in

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -1,5 +1,24 @@
 extension Database {
-    // TODO: doc
+    /// Creates a database table.
+    ///
+    ///     try db.create(table: "pointOfInterests") { t in
+    ///         t.column("id", .Integer).primaryKey()
+    ///         t.column("title", .Text)
+    ///         t.column("favorite", .Boolean).notNull().default(false)
+    ///         t.column("longitude", .Double).notNull()
+    ///         t.column("latitude", .Double).notNull()
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html and
+    /// https://www.sqlite.org/withoutrowid.html
+    ///
+    /// - parameters:
+    ///     - name: The table name.
+    ///     - temporary: If true, creates a temporary table.
+    ///     - ifNotExists: If false, no error is thrown if table already exists.
+    ///     - withoutRowID: If true, uses WITHOUT ROWID optimization.
+    ///     - body: A closure that defines table columns and constraints.
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
     @available(iOS 8.2, OSX 10.10, *)
     public func create(table name: String, temporary: Bool = false, ifNotExists: Bool = false, withoutRowID: Bool, body: (SQLTableBuilder) -> Void) throws {
         // WITHOUT ROWID was added in SQLite 3.8.2 http://www.sqlite.org/changes.html#version_3_8_2
@@ -10,7 +29,24 @@ extension Database {
         try execute(sql)
     }
 
-    // TODO: doc
+    /// Creates a database table.
+    ///
+    ///     try db.create(table: "pointOfInterests") { t in
+    ///         t.column("id", .Integer).primaryKey()
+    ///         t.column("title", .Text)
+    ///         t.column("favorite", .Boolean).notNull().default(false)
+    ///         t.column("longitude", .Double).notNull()
+    ///         t.column("latitude", .Double).notNull()
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html
+    ///
+    /// - parameters:
+    ///     - name: The table name.
+    ///     - temporary: If true, creates a temporary table.
+    ///     - ifNotExists: If false, no error is thrown if table already exists.
+    ///     - body: A closure that defines table columns and constraints.
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func create(table name: String, temporary: Bool = false, ifNotExists: Bool = false, body: (SQLTableBuilder) -> Void) throws {
         let builder = SQLTableBuilder(name: name, temporary: temporary, ifNotExists: ifNotExists, withoutRowID: false)
         body(builder)
@@ -18,12 +54,27 @@ extension Database {
         try execute(sql)
     }
     
-    // TODO: doc
+    /// Renames a database table.
+    ///
+    /// See https://www.sqlite.org/lang_altertable.html
+    ///
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func rename(table name: String, to newName: String) throws {
         try execute("ALTER TABLE \(name.quotedDatabaseIdentifier) RENAME TO \(newName.quotedDatabaseIdentifier)")
     }
     
-    // TODO: doc
+    /// Modifies a database table.
+    ///
+    ///     try db.alter(table: "persons") { t in
+    ///         t.add(column: "url", .Text)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_altertable.html
+    ///
+    /// - parameters:
+    ///     - name: The table name.
+    ///     - body: A closure that defines table alterations.
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func alter(table name: String, body: (SQLTableAlterationBuilder) -> Void) throws {
         let builder = SQLTableAlterationBuilder(name: name)
         body(builder)
@@ -31,25 +82,61 @@ extension Database {
         try execute(sql)
     }
     
-    // TODO: doc
+    /// Deletes a database table.
+    ///
+    /// See https://www.sqlite.org/lang_droptable.html
+    ///
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func drop(table name: String) throws {
         try execute("DROP TABLE \(name.quotedDatabaseIdentifier)")
     }
     
-    // TODO: doc
+    /// Creates a database index.
+    ///
+    ///     try db.create(index: "personByEmail", on: "person", columns: ["email"])
+    ///
+    /// SQLite can also index expressions (https://www.sqlite.org/expridx.html)
+    /// and use specific collations. To create such an index, use a raw SQL
+    /// query.
+    ///
+    ///     try db.execute("CREATE INDEX ...")
+    ///
+    /// See https://www.sqlite.org/lang_createindex.html
+    ///
+    /// - parameters:
+    ///     - name: The index name.
+    ///     - table: The name of the indexed table.
+    ///     - columns: The indexed columns.
+    ///     - unique: If true, creates a unique index.
+    ///     - ifNotExists: If false, no error is thrown if index already exists.
+    ///     - condition: If not nil, creates a partial index
+    ///       (see https://www.sqlite.org/partialindex.html).
     public func create(index name: String, on table: String, columns: [String], unique: Bool = false, ifNotExists: Bool = false, condition: _SQLExpressible? = nil) throws {
         let builder = IndexBuilder(name: name, table: table, columns: columns, unique: unique, ifNotExists: ifNotExists, condition: condition?.sqlExpression)
         let sql = builder.sql()
         try execute(sql)
     }
     
-    // TODO: doc
+    /// Deletes a database index.
+    ///
+    /// See https://www.sqlite.org/lang_dropindex.html
+    ///
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func drop(index name: String) throws {
         try execute("DROP INDEX \(name.quotedDatabaseIdentifier)")
     }
 }
 
-// TODO: doc
+/// The SQLTableBuilder class lets you define table columns and constraints.
+///
+/// You don't create instances of this class. Instead, you use the Database
+/// `create(table:)` method:
+///
+///     try db.create(table: "persons") { t in // t is SQLTableBuilder
+///         t.column(...)
+///     }
+///
+/// See https://www.sqlite.org/lang_createtable.html
 public final class SQLTableBuilder {
     let name: String
     let temporary: Bool
@@ -68,14 +155,38 @@ public final class SQLTableBuilder {
         self.withoutRowID = withoutRowID
     }
     
-    // TODO: doc
+    /// Appends a table column.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("name", .Text)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#tablecoldef
+    ///
+    /// - parameter name: the column name.
+    /// - parameter type: the column type.
+    /// - returns: An SQLColumnBuilder that allows you to refine the
+    ///   column definition.
     public func column(name: String, _ type: SQLColumnType) -> SQLColumnBuilder {
         let column = SQLColumnBuilder(name: name, type: type)
         columns.append(column)
         return column
     }
     
-    // TODO: doc
+    /// Defines the table primary key.
+    ///
+    ///     try db.create(table: "citizenships") { t in
+    ///         t.column("personID", .Integer)
+    ///         t.column("countryCode", .Text)
+    ///         t.primaryKey(["personID", "countryCode"])
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#primkeyconst and
+    /// https://www.sqlite.org/lang_createtable.html#rowid
+    ///
+    /// - parameter columns: The primary key columns.
+    /// - parameter conflitResolution: An optional conflict resolution
+    ///   (see https://www.sqlite.org/lang_conflict.html).
     public func primaryKey(columns: [String], onConflict conflictResolution: SQLConflictResolution? = nil) {
         guard primaryKeyConstraint == nil else {
             fatalError("can't define several primary keys")
@@ -83,169 +194,81 @@ public final class SQLTableBuilder {
         primaryKeyConstraint = (columns: columns, conflictResolution: conflictResolution)
     }
     
-    // TODO: doc
+    /// Adds a unique key.
+    ///
+    ///     try db.create(table: "pointOfInterests") { t in
+    ///         t.column("latitude", .Double)
+    ///         t.column("longitude", .Double)
+    ///         t.uniqueKey(["latitude", "longitude"])
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#uniqueconst
+    ///
+    /// - parameter columns: The unique key columns.
+    /// - parameter conflitResolution: An optional conflict resolution
+    ///   (see https://www.sqlite.org/lang_conflict.html).
     public func uniqueKey(columns: [String], onConflict conflictResolution: SQLConflictResolution? = nil) {
         uniqueKeyConstraints.append((columns: columns, conflictResolution: conflictResolution))
     }
     
-    // TODO: doc
+    /// Adds a foreign key.
+    ///
+    ///     try db.create(table: "passport") { t in
+    ///         t.column("issueDate", .Date)
+    ///         t.column("personID", .Integer)
+    ///         t.column("countryCode", .Text)
+    ///         t.foreignKey(["personID", "countryCode"], references: "citizenships", onDelete: .Cascade)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/foreignkeys.html
+    ///
+    /// - parameters:
+    ///     - columns: The foreign key columns.
+    ///     - table: The referenced table.
+    ///     - destinationColumns: The columns in the referenced table. If not
+    ///       specified, the columns of the primary key of the referenced table
+    ///       are used.
+    ///     - deleteAction: Optional action when the referenced row is deleted.
+    ///     - updateAction: Optional action when the referenced row is updated.
+    ///     - deferred: If true, defines a deferred foreign key constraint.
+    ///       See https://www.sqlite.org/foreignkeys.html#fk_deferred.
     public func foreignKey(columns: [String], references table: String, columns destinationColumns: [String]? = nil, onDelete deleteAction: SQLForeignKeyAction? = nil, onUpdate updateAction: SQLForeignKeyAction? = nil, deferred: Bool = false) {
         foreignKeyConstraints.append((columns: columns, table: table, destinationColumns: destinationColumns, deleteAction: deleteAction, updateAction: updateAction, deferred: deferred))
     }
     
-    // TODO: doc
+    /// Adds a CHECK constraint.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("personalPhone", .Text)
+    ///         t.column("workPhone", .Text)
+    ///         let personalPhone = SQLColumn("personalPhone")
+    ///         let workPhone = SQLColumn("workPhone")
+    ///         t.check(personalPhone != nil || workPhone != nil)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    ///
+    /// - parameter condition: The checked condition
     public func check(condition: _SQLExpressible) {
         checkConstraints.append(condition.sqlExpression)
     }
     
-    // TODO: doc
+    /// Adds a CHECK constraint.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("personalPhone", .Text)
+    ///         t.column("workPhone", .Text)
+    ///         t.check(sql: "personalPhone IS NOT NULL OR workPhone IS NOT NULL")
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    ///
+    /// - parameter sql: An SQL snippet
     public func check(sql sql: String) {
         checkConstraints.append(_SQLExpression.Literal(sql, nil))
     }
-}
-
-// TODO: doc
-public final class SQLTableAlterationBuilder {
-    let name: String
-    var addedColumns: [SQLColumnBuilder] = []
     
-    init(name: String) {
-        self.name = name
-    }
-    
-    // TODO: doc
-    public func add(column name: String, _ type: SQLColumnType) -> SQLColumnBuilder {
-        let column = SQLColumnBuilder(name: name, type: type)
-        addedColumns.append(column)
-        return column
-    }
-}
-
-// TODO: doc
-public final class SQLColumnBuilder {
-    let name: String
-    let type: SQLColumnType
-    var primaryKey: (ordering: SQLOrdering?, conflictResolution: SQLConflictResolution?, autoincrement: Bool)?
-    var notNullConflictResolution: SQLConflictResolution?
-    var uniqueConflictResolution: SQLConflictResolution?
-    var checkExpression: _SQLExpression?
-    var defaultExpression: _SQLExpression?
-    var collationName: String?
-    var reference: (table: String, column: String?, deleteAction: SQLForeignKeyAction?, updateAction: SQLForeignKeyAction?, deferred: Bool)?
-    
-    init(name: String, type: SQLColumnType) {
-        self.name = name
-        self.type = type
-    }
-    
-    // TODO: doc
-    public func primaryKey(ordering ordering: SQLOrdering? = nil, onConflict conflictResolution: SQLConflictResolution? = nil, autoincrement: Bool = false) -> SQLColumnBuilder {
-        primaryKey = (ordering: ordering, conflictResolution: conflictResolution, autoincrement: autoincrement)
-        return self
-    }
-    
-    // TODO: doc
-    public func notNull(onConflict conflictResolution: SQLConflictResolution? = nil) -> SQLColumnBuilder {
-        notNullConflictResolution = conflictResolution ?? .Abort
-        return self
-    }
-    
-    // TODO: doc
-    public func unique(onConflict conflictResolution: SQLConflictResolution? = nil) -> SQLColumnBuilder {
-        uniqueConflictResolution = conflictResolution ?? .Abort
-        return self
-    }
-    
-    // TODO: doc
-    public func check(@noescape condition: (SQLColumn) -> _SQLExpressible) -> SQLColumnBuilder {
-        checkExpression = condition(SQLColumn(name)).sqlExpression
-        return self
-    }
-    
-    // TODO: doc
-    public func check(sql sql: String) -> SQLColumnBuilder {
-        checkExpression = _SQLExpression.Literal(sql, nil)
-        return self
-    }
-    
-    // TODO: doc
-    public func defaults(value: DatabaseValueConvertible) -> SQLColumnBuilder {
-        defaultExpression = value.sqlExpression
-        return self
-    }
-    
-    // TODO: doc
-    public func defaults(sql sql: String) -> SQLColumnBuilder {
-        defaultExpression = _SQLExpression.Literal(sql, nil)
-        return self
-    }
-    
-    // TODO: doc
-    public func collate(collation: SQLCollation) -> SQLColumnBuilder {
-        collationName = collation.rawValue
-        return self
-    }
-    
-    // TODO: doc
-    public func collate(collation: DatabaseCollation) -> SQLColumnBuilder {
-        collationName = collation.name
-        return self
-    }
-    
-    // TODO: doc
-    public func references(table: String, column: String? = nil, onDelete deleteAction: SQLForeignKeyAction? = nil, onUpdate updateAction: SQLForeignKeyAction? = nil, deferred: Bool = false) -> SQLColumnBuilder {
-        reference = (table: table, column: column, deleteAction: deleteAction, updateAction: updateAction, deferred: deferred)
-        return self
-    }
-}
-
-// TODO: doc
-public enum SQLOrdering : String {
-    case Asc = "ASC"
-    case Desc = "DESC"
-}
-
-// TODO: doc
-public enum SQLCollation : String {
-    case Binary = "BINARY"
-    case Nocase = "NOCASE"
-    case Rtrim = "RTRIM"
-}
-
-// TODO: doc
-public enum SQLConflictResolution : String {
-    case Rollback = "ROLLBACK"
-    case Abort = "ABORT"
-    case Fail = "FAIL"
-    case Ignore = "IGNORE"
-    case Replace = "REPLACE"
-}
-
-// TODO: doc
-public enum SQLColumnType : String {
-    case Text = "TEXT"
-    case Integer = "INTEGER"
-    case Double = "DOUBLE"
-    case Numeric = "NUMERIC"
-    case Boolean = "BOOLEAN"
-    case Blob = "BLOB"
-    case Date = "DATE"
-    case Datetime = "DATETIME"
-}
-
-// TODO: doc
-public enum SQLForeignKeyAction : String {
-    case Cascade = "CASCADE"
-    case Restrict = "RESTRICT"
-    case SetNull = "SET NULL"
-    case SetDefault = "SET DEFAULT"
-}
-
-
-// MARK: - SQL Generation
-
-extension SQLTableBuilder {
-    func sql(db: Database) throws -> String {
+    private func sql(db: Database) throws -> String {
         var chunks: [String] = []
         chunks.append("CREATE")
         if temporary {
@@ -327,8 +350,43 @@ extension SQLTableBuilder {
     }
 }
 
-extension SQLTableAlterationBuilder {
-    func sql(db: Database) throws -> String {
+/// The SQLTableAlterationBuilder class lets you alter database tables.
+///
+/// You don't create instances of this class. Instead, you use the Database
+/// `alter(table:)` method:
+///
+///     try db.alter(table: "persons") { t in // t is SQLTableAlterationBuilder
+///         t.add(column: ...)
+///     }
+///
+/// See https://www.sqlite.org/lang_altertable.html
+public final class SQLTableAlterationBuilder {
+    let name: String
+    var addedColumns: [SQLColumnBuilder] = []
+    
+    init(name: String) {
+        self.name = name
+    }
+    
+    /// Appends a column to the table.
+    ///
+    ///     try db.alter(table: "persons") { t in
+    ///         t.add(column: "url", .Text)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_altertable.html
+    ///
+    /// - parameter name: the column name.
+    /// - parameter type: the column type.
+    /// - returns: An SQLColumnBuilder that allows you to refine the
+    ///   column definition.
+    public func add(column name: String, _ type: SQLColumnType) -> SQLColumnBuilder {
+        let column = SQLColumnBuilder(name: name, type: type)
+        addedColumns.append(column)
+        return column
+    }
+    
+    private func sql(db: Database) throws -> String {
         var statements: [String] = []
         
         for column in addedColumns {
@@ -345,17 +403,207 @@ extension SQLTableAlterationBuilder {
     }
 }
 
-extension SQLColumnBuilder {
-    func sql(db: Database) throws -> String {
+/// The SQLColumnBuilder class lets you refine a table column.
+///
+/// You get instances of this class when you create or alter a database table:
+///
+///     try db.create(table: "persons") { t in
+///         t.column(...)      // SQLColumnBuilder
+///     }
+///
+///     try db.alter(table: "persons") { t in
+///         t.add(column: ...) // SQLColumnBuilder
+///     }
+///
+/// See https://www.sqlite.org/lang_createtable.html and
+/// https://www.sqlite.org/lang_altertable.html
+public final class SQLColumnBuilder {
+    let name: String
+    let type: SQLColumnType
+    var primaryKey: (conflictResolution: SQLConflictResolution?, autoincrement: Bool)?
+    var notNullConflictResolution: SQLConflictResolution?
+    var uniqueConflictResolution: SQLConflictResolution?
+    var checkExpression: _SQLExpression?
+    var defaultExpression: _SQLExpression?
+    var collationName: String?
+    var reference: (table: String, column: String?, deleteAction: SQLForeignKeyAction?, updateAction: SQLForeignKeyAction?, deferred: Bool)?
+    
+    init(name: String, type: SQLColumnType) {
+        self.name = name
+        self.type = type
+    }
+    
+    /// Adds a primary key constraint on the column.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("id", .Integer).primaryKey()
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#primkeyconst and
+    /// https://www.sqlite.org/lang_createtable.html#rowid
+    ///
+    /// - parameters:
+    ///     - conflitResolution: An optional conflict resolution
+    ///       (see https://www.sqlite.org/lang_conflict.html).
+    ///     - autoincrement: If true, the primary key is autoincremented.
+    /// - returns: Self so that you can further refine the column definition.
+    public func primaryKey(onConflict conflictResolution: SQLConflictResolution? = nil, autoincrement: Bool = false) -> SQLColumnBuilder {
+        primaryKey = (conflictResolution: conflictResolution, autoincrement: autoincrement)
+        return self
+    }
+    
+    /// Adds a NOT NULL constraint on the column.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("name", .Text).notNull()
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#notnullconst
+    ///
+    /// - parameter conflitResolution: An optional conflict resolution
+    ///   (see https://www.sqlite.org/lang_conflict.html).
+    /// - returns: Self so that you can further refine the column definition.
+    public func notNull(onConflict conflictResolution: SQLConflictResolution? = nil) -> SQLColumnBuilder {
+        notNullConflictResolution = conflictResolution ?? .Abort
+        return self
+    }
+    
+    /// Adds a UNIQUE constraint on the column.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("email", .Text).unique()
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#uniqueconst
+    ///
+    /// - parameter conflitResolution: An optional conflict resolution
+    ///   (see https://www.sqlite.org/lang_conflict.html).
+    /// - returns: Self so that you can further refine the column definition.
+    public func unique(onConflict conflictResolution: SQLConflictResolution? = nil) -> SQLColumnBuilder {
+        uniqueConflictResolution = conflictResolution ?? .Abort
+        return self
+    }
+    
+    /// Adds a CHECK constraint on the column.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("name", .Text).check { length($0) > 0 }
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    ///
+    /// - parameter condition: A closure whose argument is an SQLColumn that
+    ///   represents the defined column, and returns the expression to check.
+    /// - returns: Self so that you can further refine the column definition.
+    public func check(@noescape condition: (SQLColumn) -> _SQLExpressible) -> SQLColumnBuilder {
+        checkExpression = condition(SQLColumn(name)).sqlExpression
+        return self
+    }
+    
+    /// Adds a CHECK constraint on the column.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("name", .Text).check(sql: "LENGTH(name) > 0")
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    ///
+    /// - parameter sql: An SQL snippet.
+    /// - returns: Self so that you can further refine the column definition.
+    public func check(sql sql: String) -> SQLColumnBuilder {
+        checkExpression = _SQLExpression.Literal(sql, nil)
+        return self
+    }
+    
+    /// Defines the default column value.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("name", .Text).defaults("Anonymous")
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#dfltval
+    ///
+    /// - parameter value: A DatabaseValueConvertible value.
+    /// - returns: Self so that you can further refine the column definition.
+    public func defaults(value: DatabaseValueConvertible) -> SQLColumnBuilder {
+        defaultExpression = value.sqlExpression
+        return self
+    }
+    
+    /// Defines the default column value.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("creationDate", .DateTime).defaults(sql: "CURRENT_TIMESTAMP")
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_createtable.html#dfltval
+    ///
+    /// - parameter sql: An SQL snippet.
+    /// - returns: Self so that you can further refine the column definition.
+    public func defaults(sql sql: String) -> SQLColumnBuilder {
+        defaultExpression = _SQLExpression.Literal(sql, nil)
+        return self
+    }
+    
+    // Defines the default column collation.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("email", .Text).collate(.Nocase)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/datatype3.html#collation
+    ///
+    /// - parameter collation: An SQLCollation.
+    /// - returns: Self so that you can further refine the column definition.
+    public func collate(collation: SQLCollation) -> SQLColumnBuilder {
+        collationName = collation.rawValue
+        return self
+    }
+    
+    // Defines the default column collation.
+    ///
+    ///     try db.create(table: "persons") { t in
+    ///         t.column("name", .Text).collate(.localizedCaseInsensitiveCompare)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/datatype3.html#collation
+    ///
+    /// - parameter collation: A custom DatabaseCollation.
+    /// - returns: Self so that you can further refine the column definition.
+    public func collate(collation: DatabaseCollation) -> SQLColumnBuilder {
+        collationName = collation.name
+        return self
+    }
+    
+    /// Defines a foreign key.
+    ///
+    ///     try db.create(table: "books") { t in
+    ///         t.column("authorId", .Integer).references("authors", onDelete: .Cascade)
+    ///     }
+    ///
+    /// See https://www.sqlite.org/foreignkeys.html
+    ///
+    /// - parameters
+    ///     - table: The referenced table.
+    ///     - column: The column in the referenced table. If not specified, the
+    ///       column of the primary key of the referenced table is used.
+    ///     - deleteAction: Optional action when the referenced row is deleted.
+    ///     - updateAction: Optional action when the referenced row is updated.
+    ///     - deferred: If true, defines a deferred foreign key constraint.
+    ///       See https://www.sqlite.org/foreignkeys.html#fk_deferred.
+    /// - returns: Self so that you can further refine the column definition.
+    public func references(table: String, column: String? = nil, onDelete deleteAction: SQLForeignKeyAction? = nil, onUpdate updateAction: SQLForeignKeyAction? = nil, deferred: Bool = false) -> SQLColumnBuilder {
+        reference = (table: table, column: column, deleteAction: deleteAction, updateAction: updateAction, deferred: deferred)
+        return self
+    }
+    
+    private func sql(db: Database) throws -> String {
         var chunks: [String] = []
         chunks.append(name.quotedDatabaseIdentifier)
         chunks.append(type.rawValue)
         
-        if let (ordering, conflictResolution, autoincrement) = primaryKey {
+        if let (conflictResolution, autoincrement) = primaryKey {
             chunks.append("PRIMARY KEY")
-            if let ordering = ordering {
-                chunks.append(ordering.rawValue)
-            }
             if let conflictResolution = conflictResolution {
                 chunks.append("ON CONFLICT")
                 chunks.append(conflictResolution.rawValue)
@@ -428,7 +676,7 @@ extension SQLColumnBuilder {
     }
 }
 
-struct IndexBuilder {
+private struct IndexBuilder {
     let name: String
     let table: String
     let columns: [String]
@@ -456,4 +704,53 @@ struct IndexBuilder {
         }
         return chunks.joinWithSeparator(" ")
     }
+}
+
+/// A built-in SQLite collation.
+///
+/// See https://www.sqlite.org/datatype3.html#collation
+public enum SQLCollation : String {
+    case Binary = "BINARY"
+    case Nocase = "NOCASE"
+    case Rtrim = "RTRIM"
+}
+
+/// An SQLite conflict resolution.
+///
+/// See https://www.sqlite.org/lang_conflict.html.
+public enum SQLConflictResolution : String {
+    case Rollback = "ROLLBACK"
+    case Abort = "ABORT"
+    case Fail = "FAIL"
+    case Ignore = "IGNORE"
+    case Replace = "REPLACE"
+}
+
+/// An SQL column type.
+///
+///     try db.create(table: "persons") { t in
+///         t.column("id", .Integer).primaryKey()
+///         t.column("title", .Text)
+///     }
+///
+/// See https://www.sqlite.org/datatype3.html
+public enum SQLColumnType : String {
+    case Text = "TEXT"
+    case Integer = "INTEGER"
+    case Double = "DOUBLE"
+    case Numeric = "NUMERIC"
+    case Boolean = "BOOLEAN"
+    case Blob = "BLOB"
+    case Date = "DATE"
+    case Datetime = "DATETIME"
+}
+
+/// A foreign key action.
+///
+/// See https://www.sqlite.org/foreignkeys.html
+public enum SQLForeignKeyAction : String {
+    case Cascade = "CASCADE"
+    case Restrict = "RESTRICT"
+    case SetNull = "SET NULL"
+    case SetDefault = "SET DEFAULT"
 }

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -79,7 +79,7 @@ public final class SQLTableBuilder {
     }
     
     // TODO: doc
-    public func foreignKey(columns: [String], to table: String, columns destinationColumns: [String]? = nil, onDelete deleteAction: SQLForeignKeyAction? = nil, onUpdate updateAction: SQLForeignKeyAction? = nil, deferred: Bool = false) {
+    public func foreignKey(columns: [String], references table: String, columns destinationColumns: [String]? = nil, onDelete deleteAction: SQLForeignKeyAction? = nil, onUpdate updateAction: SQLForeignKeyAction? = nil, deferred: Bool = false) {
         foreignKeyConstraints.append((columns: columns, table: table, destinationColumns: destinationColumns, deleteAction: deleteAction, updateAction: updateAction, deferred: deferred))
     }
     

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -9,15 +9,20 @@ extension Database {
     }
     
     // TODO: doc
+    public func rename(table name: String, to newName: String) throws {
+        try execute("ALTER TABLE \(name.quotedDatabaseIdentifier) RENAME TO \(newName.quotedDatabaseIdentifier)")
+    }
+    
+    // TODO: doc
+    public func drop(table name: String) throws {
+        try execute("DROP TABLE \(name.quotedDatabaseIdentifier)")
+    }
+    
+    // TODO: doc
     public func create(index name: String, on table: String, columns: [String], unique: Bool = false, ifNotExists: Bool = false, condition: _SQLExpressible? = nil) throws {
         let builder = IndexBuilder(name: name, table: table, columns: columns, unique: unique, ifNotExists: ifNotExists, condition: condition?.sqlExpression)
         let sql = builder.sql()
         try execute(sql)
-    }
-
-    // TODO: doc
-    public func drop(table name: String) throws {
-        try execute("DROP TABLE \(name.quotedDatabaseIdentifier)")
     }
     
     // TODO: doc

--- a/GRDB/QueryInterface/SQLTableBuilder.swift
+++ b/GRDB/QueryInterface/SQLTableBuilder.swift
@@ -64,7 +64,7 @@ public final class SQLColumnBuilder {
     var notNullConflictResolution: SQLConflictResolution?
     var uniqueConflictResolution: SQLConflictResolution?
     var checkExpression: _SQLExpression?
-    var defaultValue: DatabaseValueConvertible?
+    var defaultExpression: _SQLExpression?
     var collationName: String?
     var reference: (table: String, column: String?, deleteAction: SQLForeignKeyAction?, updateAction: SQLForeignKeyAction?, deferred: Bool)?
     
@@ -94,9 +94,18 @@ public final class SQLColumnBuilder {
     }
     
     // TODO: doc
-    // TODO: defaults(sql: "CURRENT_TIMESTAMP")
+    public func check(sql sql: String) {
+        checkExpression = _SQLExpression.Literal(sql, nil)
+    }
+    
+    // TODO: doc
     public func defaults(value: DatabaseValueConvertible) {
-        defaultValue = value
+        defaultExpression = value.sqlExpression
+    }
+    
+    // TODO: doc
+    public func defaults(sql sql: String) {
+        defaultExpression = _SQLExpression.Literal(sql, nil)
     }
     
     // TODO: doc
@@ -281,10 +290,10 @@ extension SQLColumnBuilder {
             chunks.append("(" + checkExpression.sql(&arguments) + ")")
         }
         
-        if let defaultValue = defaultValue {
-            var arguments: StatementArguments? = nil // nil so that defaultValue.sqlExpression.sql(&arguments) embeds literals
+        if let defaultExpression = defaultExpression {
+            var arguments: StatementArguments? = nil // nil so that defaultExpression.sql(&arguments) embeds literals
             chunks.append("DEFAULT")
-            chunks.append("(" + defaultValue.sqlExpression.sql(&arguments) + ")")
+            chunks.append("(" + defaultExpression.sql(&arguments) + ")")
         }
         
         if let collationName = collationName {

--- a/GRDB/Record/Persistable.swift
+++ b/GRDB/Record/Persistable.swift
@@ -517,7 +517,7 @@ final class DataMapper {
     let databaseTableName: String
     
     /// The table primary key
-    let primaryKey: PrimaryKey?
+    let primaryKey: PrimaryKeyInfo?
     
     init(_ db: Database, _ persistable: MutablePersistable) {
         // Fail early if database table does not exist.

--- a/README.md
+++ b/README.md
@@ -2530,9 +2530,9 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
 
 #### SQL Functions
 
-- `ABS`, `AVG`, `COUNT`, `MAX`, `MIN`, `SUM`:
+- `ABS`, `AVG`, `COUNT`, `LENGTH`, `MAX`, `MIN`, `SUM`:
     
-    Those are based on the `abs`, `average`, `count`, `max`, `min` and `sum` Swift functions:
+    Those are based on the `abs`, `average`, `count`, `length`, `max`, `min` and `sum` Swift functions:
     
     ```swift
     // SELECT MIN(age), MAX(age) FROM persons

--- a/README.md
+++ b/README.md
@@ -2258,7 +2258,7 @@ try db.drop(table: "obsolete")
 
 #### Create Indexes
 
-Create index with the `create(index:)` method:
+Create indexes with the `create(index:)` method:
 
 ```swift
 // CREATE UNIQUE INDEX byEmail ON users(email)

--- a/README.md
+++ b/README.md
@@ -2645,6 +2645,12 @@ For multiple-column primary keys, provide a dictionary:
 Citizenship.fetchOne(db, key: ["personID": 1, "countryISOCode": "FR"]) // Citizenship?
 ```
 
+You can use generally use a dictionary for any **unique key** (primary key and columns involved in a unique index):
+
+```swift
+Person.fetchOne(db, key: ["email": "arthur@example.com"]) // Person?
+```
+
 
 ### Fetching Aggregated Values
 

--- a/README.md
+++ b/README.md
@@ -2265,7 +2265,7 @@ try db.alter(table: "persons") { t in
 }
 ```
 
-> :point_up: **Note**: Table alterations are restricted, and may require you to recreate triggers or views: see the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html), and [Advanced Database Schema Changes](#advanced-database-schema-changes) for a way to lift those restrictions.
+> :point_up: **Note**: Table alterations are restricted, and may require you to recreate triggers or views. See the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html) for details. See [Advanced Database Schema Changes](#advanced-database-schema-changes) for a way to lift restrictions.
 
 
 #### Drop Tables

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Follow [@groue](http://twitter.com/groue) on Twitter for release announcements a
 <p align="center">
     <a href="#features">Features</a> &bull;
     <a href="#usage">Usage</a> &bull;
+    <a href="#installation">Installation</a> &bull;
     <a href="#documentation">Documentation</a> &bull;
     <a href="#faq">FAQ</a>
 </p>

--- a/README.md
+++ b/README.md
@@ -1356,7 +1356,7 @@ GRDB provides four high-level methods as well:
 db.tableExists("persons")    // Bool, true if the table exists
 db.indexes(on: "persons")    // [IndexInfo], the indexes defined on the table
 try db.table("persons", hasUniqueKey: ["email"]) // Bool, true if column(s) is a unique key
-try db.primaryKey("persons") // PrimaryKey?
+try db.primaryKey("persons") // PrimaryKeyInfo?
 ```
 
 Primary key is nil when table has no primary key:
@@ -2165,9 +2165,22 @@ try db.create(table: "pointOfInterests") { t in
 }
 ```
 
-The `create(table:)` method covers nearly all [CREATE TABLE](https://www.sqlite.org/lang_createtable.html) SQLite statements:
+The `create(table:)` method covers nearly all SQLite table creation features.
+
+Relevant SQLite documentation:
+
+- [CREATE TABLE](https://www.sqlite.org/lang_createtable.html)
+- [Datatypes In SQLite Version 3](https://www.sqlite.org/datatype3.html)
+- [SQLite Foreign Key Support](https://www.sqlite.org/foreignkeys.html)
+- [ON CONFLICT](https://www.sqlite.org/lang_conflict.html)
+- [The WITHOUT ROWID Optimization](https://www.sqlite.org/withoutrowid.html)
+
+**Configure table creation**:
 
 ```swift
+// CREATE TABLE demo (
+try db.create(table: "demo") { t in ... }
+    
 // CREATE TEMPORARY TABLE demo IF NOT EXISTS (
 try db.create(table: "demo", temporary: true, ifNotExists: true) { t in
 ```
@@ -2247,7 +2260,7 @@ try db.alter(table: "persons") { t in
 }
 ```
 
-Table alterations are restricted: see the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html), and  [Migrations](#migrations) for a way to lift those restrictions.
+> :point_up: **Note**: Table alterations are restricted, and may require you to recreate triggers or views: see the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html), and  [migrations](#migrations) for a way to lift those restrictions.
 
 
 #### Drop Tables
@@ -2266,6 +2279,12 @@ Create indexes with the `create(index:)` method:
 // CREATE UNIQUE INDEX byEmail ON users(email)
 try db.create(index: "byEmail", on: "users", columns: ["email"], unique: true)
 ```
+
+Relevant SQLite documentation:
+
+- [CREATE INDEX](https://www.sqlite.org/lang_createindex.html)
+- [Indexes On Expressions](https://www.sqlite.org/expridx.html)
+- [Partial Indexes](https://www.sqlite.org/partialindex.html)
 
 
 ### Requests

--- a/README.md
+++ b/README.md
@@ -2253,7 +2253,7 @@ Other **table constraints** can involve several columns:
 
 #### Modify Tables
 
-SQLite let you rename tables, and add columns to existing tables:
+SQLite lets you rename tables, and add columns to existing tables:
 
 ```swift
 // ALTER TABLE referers RENAME TO referrers

--- a/README.md
+++ b/README.md
@@ -2241,9 +2241,9 @@ SQLite let you rename tables, and add columns to existing tables:
 // ALTER TABLE referers RENAME TO referrers
 try db.rename(table: "referers", to: "referrers")
 
-// ALTER TABLE persons ADD COLUMN website TEXT
+// ALTER TABLE persons ADD COLUMN url TEXT
 try db.alter(table: "persons") { t in
-    t.add(column: "website", .Text)
+    t.add(column: "url", .Text)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2268,7 +2268,12 @@ try db.create(index: "byEmail", on: "users", columns: ["email"], unique: true)
 
 ### Requests
 
-**The query interface requests** let you fetch values from the database.
+**The query interface requests** let you fetch values from the database:
+
+```swift
+let count = Wine.filter(color == Color.Red).fetchCount(db)
+let wines = Wine.filter(origin == "Burgundy").order(price).fetchAll(db)
+```
 
 All requests start from **a type** that adopts the `TableMapping` protocol, such as a `Record` subclass (see [Records](#records)):
 

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ Documentation
 
 **SQLite and SQL**
 
-- [SQLite API](#sqlite-api)
+- [SQLite API](#sqlite-api): The low-level SQLite API &bull; [executing updates](#executing-updates), [fetch queries](#fetch-queries), etc.
 
 **Application tools**
 
 - [Records](#records): Fetching and persistence methods for your custom structs and class hierarchies.
-- [Query Interface](#the-query-interface): A swift way to generate SQL.
+- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema), [requests](#requests), etc.
 - [Migrations](#migrations): Transform your database as your application evolves.
 - [Database Changes Observation](#database-changes-observation): Perform post-commit and post-rollback actions.
 - [FetchedRecordsController](#fetchedrecordscontroller): Automatic database changes tracking, plus UITableView animations.

--- a/README.md
+++ b/README.md
@@ -2159,7 +2159,7 @@ Once granted with a [database connection](#database-connections), you can use th
 try db.create(table: "pointOfInterests") { t in
     t.column("id", .Integer).primaryKey()
     t.column("title", .Text)
-    t.column("favorite", .Boolean).notNull().default(false)
+    t.column("favorite", .Boolean).notNull().defaults(false)
     t.column("longitude", .Double).notNull()
     t.column("latitude", .Double).notNull()
 }
@@ -2191,7 +2191,7 @@ Define **not null** and **unique** columns, and set **default** values:
     t.column("uuid", .Text).unique(onConflict: .Replace)
     
     // name TEXT NOT NULL DEFAULT 'Anonymous',
-    t.column("name", .Text).notNull().default("Anonymous")
+    t.column("name", .Text).notNull().defaults("Anonymous")
 ```
     
 **Perform integrity checks** on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).

--- a/README.md
+++ b/README.md
@@ -3364,9 +3364,9 @@ do {
 
 **Fatal errors notify that the program, or the database, has to be changed.**
 
-They uncover programmer errors, false assumptions, and prevent misuses.
+They uncover programmer errors, false assumptions, and prevent misuses. Here are a few examples:
 
-1. For example, the code contains a wrong SQL query:
+- The code contains a wrong SQL query:
     
     ```swift
     // fatal error:
@@ -3383,7 +3383,7 @@ They uncover programmer errors, false assumptions, and prevent misuses.
     
     If you do have to run untrusted SQL queries, jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
 
-2. The code asks for a non-optional values, when the database contains NULL:
+- The code asks for a non-optional values, when the database contains NULL:
     
     ```swift
     // fatal error: could not convert NULL to String.
@@ -3396,7 +3396,7 @@ They uncover programmer errors, false assumptions, and prevent misuses.
     let name: String? = row.value(named: "name")
     ```
 
-3. The code asks for an NSDate, when the database contains garbage:
+- The code asks for an NSDate, when the database contains garbage:
     
     ```swift
     // fatal error: could not convert "Mom's birthday" to NSDate.
@@ -3405,7 +3405,7 @@ They uncover programmer errors, false assumptions, and prevent misuses.
     
     Solution: fix the contents of the database, or jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
 
-4. Database connections are not reentrant:
+- Database connections are not reentrant:
     
     ```swift
     // fatal error: Database methods are not reentrant.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,30 @@
 GRDB.swift [![Swift](https://img.shields.io/badge/swift-2.2-orange.svg?style=flat)](https://developer.apple.com/swift/) [![Platforms](https://img.shields.io/cocoapods/p/GRDB.swift.svg)](https://developer.apple.com/swift/) [![License](https://img.shields.io/github/license/groue/GRDB.swift.svg?maxAge=2592000)](/LICENSE)
 ==========
 
-GRDB.swift is a Swift application toolkit that provides access to SQLite databases.
+### A Swift application toolkit that provides access to SQLite databases.
+
+GRDB provides raw SQLite access and high-level APIs that help building applications.
 
 It targets Swift 2.2, and Swift 3 in the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch.
 
-It ships with a **low-level SQLite API**, and high-level tools that help dealing with databases:
+**July 28, 2016: GRDB.swift 0.77.0 is out** ([CHANGELOG](CHANGELOG.md)). Follow [@groue](http://twitter.com/groue) on Twitter for release announcements and usage tips.
+
+**Requirements**: iOS 8.0+ / OSX 10.9+, Xcode 7.3+
+
+---
+
+<p align="center">
+    <a href="#features">Features</a> &bull;
+    <a href="#usage">Usage</a> &bull;
+    <a href="#documentation">Documentation</a> &bull;
+    <a href="#faq">FAQ</a> &bull;
+</p>
+
+---
+
+## Features
+
+GRDB ships with a **low-level SQLite API**, and high-level tools that help dealing with databases:
 
 - **Records**: fetching and persistence methods for your custom structs and class hierarchies
 - **Query Interface**: a swift way to avoid the SQL language
@@ -25,14 +44,7 @@ More than a set of tools that leverage SQLite abilities, GRDB is also:
 For a general overview of how a protocol-oriented library impacts database acesses, have a look at [How to build an iOS application with SQLite and GRDB.swift](https://medium.com/@gwendal.roue/how-to-build-an-ios-application-with-sqlite-and-grdb-swift-d023a06c29b3).
 
 
----
-
-**July 28, 2016: GRDB.swift 0.77.0 is out** ([changelog](CHANGELOG.md)). Follow [@groue](http://twitter.com/groue) on Twitter for release announcements and usage tips.
-
-**Requirements**: iOS 8.0+ / OSX 10.9+, Xcode 7.3+
-
-
-### Usage
+## Usage
 
 Open a [connection](#database-connections) to the database:
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ GRDB.swift [![Swift](https://img.shields.io/badge/swift-2.2-orange.svg?style=fla
 
 ### A Swift application toolkit that provides access to SQLite databases.
 
-**Requirements**: iOS 8.0+ / OSX 10.9+, Xcode 7.3+, Swift 2.2 (see the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch for Swift 3).
+**Requirements**: iOS 8.0+ / OSX 10.9+ &bull; Xcode 7.3+ &bull; Swift 2.2 (see the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch for Swift 3).
 
-**Last release**: July 28, 2016 &bull; version 0.77.0 &bull; [CHANGELOG](CHANGELOG.md).
+**Last release**: July 28, 2016 &bull; version 0.77.0 &bull; [CHANGELOG](CHANGELOG.md)
 
 Follow [@groue](http://twitter.com/groue) on Twitter for release announcements and usage tips.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ More than a set of tools that leverage SQLite abilities, GRDB is also:
 - **Faster**: see [Comparing the Performances of Swift SQLite libraries](https://github.com/groue/GRDB.swift/wiki/Performance)
 - Well documented & tested
 
-For a general overview of how a protocol-oriented library impacts database acesses, have a look at [How to build an iOS application with SQLite and GRDB.swift](https://medium.com/@gwendal.roue/how-to-build-an-ios-application-with-sqlite-and-grdb-swift-d023a06c29b3).
+For a general overview of how a protocol-oriented library impacts database accesses, have a look at [How to build an iOS application with SQLite and GRDB.swift](https://medium.com/@gwendal.roue/how-to-build-an-ios-application-with-sqlite-and-grdb-swift-d023a06c29b3).
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -2116,6 +2116,7 @@ For an efficient algorithm which synchronizes the content of a database table wi
 **The query interface lets you write pure Swift instead of SQL:**
 
 ```swift
+try db.create(table: "wines") { t in ... }
 let count = Wine.filter(color == Color.Red).fetchCount(db)
 let wines = Wine.filter(origin == "Burgundy").order(price).fetchAll(db)
 ```
@@ -2123,6 +2124,7 @@ let wines = Wine.filter(origin == "Burgundy").order(price).fetchAll(db)
 Please bear in mind that the query interface can not generate all possible SQL queries. You may also *prefer* writing SQL, and this is just OK. From little snippets to full queries, your SQL skills are welcome:
 
 ```swift
+try db.execute("CREATE TABLE wines (...)")
 let count = Wine.filter(sql: "color = ?", arguments: [Color.Red]).fetchCount(db)
 let wines = Wine.fetchAll(db, "SELECT * FROM wines WHERE origin = ? ORDER BY price", arguments: ["Burgundy"])
 ```

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Generally speaking, you can extract the type you need, *provided it can be conve
 
 - **Successful conversions include:**
     
-    - Numeric SQLite values to numeric Swift types, and Bool (zero is the only false boolean).
+    - All numeric SQLite values to all numeric Swift types, and Bool (zero is the only false boolean).
     - Text SQLite values to Swift String.
     - Blob SQLite values to NSData.
     
@@ -1043,7 +1043,7 @@ enum Grape : String {
     case Chardonnay, Merlot, Riesling
 }
 
-// Declare DatabaseValueConvertible adoption
+// Declare empty DatabaseValueConvertible adoption
 extension Color : DatabaseValueConvertible { }
 extension Grape : DatabaseValueConvertible { }
 
@@ -2305,7 +2305,7 @@ let count = request.fetchCount(db)  // Int
 All requests start from **a type** that adopts the `TableMapping` protocol, such as a `Record` subclass (see [Records](#records)):
 
 ```swift
-class Person: Record { ... }
+class Person : Record { ... }
 ```
 
 Declare the table **columns** that you want to use for filtering, or sorting:
@@ -2881,7 +2881,7 @@ At first sight, this looks somewhat redundant with the checks that observers can
 
 ```swift
 // BAD: An inefficient way to track the "persons" table:
-class PersonObserver: TransactionObserverType {
+class PersonObserver : TransactionObserverType {
     func databaseDidChangeWithEvent(event: DatabaseEvent) {
         guard event.tableName == "persons" else {
             return

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 GRDB.swift [![Swift](https://img.shields.io/badge/swift-2.2-orange.svg?style=flat)](https://developer.apple.com/swift/) [![Platforms](https://img.shields.io/cocoapods/p/GRDB.swift.svg)](https://developer.apple.com/swift/) [![License](https://img.shields.io/github/license/groue/GRDB.swift.svg?maxAge=2592000)](/LICENSE)
 ==========
 
-### A Swift application toolkit that provides access to SQLite databases.
+### A Swift application toolkit for SQLite databases.
 
 **Requirements**: iOS 8.0+ / OSX 10.9+ &bull; Xcode 7.3+ &bull; Swift 2.2 (see the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch for Swift 3).
 

--- a/README.md
+++ b/README.md
@@ -3380,7 +3380,7 @@ For example, the code contains a wrong SQL query:
 Row.fetchAll(db, "SELECT * FROM boooks")
 ```
 
-**Solution**: fix the SQL query.
+Solution: fix the SQL query.
 
 ```swift
 Row.fetchAll(db, "SELECT * FROM books")
@@ -3398,7 +3398,7 @@ For example, the code asks for a non-optional values, when the database contains
 let name: String = row.value(named: "name")
 ```
 
-**Solution**: fix the contents of the database, use [NOT NULL constraints](#create-tables), or load an optional:
+Solution: fix the contents of the database, use [NOT NULL constraints](#create-tables), or load an optional:
 
 ```swift
 let name: String? = row.value(named: "name")
@@ -3411,12 +3411,12 @@ Second example: the code asks for an NSDate, when the database contains garbage:
 let date: NSDate? = row.value(named: "date")
 ```
 
-**Solution**: fix the contents of the database, or jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
+Solution: fix the contents of the database, or jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
 
 
 #### Misuses
 
-For example, did you know that database connections are not reentrant?
+For example, database connections are not reentrant:
 
 ```swift
 // fatal error: Database methods are not reentrant.
@@ -3427,7 +3427,7 @@ dbQueue.inDatabase { db in
 }
 ```
 
-Well, now you know. Avoid reentrancy, and instead pass a database connection along.
+Solution: Avoid reentrancy, and instead pass a database connection along.
 
 
 ### How to Deal with Untrusted Inputs

--- a/README.md
+++ b/README.md
@@ -2181,19 +2181,29 @@ try db.create(table: "demo", temporary: true, ifNotExists: true) { t in
     t.column("creationDate", .Datetime)
 ```
 
-Define **not null** and **unique** columns, and set **default** values:
+Define **not null** columns, and set **default** values:
 
 ```swift
-    // email TEXT NOT NULL UNIQUE,
-    t.column("email", .Text).notNull().unique()
-    
-    // uuid TEXT UNIQUE ON CONFLICT REPLACE,
-    t.column("uuid", .Text).unique(onConflict: .Replace)
+    // email TEXT NOT NULL,
+    t.column("email", .Text).notNull()
     
     // name TEXT NOT NULL DEFAULT 'Anonymous',
     t.column("name", .Text).notNull().defaults("Anonymous")
 ```
     
+Use an individual column as **primary**, **unique**, or **foreign key**. When not specified, the referenced column is the primary key of the referenced table:
+
+```swift
+    // id INTEGER PRIMARY KEY,
+    t.column("id", .Integer).primaryKey()
+    
+    // email TEXT UNIQUE,
+    t.column("email", .Text).unique()
+    
+    // countryCode TEXT REFERENCES countries(code) ON DELETE CASCADE,
+    t.column("countryCode", .Text).references("countries", onDelete: .Cascade)
+```
+
 **Perform integrity checks** on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).
 
 ```swift
@@ -2201,16 +2211,6 @@ Define **not null** and **unique** columns, and set **default** values:
     // name TEXT CHECK (LENGTH(name) > 0)
     t.column("age", .Integer).check { $0 > 0 }
     t.column("name", .Text).check { length($0) > 0 }
-```
-
-Use an individual column as **primary** or **foreign key**. When not specified, the referenced column is the primary key of the referenced table:
-
-```swift
-    // id INTEGER PRIMARY KEY,
-    t.column("id", .Integer).primaryKey()
-    
-    // countryCode TEXT REFERENCES countries(code) ON DELETE CASCADE,
-    t.column("countryCode", .Text).references("countries", onDelete: .Cascade)
 ```
 
 Other **table constraints** can involve several columns. Integrity checks accept any [expression](#expressions), or a raw SQL snippet:

--- a/README.md
+++ b/README.md
@@ -2265,7 +2265,7 @@ try db.alter(table: "persons") { t in
 }
 ```
 
-> :point_up: **Note**: Table alterations are restricted, and may require you to recreate triggers or views: see the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html), and  [migrations](#migrations) for a way to lift those restrictions.
+> :point_up: **Note**: Table alterations are restricted, and may require you to recreate triggers or views: see the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html), and [Advanced Database Schema Changes](#advanced-database-schema-changes) for a way to lift those restrictions.
 
 
 #### Drop Tables

--- a/README.md
+++ b/README.md
@@ -2190,8 +2190,8 @@ Define not null and unique columns, and set default values:
     // uuid TEXT UNIQUE ON CONFLICT REPLACE,
     t.column("uuid", .Text).unique(onConflict: .Replace)
     
-    // flag BOOLEAN NOT NULL DEFAULT 0,
-    t.column("flag", .Boolean).notNull().default(false)
+    // name TEXT NOT NULL DEFAULT 'Anonymous',
+    t.column("name", .Text).notNull().default("Anonymous")
 ```
     
 Perform integrity checks on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).

--- a/README.md
+++ b/README.md
@@ -3386,7 +3386,7 @@ Solution: fix the SQL query.
 Row.fetchAll(db, "SELECT * FROM books")
 ```
 
-If you have to run untrusted SQL queries, jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
+If you do have to run untrusted SQL queries, jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
 
 
 #### False Assumptions
@@ -3427,7 +3427,7 @@ dbQueue.inDatabase { db in
 }
 ```
 
-Solution: Avoid reentrancy, and instead pass a database connection along.
+Solution: avoid reentrancy, and instead pass a database connection along.
 
 
 ### How to Deal with Untrusted Inputs

--- a/README.md
+++ b/README.md
@@ -3403,7 +3403,18 @@ They uncover programmer errors, false assumptions, and prevent misuses. Here are
     let date: NSDate? = row.value(named: "date")
     ```
     
-    Solution: fix the contents of the database, or jump to [untrusted databases](#how-to-deal-with-untrusted-inputs).
+    Solution: fix the contents of the database, or use [DatabaseValue](#databasevalue) to handle all possible cases:
+    
+    ```swift
+    let dbv = row.databaseValue(named: "date")
+    if dbv.isNull {
+        // Handle NULL
+    if let date = NSDate.fromDatabaseValue(dbv) {
+        // Handle valid date
+    } else {
+        // Handle invalid date
+    }
+    ```
 
 - Database connections are not reentrant:
     

--- a/README.md
+++ b/README.md
@@ -2223,7 +2223,7 @@ Other **table constraints** can involve several columns:
     t.uniqueKey(["a", "b"], onConfict: .Replace)
     
     // FOREIGN KEY (c, d) REFERENCES parents(a, b),
-    t.foreignKey(["c", "d"], references: "parent", columns: ["a", "b"])
+    t.foreignKey(["c", "d"], references: "parent")
     
     // CHECK (a + b < 10),
     t.check(SQLColumn("a") + SQLColumn("b") < 10)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ GRDB.swift [![Swift](https://img.shields.io/badge/swift-2.2-orange.svg?style=fla
 
 ### A Swift application toolkit that provides access to SQLite databases.
 
-GRDB provides raw SQLite access and high-level APIs that help building applications. It targets Swift 2.2, and Swift 3 in the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch.
-
-**Requirements**: iOS 8.0+ / OSX 10.9+, Xcode 7.3+
+**Requirements**: iOS 8.0+ / OSX 10.9+, Xcode 7.3+, Swift 2.2 (see the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch for Swift 3).
 
 **Last release**: July 28, 2016 &bull; version 0.77.0 &bull; [CHANGELOG](CHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -2194,11 +2194,13 @@ Define not null and unique columns, and set default values:
     t.column("flag", .Boolean).notNull().default(false)
 ```
     
-Perform integrity checks on individual columns (SQLite will only allow conforming rows):
+Perform integrity checks on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).
 
 ```swift
     // age INTEGER CHECK (age > 0)
+    // name TEXT CHECK (LENGTH(name) > 0)
     t.column("age", .Integer).check { $0 > 0 }
+    t.column("name", .Text).check { length($0) > 0 }
 ```
 
 Use individual columns as primary or foreign keys. When not specified, the referenced column is the primary key of the referenced table:

--- a/README.md
+++ b/README.md
@@ -2223,7 +2223,7 @@ Other **table constraints** can involve several columns. Integrity checks accept
     t.uniqueKey(["a", "b"], onConfict: .Replace)
     
     // FOREIGN KEY (c, d) REFERENCES parents(a, b),
-    t.foreignKey(["c", "d"], to: "parent", columns: ["a", "b"])
+    t.foreignKey(["c", "d"], references: "parent", columns: ["a", "b"])
     
     // CHECK (a + b < 10),
     t.check(SQLColumn("a") + SQLColumn("b") < 10)

--- a/README.md
+++ b/README.md
@@ -2213,7 +2213,7 @@ Use an individual column as **primary**, **unique**, or **foreign key**. When no
     t.column("name", .Text).check { length($0) > 0 }
 ```
 
-Other **table constraints** can involve several columns. Integrity checks accept any [expression](#expressions), or a raw SQL snippet:
+Other **table constraints** can involve several columns:
 
 ```swift
     // PRIMARY KEY (a, b),

--- a/README.md
+++ b/README.md
@@ -2138,7 +2138,7 @@ So don't miss the [SQL API](#sqlite-api).
 
 ### Database Schema
 
-Once granted with a [database connection](#database-connections), you can use the query interface to setup your database schema:
+Once granted with a [database connection](#database-connections), you can setup your database schema without writing SQL:
 
 - [Create Tables](#create-tables)
 - [Modify Tables](#modify-tables)

--- a/README.md
+++ b/README.md
@@ -2172,7 +2172,7 @@ The `create(table:)` method covers nearly all [CREATE TABLE](https://www.sqlite.
 try db.create(table: "demo", temporary: true, ifNotExists: true) { t in
 ```
 
-Add regular columns with their name and type (text, integer, double, numeric, boolean, blob, date and datetime) - see [SQLite data types](https://www.sqlite.org/datatype3.html):
+**Add regular columns** with their name and type (text, integer, double, numeric, boolean, blob, date and datetime) - see [SQLite data types](https://www.sqlite.org/datatype3.html):
 
 ```swift
     // name TEXT,
@@ -2181,7 +2181,7 @@ Add regular columns with their name and type (text, integer, double, numeric, bo
     t.column("creationDate", .Datetime)
 ```
 
-Define not null and unique columns, and set default values:
+Define **not null** and **unique** columns, and set **default** values:
 
 ```swift
     // email TEXT NOT NULL UNIQUE,
@@ -2194,7 +2194,7 @@ Define not null and unique columns, and set default values:
     t.column("name", .Text).notNull().default("Anonymous")
 ```
     
-Perform integrity checks on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).
+**Perform integrity checks** on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).
 
 ```swift
     // age INTEGER CHECK (age > 0)
@@ -2203,7 +2203,7 @@ Perform integrity checks on individual columns, and SQLite will only let conform
     t.column("name", .Text).check { length($0) > 0 }
 ```
 
-Use individual columns as primary or foreign keys. When not specified, the referenced column is the primary key of the referenced table:
+Use an individual columns as a **primary** or **foreign key**. When not specified, the referenced column is the primary key of the referenced table:
 
 ```swift
     // id INTEGER PRIMARY KEY,
@@ -2213,7 +2213,7 @@ Use individual columns as primary or foreign keys. When not specified, the refer
     t.column("countryCode", .Text).references("countries", onDelete: .Cascade)
 ```
 
-Other constraints can involve several columns:
+Other **table constraints** can involve several columns. Integrity checks accept any [expression](#expressions), or a raw SQL snippet:
 
 ```swift
     // PRIMARY KEY (a, b),

--- a/README.md
+++ b/README.md
@@ -2712,23 +2712,26 @@ let maxHeight = row.value(atIndex: 1) as Double?
 
 Migrations run in order, once and only once. When a user upgrades your application, only non-applied migrations are run.
 
+Inside each migration, you typically [define and update your database tables](#database-schema) according to your evolving application needs:
+
 ```swift
 var migrator = DatabaseMigrator()
 
-// v1.0 database
+// v1 database
 migrator.registerMigration("v1") { db in
     try db.create(table: "persons") { t in ... }
     try db.create(table: "books") { t in ... }
+    try db.create(index: ...)
 }
 
-// v2.0 database
+// v2 database
 migrator.registerMigration("v2") { db in
     try db.alter(table: "persons") { t in ... }
 }
 
 // Migrations for future versions will be inserted here:
 //
-// // v3.0 database
+// // v3 database
 // migrator.registerMigration("v3") { db in
 //     ...
 // }

--- a/README.md
+++ b/README.md
@@ -2203,7 +2203,7 @@ Define **not null** and **unique** columns, and set **default** values:
     t.column("name", .Text).check { length($0) > 0 }
 ```
 
-Use an individual columns as a **primary** or **foreign key**. When not specified, the referenced column is the primary key of the referenced table:
+Use an individual column as **primary** or **foreign key**. When not specified, the referenced column is the primary key of the referenced table:
 
 ```swift
     // id INTEGER PRIMARY KEY,

--- a/README.md
+++ b/README.md
@@ -2138,7 +2138,7 @@ So don't miss the [SQL API](#sqlite-api).
 
 ### Database Schema
 
-Once granted with a [database connection](#database-connections), you can use the query interface to setup your database schema.
+Once granted with a [database connection](#database-connections), you can use the query interface to setup your database schema:
 
 - [Create Tables](#create-tables)
 - [Modify Tables](#alter-tables)
@@ -2176,8 +2176,8 @@ Add regular columns with their name and type (text, integer, double, numeric, bo
 
 ```swift
     // name TEXT,
-    t.column("name", .Text)
     // creationDate DATETIME,
+    t.column("name", .Text)
     t.column("creationDate", .Datetime)
 ```
 

--- a/README.md
+++ b/README.md
@@ -2265,7 +2265,7 @@ try db.alter(table: "persons") { t in
 }
 ```
 
-> :point_up: **Note**: Table alterations are restricted, and may require you to recreate triggers or views. See the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html) for details. See [Advanced Database Schema Changes](#advanced-database-schema-changes) for a way to lift restrictions.
+> :point_up: **Note**: SQLite restricts the possible table alterations, and may require you to recreate dependent triggers or views. See the documentation of the [ALTER TABLE](https://www.sqlite.org/lang_altertable.html) for details. See [Advanced Database Schema Changes](#advanced-database-schema-changes) for a way to lift restrictions.
 
 
 #### Drop Tables

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Documentation
 
 - [GRDB Reference](http://cocoadocs.org/docsets/GRDB.swift/0.77.0/index.html) (on cocoadocs.org)
 
-**Getting started**
+**Getting Started**
 
 - [Installation](#installation)
 - [Database Connections](#database-connections): Connect to SQLite databases
@@ -174,7 +174,7 @@ Documentation
 
 - [SQLite API](#sqlite-api): The low-level SQLite API &bull; [executing updates](#executing-updates) &bull; [fetch queries](#fetch-queries)
 
-**Application tools**
+**Application Tools**
 
 - [Records](#records): Fetching and persistence methods for your custom structs and class hierarchies.
 - [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema) &bull; [fetch requests](#requests)
@@ -184,7 +184,7 @@ Documentation
 - [Encryption](#encryption): Encrypt your database with SQLCipher.
 - [Backup](#backup): Dump the content of a database to another.
 
-**Good to know**
+**Good to Know**
 
 - [Avoiding SQL Injection](#avoiding-sql-injection)
 - [Error Handling](#error-handling)

--- a/README.md
+++ b/README.md
@@ -2268,7 +2268,9 @@ try db.create(index: "byEmail", on: "users", columns: ["email"], unique: true)
 
 ### Requests
 
-**All requests** start from a type that adopts the `TableMapping` protocol, such as a `Record` subclass (see [Records](#records)):
+**The query interface requests** let you fetch values from the database.
+
+All requests start from **a type** that adopts the `TableMapping` protocol, such as a `Record` subclass (see [Records](#records)):
 
 ```swift
 class Person: Record { ... }

--- a/README.md
+++ b/README.md
@@ -2273,7 +2273,7 @@ try db.create(index: "byEmail", on: "users", columns: ["email"], unique: true)
 **The query interface requests** let you fetch values from the database:
 
 ```swift
-let request = Person.filter(email != nil).order(name)
+let request = Person.filter(emailColumn != nil).order(nameColumn)
 let persons = request.fetchAll(db)  // [Person]
 let count = request.fetchCount(db)  // Int
 ```

--- a/README.md
+++ b/README.md
@@ -172,12 +172,12 @@ Documentation
 
 **SQLite and SQL**
 
-- [SQLite API](#sqlite-api): The low-level SQLite API &bull; [executing updates](#executing-updates), [fetch queries](#fetch-queries), etc.
+- [SQLite API](#sqlite-api): The low-level SQLite API &bull; [executing updates](#executing-updates) &bull; [fetch queries](#fetch-queries)
 
 **Application tools**
 
 - [Records](#records): Fetching and persistence methods for your custom structs and class hierarchies.
-- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema), [requests](#requests), etc.
+- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema) &bull; [fetch requests](#requests)
 - [Migrations](#migrations): Transform your database as your application evolves.
 - [Database Changes Observation](#database-changes-observation): Perform post-commit and post-rollback actions.
 - [FetchedRecordsController](#fetchedrecordscontroller): Automatic database changes tracking, plus UITableView animations.

--- a/README.md
+++ b/README.md
@@ -2308,41 +2308,41 @@ All the methods above return another request, which you can further refine by ap
 - `all()`: the request for all rows.
 
     ```swift
-    // SELECT * FROM "persons"
+    // SELECT * FROM persons
     Person.all()
     ```
 
 - `select(expression, ...)` defines the selected columns.
     
     ```swift
-    // SELECT "id", "name" FROM "persons"
+    // SELECT id, name FROM persons
     Person.select(idColumn, nameColumn)
     
-    // SELECT MAX("age") AS "maxAge" FROM "persons"
+    // SELECT MAX(age) AS maxAge FROM persons
     Person.select(max(ageColumn).aliased("maxAge"))
     ```
 
 - `distinct` performs uniquing:
     
     ```swift
-    // SELECT DISTINCT "name" FROM "persons"
+    // SELECT DISTINCT name FROM persons
     Person.select(nameColumn).distinct
     ```
 
 - `filter(expression)` applies conditions.
     
     ```swift
-    // SELECT * FROM "persons" WHERE ("id" IN (1, 2, 3))
+    // SELECT * FROM persons WHERE id IN (1, 2, 3)
     Person.filter([1,2,3].contains(idColumn))
     
-    // SELECT * FROM "persons" WHERE (("name" IS NOT NULL) AND ("height" > 1.75))
+    // SELECT * FROM persons WHERE (name IS NOT NULL) AND (height > 1.75)
     Person.filter(nameColumn != nil && heightColumn > 1.75)
     ```
 
 - `group(expression, ...)` groups rows.
     
     ```swift
-    // SELECT "name", MAX("age") FROM "persons" GROUP BY "name"
+    // SELECT name, MAX(age) FROM persons GROUP BY name
     Person
         .select(nameColumn, max(ageColumn))
         .group(nameColumn)
@@ -2351,7 +2351,7 @@ All the methods above return another request, which you can further refine by ap
 - `having(expression)` applies conditions on grouped rows.
     
     ```swift
-    // SELECT "name", MAX("age") FROM "persons" GROUP BY "name" HAVING MIN("age") >= 18
+    // SELECT name, MAX(age) FROM persons GROUP BY name HAVING MIN(age) >= 18
     Person
         .select(nameColumn, max(ageColumn))
         .group(nameColumn)
@@ -2361,59 +2361,59 @@ All the methods above return another request, which you can further refine by ap
 - `order(ordering, ...)` sorts.
     
     ```swift
-    // SELECT * FROM "persons" ORDER BY "name"
+    // SELECT * FROM persons ORDER BY name
     Person.order(nameColumn)
     
-    // SELECT * FROM "persons" ORDER BY "score" DESC, "name"
+    // SELECT * FROM persons ORDER BY score DESC, name
     Person.order(scoreColumn.desc, nameColumn)
     ```
     
     Each `order` call clears any previous ordering:
     
     ```swift
-    // SELECT * FROM "persons" ORDER BY "name"
+    // SELECT * FROM persons ORDER BY name
     Person.order(scoreColumn).order(nameColumn)
     ```
 
 - `reverse()` reverses the eventual orderings.
     
     ```swift
-    // SELECT * FROM "persons" ORDER BY "score" ASC, "name" DESC
+    // SELECT * FROM persons ORDER BY score ASC, name DESC
     Person.order(scoreColumn.desc, nameColumn).reverse()
     ```
     
     If no ordering was specified, the result is ordered by rowID in reverse order.
     
     ```swift
-    // SELECT * FROM "persons" ORDER BY "_rowid_" DESC
+    // SELECT * FROM persons ORDER BY _rowid_ DESC
     Person.all().reverse()
     ```
 
 - `limit(limit, offset: offset)` limits and pages results.
     
     ```swift
-    // SELECT * FROM "persons" LIMIT 5
+    // SELECT * FROM persons LIMIT 5
     Person.limit(5)
     
-    // SELECT * FROM "persons" LIMIT 5 OFFSET 10
+    // SELECT * FROM persons LIMIT 5 OFFSET 10
     Person.limit(5, offset: 10)
     ```
 
 You can refine requests by chaining those methods:
 
 ```swift
-// SELECT * FROM "persons" WHERE ("email" IS NOT NULL) ORDER BY "name"
+// SELECT * FROM persons WHERE (email IS NOT NULL) ORDER BY name
 Person.order(nameColumn).filter(emailColumn != nil)
 ```
 
 The `select`, `order`, `group`, and `limit` methods ignore and replace previously applied selection, orderings, grouping, and limits. On the opposite, `filter`, and `having` methods extend the query:
 
 ```swift
-Person                          // SELECT * FROM "persons"
-    .filter(nameColumn != nil)  // WHERE (("name" IS NOT NULL)
-    .filter(emailColumn != nil) //        AND ("email IS NOT NULL"))
+Person                          // SELECT * FROM persons
+    .filter(nameColumn != nil)  // WHERE (name IS NOT NULL)
+    .filter(emailColumn != nil) //        AND (email IS NOT NULL)
     .order(nameColumn)          // - ignored -
-    .order(ageColumn)           // ORDER BY "age"
+    .order(ageColumn)           // ORDER BY age
     .limit(20, offset: 40)      // - ignored -
     .limit(10)                  // LIMIT 10
 ```
@@ -2422,7 +2422,7 @@ Person                          // SELECT * FROM "persons"
 Raw SQL snippets are also accepted, with eventual arguments:
 
 ```swift
-// SELECT DATE(creationDate), COUNT(*) FROM "persons" WHERE name = 'Arthur' GROUP BY date(creationDate)
+// SELECT DATE(creationDate), COUNT(*) FROM persons WHERE name = 'Arthur' GROUP BY date(creationDate)
 Person
     .select(sql: "DATE(creationDate), COUNT(*)")
     .filter(sql: "name = ?", arguments: ["Arthur"])
@@ -2442,19 +2442,19 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     Comparison operators are based on the Swift operators `==`, `!=`, `===`, `!==`, `<`, `<=`, `>`, `>=`:
     
     ```swift
-    // SELECT * FROM "persons" WHERE ("name" = 'Arthur')
+    // SELECT * FROM persons WHERE (name = 'Arthur')
     Person.filter(nameColumn == "Arthur")
     
-    // SELECT * FROM "persons" WHERE ("name" IS NULL)
+    // SELECT * FROM persons WHERE (name IS NULL)
     Person.filter(nameColumn == nil)
     
-    // SELECT * FROM "persons" WHERE ("age" <> 18)
+    // SELECT * FROM persons WHERE (age <> 18)
     Person.filter(ageColumn != 18)
     
-    // SELECT * FROM "persons" WHERE ("age" IS NOT 18)
+    // SELECT * FROM persons WHERE (age IS NOT 18)
     Person.filter(ageColumn !== 18)
     
-    // SELECT * FROM "rectangles" WHERE ("width" < "height")
+    // SELECT * FROM rectangles WHERE width < height
     Rectangle.filter(widthColumn < heightColumn)
     ```
     
@@ -2466,7 +2466,7 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     SQLite arithmetic operators are derived from their Swift equivalent:
     
     ```swift
-    // SELECT (("temperature" * 1.8) + 32) AS "farenheit" FROM "persons"
+    // SELECT ((temperature * 1.8) + 32) AS farenheit FROM persons
     Planet.select((temperatureColumn * 1.8 + 32).aliased("farenheit"))
     ```
     
@@ -2477,7 +2477,7 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     The SQL logical operators are derived from the Swift `&&`, `||` and `!`:
     
     ```swift
-    // SELECT * FROM "persons" WHERE ((NOT "verified") OR ("age" < 18))
+    // SELECT * FROM persons WHERE ((NOT verified) OR (age < 18))
     Person.filter(!verifiedColumn || ageColumn < 18)
     ```
 
@@ -2486,22 +2486,22 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     To check inclusion in a collection, call the `contains` method on any Swift sequence:
     
     ```swift
-    // SELECT * FROM "persons" WHERE ("id" IN (1, 2, 3))
+    // SELECT * FROM persons WHERE id IN (1, 2, 3)
     Person.filter([1, 2, 3].contains(idColumn))
     
-    // SELECT * FROM "persons" WHERE ("id" NOT IN (1, 2, 3))
+    // SELECT * FROM persons WHERE id NOT IN (1, 2, 3)
     Person.filter(![1, 2, 3].contains(idColumn))
     
-    // SELECT * FROM "persons" WHERE ("age" BETWEEN 0 AND 17)
+    // SELECT * FROM persons WHERE age BETWEEN 0 AND 17
     Person.filter((0..<18).contains(ageColumn))
     
-    // SELECT * FROM "persons" WHERE ("age" BETWEEN 0 AND 17)
+    // SELECT * FROM persons WHERE age BETWEEN 0 AND 17
     Person.filter((0...17).contains(ageColumn))
     
-    // SELECT * FROM "persons" WHERE ("name" BETWEEN 'A' AND 'z')
+    // SELECT * FROM persons WHERE name BETWEEN 'A' AND 'z'
     Person.filter(("A"..."z").contains(nameColumn))
     
-    // SELECT * FROM "persons" WHERE (("name" >= 'A') AND ("name" < 'z'))
+    // SELECT * FROM persons WHERE (name >= 'A') AND (name < 'z')
     Person.filter(("A"..<"z").contains(nameColumn))
     ```
     
@@ -2510,8 +2510,8 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     To check inclusion in a subquery, call the `contains` method on another request:
     
     ```swift
-    // SELECT * FROM "events"
-    //  WHERE ("userId" IN (SELECT "id" FROM "persons" WHERE "verified"))
+    // SELECT * FROM events
+    //  WHERE userId IN (SELECT id FROM persons WHERE verified)
     let verifiedUserIds = User.select(idColumn).filter(verifiedColumn)
     Event.filter(verifiedUserIds.contains(userIdColumn))
     ```
@@ -2521,8 +2521,8 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     To check is a subquery would return any row, use the `exists` property on another request:
     
     ```swift
-    // SELECT * FROM "persons"
-    // WHERE EXISTS (SELECT * FROM "books"
+    // SELECT * FROM persons
+    // WHERE EXISTS (SELECT * FROM books
     //                WHERE books.ownerId = persons.id)
     Person.filter(Book.filter(sql: "books.ownerId = persons.id").exists)
     ```
@@ -2535,13 +2535,13 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     Those are based on the `abs`, `average`, `count`, `max`, `min` and `sum` Swift functions:
     
     ```swift
-    // SELECT MIN("age"), MAX("age") FROM persons
+    // SELECT MIN(age), MAX(age) FROM persons
     Person.select(min(ageColumn), max(ageColumn))
     
-    // SELECT COUNT("name") FROM persons
+    // SELECT COUNT(name) FROM persons
     Person.select(count(nameColumn))
     
-    // SELECT COUNT(DISTINCT "name") FROM persons
+    // SELECT COUNT(DISTINCT name) FROM persons
     Person.select(count(distinct: nameColumn))
     ```
 
@@ -2550,10 +2550,10 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     Use the Swift `??` operator:
     
     ```swift
-    // SELECT IFNULL("name", 'Anonymous') FROM persons
+    // SELECT IFNULL(name, 'Anonymous') FROM persons
     Person.select(nameColumn ?? "Anonymous")
     
-    // SELECT IFNULL("name", "email") FROM persons
+    // SELECT IFNULL(name, email) FROM persons
     Person.select(nameColumn ?? emailColumn)
     ```
 
@@ -2576,7 +2576,7 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     ```swift
     let f = DatabaseFunction("f", ...)
     
-    // SELECT f("name") FROM persons
+    // SELECT f(name) FROM persons
     Person.select(f.apply(nameColumn))
     ```
 
@@ -2651,16 +2651,16 @@ Citizenship.fetchOne(db, key: ["personID": 1, "countryISOCode": "FR"]) // Citize
 **Requests can count.** The `fetchCount()` method returns the number of rows that would be returned by a fetch request:
 
 ```swift
-// SELECT COUNT(*) FROM "persons"
+// SELECT COUNT(*) FROM persons
 let count = Person.fetchCount(db) // Int
 
-// SELECT COUNT(*) FROM "persons" WHERE "email" IS NOT NULL
+// SELECT COUNT(*) FROM persons WHERE email IS NOT NULL
 let count = Person.filter(emailColumn != nil).fetchCount(db)
 
-// SELECT COUNT(DISTINCT "name") FROM "persons"
+// SELECT COUNT(DISTINCT name) FROM persons
 let count = Person.select(nameColumn).distinct.fetchCount(db)
 
-// SELECT COUNT(*) FROM (SELECT DISTINCT "name", "age" FROM "persons")
+// SELECT COUNT(*) FROM (SELECT DISTINCT name, age FROM persons)
 let count = Person.select(nameColumn, ageColumn).distinct.fetchCount(db)
 ```
 
@@ -2688,24 +2688,21 @@ Migrations run in order, once and only once. When a user upgrades your applicati
 var migrator = DatabaseMigrator()
 
 // v1.0 database
-migrator.registerMigration("createTables") { db in
-    try db.execute(
-        "CREATE TABLE persons (...); " +
-        "CREATE TABLE books (...)")
+migrator.registerMigration("v1") { db in
+    try db.create(table: "persons") { t in ... }
+    try db.create(table: "books") { t in ... }
 }
 
 // v2.0 database
-migrator.registerMigration("AddBirthDateToPersons") { db in
-    try db.execute(
-        "ALTER TABLE persons ADD COLUMN birthDate DATE")
+migrator.registerMigration("v2") { db in
+    try db.alter(table: "persons") { t in ... }
 }
 
 // Migrations for future versions will be inserted here:
 //
 // // v3.0 database
-// migrator.registerMigration("AddYearAgeToBooks") { db in
-//     try db.execute(
-//         "ALTER TABLE books ADD COLUMN year INT")
+// migrator.registerMigration("v3") { db in
+//     ...
 // }
 
 try migrator.migrate(dbQueue) // or migrator.migrate(dbPool)

--- a/README.md
+++ b/README.md
@@ -2207,7 +2207,7 @@ Define **not null** columns, and set **default** values:
     t.column("name", .Text).notNull().defaults("Anonymous")
 ```
     
-Use an individual column as **primary**, **unique**, or **foreign key**. When not specified, the referenced column is the primary key of the referenced table:
+Use an individual column as **primary**, **unique**, or **foreign key**. When defining a foreign key, the referenced column is the primary key of the referenced table (unless you specify it):
 
 ```swift
     // id INTEGER PRIMARY KEY,
@@ -2223,10 +2223,10 @@ Use an individual column as **primary**, **unique**, or **foreign key**. When no
 **Perform integrity checks** on individual columns, and SQLite will only let conforming rows in. In the example below, the `$0` closure variable is a column which lets you build any SQL [expression](#expressions).
 
 ```swift
-    // age INTEGER CHECK (age > 0)
     // name TEXT CHECK (LENGTH(name) > 0)
-    t.column("age", .Integer).check { $0 > 0 }
+    // age INTEGER CHECK (age > 0)
     t.column("name", .Text).check { length($0) > 0 }
+    t.column("age", .Integer).check(sql: "age > 0")
 ```
 
 Other **table constraints** can involve several columns:

--- a/README.md
+++ b/README.md
@@ -2141,7 +2141,7 @@ So don't miss the [SQL API](#sqlite-api).
 Once granted with a [database connection](#database-connections), you can use the query interface to setup your database schema:
 
 - [Create Tables](#create-tables)
-- [Modify Tables](#alter-tables)
+- [Modify Tables](#modify-tables)
 - [Drop Tables](#drop-tables)
 - [Create Indexes](#create-indexes)
 
@@ -2273,8 +2273,7 @@ try db.create(index: "byEmail", on: "users", columns: ["email"], unique: true)
 **The query interface requests** let you fetch values from the database:
 
 ```swift
-let count = Wine.filter(color == Color.Red).fetchCount(db)
-let wines = Wine.filter(origin == "Burgundy").order(price).fetchAll(db)
+let persons = Person.filter(email != nil).order(name).fetchAll(db)
 ```
 
 All requests start from **a type** that adopts the `TableMapping` protocol, such as a `Record` subclass (see [Records](#records)):

--- a/README.md
+++ b/README.md
@@ -2273,7 +2273,9 @@ try db.create(index: "byEmail", on: "users", columns: ["email"], unique: true)
 **The query interface requests** let you fetch values from the database:
 
 ```swift
-let persons = Person.filter(email != nil).order(name).fetchAll(db)
+let request = Person.filter(email != nil).order(name)
+let persons = request.fetchAll(db)  // [Person]
+let count = request.fetchCount(db)  // Int
 ```
 
 All requests start from **a type** that adopts the `TableMapping` protocol, such as a `Record` subclass (see [Records](#records)):

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ GRDB.swift [![Swift](https://img.shields.io/badge/swift-2.2-orange.svg?style=fla
 
 ### A Swift application toolkit that provides access to SQLite databases.
 
-GRDB provides raw SQLite access and high-level APIs that help building applications.
-
-It targets Swift 2.2, and Swift 3 in the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch.
-
-**July 28, 2016: GRDB.swift 0.77.0 is out** ([CHANGELOG](CHANGELOG.md)). Follow [@groue](http://twitter.com/groue) on Twitter for release announcements and usage tips.
+GRDB provides raw SQLite access and high-level APIs that help building applications. It targets Swift 2.2, and Swift 3 in the [Swift3](https://github.com/groue/GRDB.swift/tree/Swift3) branch.
 
 **Requirements**: iOS 8.0+ / OSX 10.9+, Xcode 7.3+
+
+**Last release**: July 28, 2016 &bull; version 0.77.0 &bull; [CHANGELOG](CHANGELOG.md).
+
+Follow [@groue](http://twitter.com/groue) on Twitter for release announcements and usage tips.
 
 ---
 
@@ -17,7 +17,7 @@ It targets Swift 2.2, and Swift 3 in the [Swift3](https://github.com/groue/GRDB.
     <a href="#features">Features</a> &bull;
     <a href="#usage">Usage</a> &bull;
     <a href="#documentation">Documentation</a> &bull;
-    <a href="#faq">FAQ</a> &bull;
+    <a href="#faq">FAQ</a>
 </p>
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-- [ ] Document Statement.unsafeSetArguments
+- [ ] Rename PrimaryKey to PrimaryKeyInfo
 - [ ] What is the behavior inTransaction and inSavepoint behaviors in case of commit error? Code looks like we do not rollback, leaving the app in a weird state (out of Swift transaction block with a SQLite transaction that may still be opened).
 - [ ] GRDBCipher: remove limitations on iOS or OS X versions
 - [ ] FetchedRecordsController: take inspiration from https://github.com/jflinter/Dwifft

--- a/Tests/Private/SQLExpressionLiteralTests.swift
+++ b/Tests/Private/SQLExpressionLiteralTests.swift
@@ -11,20 +11,20 @@ import XCTest
 class SQLExpressionLiteralTests: GRDBTestCase {
 
     func testWithArguments() {
-        let expression = SQLColumn("foo").collating("NOCASE") == "'bar'" && SQLColumn("baz") >= 1
+        let expression = SQLColumn("foo").collating("NOCASE") == "'fooéı👨👨🏿🇫🇷🇨🇮'" && SQLColumn("baz") >= 1
         var arguments: StatementArguments? = StatementArguments()
         let sql = expression.sql(&arguments)
         XCTAssertEqual(sql, "((\"foo\" = ? COLLATE NOCASE) AND (\"baz\" >= ?))")
         let values = arguments!.values
         XCTAssertEqual(values.count, 2)
-        XCTAssertEqual((values[0] as! String), "'bar'")
+        XCTAssertEqual((values[0] as! String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
         XCTAssertEqual((values[1] as! Int), 1)
     }
     
     func testWithoutArguments() {
-        let expression = SQLColumn("foo").collating("NOCASE") == "'bar'" && SQLColumn("baz") >= 1
+        let expression = SQLColumn("foo").collating("NOCASE") == "'fooéı👨👨🏿🇫🇷🇨🇮'" && SQLColumn("baz") >= 1
         var arguments: StatementArguments? = nil
         let sql = expression.sql(&arguments)
-        XCTAssertEqual(sql, "((\"foo\" = '''bar''' COLLATE NOCASE) AND (\"baz\" >= 1))")
+        XCTAssertEqual(sql, "((\"foo\" = '''fooéı👨👨🏿🇫🇷🇨🇮''' COLLATE NOCASE) AND (\"baz\" >= 1))")
     }
 }

--- a/Tests/Public/Core/DatabaseValueConvertible/DatabaseValueConversionTests.swift
+++ b/Tests/Public/Core/DatabaseValueConvertible/DatabaseValueConversionTests.swift
@@ -172,10 +172,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 return .Rollback
             }
             
-            // "fooéı👨👨🏿🇫🇷🇨🇮" is turned to Text
+            // "'fooéı👨👨🏿🇫🇷🇨🇮'" is turned to Text
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮"])
+                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'"])
                 let dbv = Row.fetchOne(db, "SELECT textAffinity FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Text)
                 
@@ -185,11 +185,11 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int32.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(String.fromDatabaseValue(dbv)!, "fooéı👨👨🏿🇫🇷🇨🇮")
+                XCTAssertEqual(String.fromDatabaseValue(dbv)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 XCTAssertTrue(NSData.fromDatabaseValue(dbv) == nil)
                 
-                XCTAssertEqual((dbv.value() as String?)!, "fooéı👨👨🏿🇫🇷🇨🇮")
-                XCTAssertEqual((dbv.value() as String), "fooéı👨👨🏿🇫🇷🇨🇮")
+                XCTAssertEqual((dbv.value() as String?)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
+                XCTAssertEqual((dbv.value() as String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 
                 return .Rollback
             }
@@ -197,7 +197,7 @@ class DatabaseValueConversionTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 let dbv = Row.fetchOne(db, "SELECT textAffinity FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Blob)
                 
@@ -208,10 +208,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(String.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 
-                XCTAssertEqual((dbv.value() as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
-                XCTAssertTrue((dbv.value() as NSData).isEqualToData("fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)!))
+                XCTAssertEqual((dbv.value() as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertTrue((dbv.value() as NSData).isEqualToData("'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)!))
                 
                 return .Rollback
             }
@@ -460,10 +460,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 return .Rollback
             }
             
-            // "fooéı👨👨🏿🇫🇷🇨🇮" is turned to Text
+            // "'fooéı👨👨🏿🇫🇷🇨🇮'" is turned to Text
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮"])
+                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'"])
                 let dbv = Row.fetchOne(db, "SELECT realAffinity FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Text)
                 
@@ -473,11 +473,11 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int32.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(String.fromDatabaseValue(dbv)!, "fooéı👨👨🏿🇫🇷🇨🇮")
+                XCTAssertEqual(String.fromDatabaseValue(dbv)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 XCTAssertTrue(NSData.fromDatabaseValue(dbv) == nil)
                 
-                XCTAssertEqual((dbv.value() as String?)!, "fooéı👨👨🏿🇫🇷🇨🇮")
-                XCTAssertEqual((dbv.value() as String), "fooéı👨👨🏿🇫🇷🇨🇮")
+                XCTAssertEqual((dbv.value() as String?)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
+                XCTAssertEqual((dbv.value() as String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 
                 return .Rollback
             }
@@ -485,7 +485,7 @@ class DatabaseValueConversionTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 let dbv = Row.fetchOne(db, "SELECT realAffinity FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Blob)
                 
@@ -496,10 +496,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(String.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 
-                XCTAssertEqual((dbv.value() as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
-                XCTAssertTrue((dbv.value() as NSData).isEqualToData("fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)!))
+                XCTAssertEqual((dbv.value() as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertTrue((dbv.value() as NSData).isEqualToData("'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)!))
                 
                 return .Rollback
             }
@@ -661,7 +661,7 @@ class DatabaseValueConversionTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (noneAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (noneAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 let dbv = Row.fetchOne(db, "SELECT noneAffinity FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Blob)
                 
@@ -672,10 +672,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(String.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 
-                XCTAssertEqual((dbv.value() as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
-                XCTAssertTrue((dbv.value() as NSData).isEqualToData("fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)!))
+                XCTAssertEqual((dbv.value() as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertTrue((dbv.value() as NSData).isEqualToData("'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)!))
                 
                 return .Rollback
             }
@@ -898,10 +898,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 return .Rollback
             }
             
-            // "fooéı👨👨🏿🇫🇷🇨🇮" is turned to Text
+            // "'fooéı👨👨🏿🇫🇷🇨🇮'" is turned to Text
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮"])
+                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'"])
                 let dbv = Row.fetchOne(db, "SELECT \(columnName) FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Text)
                 
@@ -911,11 +911,11 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int32.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(String.fromDatabaseValue(dbv)!, "fooéı👨👨🏿🇫🇷🇨🇮")
+                XCTAssertEqual(String.fromDatabaseValue(dbv)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 XCTAssertTrue(NSData.fromDatabaseValue(dbv) == nil)
                 
-                XCTAssertEqual((dbv.value() as String?)!, "fooéı👨👨🏿🇫🇷🇨🇮")
-                XCTAssertEqual((dbv.value() as String), "fooéı👨👨🏿🇫🇷🇨🇮")
+                XCTAssertEqual((dbv.value() as String?)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
+                XCTAssertEqual((dbv.value() as String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 
                 return .Rollback
             }
@@ -923,7 +923,7 @@ class DatabaseValueConversionTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 let dbv = Row.fetchOne(db, "SELECT \(columnName) FROM `values`")!.first!.1   // first is (columnName, dbv)
                 XCTAssertEqual(dbv.storageClass, SQLiteStorageClass.Blob)
                 
@@ -934,10 +934,10 @@ class DatabaseValueConversionTests : GRDBTestCase {
                 XCTAssertTrue(Int64.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(Double.fromDatabaseValue(dbv) == nil)
                 XCTAssertTrue(String.fromDatabaseValue(dbv) == nil)
-                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertEqual(NSData.fromDatabaseValue(dbv), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 
-                XCTAssertEqual((dbv.value() as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
-                XCTAssertTrue((dbv.value() as NSData).isEqualToData("fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)!))
+                XCTAssertEqual((dbv.value() as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
+                XCTAssertTrue((dbv.value() as NSData).isEqualToData("'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)!))
                 
                 return .Rollback
             }

--- a/Tests/Public/Core/StatementColumnConvertible/StatementColumnConvertibleTests.swift
+++ b/Tests/Public/Core/StatementColumnConvertible/StatementColumnConvertibleTests.swift
@@ -202,10 +202,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                 return .Rollback
             }
             
-            // "fooéı👨👨🏿🇫🇷🇨🇮" is turned to Text
+            // "'fooéı👨👨🏿🇫🇷🇨🇮'" is turned to Text
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮"])
+                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'"])
                 // Check SQLite conversions from Text storage:
                 for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -223,12 +223,12 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?)!, "fooéı👨👨🏿🇫🇷🇨🇮")
+                    XCTAssertEqual((row.value(atIndex: 0) as String?)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 }
                 for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String), "fooéı👨👨🏿🇫🇷🇨🇮")
+                    XCTAssertEqual((row.value(atIndex: 0) as String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 }
-                // NSData extraction: precondition failed: could not convert "fooéı👨👨🏿🇫🇷🇨🇮" to NSData
+                // NSData extraction: precondition failed: could not convert "'fooéı👨👨🏿🇫🇷🇨🇮'" to NSData
 //                for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
 //                    XCTAssertTrue((row.value(atIndex: 0) as NSData?) == nil)
 //                }
@@ -238,7 +238,7 @@ class StatementColumnConvertibleTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (textAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 // Check SQLite conversions from Blob storage:
                 for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -256,10 +256,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?), "fooéı👨👨🏿🇫🇷🇨🇮")   // incompatible with DatabaseValue conversion
+                    XCTAssertEqual((row.value(atIndex: 0) as String?), "'fooéı👨👨🏿🇫🇷🇨🇮'")   // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT textAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 }
                 return .Rollback
             }
@@ -595,10 +595,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                 return .Rollback
             }
             
-            // "fooéı👨👨🏿🇫🇷🇨🇮" is turned to Text
+            // "'fooéı👨👨🏿🇫🇷🇨🇮'" is turned to Text
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮"])
+                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'"])
                 // Check SQLite conversions from Text storage:
                 for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -616,12 +616,12 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?)!, "fooéı👨👨🏿🇫🇷🇨🇮")
+                    XCTAssertEqual((row.value(atIndex: 0) as String?)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 }
                 for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String), "fooéı👨👨🏿🇫🇷🇨🇮")
+                    XCTAssertEqual((row.value(atIndex: 0) as String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 }
-                // NSData extraction: precondition failed: could not convert "fooéı👨👨🏿🇫🇷🇨🇮" to NSData
+                // NSData extraction: precondition failed: could not convert "'fooéı👨👨🏿🇫🇷🇨🇮'" to NSData
 //                for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
 //                    XCTAssertTrue((row.value(atIndex: 0) as NSData?) == nil)
 //                }
@@ -631,7 +631,7 @@ class StatementColumnConvertibleTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (realAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 // Check SQLite conversions from Blob storage:
                 for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -649,10 +649,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?), "fooéı👨👨🏿🇫🇷🇨🇮")   // incompatible with DatabaseValue conversion
+                    XCTAssertEqual((row.value(atIndex: 0) as String?), "'fooéı👨👨🏿🇫🇷🇨🇮'")   // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT realAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 }
                 return .Rollback
             }
@@ -885,7 +885,7 @@ class StatementColumnConvertibleTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (noneAffinity) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (noneAffinity) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 // Check SQLite conversions from Blob storage
                 for row in Row.fetch(db, "SELECT noneAffinity FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -903,10 +903,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT noneAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?), "fooéı👨👨🏿🇫🇷🇨🇮")   // incompatible with DatabaseValue conversion
+                    XCTAssertEqual((row.value(atIndex: 0) as String?), "'fooéı👨👨🏿🇫🇷🇨🇮'")   // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT noneAffinity FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 }
                 return .Rollback
             }
@@ -1216,10 +1216,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                 return .Rollback
             }
             
-            // "fooéı👨👨🏿🇫🇷🇨🇮" is turned to Text
+            // "'fooéı👨👨🏿🇫🇷🇨🇮'" is turned to Text
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮"])
+                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'"])
                 // Check SQLite conversions from Text storage:
                 for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -1237,12 +1237,12 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?)!, "fooéı👨👨🏿🇫🇷🇨🇮")
+                    XCTAssertEqual((row.value(atIndex: 0) as String?)!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 }
                 for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String), "fooéı👨👨🏿🇫🇷🇨🇮")
+                    XCTAssertEqual((row.value(atIndex: 0) as String), "'fooéı👨👨🏿🇫🇷🇨🇮'")
                 }
-                // NSData extraction: precondition failed: could not convert "fooéı👨👨🏿🇫🇷🇨🇮" to NSData
+                // NSData extraction: precondition failed: could not convert "'fooéı👨👨🏿🇫🇷🇨🇮'" to NSData
 //                for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
 //                    XCTAssertTrue((row.value(atIndex: 0) as NSData?) == nil)
 //                }
@@ -1252,7 +1252,7 @@ class StatementColumnConvertibleTests : GRDBTestCase {
             // Blob is turned to Blob
             
             try dbQueue.inTransaction { db in
-                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding)])
+                try db.execute("INSERT INTO `values` (\(columnName)) VALUES (?)", arguments: ["'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding)])
                 // Check SQLite conversions from Blob storage:
                 for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
                     XCTAssertEqual((row.value(atIndex: 0) as Bool?), false)     // incompatible with DatabaseValue conversion
@@ -1270,10 +1270,10 @@ class StatementColumnConvertibleTests : GRDBTestCase {
                     XCTAssertEqual((row.value(atIndex: 0) as Double?), 0.0)     // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as String?), "fooéı👨👨🏿🇫🇷🇨🇮")   // incompatible with DatabaseValue conversion
+                    XCTAssertEqual((row.value(atIndex: 0) as String?), "'fooéı👨👨🏿🇫🇷🇨🇮'")   // incompatible with DatabaseValue conversion
                 }
                 for row in Row.fetch(db, "SELECT \(columnName) FROM `values`") {
-                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "fooéı👨👨🏿🇫🇷🇨🇮".dataUsingEncoding(NSUTF8StringEncoding))
+                    XCTAssertEqual((row.value(atIndex: 0) as NSData?), "'fooéı👨👨🏿🇫🇷🇨🇮'".dataUsingEncoding(NSUTF8StringEncoding))
                 }
                 return .Rollback
             }

--- a/Tests/Public/QueryInterfaceRequest/QueryInterfaceRequestTests.swift
+++ b/Tests/Public/QueryInterfaceRequest/QueryInterfaceRequestTests.swift
@@ -401,10 +401,10 @@ class QueryInterfaceRequestTests: GRDBTestCase {
     func testSortWithCollation() {
         let dbQueue = try! makeDatabaseQueue()
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.order(Col.name.collating("NOCASE"))),
+            sql(dbQueue, tableRequest.order(Col.name.collating(.Nocase))),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.order(Col.name.collating("NOCASE").asc)),
+            sql(dbQueue, tableRequest.order(Col.name.collating(.Nocase).asc)),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.name.collating(collation))),
@@ -446,10 +446,10 @@ class QueryInterfaceRequestTests: GRDBTestCase {
     func testReverseWithCollation() {
         let dbQueue = try! makeDatabaseQueue()
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.order(Col.name.collating("NOCASE")).reverse()),
+            sql(dbQueue, tableRequest.order(Col.name.collating(.Nocase)).reverse()),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.order(Col.name.collating("NOCASE").asc).reverse()),
+            sql(dbQueue, tableRequest.order(Col.name.collating(.Nocase).asc).reverse()),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.name.collating(collation)).reverse()),

--- a/Tests/Public/QueryInterfaceRequest/SQLSupportTests.swift
+++ b/Tests/Public/QueryInterfaceRequest/SQLSupportTests.swift
@@ -885,6 +885,14 @@ class SQLSupportTests: GRDBTestCase {
             "SELECT AVG((\"age\" / 2)) FROM \"readers\"")
     }
     
+    func testLengthExpression() {
+        let dbQueue = try! makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(length(Col.name))),
+            "SELECT LENGTH(\"name\") FROM \"readers\"")
+    }
+    
     func testMinExpression() {
         let dbQueue = try! makeDatabaseQueue()
         

--- a/Tests/Public/QueryInterfaceRequest/SQLSupportTests.swift
+++ b/Tests/Public/QueryInterfaceRequest/SQLSupportTests.swift
@@ -126,29 +126,29 @@ class SQLSupportTests: GRDBTestCase {
         
         // Array.contains(): IN operator
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(["arthur", "barbara"].contains(Col.name.collating("NOCASE")))),
+            sql(dbQueue, tableRequest.filter(["arthur", "barbara"].contains(Col.name.collating(.Nocase)))),
             "SELECT * FROM \"readers\" WHERE (\"name\" IN ('arthur', 'barbara') COLLATE NOCASE)")
         
         // Sequence.contains(): IN operator
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(AnySequence(["arthur", "barbara"]).contains(Col.name.collating("NOCASE")))),
+            sql(dbQueue, tableRequest.filter(AnySequence(["arthur", "barbara"]).contains(Col.name.collating(.Nocase)))),
             "SELECT * FROM \"readers\" WHERE (\"name\" IN ('arthur', 'barbara') COLLATE NOCASE)")
         
         // Sequence.contains(): IN operator
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(AnySequence([Col.name]).contains(Col.name.collating("NOCASE")))),
+            sql(dbQueue, tableRequest.filter(AnySequence([Col.name]).contains(Col.name.collating(.Nocase)))),
             "SELECT * FROM \"readers\" WHERE (\"name\" IN (\"name\") COLLATE NOCASE)")
         
         // ClosedInterval: BETWEEN operator
         let closedInterval: ClosedInterval<String> = "A"..."z"
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(closedInterval.contains(Col.name.collating("NOCASE")))),
+            sql(dbQueue, tableRequest.filter(closedInterval.contains(Col.name.collating(.Nocase)))),
             "SELECT * FROM \"readers\" WHERE (\"name\" BETWEEN 'A' AND 'z' COLLATE NOCASE)")
         
         // HalfOpenInterval:  min <= x < max
         let halfOpenInterval: HalfOpenInterval<String> = "A"..<"z"
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(halfOpenInterval.contains(Col.name.collating("NOCASE")))),
+            sql(dbQueue, tableRequest.filter(halfOpenInterval.contains(Col.name.collating(.Nocase)))),
             "SELECT * FROM \"readers\" WHERE ((\"name\" >= 'A' COLLATE NOCASE) AND (\"name\" < 'z' COLLATE NOCASE))")
     }
     
@@ -190,7 +190,7 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") > "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) > "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" > 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) > "fOo")),
@@ -235,7 +235,7 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") >= "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) >= "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" >= 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) >= "fOo")),
@@ -280,7 +280,7 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") < "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) < "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" < 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) < "fOo")),
@@ -325,7 +325,7 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") <= "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) <= "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" <= 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) <= "fOo")),
@@ -404,13 +404,13 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") == "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) == "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" = 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") == ("fOo" as String?))),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) == ("fOo" as String?))),
             "SELECT * FROM \"readers\" WHERE (\"name\" = 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") == nil)),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) == nil)),
             "SELECT * FROM \"readers\" WHERE (\"name\" IS NULL COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) == "fOo")),
@@ -489,13 +489,13 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") != "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) != "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" <> 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") != ("fOo" as String?))),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) != ("fOo" as String?))),
             "SELECT * FROM \"readers\" WHERE (\"name\" <> 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") != nil)),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) != nil)),
             "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT NULL COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) != "fOo")),
@@ -573,7 +573,7 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") === "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) === "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" IS 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) === "fOo")),
@@ -624,7 +624,7 @@ class SQLSupportTests: GRDBTestCase {
         let dbQueue = try! makeDatabaseQueue()
         
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.name.collating("NOCASE") !== "fOo")),
+            sql(dbQueue, tableRequest.filter(Col.name.collating(.Nocase) !== "fOo")),
             "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT 'fOo' COLLATE NOCASE)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) !== "fOo")),

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -124,16 +124,18 @@ class SQLTableBuilderTests: GRDBTestCase {
             try dbQueue.inDatabase { db in
                 try db.create(table: "test") { t in
                     t.column("a", .Integer).check { $0 > 0 }
+                    t.column("b", .Integer).check(sql: "b <> 2")
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
-                        "\"a\" INTEGER CHECK ((\"a\" > 0))" +
+                        "\"a\" INTEGER CHECK ((\"a\" > 0)), " +
+                        "\"b\" INTEGER CHECK (b <> 2)" +
                     ")")
                 
                 // Sanity check
-                try db.execute("INSERT INTO test (a) VALUES (1)")
+                try db.execute("INSERT INTO test (a, b) VALUES (1, 0)")
                 do {
-                    try db.execute("INSERT INTO test (a) VALUES (0)")
+                    try db.execute("INSERT INTO test (a, b) VALUES (0, 0)")
                     XCTFail()
                 } catch {
                 }
@@ -147,10 +149,18 @@ class SQLTableBuilderTests: GRDBTestCase {
             try dbQueue.inDatabase { db in
                 try db.create(table: "test") { t in
                     t.column("a", .Integer).defaults(1)
+                    t.column("b", .Integer).defaults(1.0)
+                    t.column("c", .Integer).defaults("foo")
+                    t.column("d", .Integer).defaults("foo".dataUsingEncoding(NSUTF8StringEncoding)!)
+                    t.column("e", .Integer).defaults(sql: "NULL")
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
-                        "\"a\" INTEGER DEFAULT (1)" +
+                        "\"a\" INTEGER DEFAULT (1), " +
+                        "\"b\" INTEGER DEFAULT (1.0), " +
+                        "\"c\" INTEGER DEFAULT ('foo'), " +
+                        "\"d\" INTEGER DEFAULT (x'666f6f'), " +
+                        "\"e\" INTEGER DEFAULT (NULL)" +
                     ")")
                 
                 // Sanity check

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -310,7 +310,7 @@ class SQLTableBuilderTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             try dbQueue.inDatabase { db in
                 try db.create(table: "test") { t in
-                    t.check(SQLColumn("a") > SQLColumn("b"))
+                    t.check(SQLColumn("a") + SQLColumn("b") < 10)
                     t.check(sql: "a + b < 10")
                     t.column("a", .Integer)
                     t.column("b", .Integer)
@@ -319,7 +319,7 @@ class SQLTableBuilderTests: GRDBTestCase {
                     "CREATE TABLE \"test\" (" +
                         "\"a\" INTEGER, " +
                         "\"b\" INTEGER, " +
-                        "CHECK ((\"a\" > \"b\")), " +
+                        "CHECK (((\"a\" + \"b\") < 10)), " +
                         "CHECK (a + b < 10)" +
                     ")")
                 

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -334,6 +334,23 @@ class SQLTableBuilderTests: GRDBTestCase {
         }
     }
     
+    func testRenameTable() {
+        assertNoError {
+            let dbQueue = try makeDatabaseQueue()
+            try dbQueue.inDatabase { db in
+                try db.create(table: "test") { t in
+                    t.column("a", .Text)
+                }
+                XCTAssertTrue(db.tableExists("test"))
+                
+                try db.rename(table: "test", to: "foo")
+                XCTAssertEqual(self.lastSQLQuery, "ALTER TABLE \"test\" RENAME TO \"foo\"")
+                XCTAssertFalse(db.tableExists("test"))
+                XCTAssertTrue(db.tableExists("foo"))
+            }
+        }
+    }
+    
     func testDropTable() {
         assertNoError {
             let dbQueue = try makeDatabaseQueue()

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -326,7 +326,7 @@ class SQLTableBuilderTests: GRDBTestCase {
                 // Sanity check
                 try db.execute("INSERT INTO test (a, b) VALUES (1, 0)")
                 do {
-                    try db.execute("INSERT INTO test (a, b) VALUES (0, 1)")
+                    try db.execute("INSERT INTO test (a, b) VALUES (5, 5)")
                     XCTFail()
                 } catch {
                 }

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -156,11 +156,11 @@ class SQLTableBuilderTests: GRDBTestCase {
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
-                        "\"a\" INTEGER DEFAULT (1), " +
-                        "\"b\" INTEGER DEFAULT (1.0), " +
-                        "\"c\" INTEGER DEFAULT ('foo'), " +
-                        "\"d\" INTEGER DEFAULT (x'666f6f'), " +
-                        "\"e\" INTEGER DEFAULT (NULL)" +
+                        "\"a\" INTEGER DEFAULT 1, " +
+                        "\"b\" INTEGER DEFAULT 1.0, " +
+                        "\"c\" INTEGER DEFAULT 'foo', " +
+                        "\"d\" INTEGER DEFAULT x'666f6f', " +
+                        "\"e\" INTEGER DEFAULT NULL" +
                     ")")
                 
                 // Sanity check
@@ -347,6 +347,26 @@ class SQLTableBuilderTests: GRDBTestCase {
                 XCTAssertEqual(self.lastSQLQuery, "ALTER TABLE \"test\" RENAME TO \"foo\"")
                 XCTAssertFalse(db.tableExists("test"))
                 XCTAssertTrue(db.tableExists("foo"))
+            }
+        }
+    }
+    
+    func testAlterTable() {
+        assertNoError {
+            let dbQueue = try makeDatabaseQueue()
+            try dbQueue.inDatabase { db in
+                try db.create(table: "test") { t in
+                    t.column("a", .Text)
+                }
+                
+                self.sqlQueries.removeAll()
+                try db.alter(table: "test") { t in
+                    t.add(column: "b", .Text)
+                    t.add(column: "c", .Integer).notNull().defaults(1)
+                }
+                
+                XCTAssertEqual(self.sqlQueries[0], "ALTER TABLE \"test\" ADD COLUMN \"b\" TEXT;")
+                XCTAssertEqual(self.sqlQueries[1], " ALTER TABLE \"test\" ADD COLUMN \"c\" INTEGER NOT NULL DEFAULT 1")
             }
         }
     }

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -150,7 +150,7 @@ class SQLTableBuilderTests: GRDBTestCase {
                 try db.create(table: "test") { t in
                     t.column("a", .Integer).defaults(1)
                     t.column("b", .Integer).defaults(1.0)
-                    t.column("c", .Integer).defaults("foo")
+                    t.column("c", .Integer).defaults("'fooéı👨👨🏿🇫🇷🇨🇮'")
                     t.column("d", .Integer).defaults("foo".dataUsingEncoding(NSUTF8StringEncoding)!)
                     t.column("e", .Integer).defaults(sql: "NULL")
                 }
@@ -158,7 +158,7 @@ class SQLTableBuilderTests: GRDBTestCase {
                     "CREATE TABLE \"test\" (" +
                         "\"a\" INTEGER DEFAULT 1, " +
                         "\"b\" INTEGER DEFAULT 1.0, " +
-                        "\"c\" INTEGER DEFAULT 'foo', " +
+                        "\"c\" INTEGER DEFAULT '''fooéı👨👨🏿🇫🇷🇨🇮''', " +
                         "\"d\" INTEGER DEFAULT x'666f6f', " +
                         "\"e\" INTEGER DEFAULT NULL" +
                     ")")
@@ -166,6 +166,7 @@ class SQLTableBuilderTests: GRDBTestCase {
                 // Sanity check
                 try db.execute("INSERT INTO test DEFAULT VALUES")
                 XCTAssertEqual(Int.fetchOne(db, "SELECT a FROM test")!, 1)
+                XCTAssertEqual(String.fetchOne(db, "SELECT c FROM test")!, "'fooéı👨👨🏿🇫🇷🇨🇮'")
             }
         }
     }

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -225,9 +225,9 @@ class SQLTableBuilderTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             try dbQueue.inTransaction { db in
                 try db.create(table: "test") { t in
+                    t.primaryKey(["a", "b"])
                     t.column("a", .Text)
                     t.column("b", .Text)
-                    t.primaryKey(["a", "b"])
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
@@ -239,9 +239,9 @@ class SQLTableBuilderTests: GRDBTestCase {
             }
             try dbQueue.inTransaction { db in
                 try db.create(table: "test") { t in
+                    t.primaryKey(["a", "b"], onConflict: .Fail)
                     t.column("a", .Text)
                     t.column("b", .Text)
-                    t.primaryKey(["a", "b"], onConflict: .Fail)
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
@@ -259,11 +259,11 @@ class SQLTableBuilderTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             try dbQueue.inDatabase { db in
                 try db.create(table: "test") { t in
+                    t.uniqueKey(["a"])
+                    t.uniqueKey(["b", "c"], onConflict: .Fail)
                     t.column("a", .Text)
                     t.column("b", .Text)
                     t.column("c", .Text)
-                    t.uniqueKey(["a"])
-                    t.uniqueKey(["b", "c"], onConflict: .Fail)
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
@@ -282,16 +282,16 @@ class SQLTableBuilderTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             try dbQueue.inDatabase { db in
                 try db.create(table: "parent") { t in
+                    t.primaryKey(["a", "b"])
                     t.column("a", .Text)
                     t.column("b", .Text)
-                    t.primaryKey(["a", "b"])
                 }
                 try db.create(table: "child") { t in
+                    t.foreignKey(["c", "d"], to: "parent", onDelete: .Cascade, onUpdate: .Cascade)
+                    t.foreignKey(["d", "e"], to: "parent", columns: ["b", "a"], onDelete: .Restrict, deferred: true)
                     t.column("c", .Text)
                     t.column("d", .Text)
                     t.column("e", .Text)
-                    t.foreignKey(["c", "d"], to: "parent", onDelete: .Cascade, onUpdate: .Cascade)
-                    t.foreignKey(["d", "e"], to: "parent", columns: ["b", "a"], onDelete: .Restrict, deferred: true)
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"child\" (" +
@@ -310,10 +310,10 @@ class SQLTableBuilderTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             try dbQueue.inDatabase { db in
                 try db.create(table: "test") { t in
-                    t.column("a", .Integer)
-                    t.column("b", .Integer)
                     t.check(SQLColumn("a") > SQLColumn("b"))
                     t.check(sql: "a + b < 10")
+                    t.column("a", .Integer)
+                    t.column("b", .Integer)
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -47,11 +47,11 @@ class SQLTableBuilderTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             try dbQueue.inTransaction { db in
                 try db.create(table: "test") { t in
-                    t.column("id", .Integer).primaryKey(ordering: .Desc, onConflict: .Fail)
+                    t.column("id", .Integer).primaryKey(onConflict: .Fail)
                 }
                 XCTAssertEqual(self.lastSQLQuery,
                     "CREATE TABLE \"test\" (" +
-                        "\"id\" INTEGER PRIMARY KEY DESC ON CONFLICT FAIL" +
+                        "\"id\" INTEGER PRIMARY KEY ON CONFLICT FAIL" +
                     ")")
                 return .Rollback
             }

--- a/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
+++ b/Tests/Public/SQLTableBuilder/SQLTableBuilderTests.swift
@@ -288,8 +288,8 @@ class SQLTableBuilderTests: GRDBTestCase {
                     t.column("b", .Text)
                 }
                 try db.create(table: "child") { t in
-                    t.foreignKey(["c", "d"], to: "parent", onDelete: .Cascade, onUpdate: .Cascade)
-                    t.foreignKey(["d", "e"], to: "parent", columns: ["b", "a"], onDelete: .Restrict, deferred: true)
+                    t.foreignKey(["c", "d"], references: "parent", onDelete: .Cascade, onUpdate: .Cascade)
+                    t.foreignKey(["d", "e"], references: "parent", columns: ["b", "a"], onDelete: .Restrict, deferred: true)
                     t.column("c", .Text)
                     t.column("d", .Text)
                     t.column("e", .Text)


### PR DESCRIPTION
This PR closes #83.

It contains:

- A DSL for creating and altering tables and indexes
- Support for the LENGTH SQLite built-in function (it helps documenting CHECK constraints)
- New SQLCollation enum replaces collation names everywhere in the API
- Promotion of _SQLExpressible to the fully public SQLExpressible protocol
- Extensive testing and documentation
- Unrelated: renaming of PrimaryKey into PrimaryKeyInfo, for consistency with ColumnInfo and IndexInfo.

Many thanks, @cfilipov, for your intense and great contributions. This would have simply not existed without you.