### PR TITLE
Replace "persistentDictionary" with PersistenceContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ Release Notes
 - `DatabaseCoder` has been removed.
 - `QueryInterfaceRequest.exists` has been removed.
 - `QueryInterfaceRequest.contains` has been removed.
+- `MutablePersistable`, the protocol that defines persistence methods, has been changed:
+    
+    ```diff
+     protocol MutablePersistable : TableMapping {
+    -    var persistentDictionary: [String: DatabaseValueConvertible?] { get }
+    +    func encode(to container: inout PersistenceContainer)
+     }
+    ```
+    
+    For example:
+
+    ```diff
+     struct Player : MutablePersistable {
+         let name: String
+         let score: Int
+
+    -    var persistentDictionary: [String: DatabaseValueConvertible?] {
+    -        return [
+    -            "name": name,
+    -            "score": score,
+    -        ]
+    -    }
+    +    func encode(to container: inout PersistenceContainer) {
+    +        container["name"] = name
+    +        container["score"] = score
+    +    }
+     }
+    ```
 
 
 ## 0.110.0

--- a/DemoApps/GRDBDemoiOS/GRDBDemoiOS/Person.swift
+++ b/DemoApps/GRDBDemoiOS/GRDBDemoiOS/Person.swift
@@ -24,11 +24,10 @@ class Person: Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String : DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "name": name,
-            "score": score]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["score"] = score
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Documentation/ExtendingGRDB.md
+++ b/Documentation/ExtendingGRDB.md
@@ -117,8 +117,9 @@ Well, you will be able to use UIColor like all other [value types](../../../#val
             super.init(row: row)
         }
         
-        override var persistentDictionary: [String: DatabaseValueConvertible?] {
-            return ["name": name, "color": color]
+        override func encode(to container: inout PersistenceContainer) {
+            container["name"] = name
+            container["color"] = color
         }
     }
     ```

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -815,7 +815,7 @@ extension FetchedRecordsController where Record: MutablePersistable {
     /// - returns: The index path of *record* in the fetched records, or nil
     ///   if record could not be found.
     public func indexPath(for record: Record) -> IndexPath? {
-        let item = Item<Record>(row: Row(record.persistentDictionary))
+        let item = Item<Record>(row: Row(record))
         guard let fetchedItems = fetchedItems, let index = fetchedItems.index(where: { itemsAreIdentical($0, item) }) else {
             return nil
         }

--- a/Playgrounds/JSONSynchronization.playground/Contents.swift
+++ b/Playgrounds/JSONSynchronization.playground/Contents.swift
@@ -54,8 +54,9 @@ class Person : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "name": name]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Playgrounds/Record.playground/Contents.swift
+++ b/Playgrounds/Record.playground/Contents.swift
@@ -68,8 +68,10 @@ class Person : Record {
     
 //: 3. The dictionary of values that are stored in the database:
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "firstName": firstName, "lastName": lastName]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["firstName"] = firstName
+        container["lastName"] = lastName
     }
     
 //: 4. When relevant, update the person's id after a database row has been inserted:

--- a/Playgrounds/Tour.playground/Contents.swift
+++ b/Playgrounds/Tour.playground/Contents.swift
@@ -83,14 +83,12 @@ extension PointOfInterest : TableMapping {
 
 // Adopt MutablePersistable
 extension PointOfInterest : MutablePersistable {
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "title": title,
-            "favorite": favorite,
-            "latitude": coordinate.latitude,
-            "longitude": coordinate.longitude
-        ]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["title"] = title
+        container["favorite"] = favorite
+        container["latitude"] = coordinate.latitude
+        container["longitude"] = coordinate.longitude
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/README.md
+++ b/README.md
@@ -975,8 +975,9 @@ class Link : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["url": url, "verified": isVerified]
+    override func encode(to container: inout PersistenceContainer) {
+        container["url"] = url
+        container["verified"] = isVerified
     }
 }
 ```
