### PR TITLE
Activate extended result codes, and expose result codes as Swift constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release Notes
     }
     ```
 
+
 **New: Request**
 
 - The Request protocol for [custom requests](https://github.com/groue/GRDB.swift#custom-requests) learned how to count:
@@ -29,7 +30,12 @@ Release Notes
     ```
     
     Default implementation performs a naive counting based on the request SQL: `SELECT COUNT(*) FROM (...)`. Adopting types can refine the counting SQL by refining their `fetchCount` implementation.
-    
+
+
+**Breaking Changes**
+
+- `DatabaseError.code` has been removed, replaced with `DatabaseError.resultCode` and `DatabaseError.extendedResultCode`.
+
 
 ## 0.101.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Release Notes
 
 **New**
 
-- GRDB activates SQLite's [extended result codes](https://www.sqlite.org/rescode.html)
-- The new `ResultCode` type defines constants for all SQLite [result codes and extended result codes](https://www.sqlite.org/rescode.html):
+- GRDB activates SQLite's [extended result codes](https://www.sqlite.org/rescode.html).
+- The new `ResultCode` type defines constants for all SQLite [result codes and extended result codes](https://www.sqlite.org/rescode.html).
 - The SQLite error code of `DatabaseError` can be queried with `resultCode`, or `extendedResultCode`, depending on the level of details you need:
     
     ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Release Notes
 =============
 
+## Next version
+
+**New**
+
+- GRDB activates SQLite's [extended result codes](https://www.sqlite.org/rescode.html)
+- The new `ResultCode` type defines constants for all SQLite [result codes and extended result codes](https://www.sqlite.org/rescode.html):
+- The SQLite error code of `DatabaseError` can be queried with `resultCode`, or `extendedResultCode`, depending on the level of details you need:
+    
+    ```swift
+    do {
+        ...
+    } catch let error as DatabaseError where error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY {
+        // handle foreign key constraint error
+    } catch let error as DatabaseError where error.resultCode == .SQLITE_CONSTRAINT {
+        // handle any other constraint error
+    }
+    ```
+
 ## 0.101.1
 
 Released January 20, 2017

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Release Notes
 
 **New**
 
-- GRDB activates SQLite's [extended result codes](https://www.sqlite.org/rescode.html).
+- GRDB activates SQLite's [extended result codes](https://www.sqlite.org/rescode.html) for more detailed error reporting.
 - The new `ResultCode` type defines constants for all SQLite [result codes and extended result codes](https://www.sqlite.org/rescode.html).
 - The SQLite error code of `DatabaseError` can be queried with `resultCode`, or `extendedResultCode`, depending on the level of details you need:
     

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -1215,6 +1215,13 @@
 		56F3E74E1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
 		56F3E74F1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
 		56F3E7501E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E7631E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
+		56F3E7641E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
+		56F3E7651E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
+		56F3E7661E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
+		56F3E7671E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
+		56F3E7681E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
+		56F3E7691E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */; };
 		56F5ABD91D814330001F60CB /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
 		56F5ABDA1D814330001F60CB /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		56F5ABDC1D814330001F60CB /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AB0E1D10899D006283EF /* URL.swift */; };
@@ -1926,6 +1933,7 @@
 		56EE573C1BB317B7007A6A95 /* StatementColumnConvertibleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementColumnConvertibleTests.swift; sourceTree = "<group>"; };
 		56F0B98E1B6001C600A2F135 /* NSDateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateTests.swift; sourceTree = "<group>"; };
 		56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultCodeTests.swift; sourceTree = "<group>"; };
+		56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fixits-0.101.1.swift"; sourceTree = "<group>"; };
 		56FC98771D969DEF00E3C842 /* SQLExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLExpression.swift; sourceTree = "<group>"; };
 		56FDECE11BB32DFD009AD709 /* MetalRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalRowTests.swift; sourceTree = "<group>"; };
 		56FF453F1D2C23BA00F21EF9 /* DeleteByKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteByKeyTests.swift; sourceTree = "<group>"; };
@@ -2655,6 +2663,7 @@
 			children = (
 				56BF6D2C1DEF47DA006039A3 /* Fixits-0-84-0.swift */,
 				56BF6D2D1DEF47DA006039A3 /* Fixits-0-90-1.swift */,
+				56F3E7621E67F8C100BF0F01 /* Fixits-0.101.1.swift */,
 				56BF6D2E1DEF47DA006039A3 /* Fixits-Swift2.swift */,
 			);
 			path = Legacy;
@@ -3665,6 +3674,7 @@
 				567404891CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
 				560FC5241CB003810014AA8E /* DatabaseWriter.swift in Sources */,
 				5698AD191DAAD17B0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56F3E7641E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				566475C31D981C5D00FF74B8 /* SQLSelectQuery.swift in Sources */,
 				56B964B21DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				560FC5261CB003810014AA8E /* SerializedDatabase.swift in Sources */,
@@ -3859,6 +3869,7 @@
 				5698AD271DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift in Sources */,
 				565490D51D5AE252005622CB /* RawRepresentable.swift in Sources */,
 				565490C51D5AE236005622CB /* SerializedDatabase.swift in Sources */,
+				56F3E7691E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				5698AC7E1DA37DCB0056AF8C /* VirtualTableModule.swift in Sources */,
 				565490D71D5AE252005622CB /* Utils.swift in Sources */,
 				5698AC3D1D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
@@ -4071,6 +4082,7 @@
 				5674048B1CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
 				56AFC9F91CB1A8BB00F48B96 /* DatabaseWriter.swift in Sources */,
 				5698AD1A1DAAD17C0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56F3E7671E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				566475C61D981C5D00FF74B8 /* SQLSelectQuery.swift in Sources */,
 				56B964B51DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				56AFC9FB1CB1A8BB00F48B96 /* SerializedDatabase.swift in Sources */,
@@ -4384,6 +4396,7 @@
 				5674048A1CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
 				563363C51C942C37000BE133 /* DatabaseWriter.swift in Sources */,
 				5698AD1B1DAAD17D0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56F3E7661E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				566475C51D981C5D00FF74B8 /* SQLSelectQuery.swift in Sources */,
 				56B964B41DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				560A37A81C8FF6E500949E71 /* SerializedDatabase.swift in Sources */,
@@ -4695,6 +4708,7 @@
 				567404881CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
 				563363C41C942C37000BE133 /* DatabaseWriter.swift in Sources */,
 				5698AD181DAAD17A0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56F3E7631E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				566475C21D981C5D00FF74B8 /* SQLSelectQuery.swift in Sources */,
 				56B964B11DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				560A37A71C8FF6E500949E71 /* SerializedDatabase.swift in Sources */,
@@ -4768,6 +4782,7 @@
 				5664759F1D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
 				F3BA802B1CFB289B003DC1BA /* QueryInterfaceRequest.swift in Sources */,
 				5698AD171DAAD16F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56F3E7681E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				F3BA80131CFB2876003DC1BA /* DatabaseValue.swift in Sources */,
 				56B964B61DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				566475C71D981C5D00FF74B8 /* SQLSelectQuery.swift in Sources */,
@@ -4966,6 +4981,7 @@
 				5664759C1D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
 				F3BA80871CFB2E70003DC1BA /* QueryInterfaceRequest.swift in Sources */,
 				5698AD161DAAD16F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56F3E7651E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
 				F3BA806F1CFB2E55003DC1BA /* DatabaseValue.swift in Sources */,
 				56B964B31DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				566475C41D981C5D00FF74B8 /* SQLSelectQuery.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -1199,6 +1199,14 @@
 		56F0B9921B6001C600A2F135 /* NSDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F0B98E1B6001C600A2F135 /* NSDateTests.swift */; };
 		56F26C1C1CEE3F32007969C4 /* AdapterRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565F03C11CE5D3AA00DE108F /* AdapterRowTests.swift */; };
 		56F26C241CEE3F34007969C4 /* AdapterRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565F03C11CE5D3AA00DE108F /* AdapterRowTests.swift */; };
+		56F3E7491E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E74A1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E74B1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E74C1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E74D1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E74E1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E74F1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
+		56F3E7501E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
 		56F5ABD91D814330001F60CB /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
 		56F5ABDA1D814330001F60CB /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		56F5ABDC1D814330001F60CB /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AB0E1D10899D006283EF /* URL.swift */; };
@@ -1908,6 +1916,7 @@
 		56ED8A7E1DAB8D6800BD0ABC /* FTS5WrapperTokenizerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5WrapperTokenizerTests.swift; sourceTree = "<group>"; };
 		56EE573C1BB317B7007A6A95 /* StatementColumnConvertibleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementColumnConvertibleTests.swift; sourceTree = "<group>"; };
 		56F0B98E1B6001C600A2F135 /* NSDateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDateTests.swift; sourceTree = "<group>"; };
+		56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultCodeTests.swift; sourceTree = "<group>"; };
 		56FC98771D969DEF00E3C842 /* SQLExpression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLExpression.swift; sourceTree = "<group>"; };
 		56FDECE11BB32DFD009AD709 /* MetalRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetalRowTests.swift; sourceTree = "<group>"; };
 		56FF453F1D2C23BA00F21EF9 /* DeleteByKeyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteByKeyTests.swift; sourceTree = "<group>"; };
@@ -2434,6 +2443,7 @@
 			isa = PBXGroup;
 			children = (
 				56A238161B9C74A90082EB20 /* DatabaseErrorTests.swift */,
+				56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */,
 			);
 			path = DatabaseError;
 			sourceTree = "<group>";
@@ -3751,6 +3761,7 @@
 				560FC5871CB00B880014AA8E /* RecordSubClassTests.swift in Sources */,
 				560FC5891CB00B880014AA8E /* TransactionObserverTests.swift in Sources */,
 				56C3F7541CF9F12400F6A361 /* SavepointTests.swift in Sources */,
+				56F3E74A1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				567A80541D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				560FC58B1CB00B880014AA8E /* DatabaseValueTests.swift in Sources */,
 				567156171CB142AA007DC145 /* ReadOnlyDatabaseTests.swift in Sources */,
@@ -3962,6 +3973,7 @@
 				567A80551D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				567156481CB16729007DC145 /* DatabaseValueTests.swift in Sources */,
 				5671564A1CB16729007DC145 /* ReadOnlyDatabaseTests.swift in Sources */,
+				56F3E74B1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				5671564B1CB16729007DC145 /* Row+FoundationTests.swift in Sources */,
 				56A8C2431D1918EE0096E9D4 /* NSUUIDTests.swift in Sources */,
 				5671564C1CB16729007DC145 /* InMemoryDatabaseTests.swift in Sources */,
@@ -4153,6 +4165,7 @@
 				5698AC851DA380A20056AF8C /* VirtualTableModuleTests.swift in Sources */,
 				5698AC451DA2BED90056AF8C /* FTS3PatternTests.swift in Sources */,
 				56AF74701D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
+				56F3E74E1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				5690C33C1D23E7D200E59934 /* DateTests.swift in Sources */,
 				56AFCA581CB1AA9900F48B96 /* Row+FoundationTests.swift in Sources */,
 				56AFCA5A1CB1AA9900F48B96 /* RecordSubClassTests.swift in Sources */,
@@ -4271,6 +4284,7 @@
 				5698AC461DA2BED90056AF8C /* FTS3PatternTests.swift in Sources */,
 				56AF74711D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
 				56AFCAAE1CB1ABC800F48B96 /* RawRepresentableTests.swift in Sources */,
+				56F3E74F1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				56AFCAAF1CB1ABC800F48B96 /* DatabasePoolConcurrencyTests.swift in Sources */,
 				56AFCAB01CB1ABC800F48B96 /* TransactionObserverTests.swift in Sources */,
 				56AFCAB11CB1ABC800F48B96 /* Row+FoundationTests.swift in Sources */,
@@ -4448,6 +4462,7 @@
 				56EA869F1C932597002BB4DF /* DatabasePoolReadOnlyTests.swift in Sources */,
 				5657AB621D108BA9006283EF /* NSURLTests.swift in Sources */,
 				5657AB6A1D108BA9006283EF /* URLTests.swift in Sources */,
+				56F3E74D1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				56EB0AB31BCD787300A3DC55 /* DataMemoryTests.swift in Sources */,
 				5672DE5C1CDB72520022BA81 /* DatabaseQueueBackupTests.swift in Sources */,
 				56A2385E1B9C74A90082EB20 /* RecordCopyTests.swift in Sources */,
@@ -4565,6 +4580,7 @@
 				56D496601D81304E008276D7 /* NSUUIDTests.swift in Sources */,
 				56D4968D1D81316E008276D7 /* FunctionTests.swift in Sources */,
 				56D496661D813086008276D7 /* QueryInterfaceRequestTests.swift in Sources */,
+				56F3E7491E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				5698ACD71DA925420056AF8C /* RowTestCase.swift in Sources */,
 				56D496831D813147008276D7 /* SavepointTests.swift in Sources */,
 				56D496871D81316E008276D7 /* DatabaseTimestampTests.swift in Sources */,
@@ -4849,6 +4865,7 @@
 				567A805A1D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				F3BA81211CFB3063003DC1BA /* PrimaryKeyNoneTests.swift in Sources */,
 				F3BA80F71CFB3021003DC1BA /* SelectStatementTests.swift in Sources */,
+				56F3E7501E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				F3BA80FE1CFB3024003DC1BA /* TransactionObserverTests.swift in Sources */,
 				F3BA80BA1CFB2FD1003DC1BA /* DatabasePoolCollationTests.swift in Sources */,
 				F3BA80BD1CFB2FD1003DC1BA /* DatabasePoolFunctionTests.swift in Sources */,
@@ -5045,6 +5062,7 @@
 				F3BA81191CFB305F003DC1BA /* QueryInterfaceRequestTests.swift in Sources */,
 				F3BA812F1CFB3064003DC1BA /* PrimaryKeyNoneTests.swift in Sources */,
 				5690C33A1D23E7D200E59934 /* DateTests.swift in Sources */,
