### PR TITLE
SQLite 3.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+## Next Version
+
+**New**
+
+- Upgrade custom SQLite builds to [v3.19.0](http://www.sqlite.org/changes.html) (thanks to [@swiftlyfalling](https://github.com/swiftlyfalling/SQLiteLib)).
+
+
 ## 0.109.0
 
 Released May 22, 2017

--- a/Documentation/CustomSQLiteBuilds.md
+++ b/Documentation/CustomSQLiteBuilds.md
@@ -3,7 +3,7 @@ Custom SQLite Builds
 
 By default, GRDB uses the version of SQLite that ships with the target operating system.
 
-**You can build GRDB with a custom build of [SQLite 3.19.0](https://www.sqlite.org/changes.html).**
+**You can build GRDB with a custom build of [SQLite 3.19.2](https://www.sqlite.org/changes.html).**
 
 A custom SQLite build can activate extra SQLite features, and extra GRDB features as well, such as support for the [FTS5 full-text search engine](../../../#full-text-search), and [SQLite Pre-Update Hooks](../../../#support-for-sqlite-pre-update-hooks).
 

--- a/Documentation/CustomSQLiteBuilds.md
+++ b/Documentation/CustomSQLiteBuilds.md
@@ -3,7 +3,7 @@ Custom SQLite Builds
 
 By default, GRDB uses the version of SQLite that ships with the target operating system.
 
-**You can build GRDB with a custom build of [SQLite 3.18.0](https://www.sqlite.org/changes.html).**
+**You can build GRDB with a custom build of [SQLite 3.19.0](https://www.sqlite.org/changes.html).**
 
 A custom SQLite build can activate extra SQLite features, and extra GRDB features as well, such as support for the [FTS5 full-text search engine](../../../#full-text-search), and [SQLite Pre-Update Hooks](../../../#support-for-sqlite-pre-update-hooks).
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Installation
 
 See [Encryption](#encryption) for the installation procedure of GRDB with SQLCipher.
 
-See [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) for the installation procedure of GRDB with a customized build of SQLite 3.19.0.
+See [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) for the installation procedure of GRDB with a customized build of SQLite 3.19.2.
 
 
 ## CocoaPods

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Installation
 
 See [Encryption](#encryption) for the installation procedure of GRDB with SQLCipher.
 
-See [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) for the installation procedure of GRDB with a customized build of SQLite 3.18.0.
+See [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) for the installation procedure of GRDB with a customized build of SQLite 3.19.0.
 
 
 ## CocoaPods

--- a/Tests/GRDBTests/SelectStatementTests.swift
+++ b/Tests/GRDBTests/SelectStatementTests.swift
@@ -1,4 +1,7 @@
 import XCTest
+#if SWIFT_PACKAGE
+    import CSQLite
+#endif
 #if GRDBCIPHER
     import GRDBCipher
 #elseif GRDBCUSTOMSQLITE


### PR DESCRIPTION
This PR bumps custom SQLite builds to 3.19.2.

It also leverages the [new authorizer callback](http://www.sqlite.org/changes.html#version_3_19_0) in order to better track requests that do not select any column from a table, like `SELECT COUNT(*) FROM t1` or `SELECT t1.* FROM t1, t2`.