### PR TITLE
Generalized “TableViewEvent” for both platforms & more views

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -32,10 +32,10 @@
 		5605F1931C6B1A8700235C62 /* QueryInterfaceSelectQueryDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F18C1C6B1A8700235C62 /* QueryInterfaceSelectQueryDefinition.swift */; };
 		5605F1941C6B1A8700235C62 /* QueryInterfaceSelectQueryDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F18C1C6B1A8700235C62 /* QueryInterfaceSelectQueryDefinition.swift */; };
 		5606AF911C0ED37000D20487 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 56BB86301BA98AB0001F9168 /* libsqlite3.tbd */; };
-		56071A411DB54ED000CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
-		56071A4E1DB54ED200CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
-		56071A4F1DB54ED300CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
-		56071A501DB54ED300CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
+		56071A411DB54ED000CA6E47 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
+		56071A4E1DB54ED200CA6E47 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
+		56071A4F1DB54ED300CA6E47 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
+		56071A501DB54ED300CA6E47 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
 		5607EFD41BB827FD00605DE3 /* TransactionObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5607EFD21BB8254800605DE3 /* TransactionObserverTests.swift */; };
 		560A37A41C8F625000949E71 /* DatabasePool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560A37A31C8F625000949E71 /* DatabasePool.swift */; };
 		560A37A51C8F625000949E71 /* DatabasePool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560A37A31C8F625000949E71 /* DatabasePool.swift */; };
@@ -269,8 +269,6 @@
 		5636E9C01D22574100B9B05F /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* Request.swift */; };
 		5636E9C11D22574100B9B05F /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* Request.swift */; };
 		564A50C81BFF4B7F00B3A3A2 /* CollationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A50C61BFF4B7F00B3A3A2 /* CollationTests.swift */; };
-		565049061CE32543000A97D8 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
-		565049071CE32543000A97D8 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
 		565490B41D5A4820005622CB /* GRDB.h in Headers */ = {isa = PBXBuildFile; fileRef = DC3773F819C8CBB3004FCF85 /* GRDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		565490B51D5A4827005622CB /* GRDB-Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2393C61ABE35F8003FF113 /* GRDB-Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		565490B61D5AE236005622CB /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A238701B9C75030082EB20 /* Configuration.swift */; };
@@ -577,9 +575,6 @@
 		5690C3431D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
 		5690C3441D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
 		5690C3451D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
-		569178391CED8E0A00E179EA /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
-		569178411CED8E0C00E179EA /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
-		569178421CED8E0D00E179EA /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
 		569178471CED9B6000E179EA /* DatabaseQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569178451CED9B6000E179EA /* DatabaseQueueTests.swift */; };
 		569178481CED9B6000E179EA /* DatabaseQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569178451CED9B6000E179EA /* DatabaseQueueTests.swift */; };
 		569178491CED9B6000E179EA /* DatabaseQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569178451CED9B6000E179EA /* DatabaseQueueTests.swift */; };
@@ -999,9 +994,9 @@
 		56B14E841D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B14E7E1D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift */; };
 		56B14E851D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B14E7E1D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift */; };
 		56B14E861D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B14E7E1D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift */; };
-		56B15D0B1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
-		56B15D0C1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
-		56B15D0D1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
+		56B15D0B1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
+		56B15D0C1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
+		56B15D0D1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
 		56B7F42A1BE14A1900E39BBF /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4291BE14A1900E39BBF /* CGFloatTests.swift */; };
 		56B7F4381BE4C11200E39BBF /* DatabaseCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4361BE4C11200E39BBF /* DatabaseCoderTests.swift */; };
 		56B7F43A1BEB42D500E39BBF /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4391BEB42D500E39BBF /* Migration.swift */; };
@@ -1107,7 +1102,6 @@
 		56D496781D81309E008276D7 /* RecordSubClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A238331B9C74A90082EB20 /* RecordSubClassTests.swift */; };
 		56D496791D81309E008276D7 /* RecordWithColumnNameManglingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A5E4081BA2BCF900707640 /* RecordWithColumnNameManglingTests.swift */; };
 		56D4967C1D8130DB008276D7 /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4291BE14A1900E39BBF /* CGFloatTests.swift */; };
-		56D4967E1D8130DB008276D7 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
 		56D4967F1D813131008276D7 /* StatementColumnConvertibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EE573C1BB317B7007A6A95 /* StatementColumnConvertibleTests.swift */; };
 		56D496801D813131008276D7 /* StatementColumnConvertibleFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E8CE0F1BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift */; };
 		56D496811D813131008276D7 /* TransactionObserverSavepointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5634B1061CF9B970005360B9 /* TransactionObserverSavepointsTests.swift */; };
@@ -1396,9 +1390,7 @@
 		F3BA81001CFB3025003DC1BA /* TransactionObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5607EFD21BB8254800605DE3 /* TransactionObserverTests.swift */; };
 		F3BA81011CFB3032003DC1BA /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4291BE14A1900E39BBF /* CGFloatTests.swift */; };
 		F3BA81021CFB3032003DC1BA /* CGFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4291BE14A1900E39BBF /* CGFloatTests.swift */; };
-		F3BA81031CFB303D003DC1BA /* FetchedRecordsControlleriOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */; };
-		F3BA81041CFB3045003DC1BA /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
-		F3BA81051CFB3046003DC1BA /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */; };
+		F3BA81031CFB303D003DC1BA /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
 		F3BA81081CFB3056003DC1BA /* DatabaseCoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4361BE4C11200E39BBF /* DatabaseCoderTests.swift */; };
 		F3BA810A1CFB3056003DC1BA /* NSDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F0B98E1B6001C600A2F135 /* NSDateTests.swift */; };
 		F3BA810B1CFB3056003DC1BA /* Row+FoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565D5D701BBC694D00DC9BD4 /* Row+FoundationTests.swift */; };
