### PR TITLE
Let all requests count, introduce Request.fetchCount()

### DIFF
--- a/GRDB/Core/Request.swift
+++ b/GRDB/Core/Request.swift
@@ -13,7 +13,7 @@ public protocol Request {
     /// executed, and an eventual row adapter.
     func prepare(_ db: Database) throws -> (SelectStatement, RowAdapter?)
     
-    /// The number of rows matched by the request.
+    /// The number of rows fetched by the request.
     ///
     /// Default implementation builds a naive SQL query based on the statement
     /// returned by the `prepare` method: `SELECT COUNT(*) FROM (...)`.
@@ -26,7 +26,7 @@ public protocol Request {
 }
 
 extension Request {
-    /// The number of rows matched by the request.
+    /// The number of rows fetched by the request.
     ///
     /// This default implementation builds a naive SQL query based on the
     /// statement returned by the `prepare` method: `SELECT COUNT(*) FROM (...)`.

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -234,7 +234,7 @@ extension QueryInterfaceRequest {
     
     // MARK: Counting
     
-    /// The number of rows matched by the request.
+    /// The number of rows fetched by the request.
     ///
     /// - parameter db: A database connection.
     public func fetchCount(_ db: Database) throws -> Int {

--- a/README.md
+++ b/README.md
@@ -3275,7 +3275,7 @@ protocol TypedRequest : Request {
 
 The `prepare` method returns a tuple made of a [prepared statement](#prepared-statements) and an optional [row adapter](#row-adapters). The prepared statement tells which SQL query should be executed. The row adapter can help *presenting* the fetched rows in the way expected by the row consumers (we'll see an example below).
 
-The `fetchCount` method has a default implementation that builds a correct but naive SQL query from the statement returned by `prepare`: `SELECT COUNT(*) FROM (...)`. Adopting types can refine the counting SQL by refining their `fetchCount` implementation.
+The `fetchCount` method has a default implementation that builds a correct but naive SQL query from the statement returned by `prepare`: `SELECT COUNT(*) FROM (...)`. Adopting types can refine the counting SQL by customizing their `fetchCount` implementation.
 
 
 ### Fetching From Custom Requests

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,9 @@
 - [ ] registerMigrationWithDisabledForeignKeyChecks should be renamed registerMigrationWithDeferredForeignKeyChecks
 - [ ] Enable extended result codes (https://github.com/groue/GRDB.swift/issues/171)
-- [ ] Request.fetchCount() (see https://github.com/groue/GRDB.swift/issues/176#issuecomment-282783884). This method should be a customization point, not an extension.
+- [X] Request.fetchCount() (see https://github.com/groue/GRDB.swift/issues/176#issuecomment-282783884). This method should be a customization point, not an extension.
     - [X] implementation
     - [X] tests
-    - [ ] documentation
+    - [X] documentation
 - [ ] Check that https://github.com/groue/GRDB.swift/issues/172#issuecomment-282511719 is true (manual deferred foreign key check)
 - [ ] Document how to query external content tables (https://github.com/groue/GRDB.swift/issues/178)
 - [ ] SQLiteLib 3.17.0

--- a/Tests/Public/Core/Request/RequestTests.swift
+++ b/Tests/Public/Core/Request/RequestTests.swift
@@ -24,7 +24,7 @@ class RequestTests: GRDBTestCase {
             try db.execute("INSERT INTO table1 DEFAULT VALUES")
             try db.execute("INSERT INTO table1 DEFAULT VALUES")
             
-            let request = CustomRequest()
+            let request: Request = CustomRequest()  // Lose type
             let rows = try Row.fetchAll(db, request)
             XCTAssertEqual(lastSQLQuery, "SELECT * FROM table1")
             XCTAssertEqual(rows.count, 2)
@@ -48,7 +48,7 @@ class RequestTests: GRDBTestCase {
             try db.execute("INSERT INTO table1 DEFAULT VALUES")
             try db.execute("INSERT INTO table1 DEFAULT VALUES")
             
-            let request = CustomRequest()
+            let request: Request = CustomRequest()  // Lose type
             let count = try request.fetchCount(db)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT * FROM table1)")
             XCTAssertEqual(count, 2)
@@ -74,7 +74,7 @@ class RequestTests: GRDBTestCase {
             try db.execute("INSERT INTO table1 DEFAULT VALUES")
             try db.execute("INSERT INTO table1 DEFAULT VALUES")
             
-            let request = CustomRequest()
+            let request: Request = CustomRequest()  // Lose type
             let count = try request.fetchCount(db)
             XCTAssertEqual(lastSQLQuery, "INSERT INTO table1 DEFAULT VALUES")
             XCTAssertEqual(count, 2)


### PR DESCRIPTION
This PR addresses a [suggestion](https://github.com/groue/GRDB.swift/issues/176#issuecomment-282764867) from @hartbit, and adds a `fetchCount` method to the `Request` protocol which fuels [query interface requests](https://github.com/groue/GRDB.swift#requests) as well as [custom requests](https://github.com/groue/GRDB.swift#custom-requests):

```swift
let request: Request = ...
let count = try request.fetchCount(db) // Int
```

The `fetchCount` method has a default implementation which performs a naive counting in the form of a `SELECT COUNT(*) FROM (...)` query. For example:

```swift
let request = SQLRequest("SELECT ...")
// SELECT COUNT(*) FROM (SELECT ...)
let count = try request.fetchCount(db)
```

The `fetchCount` method is a *customization point*, though, that adopting types can implement in order to provide an efficient counting SQL query. This is the case, for example, of the requests from the query interface ([examples](https://github.com/groue/GRDB.swift#fetching-aggregated-values)).

[Documentation](https://github.com/groue/GRDB.swift/tree/RequestFetchCount#custom-requests)