+				56F3E74C1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */,
 				F3BA81001CFB3025003DC1BA /* TransactionObserverTests.swift in Sources */,
 				F3BA80C01CFB2FD2003DC1BA /* DatabasePoolCollationTests.swift in Sources */,
 				5698ACA11DA4B0430056AF8C /* FTS4TableBuilderTests.swift in Sources */,

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1635,7 +1635,7 @@ extension Database {
             // TODO: test that isInsideTransaction, savepointStack, transaction
             // observers, etc. are in good shape when such an implicit rollback
             // happens.
-            guard let underlyingError = underlyingError as? DatabaseError, [.SQLITE_FULL, .SQLITE_IOERR, .SQLITE_BUSY, .SQLITE_NOMEM].contains(underlyingError.primaryResultCode) else {
+            guard let underlyingError = underlyingError as? DatabaseError, [.SQLITE_FULL, .SQLITE_IOERR, .SQLITE_BUSY, .SQLITE_NOMEM].contains(underlyingError.resultCode) else {
                 throw error
             }
         }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -960,7 +960,7 @@ extension Database {
             sqlite3_key(sqliteConnection, bytes, Int32(data.count))
         }
         guard code == SQLITE_OK else {
-            throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
     }
 
@@ -979,7 +979,7 @@ extension Database {
             sqlite3_rekey(sqliteConnection, bytes, Int32(data.count))
         }
         guard code == SQLITE_OK else {
-            throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
     }
 }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -311,7 +311,7 @@ public final class Database {
         var sqliteConnection: SQLiteConnection? = nil
         let code = sqlite3_open_v2(path, &sqliteConnection, configuration.SQLiteOpenFlags, nil)
         guard code == SQLITE_OK else {
-            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
         
         do {
@@ -319,7 +319,7 @@ public final class Database {
             do {
                 let code = sqlite3_extended_result_codes(sqliteConnection!, 1)
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+                    throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
                 }
             }
             
@@ -338,7 +338,7 @@ public final class Database {
             do {
                 let code = sqlite3_exec(sqliteConnection, "SELECT * FROM sqlite_master LIMIT 1", nil, nil, nil)
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+                    throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
                 }
             }
         } catch {
@@ -690,7 +690,7 @@ extension Database {
                 var sqliteStatement: SQLiteStatement? = nil
                 let code = sqlite3_prepare_v2(sqliteConnection, statementStart, -1, &sqliteStatement, &statementEnd)
                 guard code == SQLITE_OK else {
-                    error = DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage, sql: sql)
+                    error = DatabaseError(resultCode: code, message: lastErrorMessage, sql: sql)
                     break
                 }
                 
@@ -787,7 +787,7 @@ extension Database {
         
         guard code == SQLITE_OK else {
             // Assume a GRDB bug: there is no point throwing any error.
-            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
+            fatalError(DatabaseError(resultCode: code, message: lastErrorMessage).description)
         }
     }
     
@@ -802,7 +802,7 @@ extension Database {
             nil, nil, nil, nil, nil)
         guard code == SQLITE_OK else {
             // Assume a GRDB bug: there is no point throwing any error.
-            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
+            fatalError(DatabaseError(resultCode: code, message: lastErrorMessage).description)
         }
     }
 }
@@ -891,7 +891,7 @@ extension Database {
             }, nil)
         guard code == SQLITE_OK else {
             // Assume a GRDB bug: there is no point throwing any error.
-            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
+            fatalError(DatabaseError(resultCode: code, message: lastErrorMessage).description)
         }
     }
     
@@ -960,7 +960,7 @@ extension Database {
             sqlite3_key(sqliteConnection, bytes, Int32(data.count))
         }
         guard code == SQLITE_OK else {
-            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
     }
 
@@ -979,7 +979,7 @@ extension Database {
             sqlite3_rekey(sqliteConnection, bytes, Int32(data.count))
         }
         guard code == SQLITE_OK else {
-            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: code, message: lastErrorMessage)
         }
     }
 }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -779,7 +779,7 @@ extension Database {
                     if let message = error.message {
                         sqlite3_result_error(context, message, -1)
                     }
-                    sqlite3_result_error_code(context, error.resultCode.rawValue)
+                    sqlite3_result_error_code(context, error.extendedResultCode.rawValue)
                 } catch {
                     sqlite3_result_error(context, "\(error)", -1)
                 }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -311,7 +311,7 @@ public final class Database {
         var sqliteConnection: SQLiteConnection? = nil
         let code = sqlite3_open_v2(path, &sqliteConnection, configuration.SQLiteOpenFlags, nil)
         guard code == SQLITE_OK else {
-            throw DatabaseError(code: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
         
         do {
@@ -319,7 +319,7 @@ public final class Database {
             do {
                 let code = sqlite3_extended_result_codes(sqliteConnection!, 1)
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(code: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
                 }
             }
             
@@ -338,7 +338,7 @@ public final class Database {
             do {
                 let code = sqlite3_exec(sqliteConnection, "SELECT * FROM sqlite_master LIMIT 1", nil, nil, nil)
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(code: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
                 }
             }
         } catch {
@@ -664,7 +664,7 @@ extension Database {
         }
         let validateRemainingArguments = {
             if !arguments.values.isEmpty {
-                throw DatabaseError(code: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)")
+                throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)")
             }
         }
         
@@ -690,7 +690,7 @@ extension Database {
                 var sqliteStatement: SQLiteStatement? = nil
                 let code = sqlite3_prepare_v2(sqliteConnection, statementStart, -1, &sqliteStatement, &statementEnd)
                 guard code == SQLITE_OK else {
-                    error = DatabaseError(code: ResultCode(rawValue: code), message: lastErrorMessage, sql: sql)
+                    error = DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage, sql: sql)
                     break
                 }
                 
@@ -779,7 +779,7 @@ extension Database {
                     if let message = error.message {
                         sqlite3_result_error(context, message, -1)
                     }
-                    sqlite3_result_error_code(context, error.code.rawValue)
+                    sqlite3_result_error_code(context, error.resultCode.rawValue)
                 } catch {
                     sqlite3_result_error(context, "\(error)", -1)
                 }
@@ -787,7 +787,7 @@ extension Database {
         
         guard code == SQLITE_OK else {
             // Assume a GRDB bug: there is no point throwing any error.
-            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: lastErrorMessage).description)
+            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
         }
     }
     
@@ -802,7 +802,7 @@ extension Database {
             nil, nil, nil, nil, nil)
         guard code == SQLITE_OK else {
             // Assume a GRDB bug: there is no point throwing any error.
-            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: lastErrorMessage).description)
+            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
         }
     }
 }
@@ -891,7 +891,7 @@ extension Database {
             }, nil)
         guard code == SQLITE_OK else {
             // Assume a GRDB bug: there is no point throwing any error.
-            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: lastErrorMessage).description)
+            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
         }
     }
     