@@ -1721,7 +1713,6 @@
 		563633981DA40F0100CB70CA /* FTS4.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS4.swift; sourceTree = "<group>"; };
 		5636E9BB1D22574100B9B05F /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		564A50C61BFF4B7F00B3A3A2 /* CollationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollationTests.swift; sourceTree = "<group>"; };
-		565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsControllerTests.swift; sourceTree = "<group>"; };
 		565490A01D5A4798005622CB /* GRDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GRDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		565490E51D5AE282005622CB /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS2.2.sdk/usr/lib/libsqlite3.tbd; sourceTree = DEVELOPER_DIR; };
 		56553C181C3E906C00522B5C /* GRDBOSXCrashTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBOSXCrashTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1846,7 +1837,7 @@
 		56AFCAD71CB1ABC800F48B96 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		56B021C81D8C0D3900B239BB /* PersistenceConflictPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistenceConflictPolicyTests.swift; sourceTree = "<group>"; };
 		56B14E7E1D4DAE54000BF4A3 /* RowAsDictionaryLiteralConvertibleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowAsDictionaryLiteralConvertibleTests.swift; sourceTree = "<group>"; };
-		56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsControlleriOSTests.swift; sourceTree = "<group>"; };
+		56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsControllerTests.swift; sourceTree = "<group>"; };
 		56B7F4291BE14A1900E39BBF /* CGFloatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatTests.swift; sourceTree = "<group>"; };
 		56B7F4361BE4C11200E39BBF /* DatabaseCoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseCoderTests.swift; sourceTree = "<group>"; };
 		56B7F4391BEB42D500E39BBF /* Migration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
@@ -2566,8 +2557,7 @@
 		56B15CFC1CD4C33A00A24C8B /* FetchedRecordsController */ = {
 			isa = PBXGroup;
 			children = (
-				56B15D0A1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift */,
-				565049041CE32543000A97D8 /* FetchedRecordsControllerTests.swift */,
+				56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */,
 			);
 			path = FetchedRecordsController;
 			sourceTree = "<group>";
@@ -3752,10 +3742,9 @@
 				56C3F7541CF9F12400F6A361 /* SavepointTests.swift in Sources */,
 				567A80541D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				560FC58B1CB00B880014AA8E /* DatabaseValueTests.swift in Sources */,
-				565049061CE32543000A97D8 /* FetchedRecordsControllerTests.swift in Sources */,
 				567156171CB142AA007DC145 /* ReadOnlyDatabaseTests.swift in Sources */,
 				560FC58D1CB00B880014AA8E /* Row+FoundationTests.swift in Sources */,
-				56071A4E1DB54ED200CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56071A4E1DB54ED200CA6E47 /* FetchedRecordsControllerTests.swift in Sources */,
 				56A4CDB11D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */,
 				567156141CB141D0007DC145 /* InMemoryDatabaseTests.swift in Sources */,
 				560FC58E1CB00B880014AA8E /* PrimaryKeyRowIDTests.swift in Sources */,
@@ -3955,14 +3944,13 @@
 				5690C3391D23E7D200E59934 /* DateTests.swift in Sources */,
 				567156461CB16729007DC145 /* TransactionObserverTests.swift in Sources */,
 				567A80551D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
-				565049071CE32543000A97D8 /* FetchedRecordsControllerTests.swift in Sources */,
 				567156481CB16729007DC145 /* DatabaseValueTests.swift in Sources */,
 				5671564A1CB16729007DC145 /* ReadOnlyDatabaseTests.swift in Sources */,
 				5671564B1CB16729007DC145 /* Row+FoundationTests.swift in Sources */,
 				56A8C2431D1918EE0096E9D4 /* NSUUIDTests.swift in Sources */,
 				5671564C1CB16729007DC145 /* InMemoryDatabaseTests.swift in Sources */,
 				56A4CDB21D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */,
-				56071A4F1DB54ED300CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56071A4F1DB54ED300CA6E47 /* FetchedRecordsControllerTests.swift in Sources */,
 				5671564D1CB16729007DC145 /* PrimaryKeyRowIDTests.swift in Sources */,
 				5671564E1CB16729007DC145 /* DatabaseReaderTests.swift in Sources */,
 				5671564F1CB16729007DC145 /* RecordEditedTests.swift in Sources */,
@@ -4122,7 +4110,7 @@
 				56AFCA471CB1AA9900F48B96 /* MetalRowTests.swift in Sources */,
 				56AFCA491CB1AA9900F48B96 /* StatementArgumentsTests.swift in Sources */,
 				5672DE6B1CDB751D0022BA81 /* DatabasePoolBackupTests.swift in Sources */,
-				56B15D0C1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56B15D0C1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */,
 				56AFCA4A1CB1AA9900F48B96 /* RecordInitializersTests.swift in Sources */,
 				566AD8CB1D531BED002EC1A8 /* SQLTableBuilderTests.swift in Sources */,
 				56AFCA4B1CB1AA9900F48B96 /* MutablePersistableTests.swift in Sources */,
@@ -4150,7 +4138,6 @@
 				56AF74701D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
 				5690C33C1D23E7D200E59934 /* DateTests.swift in Sources */,
 				56AFCA581CB1AA9900F48B96 /* Row+FoundationTests.swift in Sources */,
-				569178411CED8E0C00E179EA /* FetchedRecordsControllerTests.swift in Sources */,
 				56AFCA5A1CB1AA9900F48B96 /* RecordSubClassTests.swift in Sources */,
 				56A4CDB51D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */,
 				56AFCA5B1CB1AA9900F48B96 /* DatabaseValueTests.swift in Sources */,
@@ -4256,7 +4243,6 @@
 				5657AB6C1D108BA9006283EF /* URLTests.swift in Sources */,
 				56AFCAA81CB1ABC800F48B96 /* DataMemoryTests.swift in Sources */,
 				56AFCAA91CB1ABC800F48B96 /* RecordCopyTests.swift in Sources */,
-				569178421CED8E0D00E179EA /* FetchedRecordsControllerTests.swift in Sources */,
 				56A8C24B1D1918F10096E9D4 /* NSUUIDTests.swift in Sources */,
 				56AFCAAB1CB1ABC800F48B96 /* PersistableTests.swift in Sources */,
 				56FF45461D2C23BA00F21EF9 /* DeleteByKeyTests.swift in Sources */,
@@ -4281,7 +4267,7 @@
 				56AFCAB51CB1ABC800F48B96 /* ReadOnlyDatabaseTests.swift in Sources */,
 				56AFCAB61CB1ABC800F48B96 /* DatabaseReaderTests.swift in Sources */,
 				56AFCAB71CB1ABC800F48B96 /* RowConvertibleTests.swift in Sources */,
-				56B15D0D1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56B15D0D1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */,
 				5623931E1DECC02000A6B01F /* RowFetchTests.swift in Sources */,
 				56AFCAB81CB1ABC800F48B96 /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				5698AC8F1DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,
@@ -4438,7 +4424,7 @@
 				56AF746F1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
 				5672DE6A1CDB751D0022BA81 /* DatabasePoolBackupTests.swift in Sources */,
 				5698AC4D1DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
-				56B15D0B1CD4C35100A24C8B /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56B15D0B1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */,
 				56A238681B9C74A90082EB20 /* RecordInitializersTests.swift in Sources */,
 				563363B01C933FF8000BE133 /* MutablePersistableTests.swift in Sources */,
 				5657AB421D108BA9006283EF /* NSDataTests.swift in Sources */,
@@ -4461,7 +4447,6 @@
 				5623936D1DEE0CD200A6B01F /* FlattenCursorTests.swift in Sources */,
 				567A80571D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				5623935B1DEE013C00A6B01F /* FilterCursorTests.swift in Sources */,
-				569178391CED8E0A00E179EA /* FetchedRecordsControllerTests.swift in Sources */,
 				56A2386A1B9C74A90082EB20 /* RecordSubClassTests.swift in Sources */,
 				56A2383E1B9C74A90082EB20 /* DatabaseValueTests.swift in Sources */,
 				567156181CB142AA007DC145 /* ReadOnlyDatabaseTests.swift in Sources */,
@@ -4585,7 +4570,6 @@
 				56D4966F1D81309E008276D7 /* PrimaryKeyNoneTests.swift in Sources */,
 				56D496621D81304E008276D7 /* StatementArguments+FoundationTests.swift in Sources */,
 				56D496B21D8133CE008276D7 /* InMemoryDatabaseTests.swift in Sources */,
-				56D4967E1D8130DB008276D7 /* FetchedRecordsControllerTests.swift in Sources */,
 				562393601DEE06D300A6B01F /* CursorTests.swift in Sources */,
 				56D4968F1D81316E008276D7 /* DictionaryRowTests.swift in Sources */,
 				56D4968E1D81316E008276D7 /* DetachedRowTests.swift in Sources */,
@@ -4620,7 +4604,7 @@
 				56D4967F1D813131008276D7 /* StatementColumnConvertibleTests.swift in Sources */,
 				56D496971D81317B008276D7 /* DatabaseReaderTests.swift in Sources */,
 				56D496911D81316E008276D7 /* MetalRowTests.swift in Sources */,
-				56071A411DB54ED000CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56071A411DB54ED000CA6E47 /* FetchedRecordsControllerTests.swift in Sources */,
 				56D496B91D81346F008276D7 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
 				56D496901D81316E008276D7 /* AdapterRowTests.swift in Sources */,
 				56D496721D81309E008276D7 /* PrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
@@ -4832,7 +4816,6 @@
 				F3BA81121CFB3059003DC1BA /* DatabaseMigratorTests.swift in Sources */,
 				F3BA80EB1CFB3016003DC1BA /* RowConvertibleTests.swift in Sources */,
 				F3BA81151CFB305E003DC1BA /* Record+QueryInterfaceRequestTests.swift in Sources */,
-				F3BA81041CFB3045003DC1BA /* FetchedRecordsControllerTests.swift in Sources */,
 				F3BA80DC1CFB300E003DC1BA /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				5698AD021DAA8ACB0056AF8C /* FTS5CustomTokenizerTests.swift in Sources */,
 				56B964CA1DA521450002DA19 /* FTS5PatternTests.swift in Sources */,
@@ -4841,7 +4824,7 @@
 				56DAA2D91DE99DAB006E10C8 /* DatabaseCursorTests.swift in Sources */,
 				F3BA80F11CFB3019003DC1BA /* SavepointTests.swift in Sources */,
 				56ED8A801DAB8D6800BD0ABC /* FTS5WrapperTokenizerTests.swift in Sources */,
-				F3BA81031CFB303D003DC1BA /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				F3BA81031CFB303D003DC1BA /* FetchedRecordsControllerTests.swift in Sources */,
 				F3BA80B71CFB2FCD003DC1BA /* DatabaseErrorTests.swift in Sources */,
 				5698ACCC1DA62A2D0056AF8C /* FTS5TokenizerTests.swift in Sources */,
 				5690C33E1D23E7D200E59934 /* DateTests.swift in Sources */,
@@ -4993,7 +4976,7 @@
 				561667041D08A49900ADD404 /* NSDecimalNumberTests.swift in Sources */,
 				F3BA80E31CFB300F003DC1BA /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				566AD8C91D531BEB002EC1A8 /* SQLTableBuilderTests.swift in Sources */,
-				56071A501DB54ED300CA6E47 /* FetchedRecordsControlleriOSTests.swift in Sources */,
+				56071A501DB54ED300CA6E47 /* FetchedRecordsControllerTests.swift in Sources */,
 				F3BA80AC1CFB2FA6003DC1BA /* DatabaseQueueSchemaCacheTests.swift in Sources */,
 				56A8C2461D1918EF0096E9D4 /* UUIDTests.swift in Sources */,
 				F3BA80F61CFB301E003DC1BA /* StatementColumnConvertibleFetchTests.swift in Sources */,
@@ -5049,7 +5032,6 @@
 				F3BA80D51CFB2FFB003DC1BA /* DatabaseReaderTests.swift in Sources */,
 				F3BA81321CFB3064003DC1BA /* PrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
 				5623935A1DEE013C00A6B01F /* FilterCursorTests.swift in Sources */,
-				F3BA81051CFB3046003DC1BA /* FetchedRecordsControllerTests.swift in Sources */,
 				F3BA80FC1CFB3021003DC1BA /* UpdateStatementTests.swift in Sources */,
 				5623936C1DEE0CD200A6B01F /* FlattenCursorTests.swift in Sources */,
 				F3BA80E01CFB300F003DC1BA /* DatabaseTimestampTests.swift in Sources */,

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -1,16 +1,12 @@
 /// You use FetchedRecordsController to track changes in the results of an
 /// SQLite request.
 ///
-/// On iOS, FetchedRecordsController can feed a UITableView, and animate rows
-/// when the results of the request change.
-///
 /// See https://github.com/groue/GRDB.swift#fetchedrecordscontroller for
 /// more information.
 public final class FetchedRecordsController<Record: RowConvertible> {
     
     // MARK: - Initialization
     
-    #if os(iOS)
     /// Creates a fetched records controller initialized from a SQL query and
     /// its eventual arguments.
     ///
@@ -79,56 +75,7 @@ public final class FetchedRecordsController<Record: RowConvertible> {
         self.itemsAreIdentical = itemsAreIdentical
         self.queue = queue
     }
-    #else
-    /// Creates a fetched records controller initialized from a SQL query and
-    /// its eventual arguments.
-    ///
-    ///     let controller = FetchedRecordsController<Wine>(
-    ///         dbQueue,
-    ///         sql: "SELECT * FROM wines WHERE color = ? ORDER BY name",
-    ///         arguments: [Color.red])
-    ///
-    /// - parameters:
-    ///     - databaseWriter: A DatabaseWriter (DatabaseQueue, or DatabasePool)
-    ///     - sql: An SQL query.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    ///     - queue: Optional dispatch queue (defaults to the main queue)
-    ///
-    ///         The fetched records controller delegate will be notified of
-    ///         record changes in this queue. The controller itself must be used
-    ///         from this queue.
-    ///
-    ///         This dispatch queue must be serial.
-    public convenience init(_ databaseWriter: DatabaseWriter, sql: String, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil, queue: DispatchQueue = .main) throws {
-        try self.init(databaseWriter, request: SQLRequest(sql, arguments: arguments, adapter: adapter), queue: queue)
-    }
-    
-    /// Creates a fetched records controller initialized from a fetch request
-    /// from the [Query Interface](https://github.com/groue/GRDB.swift#the-query-interface).
-    ///
-    ///     let request = Wine.order(Column("name"))
-    ///     let controller = FetchedRecordsController<Wine>(
-    ///         dbQueue,
-    ///         request: request)
-    ///
-    /// - parameters:
-    ///     - databaseWriter: A DatabaseWriter (DatabaseQueue, or DatabasePool)
-    ///     - request: A fetch request.
-    ///     - queue: Optional dispatch queue (defaults to the main queue)
-    ///
-    ///         The fetched records controller delegate will be notified of
-    ///         record changes in this queue. The controller itself must be used
-    ///         from this queue.
-    ///
-    ///         This dispatch queue must be serial.
-    public init(_ databaseWriter: DatabaseWriter, request: Request, queue: DispatchQueue = .main) throws {
-        self.request = try databaseWriter.read { db in try ObservedRequest(db, request: request) }
-        self.databaseWriter = databaseWriter
-        self.queue = queue
-    }
-    #endif
-    
+
     /// Executes the controller's fetch request.
     ///
     /// After executing this method, you can access the the fetched objects with
@@ -204,43 +151,25 @@ public final class FetchedRecordsController<Record: RowConvertible> {
         try setRequest(SQLRequest(sql, arguments: arguments, adapter: adapter))
     }
     
-    #if os(iOS)
-    /// Registers changes notification callbacks (iOS only).
+    /// Registers changes notification callbacks
     ///
     /// - parameters:
     ///     - recordsWillChange: Invoked before records are updated.
-    ///     - tableViewEvent: Invoked for each record that has been added,
+    ///     - event: Invoked for each record that has been added,
     ///       removed, moved, or updated.
     ///     - recordsDidChange: Invoked after records have been updated.
     public func trackChanges(
         recordsWillChange: ((FetchedRecordsController<Record>) -> ())? = nil,
-        tableViewEvent: ((FetchedRecordsController<Record>, Record, TableViewEvent) -> ())? = nil,
+        event: ((FetchedRecordsController<Record>, Record, FetchedRecordsChangeEvent) -> ())? = nil,
         recordsDidChange: ((FetchedRecordsController<Record>) -> ())? = nil)
     {
         trackChanges(
             fetchAlongside: { _ in },
             recordsWillChange: recordsWillChange.flatMap { callback in { (controller, _) in callback(controller) } },
-            tableViewEvent: tableViewEvent,
+            event: event,
             recordsDidChange: recordsDidChange.flatMap { callback in { (controller, _) in callback(controller) } })
     }
-    #else
-    /// Registers changes notification callbacks.
-    ///
-    /// - parameters:
-    ///     - recordsWillChange: Invoked before records are updated.
-    ///     - recordsDidChange: Invoked after records have been updated.
-    public func trackChanges(
-        recordsWillChange: ((FetchedRecordsController<Record>) -> ())? = nil,
-        recordsDidChange: ((FetchedRecordsController<Record>) -> ())? = nil)
-    {
-        trackChanges(
-            fetchAlongside: { _ in },
-            recordsWillChange: recordsWillChange.flatMap { callback in { (controller, _) in callback(controller) } },
-            recordsDidChange: recordsDidChange.flatMap { callback in { (controller, _) in callback(controller) } })
-    }
-    #endif
-    
-    #if os(iOS)
+
     /// Registers changes notification callbacks (iOS only).
     ///
     /// - parameters:
@@ -251,13 +180,13 @@ public final class FetchedRecordsController<Record: RowConvertible> {
     ///       fetched records have been performed. Use it in order to fetch
     ///       values that must be consistent with the fetched records.
     ///     - recordsWillChange: Invoked before records are updated.
-    ///     - tableViewEvent: Invoked for each record that has been added,
+    ///     - event: Invoked for each record that has been added,
     ///       removed, moved, or updated.
     ///     - recordsDidChange: Invoked after records have been updated.
     public func trackChanges<T>(
         fetchAlongside: @escaping (Database) throws -> T,
         recordsWillChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())? = nil,
-        tableViewEvent: ((FetchedRecordsController<Record>, Record, TableViewEvent) -> ())? = nil,
+        event: ((FetchedRecordsController<Record>, Record, FetchedRecordsChangeEvent) -> ())? = nil,
         recordsDidChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())? = nil)
     {
         // If some changes are currently processed, make sure they are
@@ -265,14 +194,14 @@ public final class FetchedRecordsController<Record: RowConvertible> {
         observer?.invalidate()
         observer = nil
         
-        guard (recordsWillChange != nil) || (tableViewEvent != nil) || (recordsDidChange != nil) else {
+        guard (recordsWillChange != nil) || (event != nil) || (recordsDidChange != nil) else {
             // Stop tracking
             return
         }
         
         let initialItems = fetchedItems
         databaseWriter.write { db in
-            let fetchAndNotifyChanges = makeFetchAndNotifyChangesFunction(controller: self, fetchAlongside: fetchAlongside, itemsAreIdentical: itemsAreIdentical, recordsWillChange: recordsWillChange, tableViewEvent: tableViewEvent, recordsDidChange: recordsDidChange)
+            let fetchAndNotifyChanges = makeFetchAndNotifyChangesFunction(controller: self, fetchAlongside: fetchAlongside, itemsAreIdentical: itemsAreIdentical, recordsWillChange: recordsWillChange, event: event, recordsDidChange: recordsDidChange)
             let observer = FetchedRecordsObserver(selectionInfo: request.selectionInfo, fetchAndNotifyChanges: fetchAndNotifyChanges)
             self.observer = observer
             if let initialItems = initialItems {
@@ -282,47 +211,7 @@ public final class FetchedRecordsController<Record: RowConvertible> {
             }
         }
     }
-    #else
-    /// Registers changes notification callbacks.
-    ///
-    /// - parameters:
-    ///     - fetchAlongside: The value returned from this closure is given to
-    ///       recordsWillChange and recordsDidChange callbacks, as their
-    ///       `fetchedAlongside` argument. The closure is guaranteed to see the
-    ///       database in the state it has just after eventual changes to the
-    ///       fetched records have been performed. Use it in order to fetch
-    ///       values that must be consistent with the fetched records.
-    ///     - recordsWillChange: Invoked before records are updated.
-    ///     - recordsDidChange: Invoked after records have been updated.
-    public func trackChanges<T>(
-        fetchAlongside: @escaping (Database) throws -> T,
-        recordsWillChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())? = nil,
-        recordsDidChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())? = nil)
-    {
-        // If some changes are currently processed, make sure they are
-        // discarded because they would trigger previously set callbacks.
-        observer?.invalidate()
-        observer = nil
-        
-        guard (recordsWillChange != nil) || (recordsDidChange != nil) else {
-            // Stop tracking
-            return
-        }
-        
-        let initialItems = fetchedItems
-        databaseWriter.write { db in
-            let fetchAndNotifyChanges = makeFetchAndNotifyChangesFunction(controller: self, fetchAlongside: fetchAlongside, recordsWillChange: recordsWillChange, recordsDidChange: recordsDidChange)
-            let observer = FetchedRecordsObserver(selectionInfo: request.selectionInfo, fetchAndNotifyChanges: fetchAndNotifyChanges)
-            self.observer = observer
-            if let initialItems = initialItems {
-                observer.items = initialItems
-                db.add(transactionObserver: observer)
-                observer.fetchAndNotifyChanges(observer)
-            }
-        }
-    }
-    #endif
-    
+
     /// Registers a callback for changes tracking errors.
     ///
     /// Whenever the controller could not look for changes after a transaction
@@ -360,11 +249,9 @@ public final class FetchedRecordsController<Record: RowConvertible> {
     // The items
     fileprivate var fetchedItems: [Item<Record>]?
     
-    #if os(iOS)
     // The record comparator
     fileprivate var itemsAreIdentical: ItemComparator<Record>
-    #endif
-    
+
     // The request
     fileprivate var request: ObservedRequest<Record>
     
@@ -391,7 +278,6 @@ fileprivate struct ObservedRequest<Record: RowConvertible> : TypedRequest {
     }
 }
 
-#if os(iOS)
 extension FetchedRecordsController where Record: TableMapping {
     
     // MARK: - Initialization
@@ -455,7 +341,6 @@ extension FetchedRecordsController where Record: TableMapping {
         }
     }
 }
-#endif
 
 
 // MARK: - FetchedRecordsObserver
@@ -601,262 +486,207 @@ fileprivate func makeFetchFunction<Record, T>(
     }
 }
 