@@ -1864,6 +1865,25 @@ extension PointOfInterest : RowConvertible {
 }
 ```
 
+Rows also accept keys of type `Column`:
+
+```swift
+extension PointOfInterest : RowConvertible {
+    static let idColumn = Column("id")
+    static let titleColumn = Column("title")
+    static let latitudeColumn = Column("latitude")
+    static let longitudeColumn = Column("longitude")
+    
+    init(row: Row) {
+        id = row.value(PointOfInterest.idColumn)
+        title = row.value(PointOfInterest.titleColumn)
+        coordinate = CLLocationCoordinate2DMake(
+            row.value(PointOfInterest.latitudeColumn),
+            row.value(PointOfInterest.longitudeColumn))
+    }
+}
+```
+
 See [column values](#column-values) for more information about the `row.value()` method.
 
 > :point_up: **Note**: for performance reasons, the same row argument to `init(row:)` is reused during the iteration of a fetch query. If you want to keep the row for later use, make sure to store a copy: `self.row = row.copy()`.
@@ -1970,8 +1990,8 @@ protocol MutablePersistable : TableMapping {
     /// The name of the database table (from TableMapping)
     static var databaseTableName: String { get }
     
-    /// The values persisted in the database
-    var persistentDictionary: [String: DatabaseValueConvertible?] { get }
+    /// Defines the values persisted in the database
+    func encode(to container: inout PersistenceContainer)
     
     /// Optional method that lets your adopting type store its rowID upon
     /// successful insertion. Don't call it directly: it is called for you.
@@ -1994,7 +2014,7 @@ Yes, two protocols instead of one. Both grant exactly the same advantages. Here 
 
 - Otherwise, stick with `Persistable`. Particularly if your type is a class.
 
-The `persistentDictionary` property returns a dictionary whose keys are column names, and values any DatabaseValueConvertible value (Bool, Int, String, Date, Swift enums, etc.) See [Values](#values) for more information.
+The `encode(to:)` method defines which [values](#values) are stored in database columns.
 
 The optional `didInsert` method lets the adopting type store its rowID after successful insertion. If your table has an INTEGER PRIMARY KEY column, you are likely to define this method. Otherwise, you can safely ignore it. It is called from a protected dispatch queue, and serialized with all database updates.
 
@@ -2004,12 +2024,11 @@ The optional `didInsert` method lets the adopting type store its rowID after suc
 extension PointOfInterest : MutablePersistable {
     
     /// The values persisted in the database
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "title": title,
-            "latitude": coordinate.latitude,
-            "longitude": coordinate.longitude]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["title"] = title
+        container["latitude"] = coordinate.latitude
+        container["longitude"] = coordinate.longitude
     }
     
     // Update id upon successful insertion:
@@ -2027,20 +2046,23 @@ try paris.insert(db)
 paris.id   // some value
 ```
 
-When your record has many columns, the Swift compiler may take a long time compiling the `persistentDictionary` property:
+Persistence containers also accept keys of type `Column`:
 
 ```swift
-// May be long to compile
-var persistentDictionary: [String: DatabaseValueConvertible?] {
-    return [
-        "id": id,
-        "title": title,
-        // many other columns
-    ]
+extension PointOfInterest : MutablePersistable {
+    static let idColumn = Column("id")
+    static let titleColumn = Column("title")
+    static let latitudeColumn = Column("latitude")
+    static let longitudeColumn = Column("longitude")
+    
+    func encode(to container: inout PersistenceContainer) {
+        container[PointOfInterest.idColumn] = id
+        container[PointOfInterest.titleColumn] = title
+        container[PointOfInterest.latitudeColumn] = coordinate.latitude
+        container[PointOfInterest.longitudeColumn] = coordinate.longitude
+    }
 }
 ```
-
-If this happens, check the ["Compilation takes a long time" FAQ](#compilation-takes-a-long-time).
 
 
 ### Persistence Methods
@@ -2229,12 +2251,11 @@ class PointOfInterest : Record {
     }
     
     /// The values persisted in the database
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "title": title,
-            "latitude": coordinate.latitude,
-            "longitude": coordinate.longitude]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["title"] = title
+        container["latitude"] = coordinate.latitude
+        container["longitude"] = coordinate.longitude
     }
     
     /// Update record ID after a successful insertion