@@ -960,7 +960,7 @@ extension Database {
             sqlite3_key(sqliteConnection, bytes, Int32(data.count))
         }
         guard code == SQLITE_OK else {
-            throw DatabaseError(code: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
     }
 
@@ -979,7 +979,7 @@ extension Database {
             sqlite3_rekey(sqliteConnection, bytes, Int32(data.count))
         }
         guard code == SQLITE_OK else {
-            throw DatabaseError(code: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
+            throw DatabaseError(resultCode: code, message: String(cString: sqlite3_errmsg(sqliteConnection)))
         }
     }
 }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -315,6 +315,15 @@ public final class Database {
         }
         
         do {
+            // Use extended result codes
+            do {
+                let code = sqlite3_extended_result_codes(sqliteConnection!, 1)
+                guard code == SQLITE_OK else {
+                    throw DatabaseError(code: ResultCode(rawValue: code), message: String(cString: sqlite3_errmsg(sqliteConnection)))
+                }
+            }
+            
+            // Eventual passphrase
             #if SQLITE_HAS_CODEC
                 if let passphrase = configuration.passphrase {
                     try Database.set(passphrase: passphrase, forConnection: sqliteConnection!)

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -139,7 +139,7 @@ public struct DatabaseError : Error {
     /// The SQLite error code (see
     /// https://www.sqlite.org/rescode.html#primary_result_code_list).
     ///
-    ///     try {
+    ///     do {
     ///         ...
     ///     } catch let error as DatabaseError where error.resultCode == .SQL_CONSTRAINT {
     ///         // A constraint error
@@ -157,7 +157,7 @@ public struct DatabaseError : Error {
     /// The SQLite extended error code (see
     /// https://www.sqlite.org/rescode.html#extended_result_code_list).
     ///
-    ///     try {
+    ///     do {
     ///         ...
     ///     } catch let error as DatabaseError where error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY {
     ///         // A foreign key constraint error

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -34,12 +34,34 @@ public struct ResultCode : RawRepresentable, Equatable, CustomStringConvertible 
         return ResultCode(rawValue: rawValue & 0xFF)
     }
     
+    var isPrimary: Bool {
+        return self == primaryResultCode
+    }
+    
     public var description: String {
         return "\(rawValue) (\(String(cString: sqlite3_errstr(rawValue))))"
     }
     
     public static func == (_ lhs: ResultCode, _ rhs: ResultCode) -> Bool {
         return lhs.rawValue == rhs.rawValue
+    }
+    
+    /// Returns true if the code on the left matches the code on the right.
+    ///
+    /// Primary result codes match themselves and their extended result codes,
+    /// while extended result codes match only themselves:
+    ///
+    ///     switch error.extendedResultCode {
+    ///     case .SQLITE_CONSTRAINT_FOREIGNKEY: // foreign key constraint error
+    ///     case .SQLITE_CONSTRAINT:            // any other constraint error
+    ///     default:                            // any other database error
+    ///     }
+    public static func ~= (pattern: ResultCode, code: ResultCode) -> Bool {
+        if pattern.isPrimary {
+            return pattern == code.primaryResultCode
+        } else {
+            return pattern == code
+        }
     }
     
     public static let SQLITE_OK           = ResultCode(rawValue: 0)   // Successful result

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -132,10 +132,10 @@ public struct ResultCode : RawRepresentable, Equatable, CustomStringConvertible 
 public struct DatabaseError : Error {
     
     /// The SQLite error code (see https://www.sqlite.org/c3ref/c_abort.html).
-    public let code: ResultCode
+    public let resultCode: ResultCode
     
     public var primaryResultCode: ResultCode {
-        return code.primaryResultCode
+        return resultCode.primaryResultCode
     }
     
     /// The SQLite error message.
@@ -144,8 +144,8 @@ public struct DatabaseError : Error {
     /// The SQL query that yielded the error (if relevant).
     public let sql: String?
     
-    public init(code: ResultCode = .SQLITE_ERROR, message: String? = nil, sql: String? = nil, arguments: StatementArguments? = nil) {
-        self.code = code
+    public init(resultCode: ResultCode = .SQLITE_ERROR, message: String? = nil, sql: String? = nil, arguments: StatementArguments? = nil) {
+        self.resultCode = resultCode
         self.message = message
         self.sql = sql
         self.arguments = arguments
@@ -162,7 +162,7 @@ public struct DatabaseError : Error {
 extension DatabaseError: CustomStringConvertible {
     /// A textual representation of `self`.
     public var description: String {
-        var description = "SQLite error \(code.rawValue)"
+        var description = "SQLite error \(resultCode.rawValue)"
         if let sql = sql {
             description += " with statement `\(sql)`"
         }
@@ -185,7 +185,7 @@ extension DatabaseError : CustomNSError {
     
     /// NSError bridging: the error code within the given domain.
     public var errorCode: Int {
-        return Int(code.rawValue)
+        return Int(resultCode.rawValue)
     }
     
     /// NSError bridging: the user-info dictionary.

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -18,11 +18,125 @@ import Foundation
     #endif
 #endif
 
+public struct ResultCode : RawRepresentable, Equatable, CustomStringConvertible {
+    public let rawValue: Int32
+    
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+    
+    public var primaryResultCode: ResultCode {
+        return ResultCode(rawValue: rawValue & 0xFF)
+    }
+    
+    public var description: String {
+        return "\(rawValue) (\(String(cString: sqlite3_errstr(rawValue))))"
+    }
+    
+    public static func == (_ lhs: ResultCode, _ rhs: ResultCode) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+    
+    public static let SQLITE_OK           = ResultCode(rawValue: 0)   // Successful result
+    public static let SQLITE_ERROR        = ResultCode(rawValue: 1)   // SQL error or missing database
+    public static let SQLITE_INTERNAL     = ResultCode(rawValue: 2)   // Internal logic error in SQLite
+    public static let SQLITE_PERM         = ResultCode(rawValue: 3)   // Access permission denied
+    public static let SQLITE_ABORT        = ResultCode(rawValue: 4)   // Callback routine requested an abort
+    public static let SQLITE_BUSY         = ResultCode(rawValue: 5)   // The database file is locked
+    public static let SQLITE_LOCKED       = ResultCode(rawValue: 6)   // A table in the database is locked
+    public static let SQLITE_NOMEM        = ResultCode(rawValue: 7)   // A malloc() failed
+    public static let SQLITE_READONLY     = ResultCode(rawValue: 8)   // Attempt to write a readonly database
+    public static let SQLITE_INTERRUPT    = ResultCode(rawValue: 9)   // Operation terminated by sqlite3_interrupt()
+    public static let SQLITE_IOERR        = ResultCode(rawValue: 10)  // Some kind of disk I/O error occurred
+    public static let SQLITE_CORRUPT      = ResultCode(rawValue: 11)  // The database disk image is malformed
+    public static let SQLITE_NOTFOUND     = ResultCode(rawValue: 12)  // Unknown opcode in sqlite3_file_control()
+    public static let SQLITE_FULL         = ResultCode(rawValue: 13)  // Insertion failed because database is full
+    public static let SQLITE_CANTOPEN     = ResultCode(rawValue: 14)  // Unable to open the database file
+    public static let SQLITE_PROTOCOL     = ResultCode(rawValue: 15)  // Database lock protocol error
+    public static let SQLITE_EMPTY        = ResultCode(rawValue: 16)  // Database is empty
+    public static let SQLITE_SCHEMA       = ResultCode(rawValue: 17)  // The database schema changed
+    public static let SQLITE_TOOBIG       = ResultCode(rawValue: 18)  // String or BLOB exceeds size limit
+    public static let SQLITE_CONSTRAINT   = ResultCode(rawValue: 19)  // Abort due to constraint violation
+    public static let SQLITE_MISMATCH     = ResultCode(rawValue: 20)  // Data type mismatch
+    public static let SQLITE_MISUSE       = ResultCode(rawValue: 21)  // Library used incorrectly
+    public static let SQLITE_NOLFS        = ResultCode(rawValue: 22)  // Uses OS features not supported on host
+    public static let SQLITE_AUTH         = ResultCode(rawValue: 23)  // Authorization denied
+    public static let SQLITE_FORMAT       = ResultCode(rawValue: 24)  // Auxiliary database format error
+    public static let SQLITE_RANGE        = ResultCode(rawValue: 25)  // 2nd parameter to sqlite3_bind out of range
+    public static let SQLITE_NOTADB       = ResultCode(rawValue: 26)  // File opened that is not a database file
+    public static let SQLITE_NOTICE       = ResultCode(rawValue: 27)  // Notifications from sqlite3_log()
+    public static let SQLITE_WARNING      = ResultCode(rawValue: 28)  // Warnings from sqlite3_log()
+    public static let SQLITE_ROW          = ResultCode(rawValue: 100) // sqlite3_step() has another row ready
+    public static let SQLITE_DONE         = ResultCode(rawValue: 101) // sqlite3_step() has finished executing
+    
+    public static let SQLITE_IOERR_READ              = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (1<<8)))
+    public static let SQLITE_IOERR_SHORT_READ        = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (2<<8)))
+    public static let SQLITE_IOERR_WRITE             = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (3<<8)))
+    public static let SQLITE_IOERR_FSYNC             = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (4<<8)))
+    public static let SQLITE_IOERR_DIR_FSYNC         = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (5<<8)))
+    public static let SQLITE_IOERR_TRUNCATE          = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (6<<8)))
+    public static let SQLITE_IOERR_FSTAT             = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (7<<8)))
+    public static let SQLITE_IOERR_UNLOCK            = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (8<<8)))
+    public static let SQLITE_IOERR_RDLOCK            = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (9<<8)))
+    public static let SQLITE_IOERR_DELETE            = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (10<<8)))
+    public static let SQLITE_IOERR_BLOCKED           = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (11<<8)))
+    public static let SQLITE_IOERR_NOMEM             = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (12<<8)))
+    public static let SQLITE_IOERR_ACCESS            = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (13<<8)))
+    public static let SQLITE_IOERR_CHECKRESERVEDLOCK = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (14<<8)))
+    public static let SQLITE_IOERR_LOCK              = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (15<<8)))
+    public static let SQLITE_IOERR_CLOSE             = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (16<<8)))
+    public static let SQLITE_IOERR_DIR_CLOSE         = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (17<<8)))
+    public static let SQLITE_IOERR_SHMOPEN           = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (18<<8)))
+    public static let SQLITE_IOERR_SHMSIZE           = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (19<<8)))
+    public static let SQLITE_IOERR_SHMLOCK           = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (20<<8)))
+    public static let SQLITE_IOERR_SHMMAP            = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (21<<8)))
+    public static let SQLITE_IOERR_SEEK              = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (22<<8)))
+    public static let SQLITE_IOERR_DELETE_NOENT      = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (23<<8)))
+    public static let SQLITE_IOERR_MMAP              = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (24<<8)))
+    public static let SQLITE_IOERR_GETTEMPPATH       = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (25<<8)))
+    public static let SQLITE_IOERR_CONVPATH          = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (26<<8)))
+    public static let SQLITE_IOERR_VNODE             = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (27<<8)))
+    public static let SQLITE_IOERR_AUTH              = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (28<<8)))
+    public static let SQLITE_LOCKED_SHAREDCACHE      = ResultCode(rawValue: (SQLITE_LOCKED.rawValue |  (1<<8)))
+    public static let SQLITE_BUSY_RECOVERY           = ResultCode(rawValue: (SQLITE_BUSY.rawValue |  (1<<8)))
+    public static let SQLITE_BUSY_SNAPSHOT           = ResultCode(rawValue: (SQLITE_BUSY.rawValue |  (2<<8)))
+    public static let SQLITE_CANTOPEN_NOTEMPDIR      = ResultCode(rawValue: (SQLITE_CANTOPEN.rawValue | (1<<8)))
+    public static let SQLITE_CANTOPEN_ISDIR          = ResultCode(rawValue: (SQLITE_CANTOPEN.rawValue | (2<<8)))
+    public static let SQLITE_CANTOPEN_FULLPATH       = ResultCode(rawValue: (SQLITE_CANTOPEN.rawValue | (3<<8)))
+    public static let SQLITE_CANTOPEN_CONVPATH       = ResultCode(rawValue: (SQLITE_CANTOPEN.rawValue | (4<<8)))
+    public static let SQLITE_CORRUPT_VTAB            = ResultCode(rawValue: (SQLITE_CORRUPT.rawValue | (1<<8)))
+    public static let SQLITE_READONLY_RECOVERY       = ResultCode(rawValue: (SQLITE_READONLY.rawValue | (1<<8)))
+    public static let SQLITE_READONLY_CANTLOCK       = ResultCode(rawValue: (SQLITE_READONLY.rawValue | (2<<8)))
+    public static let SQLITE_READONLY_ROLLBACK       = ResultCode(rawValue: (SQLITE_READONLY.rawValue | (3<<8)))
+    public static let SQLITE_READONLY_DBMOVED        = ResultCode(rawValue: (SQLITE_READONLY.rawValue | (4<<8)))
+    public static let SQLITE_ABORT_ROLLBACK          = ResultCode(rawValue: (SQLITE_ABORT.rawValue | (2<<8)))
+    public static let SQLITE_CONSTRAINT_CHECK        = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (1<<8)))
+    public static let SQLITE_CONSTRAINT_COMMITHOOK   = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (2<<8)))
+    public static let SQLITE_CONSTRAINT_FOREIGNKEY   = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (3<<8)))
+    public static let SQLITE_CONSTRAINT_FUNCTION     = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (4<<8)))
+    public static let SQLITE_CONSTRAINT_NOTNULL      = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (5<<8)))
+    public static let SQLITE_CONSTRAINT_PRIMARYKEY   = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (6<<8)))
+    public static let SQLITE_CONSTRAINT_TRIGGER      = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (7<<8)))
+    public static let SQLITE_CONSTRAINT_UNIQUE       = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (8<<8)))
+    public static let SQLITE_CONSTRAINT_VTAB         = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (9<<8)))
+    public static let SQLITE_CONSTRAINT_ROWID        = ResultCode(rawValue: (SQLITE_CONSTRAINT.rawValue | (10<<8)))
+    public static let SQLITE_NOTICE_RECOVER_WAL      = ResultCode(rawValue: (SQLITE_NOTICE.rawValue | (1<<8)))
+    public static let SQLITE_NOTICE_RECOVER_ROLLBACK = ResultCode(rawValue: (SQLITE_NOTICE.rawValue | (2<<8)))
+    public static let SQLITE_WARNING_AUTOINDEX       = ResultCode(rawValue: (SQLITE_WARNING.rawValue | (1<<8)))
+    public static let SQLITE_AUTH_USER               = ResultCode(rawValue: (SQLITE_AUTH.rawValue | (1<<8)))
+    public static let SQLITE_OK_LOAD_PERMANENTLY     = ResultCode(rawValue: (SQLITE_OK.rawValue | (1<<8)))
+
+}
+
 /// DatabaseError wraps an SQLite error.
 public struct DatabaseError : Error {
     
     /// The SQLite error code (see https://www.sqlite.org/c3ref/c_abort.html).
-    public let code: Int32
+    public let code: ResultCode
+    
+    public var primaryResultCode: ResultCode {
+        return code.primaryResultCode
+    }
     
     /// The SQLite error message.
     public let message: String?
@@ -30,7 +144,7 @@ public struct DatabaseError : Error {
     /// The SQL query that yielded the error (if relevant).
     public let sql: String?
     
-    public init(code: Int32 = SQLITE_ERROR, message: String? = nil, sql: String? = nil, arguments: StatementArguments? = nil) {
+    public init(code: ResultCode = .SQLITE_ERROR, message: String? = nil, sql: String? = nil, arguments: StatementArguments? = nil) {
         self.code = code
         self.message = message
         self.sql = sql
@@ -48,7 +162,7 @@ public struct DatabaseError : Error {
 extension DatabaseError: CustomStringConvertible {
     /// A textual representation of `self`.
     public var description: String {
-        var description = "SQLite error \(code)"
+        var description = "SQLite error \(code.rawValue)"
         if let sql = sql {
             description += " with statement `\(sql)`"
         }
@@ -71,7 +185,7 @@ extension DatabaseError : CustomNSError {
     
     /// NSError bridging: the error code within the given domain.
     public var errorCode: Int {
-        return Int(code)
+        return Int(code.rawValue)
     }
     
     /// NSError bridging: the user-info dictionary.

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -64,6 +64,9 @@ public struct ResultCode : RawRepresentable, Equatable, CustomStringConvertible 
         }
     }
     
+    // Primary Result codes
+    // https://www.sqlite.org/rescode.html#primary_result_code_list
+    
     public static let SQLITE_OK           = ResultCode(rawValue: 0)   // Successful result
     public static let SQLITE_ERROR        = ResultCode(rawValue: 1)   // SQL error or missing database
     public static let SQLITE_INTERNAL     = ResultCode(rawValue: 2)   // Internal logic error in SQLite
@@ -95,6 +98,9 @@ public struct ResultCode : RawRepresentable, Equatable, CustomStringConvertible 
     public static let SQLITE_WARNING      = ResultCode(rawValue: 28)  // Warnings from sqlite3_log()
     public static let SQLITE_ROW          = ResultCode(rawValue: 100) // sqlite3_step() has another row ready
     public static let SQLITE_DONE         = ResultCode(rawValue: 101) // sqlite3_step() has finished executing
+    
+    // Extended Result Code
+    // https://www.sqlite.org/rescode.html#extended_result_code_list
     
     public static let SQLITE_IOERR_READ              = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (1<<8)))
     public static let SQLITE_IOERR_SHORT_READ        = ResultCode(rawValue: (SQLITE_IOERR.rawValue | (2<<8)))

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -200,6 +200,7 @@ public struct DatabaseError : Error {
     /// The SQL query that yielded the error (if relevant).
     public let sql: String?
     
+    /// Creates a Database Error
     public init(resultCode: ResultCode = .SQLITE_ERROR, message: String? = nil, sql: String? = nil, arguments: StatementArguments? = nil) {
         self.extendedResultCode = resultCode
         self.message = message
@@ -207,6 +208,13 @@ public struct DatabaseError : Error {
         self.arguments = arguments
     }
     
+    /// Creates a Database Error with a raw Int32 result code.
+    ///
+    /// This initializer is not public because library user is not supposed to
+    /// be exposed to raw result codes.
+    init(resultCode: Int32, message: String? = nil, sql: String? = nil, arguments: StatementArguments? = nil) {
+        self.init(resultCode: ResultCode(rawValue: resultCode), message: message, sql: sql, arguments: arguments)
+    }
     
     // MARK: Not public
     

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -133,7 +133,7 @@ public final class DatabasePool {
             // when kind is not .Passive.
             let code = sqlite3_wal_checkpoint_v2(db.sqliteConnection, nil, kind.rawValue, nil, nil)
             guard code == SQLITE_OK else {
-                throw DatabaseError(code: code, message: db.lastErrorMessage, sql: nil)
+                throw DatabaseError(code: ResultCode(rawValue: code), message: db.lastErrorMessage, sql: nil)
             }
         }
     }

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -133,7 +133,7 @@ public final class DatabasePool {
             // when kind is not .Passive.
             let code = sqlite3_wal_checkpoint_v2(db.sqliteConnection, nil, kind.rawValue, nil, nil)
             guard code == SQLITE_OK else {
-                throw DatabaseError(code: ResultCode(rawValue: code), message: db.lastErrorMessage, sql: nil)
+                throw DatabaseError(resultCode: ResultCode(rawValue: code), message: db.lastErrorMessage, sql: nil)
             }
         }
     }

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -133,7 +133,7 @@ public final class DatabasePool {
             // when kind is not .Passive.
             let code = sqlite3_wal_checkpoint_v2(db.sqliteConnection, nil, kind.rawValue, nil, nil)
             guard code == SQLITE_OK else {
-                throw DatabaseError(resultCode: ResultCode(rawValue: code), message: db.lastErrorMessage, sql: nil)
+                throw DatabaseError(resultCode: code, message: db.lastErrorMessage, sql: nil)
             }
         }
     }

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -141,10 +141,10 @@ extension DatabaseReader {
         try read { dbFrom in
             try writer.write { dbDest in
                 guard let backup = sqlite3_backup_init(dbDest.sqliteConnection, "main", dbFrom.sqliteConnection, "main") else {
-                    throw DatabaseError(code: dbDest.lastErrorCode, message: dbDest.lastErrorMessage)
+                    throw DatabaseError(resultCode: dbDest.lastErrorCode, message: dbDest.lastErrorMessage)
                 }
                 guard Int(bitPattern: backup) != Int(SQLITE_ERROR) else {
-                    throw DatabaseError(code: .SQLITE_ERROR)
+                    throw DatabaseError(resultCode: .SQLITE_ERROR)
                 }
                 
                 afterBackupInit?()
@@ -158,7 +158,7 @@ extension DatabaseReader {
                         case SQLITE_OK:
                             afterBackupStep?()
                         case let code:
-                            throw DatabaseError(code: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
+                            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
                         }
                     }
                 } catch {
@@ -170,7 +170,7 @@ extension DatabaseReader {
                 case SQLITE_OK:
                     break
                 case let code:
-                    throw DatabaseError(code: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
+                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
                 }
                 
                 dbDest.clearSchemaCache()

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -158,7 +158,7 @@ extension DatabaseReader {
                         case SQLITE_OK:
                             afterBackupStep?()
                         case let code:
-                            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
+                            throw DatabaseError(resultCode: code, message: dbDest.lastErrorMessage)
                         }
                     }
                 } catch {
@@ -170,7 +170,7 @@ extension DatabaseReader {
                 case SQLITE_OK:
                     break
                 case let code:
-                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
+                    throw DatabaseError(resultCode: code, message: dbDest.lastErrorMessage)
                 }
                 
                 dbDest.clearSchemaCache()

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -144,7 +144,7 @@ extension DatabaseReader {
                     throw DatabaseError(code: dbDest.lastErrorCode, message: dbDest.lastErrorMessage)
                 }
                 guard Int(bitPattern: backup) != Int(SQLITE_ERROR) else {
-                    throw DatabaseError(code: SQLITE_ERROR)
+                    throw DatabaseError(code: .SQLITE_ERROR)
                 }
                 
                 afterBackupInit?()
@@ -158,7 +158,7 @@ extension DatabaseReader {
                         case SQLITE_OK:
                             afterBackupStep?()
                         case let code:
-                            throw DatabaseError(code: code, message: dbDest.lastErrorMessage)
+                            throw DatabaseError(code: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
                         }
                     }
                 } catch {
@@ -170,7 +170,7 @@ extension DatabaseReader {
                 case SQLITE_OK:
                     break
                 case let code:
-                    throw DatabaseError(code: code, message: dbDest.lastErrorMessage)
+                    throw DatabaseError(code: ResultCode(rawValue: code), message: dbDest.lastErrorMessage)
                 }
                 
                 dbDest.clearSchemaCache()

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -121,7 +121,7 @@ extension DatabaseValueConvertible {
             if let value = Self.fromDatabaseValue(dbv) {
                 return value
             } else {
-                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(resultCode: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
             }
         }
     }
@@ -165,7 +165,7 @@ extension DatabaseValueConvertible {
             } else if dbv.isNull {
                 return nil
             } else {
-                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(resultCode: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
             }
         }
         return try cursor.next() ?? nil
@@ -336,7 +336,7 @@ extension Optional where Wrapped: DatabaseValueConvertible {
             } else if dbv.isNull {
                 return nil
             } else {
-                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Wrapped.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(resultCode: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Wrapped.self)", sql: statement.sql, arguments: arguments)
             }
         }
     }

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -121,7 +121,7 @@ extension DatabaseValueConvertible {
             if let value = Self.fromDatabaseValue(dbv) {
                 return value
             } else {
-                throw DatabaseError(code: SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
             }
         }
     }
@@ -165,7 +165,7 @@ extension DatabaseValueConvertible {
             } else if dbv.isNull {
                 return nil
             } else {
-                throw DatabaseError(code: SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Self.self)", sql: statement.sql, arguments: arguments)
             }
         }
         return try cursor.next() ?? nil
@@ -336,7 +336,7 @@ extension Optional where Wrapped: DatabaseValueConvertible {
             } else if dbv.isNull {
                 return nil
             } else {
-                throw DatabaseError(code: SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Wrapped.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value \(dbv) to \(Wrapped.self)", sql: statement.sql, arguments: arguments)
             }
         }
     }

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -208,7 +208,7 @@ public struct ColumnMapping : RowAdapter {
             .map { (mappedColumn, baseColumn) -> (Int, String) in
                 guard let index = layout.layoutIndex(ofColumn: baseColumn) else {
                     let columnNames = layout.layoutColumns.map { $0.1 }
-                    throw DatabaseError(code: .SQLITE_MISUSE, message: "Mapping references missing column \(baseColumn). Valid column names are: \(columnNames.joined(separator: ", ")).")
+                    throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "Mapping references missing column \(baseColumn). Valid column names are: \(columnNames.joined(separator: ", ")).")
                 }
                 let baseIndex = layout.layoutColumns[index].0
                 return (baseIndex, mappedColumn)

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -208,7 +208,7 @@ public struct ColumnMapping : RowAdapter {
             .map { (mappedColumn, baseColumn) -> (Int, String) in
                 guard let index = layout.layoutIndex(ofColumn: baseColumn) else {
                     let columnNames = layout.layoutColumns.map { $0.1 }
-                    throw DatabaseError(code: SQLITE_MISUSE, message: "Mapping references missing column \(baseColumn). Valid column names are: \(columnNames.joined(separator: ", ")).")
+                    throw DatabaseError(code: .SQLITE_MISUSE, message: "Mapping references missing column \(baseColumn). Valid column names are: \(columnNames.joined(separator: ", ")).")
                 }
                 let baseIndex = layout.layoutColumns[index].0
                 return (baseIndex, mappedColumn)

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -62,12 +62,12 @@ public class Statement {
         }
         
         guard code == SQLITE_OK else {
-            throw DatabaseError(code: code, message: database.lastErrorMessage, sql: sql)
+            throw DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql)
         }
         
         guard remainingSQL.isEmpty else {
             sqlite3_finalize(sqliteStatement)
-            throw DatabaseError(code: SQLITE_MISUSE, message: "Multiple statements found. To execute multiple statements, use Database.execute() instead.", sql: sql, arguments: nil)
+            throw DatabaseError(code: .SQLITE_MISUSE, message: "Multiple statements found. To execute multiple statements, use Database.execute() instead.", sql: sql, arguments: nil)
         }
         
         self.database = database
@@ -86,7 +86,7 @@ public class Statement {
         // throwing any error.
         let code = sqlite3_reset(sqliteStatement)
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(code: code, message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
         }
     }
     
@@ -183,7 +183,7 @@ public class Statement {
         // It looks like sqlite3_bind_xxx() functions do not access the file system.
         // They should thus succeed, unless a GRDB bug: there is no point throwing any error.
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(code: code, message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
         }
     }
     
@@ -194,7 +194,7 @@ public class Statement {
         // no point throwing any error.
         let code = sqlite3_clear_bindings(sqliteStatement)
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(code: code, message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
         }
     }
 
@@ -327,7 +327,7 @@ public final class DatabaseCursor<Element> : Cursor {
             return try element()
         case let errorCode:
             statement.database.selectStatementDidFail(statement)
-            throw DatabaseError(code: errorCode, message: statement.database.lastErrorMessage, sql: statement.sql, arguments: statement.arguments)
+            throw DatabaseError(code: ResultCode(rawValue: errorCode), message: statement.database.lastErrorMessage, sql: statement.sql, arguments: statement.arguments)
         }
     }
 }
@@ -432,7 +432,7 @@ public final class UpdateStatement : Statement {
                 // Let database rethrow eventual transaction observer error:
                 try database.updateStatementDidFail(self)
                 
-                throw DatabaseError(code: errorCode, message: database.lastErrorMessage, sql: sql, arguments: self.arguments) // Error uses self.arguments, not the optional arguments parameter.
+                throw DatabaseError(code: ResultCode(rawValue: errorCode), message: database.lastErrorMessage, sql: sql, arguments: self.arguments) // Error uses self.arguments, not the optional arguments parameter.
             }
         }
     }
