### PR TITLE
Add test_docker Makefile target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git/
+.build/
+!.build/checkouts/
+!.build/repositories/
+!.build/workspace-state.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM swift:3.1
+
+WORKDIR /package
+
+COPY . ./
+
+# Not neccessary because dependencies are copied from host
+# but let's ensure they're in clean state
+RUN swift package fetch
+RUN swift package clean
+
+# https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/
+RUN apt-get update && \
+    apt-get install -y libsqlite3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Tests are not working yet on Linux
+#CMD swift build && swift test --parallel
+CMD swift build
+

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GIT := $(shell command -v git)
 JAZZY := $(shell command -v jazzy)
 POD := $(shell command -v pod)
 SWIFT := $(shell command -v swift)
+DOCKER := $(shell command -v docker)
 XCODEBUILD := $(shell command -v xcodebuild)
 
 
@@ -124,6 +125,10 @@ test_framework_GRDBCipheriOS_minTarget: SQLCipher
 test_SPM:
 	$(SWIFT) package clean
 	$(SWIFT) test
+
+test_docker:
+	$(DOCKER) build --tag grdb .
+	$(DOCKER) run --rm grdb
 
 test_install_manual:
 	$(XCODEBUILD) \


### PR DESCRIPTION
Run `make test_docker` to try building GRDB on official Swift Docker image.
The code in 'pr_linux' (https://github.com/groue/GRDB.swift/pull/205) branch should build cleanly, tests aren't working yet and are commented out in Dockerfile.
I've followed this article: https://oleb.net/blog/2017/03/testing-swift-packages-on-linux/