@@ -2369,18 +2390,16 @@ When SQLite won't let you provide an explicit primary key (as in [full-text](#fu
     event.id // some value
     ```
 
-3. Include the rowid in your `persistentDictionary`, and keep it in the `didInsert(with:for:)` method (both from the [Persistable and MutablePersistable](#persistable-protocol) protocols):
+3. Encode the rowid in `encode(to:)`, and keep it in the `didInsert(with:for:)` method (both from the [Persistable and MutablePersistable](#persistable-protocol) protocols):
     
     ```swift
     struct Event : MutablePersistable {
         var id: Int64?
         
-        var persistentDictionary: [String: DatabaseValueConvertible?] {
-            return [
-                "rowid": id,
-                "message": message,
-                "date": date,
-            ]
+        func encode(to container: inout PersistenceContainer) {
+            container[.rowID] = id
+            container["message"] = message
+            container["date"] = date
         }
         
         mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -5473,8 +5492,10 @@ class Person : Record {
         super.init()
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "name": name, "email": email] // Dictionary
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id              // String
+        container["name"] = name          // String
+        container["email"] = email        // String
     }
 }
 ```
@@ -5595,44 +5616,6 @@ let string = try dbQueue.inDatabase { db in
     try String.fetchOne(db, ...)
 }
 ```