@@ -778,20 +778,20 @@ public struct StatementArguments {
                 if let databaseValue = namedValues[argumentName] {
                     return databaseValue
                 } else if values.isEmpty {
-                    throw DatabaseError(code: SQLITE_MISUSE, message: "missing statement argument: \(argumentName)", sql: statement.sql, arguments: nil)
+                    throw DatabaseError(code: .SQLITE_MISUSE, message: "missing statement argument: \(argumentName)", sql: statement.sql, arguments: nil)
                 } else {
                     return values.removeFirst()
                 }
             } else {
                 if values.isEmpty {
-                    throw DatabaseError(code: SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
+                    throw DatabaseError(code: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
                 } else {
                     return values.removeFirst()
                 }
             }
         }
         if !allowingRemainingValues && !values.isEmpty {
-            throw DatabaseError(code: SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
+            throw DatabaseError(code: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
         }
         return bindings
     }

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -62,7 +62,7 @@ public class Statement {
         }
         
         guard code == SQLITE_OK else {
-            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql)
+            throw DatabaseError(resultCode: code, message: database.lastErrorMessage, sql: sql)
         }
         
         guard remainingSQL.isEmpty else {
@@ -86,7 +86,7 @@ public class Statement {
         // throwing any error.
         let code = sqlite3_reset(sqliteStatement)
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(resultCode: code, message: database.lastErrorMessage, sql: sql).description)
         }
     }
     
@@ -183,7 +183,7 @@ public class Statement {
         // It looks like sqlite3_bind_xxx() functions do not access the file system.
         // They should thus succeed, unless a GRDB bug: there is no point throwing any error.
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(resultCode: code, message: database.lastErrorMessage, sql: sql).description)
         }
     }
     
@@ -194,7 +194,7 @@ public class Statement {
         // no point throwing any error.
         let code = sqlite3_clear_bindings(sqliteStatement)
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(resultCode: code, message: database.lastErrorMessage, sql: sql).description)
         }
     }
 
@@ -325,9 +325,9 @@ public final class DatabaseCursor<Element> : Cursor {
             return nil
         case SQLITE_ROW:
             return try element()
-        case let errorCode:
+        case let code:
             statement.database.selectStatementDidFail(statement)
-            throw DatabaseError(resultCode: ResultCode(rawValue: errorCode), message: statement.database.lastErrorMessage, sql: statement.sql, arguments: statement.arguments)
+            throw DatabaseError(resultCode: code, message: statement.database.lastErrorMessage, sql: statement.sql, arguments: statement.arguments)
         }
     }
 }
@@ -426,13 +426,13 @@ public final class UpdateStatement : Statement {
                 database.updateStatementDidExecute(self)
                 return
                 
-            case let errorCode:
+            case let code:
                 // Failure
                 //
                 // Let database rethrow eventual transaction observer error:
                 try database.updateStatementDidFail(self)
                 
-                throw DatabaseError(resultCode: ResultCode(rawValue: errorCode), message: database.lastErrorMessage, sql: sql, arguments: self.arguments) // Error uses self.arguments, not the optional arguments parameter.
+                throw DatabaseError(resultCode: code, message: database.lastErrorMessage, sql: sql, arguments: self.arguments) // Error uses self.arguments, not the optional arguments parameter.
             }
         }
     }

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -62,12 +62,12 @@ public class Statement {
         }
         
         guard code == SQLITE_OK else {
-            throw DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql)
+            throw DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql)
         }
         
         guard remainingSQL.isEmpty else {
             sqlite3_finalize(sqliteStatement)
-            throw DatabaseError(code: .SQLITE_MISUSE, message: "Multiple statements found. To execute multiple statements, use Database.execute() instead.", sql: sql, arguments: nil)
+            throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "Multiple statements found. To execute multiple statements, use Database.execute() instead.", sql: sql, arguments: nil)
         }
         
         self.database = database
@@ -86,7 +86,7 @@ public class Statement {
         // throwing any error.
         let code = sqlite3_reset(sqliteStatement)
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
         }
     }
     
@@ -183,7 +183,7 @@ public class Statement {
         // It looks like sqlite3_bind_xxx() functions do not access the file system.
         // They should thus succeed, unless a GRDB bug: there is no point throwing any error.
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
         }
     }
     
@@ -194,7 +194,7 @@ public class Statement {
         // no point throwing any error.
         let code = sqlite3_clear_bindings(sqliteStatement)
         guard code == SQLITE_OK else {
-            fatalError(DatabaseError(code: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
+            fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: database.lastErrorMessage, sql: sql).description)
         }
     }
 
@@ -327,7 +327,7 @@ public final class DatabaseCursor<Element> : Cursor {
             return try element()
         case let errorCode:
             statement.database.selectStatementDidFail(statement)
-            throw DatabaseError(code: ResultCode(rawValue: errorCode), message: statement.database.lastErrorMessage, sql: statement.sql, arguments: statement.arguments)
+            throw DatabaseError(resultCode: ResultCode(rawValue: errorCode), message: statement.database.lastErrorMessage, sql: statement.sql, arguments: statement.arguments)
         }
     }
 }
@@ -432,7 +432,7 @@ public final class UpdateStatement : Statement {
                 // Let database rethrow eventual transaction observer error:
                 try database.updateStatementDidFail(self)
                 
-                throw DatabaseError(code: ResultCode(rawValue: errorCode), message: database.lastErrorMessage, sql: sql, arguments: self.arguments) // Error uses self.arguments, not the optional arguments parameter.
+                throw DatabaseError(resultCode: ResultCode(rawValue: errorCode), message: database.lastErrorMessage, sql: sql, arguments: self.arguments) // Error uses self.arguments, not the optional arguments parameter.
             }
         }
     }
@@ -778,20 +778,20 @@ public struct StatementArguments {
                 if let databaseValue = namedValues[argumentName] {
                     return databaseValue
                 } else if values.isEmpty {
-                    throw DatabaseError(code: .SQLITE_MISUSE, message: "missing statement argument: \(argumentName)", sql: statement.sql, arguments: nil)
+                    throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "missing statement argument: \(argumentName)", sql: statement.sql, arguments: nil)
                 } else {
                     return values.removeFirst()
                 }
             } else {
                 if values.isEmpty {
-                    throw DatabaseError(code: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
+                    throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
                 } else {
                     return values.removeFirst()
                 }
             }
         }
         if !allowingRemainingValues && !values.isEmpty {
-            throw DatabaseError(code: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
+            throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)", sql: statement.sql, arguments: nil)
         }
         return bindings
     }

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -77,7 +77,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         let sqliteStatement = statement.sqliteStatement
         return statement.fetchCursor(arguments: arguments) {
             if sqlite3_column_type(sqliteStatement, columnIndex) == SQLITE_NULL {
-                throw DatabaseError(code: SQLITE_ERROR, message: "could not convert database value NULL to \(Self.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value NULL to \(Self.self)", sql: statement.sql, arguments: arguments)
             }
             return Self.init(sqliteStatement: sqliteStatement, index: columnIndex)
         }

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -77,7 +77,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         let sqliteStatement = statement.sqliteStatement
         return statement.fetchCursor(arguments: arguments) {
             if sqlite3_column_type(sqliteStatement, columnIndex) == SQLITE_NULL {
-                throw DatabaseError(code: .SQLITE_ERROR, message: "could not convert database value NULL to \(Self.self)", sql: statement.sql, arguments: arguments)
+                throw DatabaseError(resultCode: .SQLITE_ERROR, message: "could not convert database value NULL to \(Self.self)", sql: statement.sql, arguments: arguments)
             }
             return Self.init(sqliteStatement: sqliteStatement, index: columnIndex)
         }

--- a/GRDB/FTS/FTS3Pattern.swift
+++ b/GRDB/FTS/FTS3Pattern.swift
@@ -24,7 +24,7 @@ public struct FTS3Pattern {
             }
         } catch let error as DatabaseError {
             // Remove private SQL & arguments from the thrown error
-            throw DatabaseError(resultCode: error.resultCode, message: error.message, sql: nil, arguments: nil)
+            throw DatabaseError(resultCode: error.extendedResultCode, message: error.message, sql: nil, arguments: nil)
         }
         
         // Pattern is valid

--- a/GRDB/FTS/FTS3Pattern.swift
+++ b/GRDB/FTS/FTS3Pattern.swift
@@ -24,7 +24,7 @@ public struct FTS3Pattern {
             }
         } catch let error as DatabaseError {
             // Remove private SQL & arguments from the thrown error
-            throw DatabaseError(code: error.code, message: error.message, sql: nil, arguments: nil)
+            throw DatabaseError(resultCode: error.resultCode, message: error.message, sql: nil, arguments: nil)
         }
         
         // Pattern is valid

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -134,7 +134,7 @@
             }
             guard code == SQLITE_OK else {
                 // Assume a GRDB bug: there is no point throwing any error.
-                fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
+                fatalError(DatabaseError(resultCode: code, message: lastErrorMessage).description)
             }
         }
     }

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -81,7 +81,7 @@
                         tokenizerHandle.pointee = tokenizerPointer
                         return SQLITE_OK
                     } catch let error as DatabaseError {
-                        return error.code
+                        return error.extendedResultCode.rawValue
                     } catch {
                         return SQLITE_ERROR
                     }
@@ -134,7 +134,7 @@
             }
             guard code == SQLITE_OK else {
                 // Assume a GRDB bug: there is no point throwing any error.
-                fatalError(DatabaseError(resultCode: code, message: lastErrorMessage).description)
+                fatalError(DatabaseError(resultCode: ResultCode(rawValue: code), message: lastErrorMessage).description)
             }
         }
     }

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -134,7 +134,7 @@
             }
             guard code == SQLITE_OK else {
                 // Assume a GRDB bug: there is no point throwing any error.
-                fatalError(DatabaseError(code: code, message: lastErrorMessage).description)
+                fatalError(DatabaseError(resultCode: code, message: lastErrorMessage).description)
             }
         }
     }

--- a/GRDB/FTS/FTS5Pattern.swift
+++ b/GRDB/FTS/FTS5Pattern.swift
@@ -67,7 +67,7 @@
                 }
             } catch let error as DatabaseError {
                 // Remove private SQL & arguments from the thrown error
-                throw DatabaseError(code: error.code, message: error.message, sql: nil, arguments: nil)
+                throw DatabaseError(resultCode: error.code, message: error.message, sql: nil, arguments: nil)
             }
             
             // Pattern is valid

--- a/GRDB/FTS/FTS5Pattern.swift
+++ b/GRDB/FTS/FTS5Pattern.swift
@@ -67,7 +67,7 @@
                 }
             } catch let error as DatabaseError {
                 // Remove private SQL & arguments from the thrown error
-                throw DatabaseError(resultCode: error.code, message: error.message, sql: nil, arguments: nil)
+                throw DatabaseError(resultCode: error.extendedResultCode, message: error.message, sql: nil, arguments: nil)
             }
             
             // Pattern is valid

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -116,7 +116,7 @@
             
             init(xTokenizer: fts5_tokenizer, contextPointer: UnsafeMutableRawPointer?, arguments: [String]) throws {
                 guard let xCreate = xTokenizer.xCreate else {
-                    throw DatabaseError(code: SQLITE_ERROR, message: "nil fts5_tokenizer.xCreate")
+                    throw DatabaseError(code: .SQLITE_ERROR, message: "nil fts5_tokenizer.xCreate")
                 }
                 
                 self.xTokenizer = xTokenizer
@@ -189,7 +189,7 @@
         ///     }
         public func makeTokenizer(_ descriptor: FTS5TokenizerDescriptor) throws -> FTS5Tokenizer {
             guard let api = FTS5.api(self) else {
-                throw DatabaseError(code: SQLITE_MISUSE, message: "FTS5 API not found")
+                throw DatabaseError(code: .SQLITE_MISUSE, message: "FTS5 API not found")
             }
             
             let xTokenizerPointer: UnsafeMutablePointer<fts5_tokenizer> = .allocate(capacity: 1)

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -87,7 +87,7 @@
                         return SQLITE_OK
                     })
                     if (code != SQLITE_OK) {
-                        throw DatabaseError(code: code)
+                        throw DatabaseError(resultCode: code)
                     }
                 }
                 return context.tokens