-#if os(iOS)
-    fileprivate func makeFetchAndNotifyChangesFunction<Record, T>(
-        controller: FetchedRecordsController<Record>,
-        fetchAlongside: @escaping (Database) throws -> T,
-        itemsAreIdentical: @escaping ItemComparator<Record>,
-        recordsWillChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())?,
-        tableViewEvent: ((FetchedRecordsController<Record>, Record, TableViewEvent) -> ())?,
-        recordsDidChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())?
-        ) -> (FetchedRecordsObserver<Record>) -> ()
-    {
-        // Make sure we keep a weak reference to the fetched records controller,
-        // so that the user can use unowned references in callbacks:
-        //
-        //      controller.trackChanges { [unowned self] ... }
-        //
-        // Should controller become strong at any point before callbacks are
-        // called, such unowned reference would have an opportunity to crash.
-        return makeFetchFunction(controller: controller, fetchAlongside: fetchAlongside) { [weak controller] result in
-            // Return if fetched records controller has been deallocated
-            guard let callbackQueue = controller?.queue else { return }
+fileprivate func makeFetchAndNotifyChangesFunction<Record, T>(
+    controller: FetchedRecordsController<Record>,
+    fetchAlongside: @escaping (Database) throws -> T,
+    itemsAreIdentical: @escaping ItemComparator<Record>,
+    recordsWillChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())?,
+    event: ((FetchedRecordsController<Record>, Record, FetchedRecordsChangeEvent) -> ())?,
+    recordsDidChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())?
+    ) -> (FetchedRecordsObserver<Record>) -> ()
+{
+    // Make sure we keep a weak reference to the fetched records controller,
+    // so that the user can use unowned references in callbacks:
+    //
+    //      controller.trackChanges { [unowned self] ... }
+    //
+    // Should controller become strong at any point before callbacks are
+    // called, such unowned reference would have an opportunity to crash.
+    return makeFetchFunction(controller: controller, fetchAlongside: fetchAlongside) { [weak controller] result in
+        // Return if fetched records controller has been deallocated
+        guard let callbackQueue = controller?.queue else { return }
+        
+        switch result {
+        case .failure(let error):
+            callbackQueue.async {
+                // Now we can retain controller
+                guard let strongController = controller else { return }
+                strongController.errorHandler?(strongController, error)
+            }
             
-            switch result {
-            case .failure(let error):
-                callbackQueue.async {
-                    // Now we can retain controller
-                    guard let strongController = controller else { return }
-                    strongController.errorHandler?(strongController, error)
-                }
+        case .success((fetchedItems: let fetchedItems, fetchedAlongside: let fetchedAlongside, observer: let observer)):
+            // Return if there is no change
+            let changes: [FetchedRecordsChange<Record>]
+            if event != nil {
+                // Compute table view changes
+                changes = computeChanges(from: observer.items, to: fetchedItems, itemsAreIdentical: itemsAreIdentical)
+                if changes.isEmpty { return }
+            } else {
+                // Don't compute changes: just look for a row difference:
+                if identicalItemArrays(fetchedItems, observer.items) { return }
+                changes = []
+            }
+            
+            // Ready for next check
+            observer.items = fetchedItems
+            
+            callbackQueue.async { [weak observer] in
+                // Return if observer has been invalidated
+                guard let strongObserver = observer else { return }
+                guard strongObserver.isValid else { return }
                 
-            case .success((fetchedItems: let fetchedItems, fetchedAlongside: let fetchedAlongside, observer: let observer)):
-                // Return if there is no change
-                let tableViewChanges: [TableViewChange<Record>]
-                if tableViewEvent != nil {
-                    // Compute table view changes
-                    tableViewChanges = computeTableViewChanges(from: observer.items, to: fetchedItems, itemsAreIdentical: itemsAreIdentical)
-                    if tableViewChanges.isEmpty { return }
-                } else {
-                    // Don't compute changes: just look for a row difference:
-                    if identicalItemArrays(fetchedItems, observer.items) { return }
-                    tableViewChanges = []
-                }
+                // Now we can retain controller
+                guard let strongController = controller else { return }
                 
-                // Ready for next check
-                observer.items = fetchedItems
-                
-                callbackQueue.async { [weak observer] in
-                    // Return if observer has been invalidated
-                    guard let strongObserver = observer else { return }
-                    guard strongObserver.isValid else { return }
-                    
-                    // Now we can retain controller
-                    guard let strongController = controller else { return }
-                    
-                    // Notify changes
-                    recordsWillChange?(strongController, fetchedAlongside)
-                    strongController.fetchedItems = fetchedItems
-                    if let tableViewEvent = tableViewEvent {
-                        for change in tableViewChanges {
-                            tableViewEvent(strongController, change.record, change.event)
-                        }
+                // Notify changes
+                recordsWillChange?(strongController, fetchedAlongside)
+                strongController.fetchedItems = fetchedItems
+                if let event = event {
+                    for change in changes {
+                        event(strongController, change.record, change.event)
                     }
-                    recordsDidChange?(strongController, fetchedAlongside)
+                }
+                recordsDidChange?(strongController, fetchedAlongside)
+            }
+        }
+    }
+}
+
+fileprivate func computeChanges<Record>(from s: [Item<Record>], to t: [Item<Record>], itemsAreIdentical: ItemComparator<Record>) -> [FetchedRecordsChange<Record>] {
+    let m = s.count
+    let n = t.count
+    
+    // Fill first row and column of insertions and deletions.
+    
+    var d: [[[FetchedRecordsChange<Record>]]] = Array(repeating: Array(repeating: [], count: n + 1), count: m + 1)
+    
+    var changes = [FetchedRecordsChange<Record>]()
+    for (row, item) in s.enumerated() {
+        let deletion = FetchedRecordsChange.deletion(item: item, indexPath: IndexPath(indexes: [0, row]))
+        changes.append(deletion)
+        d[row + 1][0] = changes
+    }
+    
+    changes.removeAll()
+    for (col, item) in t.enumerated() {
+        let insertion = FetchedRecordsChange.insertion(item: item, indexPath: IndexPath(indexes: [0, col]))
+        changes.append(insertion)
+        d[0][col + 1] = changes
+    }
+    
+    if m == 0 || n == 0 {
+        // Pure deletions or insertions
+        return d[m][n]
+    }
+    
+    // Fill body of matrix.
+    for tx in 0..<n {
+        for sx in 0..<m {
+            if s[sx] == t[tx] {
+                d[sx+1][tx+1] = d[sx][tx] // no operation
+            } else {
+                var del = d[sx][tx+1]     // a deletion
+                var ins = d[sx+1][tx]     // an insertion
+                var sub = d[sx][tx]       // a substitution
+                
+                // Record operation.
+                let minimumCount = min(del.count, ins.count, sub.count)
+                if del.count == minimumCount {
+                    let deletion = FetchedRecordsChange.deletion(item: s[sx], indexPath: IndexPath(indexes: [0, sx]))
+                    del.append(deletion)
+                    d[sx+1][tx+1] = del
+                } else if ins.count == minimumCount {
+                    let insertion = FetchedRecordsChange.insertion(item: t[tx], indexPath: IndexPath(indexes: [0, tx]))
+                    ins.append(insertion)
+                    d[sx+1][tx+1] = ins
+                } else {
+                    let deletion = FetchedRecordsChange.deletion(item: s[sx], indexPath: IndexPath(indexes: [0, sx]))
+                    let insertion = FetchedRecordsChange.insertion(item: t[tx], indexPath: IndexPath(indexes: [0, tx]))
+                    sub.append(deletion)
+                    sub.append(insertion)
+                    d[sx+1][tx+1] = sub
                 }
             }
         }
     }
     
-    fileprivate func computeTableViewChanges<Record>(from s: [Item<Record>], to t: [Item<Record>], itemsAreIdentical: ItemComparator<Record>) -> [TableViewChange<Record>] {
-        let m = s.count
-        let n = t.count
+    /// Returns an array where deletion/insertion pairs of the same element are replaced by `.move` change.
+    func standardize(changes: [FetchedRecordsChange<Record>], itemsAreIdentical: ItemComparator<Record>) -> [FetchedRecordsChange<Record>] {
         
-        // Fill first row and column of insertions and deletions.
-        
-        var d: [[[TableViewChange<Record>]]] = Array(repeating: Array(repeating: [], count: n + 1), count: m + 1)
-        
-        var changes = [TableViewChange<Record>]()
-        for (row, item) in s.enumerated() {
-            let deletion = TableViewChange.deletion(item: item, indexPath: IndexPath(row: row, section: 0))
-            changes.append(deletion)
-            d[row + 1][0] = changes
-        }
-        
-        changes.removeAll()
-        for (col, item) in t.enumerated() {
-            let insertion = TableViewChange.insertion(item: item, indexPath: IndexPath(row: col, section: 0))
-            changes.append(insertion)
-            d[0][col + 1] = changes
-        }
-        
-        if m == 0 || n == 0 {
-            // Pure deletions or insertions
-            return d[m][n]
-        }
-        
-        // Fill body of matrix.
-        for tx in 0..<n {
-            for sx in 0..<m {
-                if s[sx] == t[tx] {
-                    d[sx+1][tx+1] = d[sx][tx] // no operation
-                } else {
-                    var del = d[sx][tx+1]     // a deletion
-                    var ins = d[sx+1][tx]     // an insertion
-                    var sub = d[sx][tx]       // a substitution
-                    
-                    // Record operation.
-                    let minimumCount = min(del.count, ins.count, sub.count)
-                    if del.count == minimumCount {
-                        let deletion = TableViewChange.deletion(item: s[sx], indexPath: IndexPath(row: sx, section: 0))
-                        del.append(deletion)
-                        d[sx+1][tx+1] = del
-                    } else if ins.count == minimumCount {
-                        let insertion = TableViewChange.insertion(item: t[tx], indexPath: IndexPath(row: tx, section: 0))
-                        ins.append(insertion)
-                        d[sx+1][tx+1] = ins
+        /// Returns a potential .move or .update if *change* has a matching change in *changes*:
+        /// If *change* is a deletion or an insertion, and there is a matching inverse
+        /// insertion/deletion with the same value in *changes*, a corresponding .move or .update is returned.
+        /// As a convenience, the index of the matched change is returned as well.
+        func merge(change: FetchedRecordsChange<Record>, in changes: [FetchedRecordsChange<Record>], itemsAreIdentical: ItemComparator<Record>) -> (mergedChange: FetchedRecordsChange<Record>, mergedIndex: Int)? {
+            
+            /// Returns the changes between two rows: a dictionary [key: oldValue]
+            /// Precondition: both rows have the same columns
+            func changedValues(from oldRow: Row, to newRow: Row) -> [String: DatabaseValue] {
+                var changedValues: [String: DatabaseValue] = [:]
+                for (column, newValue) in newRow {
+                    let oldValue: DatabaseValue? = oldRow.value(named: column)
+                    if newValue != oldValue {
+                        changedValues[column] = oldValue
+                    }
+                }
+                return changedValues
+            }
+            
+            switch change {
+            case .insertion(let newItem, let newIndexPath):
+                // Look for a matching deletion
+                for (index, otherChange) in changes.enumerated() {
+                    guard case .deletion(let oldItem, let oldIndexPath) = otherChange else { continue }
+                    guard itemsAreIdentical(oldItem, newItem) else { continue }
+                    let rowChanges = changedValues(from: oldItem.row, to: newItem.row)
+                    if oldIndexPath == newIndexPath {
+                        return (FetchedRecordsChange.update(item: newItem, indexPath: oldIndexPath, changes: rowChanges), index)
                     } else {
-                        let deletion = TableViewChange.deletion(item: s[sx], indexPath: IndexPath(row: sx, section: 0))
-                        let insertion = TableViewChange.insertion(item: t[tx], indexPath: IndexPath(row: tx, section: 0))
-                        sub.append(deletion)
-                        sub.append(insertion)
-                        d[sx+1][tx+1] = sub
+                        return (FetchedRecordsChange.move(item: newItem, indexPath: oldIndexPath, newIndexPath: newIndexPath, changes: rowChanges), index)
                     }
                 }
+                return nil
+                
+            case .deletion(let oldItem, let oldIndexPath):
+                // Look for a matching insertion
+                for (index, otherChange) in changes.enumerated() {
+                    guard case .insertion(let newItem, let newIndexPath) = otherChange else { continue }
+                    guard itemsAreIdentical(oldItem, newItem) else { continue }
+                    let rowChanges = changedValues(from: oldItem.row, to: newItem.row)
+                    if oldIndexPath == newIndexPath {
+                        return (FetchedRecordsChange.update(item: newItem, indexPath: oldIndexPath, changes: rowChanges), index)
+                    } else {
+                        return (FetchedRecordsChange.move(item: newItem, indexPath: oldIndexPath, newIndexPath: newIndexPath, changes: rowChanges), index)
+                    }
+                }
+                return nil
+                
+            default:
+                return nil
             }
         }
         
-        /// Returns an array where deletion/insertion pairs of the same element are replaced by `.move` change.
-        func standardize(changes: [TableViewChange<Record>], itemsAreIdentical: ItemComparator<Record>) -> [TableViewChange<Record>] {
-            
-            /// Returns a potential .move or .update if *change* has a matching change in *changes*:
-            /// If *change* is a deletion or an insertion, and there is a matching inverse
-            /// insertion/deletion with the same value in *changes*, a corresponding .move or .update is returned.
-            /// As a convenience, the index of the matched change is returned as well.
-            func merge(change: TableViewChange<Record>, in changes: [TableViewChange<Record>], itemsAreIdentical: ItemComparator<Record>) -> (mergedChange: TableViewChange<Record>, mergedIndex: Int)? {
-                
-                /// Returns the changes between two rows: a dictionary [key: oldValue]
-                /// Precondition: both rows have the same columns
-                func changedValues(from oldRow: Row, to newRow: Row) -> [String: DatabaseValue] {
-                    var changedValues: [String: DatabaseValue] = [:]
-                    for (column, newValue) in newRow {
-                        let oldValue: DatabaseValue? = oldRow.value(named: column)
-                        if newValue != oldValue {
-                            changedValues[column] = oldValue
-                        }
-                    }
-                    return changedValues
-                }
-                
-                switch change {
-                case .insertion(let newItem, let newIndexPath):
-                    // Look for a matching deletion
-                    for (index, otherChange) in changes.enumerated() {
-                        guard case .deletion(let oldItem, let oldIndexPath) = otherChange else { continue }
-                        guard itemsAreIdentical(oldItem, newItem) else { continue }
-                        let rowChanges = changedValues(from: oldItem.row, to: newItem.row)
-                        if oldIndexPath == newIndexPath {
-                            return (TableViewChange.update(item: newItem, indexPath: oldIndexPath, changes: rowChanges), index)
-                        } else {
-                            return (TableViewChange.move(item: newItem, indexPath: oldIndexPath, newIndexPath: newIndexPath, changes: rowChanges), index)
-                        }
-                    }
-                    return nil
-                    
-                case .deletion(let oldItem, let oldIndexPath):
-                    // Look for a matching insertion
-                    for (index, otherChange) in changes.enumerated() {
-                        guard case .insertion(let newItem, let newIndexPath) = otherChange else { continue }
-                        guard itemsAreIdentical(oldItem, newItem) else { continue }
-                        let rowChanges = changedValues(from: oldItem.row, to: newItem.row)
-                        if oldIndexPath == newIndexPath {
-                            return (TableViewChange.update(item: newItem, indexPath: oldIndexPath, changes: rowChanges), index)
-                        } else {
-                            return (TableViewChange.move(item: newItem, indexPath: oldIndexPath, newIndexPath: newIndexPath, changes: rowChanges), index)
-                        }
-                    }
-                    return nil
-                    
+        // Updates must be pushed at the end
+        var mergedChanges: [FetchedRecordsChange<Record>] = []
+        var updateChanges: [FetchedRecordsChange<Record>] = []
+        for change in changes {
+            if let (mergedChange, mergedIndex) = merge(change: change, in: mergedChanges, itemsAreIdentical: itemsAreIdentical) {
+                mergedChanges.remove(at: mergedIndex)
+                switch mergedChange {
+                case .update:
+                    updateChanges.append(mergedChange)
                 default:
-                    return nil
+                    mergedChanges.append(mergedChange)
                 }
-            }
-            
-            // Updates must be pushed at the end
-            var mergedChanges: [TableViewChange<Record>] = []
-            var updateChanges: [TableViewChange<Record>] = []
-            for change in changes {
-                if let (mergedChange, mergedIndex) = merge(change: change, in: mergedChanges, itemsAreIdentical: itemsAreIdentical) {
-                    mergedChanges.remove(at: mergedIndex)
-                    switch mergedChange {
-                    case .update:
-                        updateChanges.append(mergedChange)
-                    default:
-                        mergedChanges.append(mergedChange)
-                    }
-                } else {
-                    mergedChanges.append(change)
-                }
-            }
-            return mergedChanges + updateChanges
-        }
-        
-        return standardize(changes: d[m][n], itemsAreIdentical: itemsAreIdentical)
-    }
-
-#else
-    /// Returns a function that fetches and notify changes, and erases the type
-    /// of values that are fetched alongside tracked records.
-    fileprivate func makeFetchAndNotifyChangesFunction<Record, T>(
-        controller: FetchedRecordsController<Record>,
-        fetchAlongside: @escaping (Database) throws -> T,
-        recordsWillChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())?,
-        recordsDidChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> ())?
-        ) -> (FetchedRecordsObserver<Record>) -> ()
-    {
-        // Make sure we keep a weak reference to the fetched records controller,
-        // so that the user can use unowned references in callbacks:
-        //
-        //      controller.trackChanges { [unowned self] ... }
-        //
-        // Should controller become strong at any point before callbacks are
-        // called, such unowned reference would have an opportunity to crash.
-        return makeFetchFunction(controller: controller, fetchAlongside: fetchAlongside) { [weak controller] result in
-            // Return if fetched records controller has been deallocated
-            guard let callbackQueue = controller?.queue else { return }
-            
-            switch result {
-            case .failure(let error):
-                callbackQueue.async {
-                    // Now we can retain controller
-                    guard let strongController = controller else { return }
-                    strongController.errorHandler?(strongController, error)
-                }
-                
-            case .success((fetchedItems: let fetchedItems, fetchedAlongside: let fetchedAlongside, observer: let observer)):
-                // Return if there is no change
-                if identicalItemArrays(fetchedItems, observer.items) { return }
-                
-                // Ready for next check
-                observer.items = fetchedItems
-                
-                callbackQueue.async { [weak observer] in
-                    // Return if observer has been invalidated
-                    guard let strongObserver = observer else { return }
-                    guard strongObserver.isValid else { return }
-                    
-                    // Now we can retain controller
-                    guard let strongController = controller else { return }
-                    
-                    // Notify changes
-                    recordsWillChange?(strongController, fetchedAlongside)
-                    strongController.fetchedItems = fetchedItems
-                    recordsDidChange?(strongController, fetchedAlongside)
-                }
+            } else {
+                mergedChanges.append(change)
             }
         }
+        return mergedChanges + updateChanges
     }
-#endif
+    
+    return standardize(changes: d[m][n], itemsAreIdentical: itemsAreIdentical)
+}
 
 fileprivate func identicalItemArrays<Record>(_ lhs: [Item<Record>], _ rhs: [Item<Record>]) -> Bool {
     guard lhs.count == rhs.count else {
@@ -873,179 +703,177 @@ fileprivate func identicalItemArrays<Record>(_ lhs: [Item<Record>], _ rhs: [Item
 
 // MARK: - UITableView Support
 
-#if os(iOS)
-    fileprivate typealias ItemComparator<Record: RowConvertible> = (Item<Record>, Item<Record>) -> Bool
+fileprivate typealias ItemComparator<Record: RowConvertible> = (Item<Record>, Item<Record>) -> Bool
+
+extension FetchedRecordsController {
     
-    extension FetchedRecordsController {
-        
-        // MARK: - Accessing Records
-        
-        /// Returns the object at the given index path (iOS only).
-        ///
-        /// - parameter indexPath: An index path in the fetched records.
-        ///
-        ///     If indexPath does not describe a valid index path in the fetched
-        ///     records, a fatal error is raised.
-        public func record(at indexPath: IndexPath) -> Record {
-            guard let fetchedItems = fetchedItems else {
-                // Programmer error
-                fatalError("performFetch() has not been called.")
-            }
-            return fetchedItems[indexPath.row].record
-        }
-        
-        
-        // MARK: - Querying Sections Information
-        
-        /// The sections for the fetched records (iOS only).
-        ///
-        /// You typically use the sections array when implementing
-        /// UITableViewDataSource methods, such as `numberOfSectionsInTableView`.
-        ///
-        /// The sections array is never empty, even when there are no fetched
-        /// records. In this case, there is a single empty section.
-        public var sections: [FetchedRecordsSectionInfo<Record>] {
-            // We only support a single section so far.
-            // We also return a single section when there are no fetched
-            // records, just like NSFetchedResultsController.
-            return [FetchedRecordsSectionInfo(controller: self)]
-        }
-    }
+    // MARK: - Accessing Records
     
-    extension FetchedRecordsController where Record: MutablePersistable {
-        
-        /// Returns the indexPath of a given record (iOS only).
-        ///
-        /// - returns: The index path of *record* in the fetched records, or nil
-        ///   if record could not be found.
-        public func indexPath(for record: Record) -> IndexPath? {
-            let item = Item<Record>(row: Row(record.persistentDictionary))
-            guard let fetchedItems = fetchedItems, let index = fetchedItems.index(where: { itemsAreIdentical($0, item) }) else {
-                return nil
-            }
-            return IndexPath(row: index, section: 0)
-        }
-    }
-    
-    private enum TableViewChange<T: RowConvertible> {
-        case insertion(item: Item<T>, indexPath: IndexPath)
-        case deletion(item: Item<T>, indexPath: IndexPath)
-        case move(item: Item<T>, indexPath: IndexPath, newIndexPath: IndexPath, changes: [String: DatabaseValue])
-        case update(item: Item<T>, indexPath: IndexPath, changes: [String: DatabaseValue])
-    }
-    
-    extension TableViewChange {
-        var record: T {
-            switch self {
-            case .insertion(item: let item, indexPath: _):
-                return item.record
-            case .deletion(item: let item, indexPath: _):
-                return item.record
-            case .move(item: let item, indexPath: _, newIndexPath: _, changes: _):
-                return item.record
-            case .update(item: let item, indexPath: _, changes: _):
-                return item.record
-            }
-        }
-        
-        var event: TableViewEvent {
-            switch self {
-            case .insertion(item: _, indexPath: let indexPath):
-                return .insertion(indexPath: indexPath)
-            case .deletion(item: _, indexPath: let indexPath):
-                return .deletion(indexPath: indexPath)
-            case .move(item: _, indexPath: let indexPath, newIndexPath: let newIndexPath, changes: let changes):
-                return .move(indexPath: indexPath, newIndexPath: newIndexPath, changes: changes)
-            case .update(item: _, indexPath: let indexPath, changes: let changes):
-                return .update(indexPath: indexPath, changes: changes)
-            }
-        }
-    }
-    
-    extension TableViewChange: CustomStringConvertible {
-        var description: String {
-            switch self {
-            case .insertion(let item, let indexPath):
-                return "Insert \(item) at \(indexPath)"
-                
-            case .deletion(let item, let indexPath):
-                return "Delete \(item) from \(indexPath)"
-                
-            case .move(let item, let indexPath, let newIndexPath, changes: let changes):
-                return "Move \(item) from \(indexPath) to \(newIndexPath) with changes: \(changes)"
-                
-            case .update(let item, let indexPath, let changes):
-                return "Update \(item) at \(indexPath) with changes: \(changes)"
-            }
-        }
-    }
-    
-    /// A change event given by a FetchedRecordsController to its delegate.
+    /// Returns the object at the given index path (iOS only).
     ///
-    /// The move and update events hold a *changes* dictionary. Its keys are column
-    /// names, and values the old values that have been changed.
-    public enum TableViewEvent {
-        
-        /// An insertion event, at given indexPath.
-        case insertion(indexPath: IndexPath)
-        
-        /// A deletion event, at given indexPath.
-        case deletion(indexPath: IndexPath)
-        
-        /// A move event, from indexPath to newIndexPath. The *changes* are a
-        /// dictionary whose keys are column names, and values the old values that
-        /// have been changed.
-        case move(indexPath: IndexPath, newIndexPath: IndexPath, changes: [String: DatabaseValue])
-        
-        /// An update event, at given indexPath. The *changes* are a dictionary
-        /// whose keys are column names, and values the old values that have
-        /// been changed.
-        case update(indexPath: IndexPath, changes: [String: DatabaseValue])
+    /// - parameter indexPath: An index path in the fetched records.
+    ///
+    ///     If indexPath does not describe a valid index path in the fetched
+    ///     records, a fatal error is raised.
+    public func record(at indexPath: IndexPath) -> Record {
+        guard let fetchedItems = fetchedItems else {
+            // Programmer error
+            fatalError("performFetch() has not been called.")
+        }
+        return fetchedItems[indexPath[1]].record
     }
     
-    extension TableViewEvent: CustomStringConvertible {
-        
-        /// A textual representation of `self`.
-        public var description: String {
-            switch self {
-            case .insertion(let indexPath):
-                return "Insertion at \(indexPath)"
-                
-            case .deletion(let indexPath):
-                return "Deletion from \(indexPath)"
-                
-            case .move(let indexPath, let newIndexPath, changes: let changes):
-                return "Move from \(indexPath) to \(newIndexPath) with changes: \(changes)"
-                
-            case .update(let indexPath, let changes):
-                return "Update at \(indexPath) with changes: \(changes)"
-            }
+    
+    // MARK: - Querying Sections Information
+    
+    /// The sections for the fetched records (iOS only).
+    ///
+    /// You typically use the sections array when implementing
+    /// UITableViewDataSource methods, such as `numberOfSectionsInTableView`.
+    ///
+    /// The sections array is never empty, even when there are no fetched
+    /// records. In this case, there is a single empty section.
+    public var sections: [FetchedRecordsSectionInfo<Record>] {
+        // We only support a single section so far.
+        // We also return a single section when there are no fetched
+        // records, just like NSFetchedResultsController.
+        return [FetchedRecordsSectionInfo(controller: self)]
+    }
+}
+
+extension FetchedRecordsController where Record: MutablePersistable {
+    
+    /// Returns the indexPath of a given record (iOS only).
+    ///
+    /// - returns: The index path of *record* in the fetched records, or nil
+    ///   if record could not be found.
+    public func indexPath(for record: Record) -> IndexPath? {
+        let item = Item<Record>(row: Row(record.persistentDictionary))
+        guard let fetchedItems = fetchedItems, let index = fetchedItems.index(where: { itemsAreIdentical($0, item) }) else {
+            return nil
+        }
+        return IndexPath(indexes: [0, index])
+    }
+}
+
+private enum FetchedRecordsChange<T: RowConvertible> {
+    case insertion(item: Item<T>, indexPath: IndexPath)
+    case deletion(item: Item<T>, indexPath: IndexPath)
+    case move(item: Item<T>, indexPath: IndexPath, newIndexPath: IndexPath, changes: [String: DatabaseValue])
+    case update(item: Item<T>, indexPath: IndexPath, changes: [String: DatabaseValue])
+}
+
+extension FetchedRecordsChange {
+    var record: T {
+        switch self {
+        case .insertion(item: let item, indexPath: _):
+            return item.record
+        case .deletion(item: let item, indexPath: _):
+            return item.record
+        case .move(item: let item, indexPath: _, newIndexPath: _, changes: _):
+            return item.record
+        case .update(item: let item, indexPath: _, changes: _):
+            return item.record
         }
     }
     
-    /// A section given by a FetchedRecordsController.
-    public struct FetchedRecordsSectionInfo<Record: RowConvertible> {
-        fileprivate let controller: FetchedRecordsController<Record>
-        
-        /// The number of records (rows) in the section.
-        public var numberOfRecords: Int {
-            guard let items = controller.fetchedItems else {
-                // Programmer error
-                fatalError("the performFetch() method must be called before accessing section contents")
-            }
-            return items.count
-        }
-        
-        /// The array of records in the section.
-        public var records: [Record] {
-            guard let items = controller.fetchedItems else {
-                // Programmer error
-                fatalError("the performFetch() method must be called before accessing section contents")
-            }
-            return items.map { $0.record }
+    var event: FetchedRecordsChangeEvent {
+        switch self {
+        case .insertion(item: _, indexPath: let indexPath):
+            return .insertion(indexPath: indexPath)
+        case .deletion(item: _, indexPath: let indexPath):
+            return .deletion(indexPath: indexPath)
+        case .move(item: _, indexPath: let indexPath, newIndexPath: let newIndexPath, changes: let changes):
+            return .move(indexPath: indexPath, newIndexPath: newIndexPath, changes: changes)
+        case .update(item: _, indexPath: let indexPath, changes: let changes):
+            return .update(indexPath: indexPath, changes: changes)
         }
     }
-#endif
+}
+
+extension FetchedRecordsChange: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .insertion(let item, let indexPath):
+            return "Insert \(item) at \(indexPath)"
+            
+        case .deletion(let item, let indexPath):
+            return "Delete \(item) from \(indexPath)"
+            
+        case .move(let item, let indexPath, let newIndexPath, changes: let changes):
+            return "Move \(item) from \(indexPath) to \(newIndexPath) with changes: \(changes)"
+            
+        case .update(let item, let indexPath, let changes):
+            return "Update \(item) at \(indexPath) with changes: \(changes)"
+        }
+    }
+}
+
+/// A change event given by a FetchedRecordsController to its delegate.
+///
+/// The move and update events hold a *changes* dictionary. Its keys are column
+/// names, and values the old values that have been changed.
+public enum FetchedRecordsChangeEvent {
+    
+    /// An insertion event, at given indexPath.
+    case insertion(indexPath: IndexPath)
+    
+    /// A deletion event, at given indexPath.
+    case deletion(indexPath: IndexPath)
+    
+    /// A move event, from indexPath to newIndexPath. The *changes* are a
+    /// dictionary whose keys are column names, and values the old values that
+    /// have been changed.
+    case move(indexPath: IndexPath, newIndexPath: IndexPath, changes: [String: DatabaseValue])
+    
+    /// An update event, at given indexPath. The *changes* are a dictionary
+    /// whose keys are column names, and values the old values that have
+    /// been changed.
+    case update(indexPath: IndexPath, changes: [String: DatabaseValue])
+}
+
+extension FetchedRecordsChangeEvent: CustomStringConvertible {
+    
+    /// A textual representation of `self`.
+    public var description: String {
+        switch self {
+        case .insertion(let indexPath):
+            return "Insertion at \(indexPath)"
+            
+        case .deletion(let indexPath):
+            return "Deletion from \(indexPath)"
+            
+        case .move(let indexPath, let newIndexPath, changes: let changes):
+            return "Move from \(indexPath) to \(newIndexPath) with changes: \(changes)"
+            
+        case .update(let indexPath, let changes):
+            return "Update at \(indexPath) with changes: \(changes)"
+        }
+    }
+}
+
+/// A section given by a FetchedRecordsController.
+public struct FetchedRecordsSectionInfo<Record: RowConvertible> {
+    fileprivate let controller: FetchedRecordsController<Record>
+    
+    /// The number of records (rows) in the section.
+    public var numberOfRecords: Int {
+        guard let items = controller.fetchedItems else {
+            // Programmer error
+            fatalError("the performFetch() method must be called before accessing section contents")
+        }
+        return items.count
+    }
+    
+    /// The array of records in the section.
+    public var records: [Record] {
+        guard let items = controller.fetchedItems else {
+            // Programmer error
+            fatalError("the performFetch() method must be called before accessing section contents")
+        }
+        return items.map { $0.record }
+    }
+}
 
 
 // MARK: - Item

--- a/Tests/Public/Record/PrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/Public/Record/PrimaryKeyHiddenRowIDTests.swift
@@ -657,28 +657,21 @@ class PrimaryKeyHiddenRowIDTests : GRDBTestCase {
             }
             
             let expectation = self.expectation(description: "expectation")
-            let controller: FetchedRecordsController<Person>
-            #if os(iOS)
-                controller = try FetchedRecordsController<Person>(dbQueue, request: Person.all(), compareRecordsByPrimaryKey: true)
-                var update = false
-                controller.trackChanges(
-                    tableViewEvent: { (_, _, event) in
-                        switch event {
-                        case .update:
-                            update = true
-                        default:
-                            break
-                        }
-                    },
-                    recordsDidChange: { _ in
-                        expectation.fulfill()
-                })
-            #else
-                controller = try FetchedRecordsController<Person>(dbQueue, request: Person.all())
-                controller.trackChanges { _ in
+            let controller =
+                try FetchedRecordsController<Person>(dbQueue, request: Person.all(), compareRecordsByPrimaryKey: true)
+            var update = false
+            controller.trackChanges(
+                event: { (_, _, event) in
+                    switch event {
+                    case .update:
+                        update = true
+                    default:
+                        break
+                    }
+                },
+                recordsDidChange: { _ in
                     expectation.fulfill()
-                }
-            #endif
+            })
             try controller.performFetch()
             try dbQueue.inDatabase { db in
                 person.name = "Barbara"
@@ -686,9 +679,7 @@ class PrimaryKeyHiddenRowIDTests : GRDBTestCase {
             }
             waitForExpectations(timeout: 1, handler: nil)
             
-            #if os(iOS)
-                XCTAssertTrue(update)
-            #endif
+            XCTAssertTrue(update)
         }
     }
 }


### PR DESCRIPTION
There is nothing specific to `UITableView` in the implementation of `TableViewEvent` features. The events are useful to users of `UICollectionView` also. Finally, as of macOS 10.10, both view types are now supported on macOS.  For all these reasons `TableViewEvent` features were migrated to support both platforms & renamed not to confuse end users who might be thinking they're only for table views.

* TableViewEvent features of FetchedRecordsController supported on both platforms
* Renamed TableViewEvent to FetchedRecordsChangeEvent
* Renamed TableViewChange to FetchedRecordsChange