-
-
-### Compilation takes a long time
-    
-When your [record type](#records) is very slow to compile, it is usually because its `persistentDictionary` property builds a long dictionary literal:
-
-```swift
-var persistentDictionary: [String: DatabaseValueConvertible?] {
-    // Long dictionary literals are slow to compile
-    return [
-        "a": a,
-        "b": b,
-        ...
-}
-```
-
-That's annoying, but the Swift compiler finds it difficult to compile such a dictionary. We can only hope that compiler improves over time.
-
-To speed up compilation, build your dictionary step by step:
-
-```swift
-var persistentDictionary: [String: DatabaseValueConvertible?] {
-    var dict: [String: DatabaseValueConvertible?] = [:]
-    dict.updateValue(a, forKey: "a")
-    dict.updateValue(b, forKey: "b")
-    ...
-    return dict
-}
-```
-
-> :point_up: **Note**: it is important that you use the `updateValue` method, and not the subscript setter:
-> 
-> ```swift
-> // GOOD
-> dict.updateValue(a, forKey: "a")
-> // BAD: when the value is nil, this erases the key instead of setting it to nil.
-> dict["a"] = a
-> ```
 
 
 ### SQLite error 10 "disk I/O error", SQLite error 23 "not authorized"

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ v1.0 checklit
         It's not worth the effort to introduce more concrete request types (AdaptedRequest, AdaptedTypedRequest, BoundRequest)
     - [X] Question the naming of the `request.bound(to:T.self)` method. Prefer... `request..asRequest(of: T.self)`
 - [ ] Make GRDB less stringly-typed. When a user defines a static list of columns for a record type, those columns should be easier to use:
-    - [ ] Persistable.persistentDictionary requires string keys, doesn't accept columns
+    - [X] Persistable.persistentDictionary requires string keys, doesn't accept columns
     - [ ] If possible, improve on `Person.filter(Person.email != nil)` or `Person.filter(Person.Column.email != nil)` (see [#186](https://github.com/groue/GRDB.swift/issues/186))
     - [ ] Check [SE-0166](https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md)
 

--- a/Tests/Crash/RecordCrashTests.swift
+++ b/Tests/Crash/RecordCrashTests.swift
@@ -26,8 +26,8 @@ private class RecordWithNilPrimaryKey : Record {
         return "records"
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": nil]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = nil
     }
 }
 
@@ -36,8 +36,8 @@ private class RecordForTableWithoutPrimaryKey : Record {
         return "records"
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["name": "foo"]
+    override func encode(to container: inout PersistenceContainer) {
+        container["name"] = "foo"
     }
 }
 
@@ -46,8 +46,8 @@ private class RecordForTableWithMultipleColumnsPrimaryKey : Record {
         return "records"
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["name": "foo"]
+    override func encode(to container: inout PersistenceContainer) {
+        container["name"] = "foo"
     }
 }
 
@@ -56,8 +56,8 @@ private class RecordWithRowIDPrimaryKeyNotExposedInPersistentDictionary : Record
         return "records"
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["name": "foo"]
+    override func encode(to container: inout PersistenceContainer) {
+        container["name"] = "foo"
     }
 }
 

--- a/Tests/GRDBCipher/GRDBiOS/GRDBiOS/Person.swift
+++ b/Tests/GRDBCipher/GRDBiOS/GRDBiOS/Person.swift
@@ -24,11 +24,10 @@ class Person: Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String : DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "name": name,
-            "score": score]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["score"] = score
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/FTS3RecordTests.swift
+++ b/Tests/GRDBTests/FTS3RecordTests.swift
@@ -27,13 +27,11 @@ extension Book : MutablePersistable {
     static let databaseTableName = "books"
     static let selectsRowID = true
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            Column.rowID.name: id,
-            "title": title,
-            "author": author,
-            "body": body,
-        ]
+    func encode(to container: inout PersistenceContainer) {
+        container[.rowID] = id
+        container["title"] = title
+        container["author"] = author
+        container["body"] =  body
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/FTS4RecordTests.swift
+++ b/Tests/GRDBTests/FTS4RecordTests.swift
@@ -27,13 +27,11 @@ extension Book : MutablePersistable {
     static let databaseTableName = "books"
     static let selectsRowID = true
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            Column.rowID.name: id,
-            "title": title,
-            "author": author,
-            "body": body,
-        ]
+    func encode(to container: inout PersistenceContainer) {
+        container[.rowID] = id
+        container["title"] = title
+        container["author"] = author
+        container["body"] = body
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/FTS5RecordTests.swift
+++ b/Tests/GRDBTests/FTS5RecordTests.swift
@@ -28,13 +28,11 @@ extension Book : MutablePersistable {
     static let databaseTableName = "books"
     static let selectsRowID = true
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            Column.rowID.name: id,
-            "title": title,
-            "author": author,
-            "body": body,
-        ]
+    func encode(to container: inout PersistenceContainer) {
+        container[.rowID] = id
+        container["title"] = title
+        container["author"] = author
+        container["body"] = body
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/FetchedRecordsControllerTests.swift
+++ b/Tests/GRDBTests/FetchedRecordsControllerTests.swift
@@ -74,8 +74,10 @@ private class Person : Record {
         return "persons"
     }
     
-    override var persistentDictionary: [String : DatabaseValueConvertible?] {
-        return ["id": id, "name": name, "email": email]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["email"] = email
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -117,6 +117,17 @@ class GRDBTestCase: XCTestCase {
         XCTAssertTrue(sqlQueries.contains(sql), "Did not execute \(sql)")
     }
     
+    func assert(_ record: MutablePersistable, isEncodedIn row: Row) {
+        let recordContent = AnySequence({ PersistenceContainer(record).makeIterator() })
+        for (column, value) in recordContent {
+            if let dbValue: DatabaseValue = row.value(named: column) {
+                XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
+            } else {
+                XCTFail("Missing column \(column) in fetched row")
+            }
+        }
+    }
+    
     func sql(_ databaseReader: DatabaseReader, _ request: Request) -> String {
         return try! databaseReader.unsafeRead { db in
             _ = try Row.fetchOne(db, request)

--- a/Tests/GRDBTests/MutablePersistablePersistenceConflictPolicyTests.swift
+++ b/Tests/GRDBTests/MutablePersistablePersistenceConflictPolicyTests.swift
@@ -12,8 +12,8 @@ private struct DefaultPolicy: MutablePersistable {
     
     static let databaseTableName = "records"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -27,8 +27,8 @@ private struct MixedPolicy: MutablePersistable {
     static let databaseTableName = "records"
     static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .fail, update: .rollback)
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -43,8 +43,9 @@ private struct ReplacePolicy: MutablePersistable {
     static let databaseTableName = "records"
     static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .replace, update: .replace)
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "email": email]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["email"] = email
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -58,8 +59,8 @@ private struct IgnorePolicy: MutablePersistable {
     static let databaseTableName = "records"
     static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .ignore, update: .ignore)
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -73,8 +74,8 @@ private struct FailPolicy: MutablePersistable {
     static let databaseTableName = "records"
     static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .fail, update: .fail)
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -88,8 +89,8 @@ private struct AbortPolicy: MutablePersistable {
     static let databaseTableName = "records"
     static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .abort, update: .abort)
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -103,8 +104,8 @@ private struct RollbackPolicy: MutablePersistable {
     static let databaseTableName = "records"
     static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .rollback, update: .rollback)
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/MutablePersistableTests.swift
+++ b/Tests/GRDBTests/MutablePersistableTests.swift
@@ -14,8 +14,11 @@ private struct MutablePersistablePerson : MutablePersistable {
     
     static let databaseTableName = "persons"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["iD": id, "NAme": name, "aGe": age] // various cases
+    func encode(to container: inout PersistenceContainer) {
+        // mangle cases
+        container["iD"] = id
+        container["NAme"] = name
+        container["aGe"] = age
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -30,8 +33,9 @@ private struct MutablePersistableCountry : MutablePersistable {
     
     static let databaseTableName = "countries"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["isoCode": isoCode, "name": name]
+    func encode(to container: inout PersistenceContainer) {
+        container["isoCode"] = isoCode
+        container["name"] = name
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -51,8 +55,9 @@ private struct MutablePersistableCustomizedCountry : MutablePersistable {
     
     static let databaseTableName = "countries"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["isoCode": isoCode, "name": name]
+    func encode(to container: inout PersistenceContainer) {
+        container["isoCode"] = isoCode
+        container["name"] = name
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/PersistableTests.swift
+++ b/Tests/GRDBTests/PersistableTests.swift
@@ -13,8 +13,9 @@ private struct PersistablePerson : Persistable {
     
     static let databaseTableName = "persons"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["name": name, "age": age]
+    func encode(to container: inout PersistenceContainer) {
+        container["name"] = name
+        container["age"] = age
     }
 }
 
@@ -31,8 +32,11 @@ private class PersistablePersonClass : Persistable {
     
     static let databaseTableName = "persons"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["ID": id, "naME": name, "Age": age] // various cases
+    func encode(to container: inout PersistenceContainer) {
+        // mangle case
+        container["ID"] = id
+        container["naME"] = name
+        container["Age"] = age
     }
     
     func didInsert(with rowID: Int64, for column: String?) {
@@ -46,8 +50,9 @@ private struct PersistableCountry : Persistable {
     
     static let databaseTableName = "countries"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["isoCode": isoCode, "name": name]
+    func encode(to container: inout PersistenceContainer) {
+        container["isoCode"] = isoCode
+        container["name"] = name
     }
 }
 
@@ -62,8 +67,9 @@ private struct PersistableCustomizedCountry : Persistable {
     
     static let databaseTableName = "countries"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["isoCode": isoCode, "name": name]
+    func encode(to container: inout PersistenceContainer) {
+        container["isoCode"] = isoCode
+        container["name"] = name
     }
     
     func insert(_ db: Database) throws {
@@ -98,8 +104,9 @@ private struct Citizenship : Persistable {
     
     static let databaseTableName = "citizenships"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["countryIsoCode": countryIsoCode, "personID": personID]
+    func encode(to container: inout PersistenceContainer) {
+        container["countryIsoCode"] = countryIsoCode
+        container["personID"] = personID
     }
 }
 

--- a/Tests/GRDBTests/Record+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/Record+QueryInterfaceRequestTests.swift
@@ -30,8 +30,10 @@ private class Reader : Record {
         return "readers"
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "name": name, "age": age]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["age"] = age
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/RecordCopyTests.swift
+++ b/Tests/GRDBTests/RecordCopyTests.swift
@@ -31,13 +31,11 @@ private class Person : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "name": name,
-            "age": age,
-            "creationDate": creationDate,
-        ]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["age"] = age
+        container["creationDate"] = creationDate
     }
 }
 

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -33,8 +33,8 @@ class MinimalRowID : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {
@@ -62,13 +62,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -80,13 +74,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -113,13 +101,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -148,13 +130,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -185,13 +161,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -203,13 +173,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -221,13 +185,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -240,13 +198,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalRowIDs WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
@@ -33,8 +33,8 @@ class MinimalSingle: Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["UUID": UUID]
+    override func encode(to container: inout PersistenceContainer) {
+        container["UUID"] = UUID
     }
 }
 
@@ -71,13 +71,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalSingles WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -106,13 +100,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalSingles WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -142,13 +130,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalSingles WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -193,13 +175,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalSingles WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -212,13 +188,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalSingles WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -232,13 +202,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM minimalSingles WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -49,13 +49,11 @@ private class Person : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            Column.rowID.name: id,
-            "name": name,
-            "age": age,
-            "creationDate": creationDate,
-        ]
+    override func encode(to container: inout PersistenceContainer) {
+        container[.rowID] = id
+        container["name"] = name
+        container["age"] = age
+        container["creationDate"] = creationDate
     }
     
     override func insert(_ db: Database) throws {
@@ -92,13 +90,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -111,13 +103,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
             return .rollback
         }
         // This is debatable, actually.
@@ -131,13 +117,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -175,13 +155,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -223,13 +197,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -260,13 +228,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -277,13 +239,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -293,18 +249,12 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             let record = Person(name: "Arthur", age: 41)
             try record.insert(db)
-            try record.save(db)   // Test that useless update succeeds. It is a proof that save() has performed an UPDATE statement, and not an INSERT statement: INSERT would have throw a database error for duplicated key.
+            try record.save(db)   // Test that useless update succeeds. It is a proof that save() has performed an UPDATE statement, and not an INSERT statement: INSERT would have thrown a database error for duplicated key.
             record.age = record.age! + 1
             try record.save(db)   // Actual update
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -317,13 +267,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT *, rowid FROM persons WHERE rowid = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
@@ -43,11 +43,10 @@ private class Citizenship : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "personName": personName,
-            "countryName": countryName,
-            "native": native]
+    override func encode(to container: inout PersistenceContainer) {
+        container["personName"] = personName
+        container["countryName"] = countryName
+        container["native"] = native
     }
 }
 
@@ -84,13 +83,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM citizenships WHERE personName = ? AND countryName = ?", arguments: [record.personName, record.countryName])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -117,13 +110,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM citizenships WHERE personName = ? AND countryName = ?", arguments: [record.personName, record.countryName])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -165,13 +152,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM citizenships WHERE personName = ? AND countryName = ?", arguments: [record.personName, record.countryName])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -214,13 +195,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM citizenships WHERE personName = ? AND countryName = ?", arguments: [record.personName, record.countryName])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -234,13 +209,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.save(db)   // Actual update
             
             let row = try Row.fetchOne(db, "SELECT * FROM citizenships WHERE personName = ? AND countryName = ?", arguments: [record.personName, record.countryName])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -253,13 +222,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM citizenships WHERE personName = ? AND countryName = ?", arguments: [record.personName, record.countryName])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordPrimaryKeyNoneTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyNoneTests.swift
@@ -40,8 +40,9 @@ private class Item : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["name": name, "email": email]
+    override func encode(to container: inout PersistenceContainer) {
+        container["name"] = name
+        container["email"] = email
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
@@ -46,13 +46,11 @@ private class Person : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "name": name,
-            "age": age,
-            "creationDate": creationDate,
-        ]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["age"] = age
+        container["creationDate"] = creationDate
     }
     
     override func insert(_ db: Database) throws {
@@ -89,13 +87,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -108,13 +100,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
             return .rollback
         }
         // This is debatable, actually.
@@ -128,13 +114,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -172,13 +152,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -220,13 +194,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -257,13 +225,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             XCTAssertTrue(record.id != nil)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -274,13 +236,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -294,13 +250,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.save(db)   // Actual update
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -313,13 +263,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM persons WHERE id = ?", arguments: [record.id])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
@@ -38,8 +38,9 @@ class Pet : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["UUID": UUID, "name": name]
+    override func encode(to container: inout PersistenceContainer) {
+        container["UUID"] = UUID
+        container["name"] = name
     }
 }
 
@@ -75,13 +76,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM pets WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -108,13 +103,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM pets WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -156,13 +145,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM pets WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -205,13 +188,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM pets WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -225,13 +202,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.save(db)   // Actual update
             
             let row = try Row.fetchOne(db, "SELECT * FROM pets WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -244,13 +215,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM pets WHERE UUID = ?", arguments: [record.UUID])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
@@ -37,8 +37,9 @@ class Email : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["email": email, "label": label]
+    override func encode(to container: inout PersistenceContainer) {
+        container["email"] = email
+        container["label"] = label
     }
 }
 
@@ -76,13 +77,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -97,13 +92,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -117,13 +106,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.insert(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -153,13 +136,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.update(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -204,13 +181,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -223,13 +194,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 
@@ -243,13 +208,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.save(db)
             
             let row = try Row.fetchOne(db, "SELECT * FROM emails WHERE email = ?", arguments: [record.email])!
-            for (key, value) in record.persistentDictionary {
-                if let dbValue: DatabaseValue = row.value(named: key) {
-                    XCTAssertEqual(dbValue, value?.databaseValue ?? .null)
-                } else {
-                    XCTFail("Missing column \(key) in fetched row")
-                }
-            }
+            assert(record, isEncodedIn: row)
         }
     }
 

--- a/Tests/GRDBTests/RecordSubClassTests.swift
+++ b/Tests/GRDBTests/RecordSubClassTests.swift
@@ -45,13 +45,11 @@ private class Person : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "id": id,
-            "name": name,
-            "age": age,
-            "creationDate": creationDate,
-        ]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["age"] = age
+        container["creationDate"] = creationDate
     }
     
     override func insert(_ db: Database) throws {

--- a/Tests/GRDBTests/RecordWithColumnNameManglingTests.swift
+++ b/Tests/GRDBTests/RecordWithColumnNameManglingTests.swift
@@ -37,10 +37,11 @@ class BadlyMangledStuff : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
+    override func encode(to container: inout PersistenceContainer) {
         // User won't peek fancy column names because he will notice that the
         // generated INSERT query needs actual column names.
-        return ["id": id, "name": name]
+        container["id"] = id
+        container["name"] = name
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/RowConvertible+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/RowConvertible+QueryInterfaceRequestTests.swift
@@ -24,8 +24,10 @@ extension Reader : RowConvertible {
 extension Reader : MutablePersistable {
     static let databaseTableName = "readers"
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "name": name, "age": age]
+    func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
+        container["age"] = age
     }
     
     mutating func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/GRDBTests/TransactionObserverTests.swift
+++ b/Tests/GRDBTests/TransactionObserverTests.swift
@@ -117,8 +117,9 @@ private class Artist : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "name": name]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["name"] = name
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {
@@ -160,8 +161,10 @@ private class Artwork : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["id": id, "artistId": artistId, "title": title]
+    override func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["artistId"] = artistId
+        container["title"] = title
     }
     
     override func didInsert(with rowID: Int64, for column: String?) {

--- a/Tests/Performance/GRDBProfiling/GRDBProfiling/AppDelegate.swift
+++ b/Tests/Performance/GRDBProfiling/GRDBProfiling/AppDelegate.swift
@@ -222,7 +222,16 @@ class Item : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["i0": i0, "i1": i1, "i2": i2, "i3": i3, "i4": i4, "i5": i5, "i6": i6, "i7": i7, "i8": i8, "i9": i9]
+    override func encode(to container: inout PersistenceContainer) {
+        container["i0"] = i0
+        container["i1"] = i1
+        container["i2"] = i2
+        container["i3"] = i3
+        container["i4"] = i4
+        container["i5"] = i5
+        container["i6"] = i6
+        container["i7"] = i7
+        container["i8"] = i8
+        container["i9"] = i9
     }
 }

--- a/Tests/Performance/PerformanceTests.swift
+++ b/Tests/Performance/PerformanceTests.swift
@@ -64,8 +64,17 @@ class Item : Record {
         super.init(row: row)
     }
     
-    override var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return ["i0": i0, "i1": i1, "i2": i2, "i3": i3, "i4": i4, "i5": i5, "i6": i6, "i7": i7, "i8": i8, "i9": i9]
+    override func encode(to container: inout PersistenceContainer) {
+        container["i0"] = i0
+        container["i1"] = i1
+        container["i2"] = i2
+        container["i3"] = i3
+        container["i4"] = i4
+        container["i5"] = i5
+        container["i6"] = i6
+        container["i7"] = i7
+        container["i8"] = i8
+        container["i9"] = i9
     }
 }
 


### PR DESCRIPTION
This PR changes the protocol that defines record [persistence methods](https://github.com/groue/GRDB.swift#persistence-methods):

```diff
 protocol MutablePersistable : TableMapping {
-    var persistentDictionary: [String: DatabaseValueConvertible?] { get }
+    func encode(to container: inout PersistenceContainer)
 }
```

For example:

```diff
 struct Player : MutablePersistable {
     let name: String
     let score: Int
     
-    var persistentDictionary: [String: DatabaseValueConvertible?] {
-        return [
-            "name": name,
-            "score": score,
-        ]
-    }
+    func encode(to container: inout PersistenceContainer) {
+        container["name"] = name
+        container["score"] = score
+    }
 }
```

This change fixes two problems with persistentDictionary:

1. Slow compilation, when the dictionary contains many values (see [FAQ: Compilation takes a long time](https://github.com/groue/GRDB.swift/blob/v0.110.0/README.md#compilation-takes-a-long-time)).
2. Lacking support for types that define a set of proper columns (ping @hartbit):

    ```swift
    // Before
    struct Player : MutablePersistable {
    let name: String
        let score: Int
        
        static let nameColumn = Column("name")
        static let scoreColumn = Column("score")
        
        var persistentDictionary: [String: DatabaseValueConvertible?] {
            // meh
            return [
                Player.nameColumn.name: name,
                Player.scoreColumn.name: score,
            ]
        }
    }
    
    // After
    struct Player : MutablePersistable {
    let name: String
        let score: Int
        
        static let nameColumn = Column("name")
        static let scoreColumn = Column("score")
        
        func encode(to container: inout PersistenceContainer) {
            // better
            container[Player.nameColumn] = name
            container[Player.scoreColumn] = score
        }
    }
    ```

**Note**: the concise `container[.name] = name` syntax is currently out of reach. The code snippet below, inspired by [SE-0166](https://github.com/apple/swift-evolution/blob/master/proposals/0166-swift-archival-serialization.md), can unfortunately not be implemented in a 100% satisfying manner:

```swift
// NOT IN THIS PR
struct Player : MutablePersistable {
    let name: String
    let score: Int
    
    enum Columns : Column {
        case name
        case score
    }
    
    func encode(to coder: DatabaseCoder) {
        var container = coder(keyedBy: Columns.self)
        container[.name] = name
        container[.score] = score
    }
}
```

The reason why the API above can not be achieved is that the current state of Swift would require both `GRDB.Column` and the `Columns` enum to conform to the `Equatable` protocol. But column types *must not* adopt Equatable. In the example below, the `Column("a") == Column("b")` Swift expression must unambiguously return an SQL expression, not a Bool.

```swift
// SELECT * FROM foos WHERE a = b
let foos = try Foo.filter(Column("a") == Column("b")).fetchAll(db)
```

This issue is tracked at [SR-5083](https://bugs.swift.org/browse/SR-5083).