@@ -116,7 +116,7 @@
             
             init(xTokenizer: fts5_tokenizer, contextPointer: UnsafeMutableRawPointer?, arguments: [String]) throws {
                 guard let xCreate = xTokenizer.xCreate else {
-                    throw DatabaseError(code: .SQLITE_ERROR, message: "nil fts5_tokenizer.xCreate")
+                    throw DatabaseError(resultCode: .SQLITE_ERROR, message: "nil fts5_tokenizer.xCreate")
                 }
                 
                 self.xTokenizer = xTokenizer
@@ -147,13 +147,13 @@
                 }
                 
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(code: code, message: "failed fts5_tokenizer.xCreate")
+                    throw DatabaseError(resultCode: code, message: "failed fts5_tokenizer.xCreate")
                 }
                 
                 if let tokenizerPointer = tokenizerPointer {
                     self.tokenizerPointer = tokenizerPointer
                 } else {
-                    throw DatabaseError(code: code, message: "nil tokenizer")
+                    throw DatabaseError(resultCode: code, message: "nil tokenizer")
                 }
             }
             
@@ -189,7 +189,7 @@
         ///     }
         public func makeTokenizer(_ descriptor: FTS5TokenizerDescriptor) throws -> FTS5Tokenizer {
             guard let api = FTS5.api(self) else {
-                throw DatabaseError(code: .SQLITE_MISUSE, message: "FTS5 API not found")
+                throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "FTS5 API not found")
             }
             
             let xTokenizerPointer: UnsafeMutablePointer<fts5_tokenizer> = .allocate(capacity: 1)
@@ -205,7 +205,7 @@
                 xTokenizerPointer)
             
             guard code == SQLITE_OK else {
-                throw DatabaseError(code: code)
+                throw DatabaseError(resultCode: code)
             }
             
             let contextPointer = contextHandle.pointee

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -87,7 +87,7 @@
                         return SQLITE_OK
                     })
                     if (code != SQLITE_OK) {
-                        throw DatabaseError(resultCode: code)
+                        throw DatabaseError(resultCode: ResultCode(rawValue: code))
                     }
                 }
                 return context.tokens
@@ -147,13 +147,13 @@
                 }
                 
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(resultCode: code, message: "failed fts5_tokenizer.xCreate")
+                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: "failed fts5_tokenizer.xCreate")
                 }
                 
                 if let tokenizerPointer = tokenizerPointer {
                     self.tokenizerPointer = tokenizerPointer
                 } else {
-                    throw DatabaseError(resultCode: code, message: "nil tokenizer")
+                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: "nil tokenizer")
                 }
             }
             
@@ -205,7 +205,7 @@
                 xTokenizerPointer)
             
             guard code == SQLITE_OK else {
-                throw DatabaseError(resultCode: code)
+                throw DatabaseError(resultCode: ResultCode(rawValue: code))
             }
             
             let contextPointer = contextHandle.pointee

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -87,7 +87,7 @@
                         return SQLITE_OK
                     })
                     if (code != SQLITE_OK) {
-                        throw DatabaseError(resultCode: ResultCode(rawValue: code))
+                        throw DatabaseError(resultCode: code)
                     }
                 }
                 return context.tokens
@@ -147,13 +147,13 @@
                 }
                 
                 guard code == SQLITE_OK else {
-                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: "failed fts5_tokenizer.xCreate")
+                    throw DatabaseError(resultCode: code, message: "failed fts5_tokenizer.xCreate")
                 }
                 
                 if let tokenizerPointer = tokenizerPointer {
                     self.tokenizerPointer = tokenizerPointer
                 } else {
-                    throw DatabaseError(resultCode: ResultCode(rawValue: code), message: "nil tokenizer")
+                    throw DatabaseError(resultCode: code, message: "nil tokenizer")
                 }
             }
             
@@ -205,7 +205,7 @@
                 xTokenizerPointer)
             
             guard code == SQLITE_OK else {
-                throw DatabaseError(resultCode: ResultCode(rawValue: code))
+                throw DatabaseError(resultCode: code)
             }
             
             let contextPointer = contextHandle.pointee

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -123,14 +123,14 @@
                                     // Inject token bytes into SQLite
                                     let code = tokenCallback(context, flags.rawValue, pToken, nToken, iStart, iEnd)
                                     guard code == SQLITE_OK else {
-                                        throw DatabaseError(resultCode: code, message: "token callback failed")
+                                        throw DatabaseError(resultCode: ResultCode(rawValue: code), message: "token callback failed")
                                     }
                                 }
                         })
                         
                         return SQLITE_OK
                     } catch let error as DatabaseError {
-                        return error.code
+                        return error.extendedResultCode.rawValue
                     } catch {
                         return SQLITE_ERROR
                     }

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -123,7 +123,7 @@
                                     // Inject token bytes into SQLite
                                     let code = tokenCallback(context, flags.rawValue, pToken, nToken, iStart, iEnd)
                                     guard code == SQLITE_OK else {
-                                        throw DatabaseError(resultCode: ResultCode(rawValue: code), message: "token callback failed")
+                                        throw DatabaseError(resultCode: code, message: "token callback failed")
                                     }
                                 }
                         })

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -123,7 +123,7 @@
                                     // Inject token bytes into SQLite
                                     let code = tokenCallback(context, flags.rawValue, pToken, nToken, iStart, iEnd)
                                     guard code == SQLITE_OK else {
-                                        throw DatabaseError(code: code, message: "token callback failed")
+                                        throw DatabaseError(resultCode: code, message: "token callback failed")
                                     }
                                 }
                         })

--- a/GRDB/Legacy/Fixits-0.101.1.swift
+++ b/GRDB/Legacy/Fixits-0.101.1.swift
@@ -1,0 +1,4 @@
+extension DatabaseError {
+    @available(*, unavailable, renamed:"resultCode")
+    public var code: Int32 { return 0 }
+}

--- a/GRDB/Migrations/Migration.swift
+++ b/GRDB/Migrations/Migration.swift
@@ -86,7 +86,7 @@ struct Migration {
                 //
                 // Let's turn any violation into an SQLITE_CONSTRAINT
                 // error, and rollback the transaction.
-                throw DatabaseError(code: .SQLITE_CONSTRAINT, message: "FOREIGN KEY constraint failed")
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT, message: "FOREIGN KEY constraint failed")
             }
             
             // > 11. Commit the transaction started in step 2.

--- a/GRDB/Migrations/Migration.swift
+++ b/GRDB/Migrations/Migration.swift
@@ -86,7 +86,7 @@ struct Migration {
                 //
                 // Let's turn any violation into an SQLITE_CONSTRAINT
                 // error, and rollback the transaction.
-                throw DatabaseError(code: SQLITE_CONSTRAINT, message: "FOREIGN KEY constraint failed")
+                throw DatabaseError(code: .SQLITE_CONSTRAINT, message: "FOREIGN KEY constraint failed")
             }
             
             // > 11. Commit the transaction started in step 2.

