### PR TITLE
[Swift 2.3] Add `@noescape` to appropriate closures, matching the Swift3 branch's behavior

### DIFF
--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -282,7 +282,7 @@ extension DatabasePool : DatabaseReader {
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block.
-    public func read<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func read<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         // The block isolation comes from the DEFERRED transaction.
         // See DatabasePoolTests.testReadMethodIsolationOfBlock().
         return try readerPool.get { reader in
@@ -317,7 +317,7 @@ extension DatabasePool : DatabaseReader {
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block.
-    public func nonIsolatedRead<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func nonIsolatedRead<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         return try readerPool.get { reader in
             try reader.performSync { db in
                 try block(db: db)
@@ -401,7 +401,7 @@ extension DatabasePool : DatabaseWriter {
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block.
-    public func write<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func write<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         return try writer.performSync(block)
     }
     
@@ -426,7 +426,7 @@ extension DatabasePool : DatabaseWriter {
     ///     - block: A block that executes SQL statements and return either
     ///       .Commit or .Rollback.
     /// - throws: The error thrown by the block.
-    public func writeInTransaction(kind: TransactionKind? = nil, _ block: (db: Database) throws -> TransactionCompletion) throws {
+    public func writeInTransaction(kind: TransactionKind? = nil, @noescape _ block: (db: Database) throws -> TransactionCompletion) throws {
         try writer.performSync { db in
             try db.inTransaction(kind) {
                 try block(db: db)

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -79,7 +79,7 @@ public final class DatabaseQueue {
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block.
-    public func inDatabase<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func inDatabase<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         return try serializedDatabase.performSync(block)
     }
     
@@ -104,7 +104,7 @@ public final class DatabaseQueue {
     ///     - block: A block that executes SQL statements and return either
     ///       .Commit or .Rollback.
     /// - throws: The error thrown by the block.
-    public func inTransaction(kind: TransactionKind? = nil, _ block: (db: Database) throws -> TransactionCompletion) throws {
+    public func inTransaction(kind: TransactionKind? = nil, @noescape _ block: (db: Database) throws -> TransactionCompletion) throws {
         try serializedDatabase.performSync { db in
             try db.inTransaction(kind) {
                 try block(db: db)
@@ -223,14 +223,14 @@ extension DatabaseQueue : DatabaseReader {
     /// Alias for inDatabase
     ///
     /// This method is part of the DatabaseReader protocol adoption.
-    public func read<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func read<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         return try serializedDatabase.performSync(block)
     }
     
     /// Alias for inDatabase
     ///
     /// This method is part of the DatabaseReader protocol adoption.
-    public func nonIsolatedRead<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func nonIsolatedRead<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         return try serializedDatabase.performSync(block)
     }
     
@@ -300,7 +300,7 @@ extension DatabaseQueue : DatabaseWriter {
     /// Alias for inDatabase
     ///
     /// This method is part of the DatabaseWriter protocol adoption.
-    public func write<T>(block: (db: Database) throws -> T) rethrows -> T {
+    public func write<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         return try serializedDatabase.performSync(block)
     }
 

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -55,7 +55,7 @@ public protocol DatabaseReader : class {
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block.
-    func read<T>(block: (db: Database) throws -> T) rethrows -> T
+    func read<T>(@noescape block: (db: Database) throws -> T) rethrows -> T
     
     /// Synchronously executes a read-only block that takes a database
     /// connection, and returns its result.
@@ -77,7 +77,7 @@ public protocol DatabaseReader : class {
     ///         let int1 = Int.fetchOne(db, sql)
     ///         let int2 = Int.fetchOne(db, sql)
     ///     }
-    func nonIsolatedRead<T>(block: (db: Database) throws -> T) rethrows -> T
+    func nonIsolatedRead<T>(@noescape block: (db: Database) throws -> T) rethrows -> T
     
     
     // MARK: - Functions

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -22,7 +22,7 @@ public protocol DatabaseWriter : DatabaseReader {
     ///
     /// The *block* argument is completely isolated. Eventual concurrent
     /// database updates are postponed until the block has executed.
-    func write<T>(block: (db: Database) throws -> T) rethrows -> T
+    func write<T>(@noescape block: (db: Database) throws -> T) rethrows -> T
     
     
     // MARK: - Reading from Database

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -51,7 +51,7 @@ final class SerializedDatabase {
     /// its result.
     ///
     /// This method is *not* reentrant.
-    func performSync<T>(block: (db: Database) throws -> T) rethrows -> T {
+    func performSync<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         // Three diffent cases:
         //
         // 1. A database is invoked from some queue like the main queue:
@@ -106,7 +106,7 @@ final class SerializedDatabase {
             // currently allowed databases inside.
             //
             // The impl function helps us turn dispatch_sync into a rethrowing function
-            func impl(queue: dispatch_queue_t, db: Database, block: (db: Database) throws -> T, onError: (ErrorType) throws -> ()) rethrows -> T {
+            func impl(queue: dispatch_queue_t, db: Database, @noescape block: (db: Database) throws -> T, onError: (ErrorType) throws -> ()) rethrows -> T {
                 var result: T? = nil
                 var blockError: ErrorType? = nil
                 dispatch_sync(queue) {
@@ -141,7 +141,7 @@ final class SerializedDatabase {
             // Just dispatch block to queue:
             //
             // The impl function helps us turn dispatch_sync into a rethrowing function
-            func impl(queue: dispatch_queue_t, db: Database, block: (db: Database) throws -> T, onError: (ErrorType) throws -> ()) rethrows -> T {
+            func impl(queue: dispatch_queue_t, db: Database, @noescape block: (db: Database) throws -> T, onError: (ErrorType) throws -> ()) rethrows -> T {
                 var result: T? = nil
                 var blockError: ErrorType? = nil
                 dispatch_sync(queue) {
@@ -170,7 +170,7 @@ final class SerializedDatabase {
     /// Executes the block in the current queue.
     ///
     /// - precondition: the current dispatch queue is valid.
-    func perform<T>(block: (db: Database) throws -> T) rethrows -> T {
+    func perform<T>(@noescape block: (db: Database) throws -> T) rethrows -> T {
         preconditionValidQueue()
         return try block(db: db)
     }

--- a/GRDB/Core/Utils.swift
+++ b/GRDB/Core/Utils.swift
@@ -57,8 +57,8 @@ func GRDBPrecondition(@autoclosure condition: () -> Bool, @autoclosure _ message
 
 /// A function declared as rethrows that synchronously executes a throwing
 /// block in a dispatch_queue.
-func dispatchSync<T>(queue: dispatch_queue_t, _ block: () throws -> T) rethrows -> T {
-    func impl(queue: dispatch_queue_t, block: () throws -> T, onError: (ErrorType) throws -> ()) rethrows -> T {
+func dispatchSync<T>(queue: dispatch_queue_t, @noescape _ block: () throws -> T) rethrows -> T {
+    func impl(queue: dispatch_queue_t, @noescape block: () throws -> T, onError: (ErrorType) throws -> ()) rethrows -> T {
         var result: T? = nil
         var blockError: ErrorType? = nil
         dispatch_sync(queue) {
@@ -131,7 +131,7 @@ final class ReadWriteBox<T> {
         self.queue = dispatch_queue_create("GRDB.ReadWriteBox", DISPATCH_QUEUE_CONCURRENT)
     }
     
-    func read<U>(block: (T) -> U) -> U {
+    func read<U>(@noescape block: (T) -> U) -> U {
         var result: U? = nil
         dispatch_sync(queue) {
             result = block(self._value)
@@ -139,7 +139,7 @@ final class ReadWriteBox<T> {
         return result!
     }
     
-    func write(block: (inout T) -> Void) {
+    func write(@noescape block: (inout T) -> Void) {
         dispatch_barrier_sync(queue) {
             block(&self._value)
         }
@@ -215,7 +215,7 @@ final class Pool<T> {
     
     /// Performs a block on each pool element, available or not.
     /// The block is run is some arbitrary queue.
-    func forEach(block: (T) throws -> ()) rethrows {
+    func forEach(@noescape block: (T) throws -> ()) rethrows {
         try dispatchSync(queue) {
             for item in self.items {
                 try block(item.element)
@@ -230,7 +230,7 @@ final class Pool<T> {
     
     /// Empty the pool. Currently used items won't be reused.
     /// Eventual block is executed before any other element is dequeued.
-    func clear(block: () throws -> ()) rethrows {
+    func clear(@noescape block: () throws -> ()) rethrows {
         try dispatchSync(queue) {
             self.items = []
             try block()


### PR DESCRIPTION
This PR adds some `@noescape` markers for closures in the Swift 2.3 branch. (Matching the default behavior of the Swift3 branch.)

This should result in:

- additional compiler optimizations / small performance gains
- no need to explicitly capture `self` (weakly or otherwise) in synchronous methods like `.writeInTransaction`
- explicit matching of the Swift3 branch's closure escaping behavior for those methods, easing forward/back migration between the Swift 2.3/Swift 3 branches of GRDB

This also should be a fully backwards-compatible change.