--- a/GRDB/Record/RowConvertible.swift
+++ b/GRDB/Record/RowConvertible.swift
@@ -454,7 +454,7 @@ extension RowConvertible where Self: TableMapping {
             GRDBPrecondition(dictionary.count > 0, "Invalid empty key dictionary")
             let columns = Array(dictionary.keys)
             guard let orderedColumns = try db.columnsForUniqueKey(columns, in: databaseTableName) else {
-                let error = DatabaseError(code: SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
+                let error = DatabaseError(code: .SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
                 if fatalErrorOnMissingUniqueIndex {
                     // Programmer error
                     fatalError(error.description)

--- a/GRDB/Record/RowConvertible.swift
+++ b/GRDB/Record/RowConvertible.swift
@@ -454,7 +454,7 @@ extension RowConvertible where Self: TableMapping {
             GRDBPrecondition(dictionary.count > 0, "Invalid empty key dictionary")
             let columns = Array(dictionary.keys)
             guard let orderedColumns = try db.columnsForUniqueKey(columns, in: databaseTableName) else {
-                let error = DatabaseError(code: .SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
+                let error = DatabaseError(resultCode: .SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
                 if fatalErrorOnMissingUniqueIndex {
                     // Programmer error
                     fatalError(error.description)

--- a/GRDB/Record/TableMapping.swift
+++ b/GRDB/Record/TableMapping.swift
@@ -206,7 +206,7 @@ extension TableMapping {
             GRDBPrecondition(dictionary.count > 0, "Invalid empty key dictionary")
             let columns = Array(dictionary.keys)
             guard let orderedColumns = try db.columnsForUniqueKey(columns, in: databaseTableName) else {
-                let error = DatabaseError(code: SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
+                let error = DatabaseError(code: .SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
                 if fatalErrorOnMissingUniqueIndex {
                     fatalError(error.description)
                 } else {

--- a/GRDB/Record/TableMapping.swift
+++ b/GRDB/Record/TableMapping.swift
@@ -206,7 +206,7 @@ extension TableMapping {
             GRDBPrecondition(dictionary.count > 0, "Invalid empty key dictionary")
             let columns = Array(dictionary.keys)
             guard let orderedColumns = try db.columnsForUniqueKey(columns, in: databaseTableName) else {
-                let error = DatabaseError(code: .SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
+                let error = DatabaseError(resultCode: .SQLITE_MISUSE, message: "table \(databaseTableName) has no unique index on column(s) \(columns.sorted().joined(separator: ", "))")
                 if fatalErrorOnMissingUniqueIndex {
                     fatalError(error.description)
                 } else {

--- a/README.md
+++ b/README.md
@@ -1673,7 +1673,7 @@ Before jumping in the low-level wagon, here is the list of all SQLite APIs used 
 - `sqlite3_create_collation_v2`: see [String Comparison](#string-comparison)
 - `sqlite3_create_function_v2`, `sqlite3_result_blob`, `sqlite3_result_double`, `sqlite3_result_error`, `sqlite3_result_error_code`, `sqlite3_result_int64`, `sqlite3_result_null`, `sqlite3_result_text`, `sqlite3_user_data`, `sqlite3_value_blob`, `sqlite3_value_bytes`, `sqlite3_value_double`, `sqlite3_value_int64`, `sqlite3_value_text`, `sqlite3_value_type`: see [Custom SQL Functions](#custom-sql-functions)
 - `sqlite3_db_release_memory`: see [Memory Management](#memory-management)
-- `sqlite3_errcode`, `sqlite3_errmsg`: see [Error Handling](#error-handling)
+- `sqlite3_errcode`, `sqlite3_errmsg`, `sqlite3_errstr`, `sqlite3_extended_result_codes`: see [Error Handling](#error-handling)
 - `sqlite3_key`, `sqlite3_rekey`: see [Encryption](#encryption)
 - `sqlite3_last_insert_rowid`: see [Executing Updates](#executing-updates)
 - `sqlite3_preupdate_count`, `sqlite3_preupdate_depth`, `sqlite3_preupdate_hook`, `sqlite3_preupdate_new`, `sqlite3_preupdate_old`: see [Support for SQLite Pre-Update Hooks](#support-for-sqlite-pre-update-hooks)

--- a/README.md
+++ b/README.md
@@ -4759,7 +4759,7 @@ do {
     switch error.extendedResultCode {
     case .SQLITE_CONSTRAINT_FOREIGNKEY:
         // foreign key constraint error
-    case .SQLITE_CONSTRAINT
+    case .SQLITE_CONSTRAINT:
         // any other constraint error
     default:
         // any other database error

--- a/README.md
+++ b/README.md
@@ -3711,6 +3711,8 @@ let pattern = FTS3Pattern(matchingAnyTokenIn: "")  // nil
 let pattern = FTS3Pattern(matchingAnyTokenIn: "*") // nil
 ```
 
+> :warning: **Warning**: when GRDB uses the SQLite library that ships with the host system, those three initializers do not work until iOS 8.2 and macOS 10.10. Don't use them if your application targets previous systems.
+
 FTS3Pattern are regular [values](#values). You can use them as query [arguments](http://cocoadocs.org/docsets/GRDB.swift/0.101.1/Structs/StatementArguments.html):
 
 ```swift

--- a/README.md
+++ b/README.md
@@ -5573,6 +5573,6 @@ Sample Code
 **Thanks**
 
 - [Pierlis](http://pierlis.com), where we write great software.
-- [Vladimir Babin](https://github.com/Chiliec), [Pascal Edmond](https://github.com/pakko972), [Cristian Filipov](https://github.com/cfilipov), [@peter-ss](https://github.com/peter-ss), [Pierre-Loïc Raynaud](https://github.com/pierlo), [Steven Schveighoffer](https://github.com/schveiguy), [@swiftlyfalling](https://github.com/swiftlyfalling), and [Kevin Wooten](https://github.com/kdubb) for their contributions, help, and feedback on GRDB.
+- [Vladimir Babin](https://github.com/Chiliec), [Pascal Edmond](https://github.com/pakko972), [Cristian Filipov](https://github.com/cfilipov), [David Hart](https://github.com/hartbit), [@peter-ss](https://github.com/peter-ss), [Pierre-Loïc Raynaud](https://github.com/pierlo), [Steven Schveighoffer](https://github.com/schveiguy), [@swiftlyfalling](https://github.com/swiftlyfalling), and [Kevin Wooten](https://github.com/kdubb) for their contributions, help, and feedback on GRDB.
 - [@aymerick](https://github.com/aymerick) and [Mathieu "Kali" Poumeyrol](https://github.com/kali) because SQL.
 - [ccgus/fmdb](https://github.com/ccgus/fmdb) for its excellency.

--- a/README.md
+++ b/README.md
@@ -4757,9 +4757,9 @@ do {
     try ...
 } catch let error as DatabaseError {
     switch error.extendedResultCode {
-    case .SQLITE_CONSTRAINT_FOREIGNKEY:
+    case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY:
         // foreign key constraint error
-    case .SQLITE_CONSTRAINT:
+    case ResultCode.SQLITE_CONSTRAINT:
         // any other constraint error
     default:
         // any other database error

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,5 @@
 - [ ] registerMigrationWithDisabledForeignKeyChecks should be renamed registerMigrationWithDeferredForeignKeyChecks
-- [ ] Enable extended result codes (https://github.com/groue/GRDB.swift/issues/171)
+- [X] Enable extended result codes (https://github.com/groue/GRDB.swift/issues/171)
 - [ ] Request.fetchCount() (see https://github.com/groue/GRDB.swift/issues/176#issuecomment-282783884). This method should be a customization point, not an extension.
     - [X] implementation
     - [X] tests

--- a/Tests/Private/DatabasePoolSchemaCacheTests.swift
+++ b/Tests/Private/DatabasePoolSchemaCacheTests.swift
@@ -95,7 +95,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
                     _ = try db.primaryKey("items")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: items")
                     XCTAssertEqual(error.description, "SQLite error 1: no such table: items")
                 }

--- a/Tests/Private/DatabasePoolSchemaCacheTests.swift
+++ b/Tests/Private/DatabasePoolSchemaCacheTests.swift
@@ -95,7 +95,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
                     _ = try db.primaryKey("items")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: items")
                     XCTAssertEqual(error.description, "SQLite error 1: no such table: items")
                 }

--- a/Tests/Private/DatabaseQueueSchemaCacheTests.swift
+++ b/Tests/Private/DatabaseQueueSchemaCacheTests.swift
@@ -46,7 +46,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
                     _ = try db.primaryKey("items")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: items")
                     XCTAssertEqual(error.description, "SQLite error 1: no such table: items")
                 }

--- a/Tests/Private/DatabaseQueueSchemaCacheTests.swift
+++ b/Tests/Private/DatabaseQueueSchemaCacheTests.swift
@@ -46,7 +46,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
                     _ = try db.primaryKey("items")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: items")
                     XCTAssertEqual(error.description, "SQLite error 1: no such table: items")
                 }

--- a/Tests/Private/RecordUniqueIndexTests.swift
+++ b/Tests/Private/RecordUniqueIndexTests.swift
@@ -27,7 +27,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeFetchByKeyStatement(db, keys: [["id": nil, "email": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) email, id")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) email, id")
                 }
@@ -35,7 +35,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeFetchByKeyStatement(db, keys: [["name": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) name")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) name")
                 }
@@ -55,7 +55,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeDeleteByKeyStatement(db, keys: [["id": nil, "email": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) email, id")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) email, id")
                 }
@@ -63,7 +63,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeDeleteByKeyStatement(db, keys: [["name": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) name")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) name")
                 }

--- a/Tests/Private/RecordUniqueIndexTests.swift
+++ b/Tests/Private/RecordUniqueIndexTests.swift
@@ -27,7 +27,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeFetchByKeyStatement(db, keys: [["id": nil, "email": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                    XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) email, id")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) email, id")
                 }
@@ -35,7 +35,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeFetchByKeyStatement(db, keys: [["name": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                    XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) name")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) name")
                 }
@@ -55,7 +55,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeDeleteByKeyStatement(db, keys: [["id": nil, "email": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                    XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) email, id")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) email, id")
                 }
@@ -63,7 +63,7 @@ class RecordUniqueIndexTests: GRDBTestCase {
                     _ = try Person.makeDeleteByKeyStatement(db, keys: [["name": nil]], fatalErrorOnMissingUniqueIndex: false)
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                    XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "table persons has no unique index on column(s) name")
                     XCTAssertEqual(error.description, "SQLite error 21: table persons has no unique index on column(s) name")
                 }

--- a/Tests/Public/Core/Database/DatabaseTests.swift
+++ b/Tests/Public/Core/Database/DatabaseTests.swift
@@ -316,7 +316,7 @@ class DatabaseTests : GRDBTestCase {
                 }
                 XCTFail()
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!, "FOREIGN KEY constraint failed")
                 XCTAssertEqual(error.sql!, "COMMIT TRANSACTION")
                 XCTAssertEqual(error.description, "SQLite error 787 with statement `COMMIT TRANSACTION`: FOREIGN KEY constraint failed")

--- a/Tests/Public/Core/Database/DatabaseTests.swift
+++ b/Tests/Public/Core/Database/DatabaseTests.swift
@@ -316,7 +316,7 @@ class DatabaseTests : GRDBTestCase {
                 }
                 XCTFail()
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!, "FOREIGN KEY constraint failed")
                 XCTAssertEqual(error.sql!, "COMMIT TRANSACTION")
                 XCTAssertEqual(error.description, "SQLite error 19 with statement `COMMIT TRANSACTION`: FOREIGN KEY constraint failed")

--- a/Tests/Public/Core/Database/DatabaseTests.swift
+++ b/Tests/Public/Core/Database/DatabaseTests.swift
@@ -316,10 +316,10 @@ class DatabaseTests : GRDBTestCase {
                 }
                 XCTFail()
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!, "FOREIGN KEY constraint failed")
                 XCTAssertEqual(error.sql!, "COMMIT TRANSACTION")
-                XCTAssertEqual(error.description, "SQLite error 19 with statement `COMMIT TRANSACTION`: FOREIGN KEY constraint failed")
+                XCTAssertEqual(error.description, "SQLite error 787 with statement `COMMIT TRANSACTION`: FOREIGN KEY constraint failed")
             }
             
             // Make sure we can open another transaction

--- a/Tests/Public/Core/Database/ReadOnlyDatabaseTests.swift
+++ b/Tests/Public/Core/Database/ReadOnlyDatabaseTests.swift
@@ -28,7 +28,7 @@ class ReadOnlyDatabaseTests : GRDBTestCase {
                 }
                 XCTFail()
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 8)   // SQLITE_READONLY
+                XCTAssertEqual(error.code, .SQLITE_READONLY)
                 XCTAssertEqual(error.message!, "attempt to write a readonly database")
                 XCTAssertEqual(error.sql!, "CREATE TABLE items (id INTEGER PRIMARY KEY)")
                 XCTAssertEqual(error.description, "SQLite error 8 with statement `CREATE TABLE items (id INTEGER PRIMARY KEY)`: attempt to write a readonly database")

--- a/Tests/Public/Core/Database/ReadOnlyDatabaseTests.swift
+++ b/Tests/Public/Core/Database/ReadOnlyDatabaseTests.swift
@@ -28,7 +28,7 @@ class ReadOnlyDatabaseTests : GRDBTestCase {
                 }
                 XCTFail()
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_READONLY)
+                XCTAssertEqual(error.resultCode, .SQLITE_READONLY)
                 XCTAssertEqual(error.message!, "attempt to write a readonly database")
                 XCTAssertEqual(error.sql!, "CREATE TABLE items (id INTEGER PRIMARY KEY)")
                 XCTAssertEqual(error.description, "SQLite error 8 with statement `CREATE TABLE items (id INTEGER PRIMARY KEY)`: attempt to write a readonly database")

--- a/Tests/Public/Core/DatabaseCursor/DatabaseCursorTests.swift
+++ b/Tests/Public/Core/DatabaseCursor/DatabaseCursorTests.swift
@@ -47,7 +47,7 @@ class DatabaseCursorTests: GRDBTestCase {
                     _ = try cursor.next()
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message, "\(customError)")
                     XCTAssertEqual(error.sql!, "SELECT 1 UNION ALL SELECT throw()")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT 1 UNION ALL SELECT throw()`: \(customError)")

--- a/Tests/Public/Core/DatabaseCursor/DatabaseCursorTests.swift
+++ b/Tests/Public/Core/DatabaseCursor/DatabaseCursorTests.swift
@@ -47,7 +47,7 @@ class DatabaseCursorTests: GRDBTestCase {
                     _ = try cursor.next()
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message, "\(customError)")
                     XCTAssertEqual(error.sql!, "SELECT 1 UNION ALL SELECT throw()")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT 1 UNION ALL SELECT throw()`: \(customError)")

--- a/Tests/Public/Core/DatabaseError/DatabaseErrorTests.swift
+++ b/Tests/Public/Core/DatabaseError/DatabaseErrorTests.swift
@@ -22,10 +22,10 @@ class DatabaseErrorTests: GRDBTestCase {
                     return .commit
                 }
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
-                XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
+                XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
                 
                 XCTAssertEqual(sqlQueries.count, 2)
                 XCTAssertEqual(sqlQueries[0], "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
@@ -56,10 +56,10 @@ class DatabaseErrorTests: GRDBTestCase {
                     }
                 }
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
-                XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
+                XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
             }
         }
     }
@@ -78,10 +78,10 @@ class DatabaseErrorTests: GRDBTestCase {
                     try db.execute("INSERT INTO pets (masterId, name) VALUES (?, ?)", arguments: [1, "Bobby"])
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
-                    XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
+                    XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
                 }
             }
             
@@ -92,10 +92,10 @@ class DatabaseErrorTests: GRDBTestCase {
                     try statement.execute(arguments: [1, "Bobby"])
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
-                    XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
+                    XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
                 }
             }
             
@@ -107,10 +107,10 @@ class DatabaseErrorTests: GRDBTestCase {
                     try statement.execute()
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
-                    XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
+                    XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
                 }
             }
         }
@@ -127,10 +127,10 @@ class DatabaseErrorTests: GRDBTestCase {
                         "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
-                    XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (1, 'bobby')`: foreign key constraint failed")
+                    XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (1, 'bobby')`: foreign key constraint failed")
                 }
             }
         }

--- a/Tests/Public/Core/DatabaseError/DatabaseErrorTests.swift
+++ b/Tests/Public/Core/DatabaseError/DatabaseErrorTests.swift
@@ -22,7 +22,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     return .commit
                 }
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -56,7 +56,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     }
                 }
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -78,7 +78,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     try db.execute("INSERT INTO pets (masterId, name) VALUES (?, ?)", arguments: [1, "Bobby"])
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -92,7 +92,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     try statement.execute(arguments: [1, "Bobby"])
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -107,7 +107,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     try statement.execute()
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -127,7 +127,7 @@ class DatabaseErrorTests: GRDBTestCase {
                         "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (1, 'bobby')`: foreign key constraint failed")

--- a/Tests/Public/Core/DatabaseError/DatabaseErrorTests.swift
+++ b/Tests/Public/Core/DatabaseError/DatabaseErrorTests.swift
@@ -22,7 +22,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     return .commit
                 }
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -56,7 +56,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     }
                 }
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -78,7 +78,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     try db.execute("INSERT INTO pets (masterId, name) VALUES (?, ?)", arguments: [1, "Bobby"])
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -92,7 +92,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     try statement.execute(arguments: [1, "Bobby"])
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -107,7 +107,7 @@ class DatabaseErrorTests: GRDBTestCase {
                     try statement.execute()
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [1, \"bobby\"]: foreign key constraint failed")
@@ -127,7 +127,7 @@ class DatabaseErrorTests: GRDBTestCase {
                         "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                     XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (1, 'Bobby')")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (1, 'bobby')`: foreign key constraint failed")

--- a/Tests/Public/Core/DatabaseError/ResultCodeTests.swift
+++ b/Tests/Public/Core/DatabaseError/ResultCodeTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+#if USING_SQLCIPHER
+    import GRDBCipher
+#elseif USING_CUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    import GRDB
+#endif
+
+import XCTest
+
+class ResultCodeTests: GRDBTestCase {
+    
+    func testExtendedResultCodesAreActivated() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "parents") { t in
+                t.column("id", .integer).primaryKey()
+            }
+            try db.create(table: "children") { t in
+                t.column("parentId", .integer).references("parents")
+            }
+            do {
+                try db.execute("INSERT INTO children (parentId) VALUES (1)")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode.rawValue, 19)           // primary SQLITE_CONSTRAINT
+                XCTAssertEqual(error.extendedResultCode.rawValue, 787)  // extended SQLITE_CONSTRAINT_FOREIGNKEY
+            }
+        }
+    }
+    
+    func testResultCodeEquatable() {
+        XCTAssertEqual(ResultCode(rawValue: 19), .SQLITE_CONSTRAINT)
+        XCTAssertEqual(ResultCode(rawValue: 787), .SQLITE_CONSTRAINT_FOREIGNKEY)
+        XCTAssertNotEqual(ResultCode.SQLITE_CONSTRAINT, .SQLITE_CONSTRAINT_FOREIGNKEY)
+    }
+    
+    func testResultCodeMatch() {
+        XCTAssertTrue(ResultCode.SQLITE_CONSTRAINT ~= .SQLITE_CONSTRAINT)
+        XCTAssertTrue(ResultCode.SQLITE_CONSTRAINT ~= .SQLITE_CONSTRAINT_FOREIGNKEY)
+        XCTAssertTrue(ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY ~= .SQLITE_CONSTRAINT_FOREIGNKEY)
+        XCTAssertFalse(ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY ~= .SQLITE_CONSTRAINT)
+        XCTAssertFalse(ResultCode.SQLITE_TOOBIG ~= .SQLITE_CONSTRAINT)
+    }
+    
+    func testResultCodeSwitch() {
+        switch ResultCode.SQLITE_CONSTRAINT {
+        case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY: XCTFail()
+        case ResultCode.SQLITE_CONSTRAINT: break
+        default: XCTFail()
+        }
+        
+        switch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+        case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY: break
+        case ResultCode.SQLITE_CONSTRAINT: XCTFail()
+        default: XCTFail()
+        }
+        
+        switch ResultCode.SQLITE_CONSTRAINT_CHECK {
+        case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY: XCTFail()
+        case ResultCode.SQLITE_CONSTRAINT: break
+        default: XCTFail()
+        }
+        
+        switch ResultCode.SQLITE_TOOBIG {
+        case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY: XCTFail()
+        case ResultCode.SQLITE_CONSTRAINT: XCTFail()
+        default: break
+        }
+    }
+}

--- a/Tests/Public/Core/DatabasePool/DatabasePoolConcurrencyTests.swift
+++ b/Tests/Public/Core/DatabasePool/DatabasePoolConcurrencyTests.swift
@@ -248,7 +248,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                     try db.execute("BEGIN DEFERRED TRANSACTION")
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "cannot start a transaction within a transaction")
                     XCTAssertEqual(error.sql!, "BEGIN DEFERRED TRANSACTION")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `BEGIN DEFERRED TRANSACTION`: cannot start a transaction within a transaction")
@@ -281,7 +281,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                     try dbPool.read { _ in }
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_BUSY)
+                    XCTAssertEqual(error.resultCode, .SQLITE_BUSY)
                     XCTAssertEqual(error.message!, "database is locked")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 5: database is locked")
@@ -897,7 +897,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                     }
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_BUSY)
+                    XCTAssertEqual(error.resultCode, .SQLITE_BUSY)
                     XCTAssertEqual(error.message!, "database is locked")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 5: database is locked")

--- a/Tests/Public/Core/DatabasePool/DatabasePoolConcurrencyTests.swift
+++ b/Tests/Public/Core/DatabasePool/DatabasePoolConcurrencyTests.swift
@@ -248,7 +248,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                     try db.execute("BEGIN DEFERRED TRANSACTION")
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "cannot start a transaction within a transaction")
                     XCTAssertEqual(error.sql!, "BEGIN DEFERRED TRANSACTION")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `BEGIN DEFERRED TRANSACTION`: cannot start a transaction within a transaction")
@@ -281,7 +281,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                     try dbPool.read { _ in }
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 5) // SQLITE_BUSY
+                    XCTAssertEqual(error.code, .SQLITE_BUSY)
                     XCTAssertEqual(error.message!, "database is locked")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 5: database is locked")
@@ -897,7 +897,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                     }
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 5) // SQLITE_BUSY
+                    XCTAssertEqual(error.code, .SQLITE_BUSY)
                     XCTAssertEqual(error.message!, "database is locked")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 5: database is locked")

--- a/Tests/Public/Core/DatabaseQueue/DatabaseQueueConcurrencyTests.swift
+++ b/Tests/Public/Core/DatabaseQueue/DatabaseQueueConcurrencyTests.swift
@@ -113,7 +113,7 @@ class ConcurrencyTests: GRDBTestCase {
             _ = group.wait(timeout: .distantFuture)
             
             if let concurrencyError = concurrencyError {
-                XCTAssertEqual(concurrencyError.code, .SQLITE_BUSY)
+                XCTAssertEqual(concurrencyError.resultCode, .SQLITE_BUSY)
                 XCTAssertEqual(concurrencyError.sql, "INSERT INTO stuffs (id) VALUES (NULL)")
             } else {
                 XCTFail("Expected concurrency error")
@@ -171,7 +171,7 @@ class ConcurrencyTests: GRDBTestCase {
             _ = group.wait(timeout: .distantFuture)
             
             if let concurrencyError = concurrencyError {
-                XCTAssertEqual(concurrencyError.code, .SQLITE_BUSY)
+                XCTAssertEqual(concurrencyError.resultCode, .SQLITE_BUSY)
                 XCTAssertEqual(concurrencyError.sql, "BEGIN EXCLUSIVE TRANSACTION")
             } else {
                 XCTFail("Expected concurrency error")
@@ -229,7 +229,7 @@ class ConcurrencyTests: GRDBTestCase {
             _ = group.wait(timeout: .distantFuture)
             
             if let concurrencyError = concurrencyError {
-                XCTAssertEqual(concurrencyError.code, .SQLITE_BUSY)
+                XCTAssertEqual(concurrencyError.resultCode, .SQLITE_BUSY)
                 XCTAssertEqual(concurrencyError.sql, "BEGIN IMMEDIATE TRANSACTION")
             } else {
                 XCTFail("Expected concurrency error")

--- a/Tests/Public/Core/DatabaseQueue/DatabaseQueueConcurrencyTests.swift
+++ b/Tests/Public/Core/DatabaseQueue/DatabaseQueueConcurrencyTests.swift
@@ -113,7 +113,7 @@ class ConcurrencyTests: GRDBTestCase {
             _ = group.wait(timeout: .distantFuture)
             
             if let concurrencyError = concurrencyError {
-                XCTAssertEqual(concurrencyError.code, 5) // SQLITE_BUSY
+                XCTAssertEqual(concurrencyError.code, .SQLITE_BUSY)
                 XCTAssertEqual(concurrencyError.sql, "INSERT INTO stuffs (id) VALUES (NULL)")
             } else {
                 XCTFail("Expected concurrency error")
@@ -171,7 +171,7 @@ class ConcurrencyTests: GRDBTestCase {
             _ = group.wait(timeout: .distantFuture)
             
             if let concurrencyError = concurrencyError {
-                XCTAssertEqual(concurrencyError.code, 5) // SQLITE_BUSY
+                XCTAssertEqual(concurrencyError.code, .SQLITE_BUSY)
                 XCTAssertEqual(concurrencyError.sql, "BEGIN EXCLUSIVE TRANSACTION")
             } else {
                 XCTFail("Expected concurrency error")
@@ -229,7 +229,7 @@ class ConcurrencyTests: GRDBTestCase {
             _ = group.wait(timeout: .distantFuture)
             
             if let concurrencyError = concurrencyError {
-                XCTAssertEqual(concurrencyError.code, 5) // SQLITE_BUSY
+                XCTAssertEqual(concurrencyError.code, .SQLITE_BUSY)
                 XCTAssertEqual(concurrencyError.sql, "BEGIN IMMEDIATE TRANSACTION")
             } else {
                 XCTFail("Expected concurrency error")

--- a/Tests/Public/Core/DatabaseQueue/DatabaseQueueTests.swift
+++ b/Tests/Public/Core/DatabaseQueue/DatabaseQueueTests.swift
@@ -21,7 +21,7 @@ class DatabaseQueueTests: GRDBTestCase {
                 _ = try DatabaseQueue(path: url.path)
                 XCTFail("Expected error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                XCTAssertEqual(error.code, .SQLITE_NOTADB)
                 XCTAssertEqual(error.message!.lowercased(), "file is encrypted or is not a database") // lowercased: accept multiple SQLite version
                 XCTAssertTrue(error.sql == nil)
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 26: file is encrypted or is not a database")
@@ -55,7 +55,7 @@ class DatabaseQueueTests: GRDBTestCase {
                 }
                 catch let error as DatabaseError {
                     // expected error
-                    XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!.lowercased(), "no such function: succ") // lowercaseString: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "SELECT succ(1)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 1 with statement `select succ(1)`: no such function: succ")
@@ -86,7 +86,7 @@ class DatabaseQueueTests: GRDBTestCase {
                 }
                 catch let error as DatabaseError {
                     // expected error
-                    XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!.lowercased(), "no such collation sequence: test_collation_foo") // lowercaseString: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "CREATE TABLE files_fail (name TEXT COLLATE TEST_COLLATION_FOO)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 1 with statement `create table files_fail (name text collate test_collation_foo)`: no such collation sequence: test_collation_foo")

--- a/Tests/Public/Core/DatabaseQueue/DatabaseQueueTests.swift
+++ b/Tests/Public/Core/DatabaseQueue/DatabaseQueueTests.swift
@@ -21,7 +21,7 @@ class DatabaseQueueTests: GRDBTestCase {
                 _ = try DatabaseQueue(path: url.path)
                 XCTFail("Expected error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                 XCTAssertEqual(error.message!.lowercased(), "file is encrypted or is not a database") // lowercased: accept multiple SQLite version
                 XCTAssertTrue(error.sql == nil)
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 26: file is encrypted or is not a database")
@@ -55,7 +55,7 @@ class DatabaseQueueTests: GRDBTestCase {
                 }
                 catch let error as DatabaseError {
                     // expected error
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!.lowercased(), "no such function: succ") // lowercaseString: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "SELECT succ(1)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 1 with statement `select succ(1)`: no such function: succ")
@@ -86,7 +86,7 @@ class DatabaseQueueTests: GRDBTestCase {
                 }
                 catch let error as DatabaseError {
                     // expected error
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!.lowercased(), "no such collation sequence: test_collation_foo") // lowercaseString: accept multiple SQLite version
                     XCTAssertEqual(error.sql!, "CREATE TABLE files_fail (name TEXT COLLATE TEST_COLLATION_FOO)")
                     XCTAssertEqual(error.description.lowercased(), "sqlite error 1 with statement `create table files_fail (name text collate test_collation_foo)`: no such collation sequence: test_collation_foo")

--- a/Tests/Public/Core/DatabaseValueConvertible/DatabaseValueConvertibleFetchTests.swift
+++ b/Tests/Public/Core/DatabaseValueConvertible/DatabaseValueConvertibleFetchTests.swift
@@ -68,7 +68,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -77,7 +77,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -118,7 +118,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -127,7 +127,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -161,7 +161,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -223,7 +223,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -261,7 +261,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -295,7 +295,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -403,7 +403,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -441,7 +441,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -475,7 +475,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -543,7 +543,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -584,7 +584,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -593,7 +593,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -627,7 +627,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -691,7 +691,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -729,7 +729,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -763,7 +763,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/DatabaseValueConvertible/DatabaseValueConvertibleFetchTests.swift
+++ b/Tests/Public/Core/DatabaseValueConvertible/DatabaseValueConvertibleFetchTests.swift
@@ -68,7 +68,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -77,7 +77,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -118,7 +118,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -127,7 +127,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                        XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -161,7 +161,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -223,7 +223,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -261,7 +261,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -295,7 +295,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -403,7 +403,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -441,7 +441,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -475,7 +475,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -543,7 +543,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -584,7 +584,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -593,7 +593,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                        XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -627,7 +627,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -691,7 +691,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -729,7 +729,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -763,7 +763,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/Function/FunctionTests.swift
+++ b/Tests/Public/Core/Function/FunctionTests.swift
@@ -305,7 +305,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message, "custom error message")
                 }
             }
@@ -316,7 +316,7 @@ class FunctionTests: GRDBTestCase {
         assertNoError {
             let dbQueue = try makeDatabaseQueue()
             let fn = DatabaseFunction("f", argumentCount: 1) { databaseValues in
-                throw DatabaseError(code: ResultCode(rawValue: 123))
+                throw DatabaseError(resultCode: ResultCode(rawValue: 123))
             }
             dbQueue.add(function: fn)
             try dbQueue.inDatabase { db in
@@ -325,7 +325,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code.rawValue, 123)
+                    XCTAssertEqual(error.resultCode.rawValue, 123)
                     XCTAssertEqual(error.message, "unknown error")
                 }
             }
@@ -336,7 +336,7 @@ class FunctionTests: GRDBTestCase {
         assertNoError {
             let dbQueue = try makeDatabaseQueue()
             let fn = DatabaseFunction("f", argumentCount: 1) { databaseValues in
-                throw DatabaseError(code: ResultCode(rawValue: 123), message: "custom error message")
+                throw DatabaseError(resultCode: ResultCode(rawValue: 123), message: "custom error message")
             }
             dbQueue.add(function: fn)
             try dbQueue.inDatabase { db in
@@ -345,7 +345,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code.rawValue, 123)
+                    XCTAssertEqual(error.resultCode.rawValue, 123)
                     XCTAssertEqual(error.message, "custom error message")
                 }
             }
@@ -365,7 +365,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertTrue(error.message!.contains("CustomErrorDomain"))
                     XCTAssertTrue(error.message!.contains("123"))
                     XCTAssertTrue(error.message!.contains("custom error message"))

--- a/Tests/Public/Core/Function/FunctionTests.swift
+++ b/Tests/Public/Core/Function/FunctionTests.swift
@@ -305,7 +305,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1)
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message, "custom error message")
                 }
             }
@@ -316,7 +316,7 @@ class FunctionTests: GRDBTestCase {
         assertNoError {
             let dbQueue = try makeDatabaseQueue()
             let fn = DatabaseFunction("f", argumentCount: 1) { databaseValues in
-                throw DatabaseError(code: 123)
+                throw DatabaseError(code: ResultCode(rawValue: 123))
             }
             dbQueue.add(function: fn)
             try dbQueue.inDatabase { db in
@@ -325,7 +325,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 123)
+                    XCTAssertEqual(error.code.rawValue, 123)
                     XCTAssertEqual(error.message, "unknown error")
                 }
             }
@@ -336,7 +336,7 @@ class FunctionTests: GRDBTestCase {
         assertNoError {
             let dbQueue = try makeDatabaseQueue()
             let fn = DatabaseFunction("f", argumentCount: 1) { databaseValues in
-                throw DatabaseError(code: 123, message: "custom error message")
+                throw DatabaseError(code: ResultCode(rawValue: 123), message: "custom error message")
             }
             dbQueue.add(function: fn)
             try dbQueue.inDatabase { db in
@@ -345,7 +345,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 123)
+                    XCTAssertEqual(error.code.rawValue, 123)
                     XCTAssertEqual(error.message, "custom error message")
                 }
             }
@@ -365,7 +365,7 @@ class FunctionTests: GRDBTestCase {
                     try db.execute("INSERT INTO items VALUES (f(1))")
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1)
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertTrue(error.message!.contains("CustomErrorDomain"))
                     XCTAssertTrue(error.message!.contains("123"))
                     XCTAssertTrue(error.message!.contains("custom error message"))

--- a/Tests/Public/Core/Persistable/PersistableTests.swift
+++ b/Tests/Public/Core/Persistable/PersistableTests.swift
@@ -793,7 +793,7 @@ class PersistableTests: GRDBTestCase {
                 do {
                     try Citizenship(personID: person.id!, countryIsoCode: "US").insert(db)
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 }
                 try Citizenship(personID: person.id!, countryIsoCode: "FR").insert(db)
             }

--- a/Tests/Public/Core/Persistable/PersistableTests.swift
+++ b/Tests/Public/Core/Persistable/PersistableTests.swift
@@ -793,7 +793,7 @@ class PersistableTests: GRDBTestCase {
                 do {
                     try Citizenship(personID: person.id!, countryIsoCode: "US").insert(db)
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 }
                 try Citizenship(personID: person.id!, countryIsoCode: "FR").insert(db)
             }

--- a/Tests/Public/Core/Persistable/PersistableTests.swift
+++ b/Tests/Public/Core/Persistable/PersistableTests.swift
@@ -793,7 +793,7 @@ class PersistableTests: GRDBTestCase {
                 do {
                     try Citizenship(personID: person.id!, countryIsoCode: "US").insert(db)
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                    XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 }
                 try Citizenship(personID: person.id!, countryIsoCode: "FR").insert(db)
             }

--- a/Tests/Public/Core/Row/RowConvertibleTests.swift
+++ b/Tests/Public/Core/Row/RowConvertibleTests.swift
@@ -86,7 +86,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -95,7 +95,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -129,7 +129,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -195,7 +195,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -229,7 +229,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -319,7 +319,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -353,7 +353,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/Row/RowConvertibleTests.swift
+++ b/Tests/Public/Core/Row/RowConvertibleTests.swift
@@ -86,7 +86,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -95,7 +95,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                        XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -129,7 +129,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -195,7 +195,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -229,7 +229,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -319,7 +319,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -353,7 +353,7 @@ class RowConvertibleTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/Row/RowFetchTests.swift
+++ b/Tests/Public/Core/Row/RowFetchTests.swift
@@ -57,7 +57,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -66,7 +66,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                        XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -100,7 +100,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -165,7 +165,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -199,7 +199,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -288,7 +288,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -322,7 +322,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/Row/RowFetchTests.swift
+++ b/Tests/Public/Core/Row/RowFetchTests.swift
@@ -57,7 +57,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -66,7 +66,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -100,7 +100,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -165,7 +165,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -199,7 +199,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -288,7 +288,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -322,7 +322,7 @@ class RowFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/Savepoint/SavepointTests.swift
+++ b/Tests/Public/Core/Savepoint/SavepointTests.swift
@@ -592,11 +592,11 @@ class SavepointTests: GRDBTestCase {
                 do {
                     try db.inSavepoint {
                         try insertItem(db, name: "item1")
-                        throw DatabaseError(code: 123)
+                        throw DatabaseError(code: ResultCode(rawValue: 123))
                     }
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 123)
+                    XCTAssertEqual(error.code.rawValue, 123)
                 }
                 
                 try db.inSavepoint {

--- a/Tests/Public/Core/Savepoint/SavepointTests.swift
+++ b/Tests/Public/Core/Savepoint/SavepointTests.swift
@@ -592,11 +592,11 @@ class SavepointTests: GRDBTestCase {
                 do {
                     try db.inSavepoint {
                         try insertItem(db, name: "item1")
-                        throw DatabaseError(code: ResultCode(rawValue: 123))
+                        throw DatabaseError(resultCode: ResultCode(rawValue: 123))
                     }
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code.rawValue, 123)
+                    XCTAssertEqual(error.resultCode.rawValue, 123)
                 }
                 
                 try db.inSavepoint {

--- a/Tests/Public/Core/Statement/SelectStatementTests.swift
+++ b/Tests/Public/Core/Statement/SelectStatementTests.swift
@@ -95,7 +95,7 @@ class SelectStatementTests : GRDBTestCase {
                     _ = try db.makeSelectStatement("SELECT * FROM blah")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: blah")
                     XCTAssertEqual(error.sql!, "SELECT * FROM blah")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT * FROM blah`: no such table: blah")
@@ -125,7 +125,7 @@ class SelectStatementTests : GRDBTestCase {
                     _ = try String.fetchAll(db.cachedSelectStatement(sql))
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "boom")
                     XCTAssertEqual(error.sql!, sql)
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: boom")

--- a/Tests/Public/Core/Statement/SelectStatementTests.swift
+++ b/Tests/Public/Core/Statement/SelectStatementTests.swift
@@ -95,7 +95,7 @@ class SelectStatementTests : GRDBTestCase {
                     _ = try db.makeSelectStatement("SELECT * FROM blah")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1)
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: blah")
                     XCTAssertEqual(error.sql!, "SELECT * FROM blah")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT * FROM blah`: no such table: blah")
@@ -125,7 +125,7 @@ class SelectStatementTests : GRDBTestCase {
                     _ = try String.fetchAll(db.cachedSelectStatement(sql))
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1)
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "boom")
                     XCTAssertEqual(error.sql!, sql)
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: boom")

--- a/Tests/Public/Core/Statement/UpdateStatementTests.swift
+++ b/Tests/Public/Core/Statement/UpdateStatementTests.swift
@@ -293,7 +293,7 @@ class UpdateStatementTests : GRDBTestCase {
                     _ = try db.makeUpdateStatement("UPDATE blah SET id = 12")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 1)
+                    XCTAssertEqual(error.code, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: blah")
                     XCTAssertEqual(error.sql!, "UPDATE blah SET id = 12")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `UPDATE blah SET id = 12`: no such table: blah")
@@ -310,7 +310,7 @@ class UpdateStatementTests : GRDBTestCase {
                     _ = try db.makeUpdateStatement("UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 21)  // SQLITE_MISUSE
+                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "Multiple statements found. To execute multiple statements, use Database.execute() instead.")
                     XCTAssertEqual(error.sql!, "UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
                     XCTAssertEqual(error.description, "SQLite error 21 with statement `UPDATE persons SET age = 1; UPDATE persons SET age = 2;`: Multiple statements found. To execute multiple statements, use Database.execute() instead.")
@@ -327,7 +327,7 @@ class UpdateStatementTests : GRDBTestCase {
                     _ = try db.makeUpdateStatement("UPDATE persons SET age = 1;x")
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 21)  // SQLITE_MISUSE
+                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "Multiple statements found. To execute multiple statements, use Database.execute() instead.")
                     XCTAssertEqual(error.sql!, "UPDATE persons SET age = 1;x")
                     XCTAssertEqual(error.description, "SQLite error 21 with statement `UPDATE persons SET age = 1;x`: Multiple statements found. To execute multiple statements, use Database.execute() instead.")

--- a/Tests/Public/Core/Statement/UpdateStatementTests.swift
+++ b/Tests/Public/Core/Statement/UpdateStatementTests.swift
@@ -293,7 +293,7 @@ class UpdateStatementTests : GRDBTestCase {
                     _ = try db.makeUpdateStatement("UPDATE blah SET id = 12")
                     XCTFail()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_ERROR)
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                     XCTAssertEqual(error.message!, "no such table: blah")
                     XCTAssertEqual(error.sql!, "UPDATE blah SET id = 12")
                     XCTAssertEqual(error.description, "SQLite error 1 with statement `UPDATE blah SET id = 12`: no such table: blah")
@@ -310,7 +310,7 @@ class UpdateStatementTests : GRDBTestCase {
                     _ = try db.makeUpdateStatement("UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                    XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "Multiple statements found. To execute multiple statements, use Database.execute() instead.")
                     XCTAssertEqual(error.sql!, "UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
                     XCTAssertEqual(error.description, "SQLite error 21 with statement `UPDATE persons SET age = 1; UPDATE persons SET age = 2;`: Multiple statements found. To execute multiple statements, use Database.execute() instead.")
@@ -327,7 +327,7 @@ class UpdateStatementTests : GRDBTestCase {
                     _ = try db.makeUpdateStatement("UPDATE persons SET age = 1;x")
                     XCTFail("Expected error")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                    XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                     XCTAssertEqual(error.message!, "Multiple statements found. To execute multiple statements, use Database.execute() instead.")
                     XCTAssertEqual(error.sql!, "UPDATE persons SET age = 1;x")
                     XCTAssertEqual(error.description, "SQLite error 21 with statement `UPDATE persons SET age = 1;x`: Multiple statements found. To execute multiple statements, use Database.execute() instead.")

--- a/Tests/Public/Core/StatementColumnConvertible/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/Public/Core/StatementColumnConvertible/StatementColumnConvertibleFetchTests.swift
@@ -144,7 +144,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -190,7 +190,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -199,7 +199,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 21) // SQLITE_MISUSE
+                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -233,7 +233,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -296,7 +296,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -334,7 +334,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -368,7 +368,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -478,7 +478,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -512,7 +512,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -586,7 +586,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -625,7 +625,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -693,7 +693,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -731,7 +731,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -765,7 +765,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                        XCTAssertEqual(error.code, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/StatementColumnConvertible/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/Public/Core/StatementColumnConvertible/StatementColumnConvertibleFetchTests.swift
@@ -144,7 +144,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -190,7 +190,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -199,7 +199,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_MISUSE)
+                        XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 21 with statement `\(sql)`: \(customError)")
@@ -233,7 +233,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -296,7 +296,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value NULL to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value NULL to \(Fetched.self)")
@@ -334,7 +334,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -368,7 +368,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -478,7 +478,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -512,7 +512,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try value()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -586,7 +586,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor.next()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -625,7 +625,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try cursor()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")
@@ -693,7 +693,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "could not convert database value \"foo\" to \(Fetched.self)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: could not convert database value \"foo\" to \(Fetched.self)")
@@ -731,7 +731,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "\(customError)")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: \(customError)")
@@ -765,7 +765,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                         _ = try array()
                         XCTFail()
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_ERROR)
+                        XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                         XCTAssertEqual(error.message, "no such table: nonExistingTable")
                         XCTAssertEqual(error.sql!, sql)
                         XCTAssertEqual(error.description, "SQLite error 1 with statement `\(sql)`: no such table: nonExistingTable")

--- a/Tests/Public/Core/TransactionObserver/TransactionObserverTests.swift
+++ b/Tests/Public/Core/TransactionObserver/TransactionObserverTests.swift
@@ -796,7 +796,7 @@ class TransactionObserverTests: GRDBTestCase {
                         try Artwork(title: "meh").save(db)
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 19)
+                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -809,7 +809,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19)
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -834,7 +834,7 @@ class TransactionObserverTests: GRDBTestCase {
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
                         // Immediate constraint check has failed.
-                        XCTAssertEqual(error.code, 19)
+                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -848,7 +848,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19)
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -930,7 +930,7 @@ class TransactionObserverTests: GRDBTestCase {
                         try Artwork(title: "meh").save(db)
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, 19)
+                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -943,7 +943,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19)
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -969,7 +969,7 @@ class TransactionObserverTests: GRDBTestCase {
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
                         // Immediate constraint check has failed.
-                        XCTAssertEqual(error.code, 19)
+                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -983,7 +983,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, 19)
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif

--- a/Tests/Public/Core/TransactionObserver/TransactionObserverTests.swift
+++ b/Tests/Public/Core/TransactionObserver/TransactionObserverTests.swift
@@ -796,7 +796,7 @@ class TransactionObserverTests: GRDBTestCase {
                         try Artwork(title: "meh").save(db)
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -809,7 +809,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -834,7 +834,7 @@ class TransactionObserverTests: GRDBTestCase {
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
                         // Immediate constraint check has failed.
-                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -848,7 +848,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -930,7 +930,7 @@ class TransactionObserverTests: GRDBTestCase {
                         try Artwork(title: "meh").save(db)
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -943,7 +943,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -969,7 +969,7 @@ class TransactionObserverTests: GRDBTestCase {
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
                         // Immediate constraint check has failed.
-                        XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -983,7 +983,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif

--- a/Tests/Public/Core/TransactionObserver/TransactionObserverTests.swift
+++ b/Tests/Public/Core/TransactionObserver/TransactionObserverTests.swift
@@ -796,7 +796,7 @@ class TransactionObserverTests: GRDBTestCase {
                         try Artwork(title: "meh").save(db)
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -809,7 +809,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -834,7 +834,7 @@ class TransactionObserverTests: GRDBTestCase {
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
                         // Immediate constraint check has failed.
-                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -848,7 +848,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -930,7 +930,7 @@ class TransactionObserverTests: GRDBTestCase {
                         try Artwork(title: "meh").save(db)
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
-                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -943,7 +943,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif
@@ -969,7 +969,7 @@ class TransactionObserverTests: GRDBTestCase {
                         XCTFail("Expected Error")
                     } catch let error as DatabaseError {
                         // Immediate constraint check has failed.
-                        XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                        XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                         #if SQLITE_ENABLE_PREUPDATE_HOOK
                             XCTAssertEqual(observer.willChangeCount, 0)
                         #endif
@@ -983,7 +983,7 @@ class TransactionObserverTests: GRDBTestCase {
                 }
                 XCTFail("Expected Error")
             } catch let error as DatabaseError {
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 0)
                 #endif

--- a/Tests/Public/Encryption/EncryptionTests.swift
+++ b/Tests/Public/Encryption/EncryptionTests.swift
@@ -40,7 +40,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -66,7 +66,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -146,7 +146,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -171,7 +171,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -248,7 +248,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -273,7 +273,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -353,7 +353,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -377,7 +377,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue(filename: "plaintext.sqlite")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
+                    XCTAssertEqual(error.resultCode, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")

--- a/Tests/Public/Encryption/EncryptionTests.swift
+++ b/Tests/Public/Encryption/EncryptionTests.swift
@@ -40,7 +40,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -66,7 +66,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -146,7 +146,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -171,7 +171,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -248,7 +248,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -273,7 +273,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabasePool()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -353,7 +353,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue()
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")
@@ -377,7 +377,7 @@ class EncryptionTests: GRDBTestCase {
                 do {
                     _ = try makeDatabaseQueue(filename: "plaintext.sqlite")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 26) // SQLITE_NOTADB
+                    XCTAssertEqual(error.code, .SQLITE_NOTADB)
                     XCTAssertEqual(error.message!, "file is encrypted or is not a database")
                     XCTAssertTrue(error.sql == nil)
                     XCTAssertEqual(error.description, "SQLite error 26: file is encrypted or is not a database")

--- a/Tests/Public/FetchedRecordsController/FetchedRecordsControllerTests.swift
+++ b/Tests/Public/FetchedRecordsController/FetchedRecordsControllerTests.swift
@@ -892,7 +892,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
             }
             waitForExpectations(timeout: 1, handler: nil)
             if let error = error as? DatabaseError {
-                XCTAssertEqual(error.code, 1) // SQLITE_ERROR
+                XCTAssertEqual(error.code, .SQLITE_ERROR)
                 XCTAssertEqual(error.message, "no such table: persons")
                 XCTAssertEqual(error.sql!, "SELECT * FROM \"persons\"")
                 XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT * FROM \"persons\"`: no such table: persons")

--- a/Tests/Public/FetchedRecordsController/FetchedRecordsControllerTests.swift
+++ b/Tests/Public/FetchedRecordsController/FetchedRecordsControllerTests.swift
@@ -892,7 +892,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
             }
             waitForExpectations(timeout: 1, handler: nil)
             if let error = error as? DatabaseError {
-                XCTAssertEqual(error.code, .SQLITE_ERROR)
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
                 XCTAssertEqual(error.message, "no such table: persons")
                 XCTAssertEqual(error.sql!, "SELECT * FROM \"persons\"")
                 XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT * FROM \"persons\"`: no such table: persons")

--- a/Tests/Public/Migrations/DatabaseMigratorTests.swift
+++ b/Tests/Public/Migrations/DatabaseMigratorTests.swift
@@ -118,7 +118,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // The first migration should be committed.
                 // The second migration should be rollbacked.
                 
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [123, \"bobby\"]: foreign key constraint failed")
@@ -172,7 +172,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // Migration 1 and 2 should be committed.
                 // Migration 3 should not be committed.
                 
-                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!, "FOREIGN KEY constraint failed")
                 XCTAssertTrue(error.sql == nil)
                 XCTAssertEqual(error.description, "SQLite error 19: FOREIGN KEY constraint failed")

--- a/Tests/Public/Migrations/DatabaseMigratorTests.swift
+++ b/Tests/Public/Migrations/DatabaseMigratorTests.swift
@@ -118,7 +118,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // The first migration should be committed.
                 // The second migration should be rollbacked.
                 
-                XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [123, \"bobby\"]: foreign key constraint failed")
@@ -172,7 +172,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // Migration 1 and 2 should be committed.
                 // Migration 3 should not be committed.
                 
-                XCTAssertEqual(error.code, 19) // SQLITE_CONSTRAINT
+                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!, "FOREIGN KEY constraint failed")
                 XCTAssertTrue(error.sql == nil)
                 XCTAssertEqual(error.description, "SQLite error 19: FOREIGN KEY constraint failed")

--- a/Tests/Public/Migrations/DatabaseMigratorTests.swift
+++ b/Tests/Public/Migrations/DatabaseMigratorTests.swift
@@ -118,10 +118,10 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // The first migration should be committed.
                 // The second migration should be rollbacked.
                 
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
                 XCTAssertEqual(error.sql!, "INSERT INTO pets (masterId, name) VALUES (?, ?)")
-                XCTAssertEqual(error.description.lowercased(), "sqlite error 19 with statement `insert into pets (masterid, name) values (?, ?)` arguments [123, \"bobby\"]: foreign key constraint failed")
+                XCTAssertEqual(error.description.lowercased(), "sqlite error 787 with statement `insert into pets (masterid, name) values (?, ?)` arguments [123, \"bobby\"]: foreign key constraint failed")
 
                 let names = try dbQueue.inDatabase { db in
                     try String.fetchAll(db, "SELECT name FROM persons")
@@ -172,7 +172,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // Migration 1 and 2 should be committed.
                 // Migration 3 should not be committed.
                 
-                XCTAssertEqual(error.code, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.primaryResultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.message!, "FOREIGN KEY constraint failed")
                 XCTAssertTrue(error.sql == nil)
                 XCTAssertEqual(error.description, "SQLite error 19: FOREIGN KEY constraint failed")

--- a/Tests/Public/SQLTableBuilder/VirtualTableModuleTests.swift
+++ b/Tests/Public/SQLTableBuilder/VirtualTableModuleTests.swift
@@ -40,7 +40,7 @@ private struct ThrowingFTS3TokenizeModule : VirtualTableModule {
     }
     
     func database(_ db: Database, didCreate tableName: String, using definition: FTS3TokenizeTableDefinition) throws {
-        throw DatabaseError(code: ResultCode(rawValue: 123))
+        throw DatabaseError(resultCode: ResultCode(rawValue: 123))
     }
 }
 
@@ -73,7 +73,7 @@ class VirtualTableModuleTests: GRDBTestCase {
                     }
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code.rawValue, 123)
+                    XCTAssertEqual(error.resultCode.rawValue, 123)
                 }
                 assertDidExecute(sql: "CREATE VIRTUAL TABLE \"test\" USING fts3tokenize(simple)")
                 XCTAssertFalse(try db.tableExists("test"))

--- a/Tests/Public/SQLTableBuilder/VirtualTableModuleTests.swift
+++ b/Tests/Public/SQLTableBuilder/VirtualTableModuleTests.swift
@@ -40,7 +40,7 @@ private struct ThrowingFTS3TokenizeModule : VirtualTableModule {
     }
     
     func database(_ db: Database, didCreate tableName: String, using definition: FTS3TokenizeTableDefinition) throws {
-        throw DatabaseError(code: 123)
+        throw DatabaseError(code: ResultCode(rawValue: 123))
     }
 }
 
@@ -73,7 +73,7 @@ class VirtualTableModuleTests: GRDBTestCase {
                     }
                     XCTFail("Expected DatabaseError")
                 } catch let error as DatabaseError {
-                    XCTAssertEqual(error.code, 123)
+                    XCTAssertEqual(error.code.rawValue, 123)
                 }
                 assertDidExecute(sql: "CREATE VIRTUAL TABLE \"test\" USING fts3tokenize(simple)")
                 XCTAssertFalse(try db.tableExists("test"))


### PR DESCRIPTION
This PR addresses #171 by @hartbit.

- it activates [extended result codes](https://www.sqlite.org/rescode.html#primary_result_codes_versus_extended_result_codes), so that SQLite reports more precise errors.
- it introduces a new type `ResultCode` which has constants for all SQLite-declared result codes, so that the end user can access those result codes by name without importing the low-level C SQLite module.
- it modifies `DatabaseError` so that its former `code: Int32` property is replaced with two new properties: `resultCode` and `extendedResultCode`, which both let the user handle errors at the desired level of precision.

[Documentation](https://github.com/groue/GRDB.swift/tree/Issue171#databaseerror)

Remaining TODOs:

- [x] add a fixit for migrating away from obsolete `code` property
- [x] check the availability of `sqlite3_extended_result_codes`
