### PR TITLE
Fix compilation with Xcode 9 in compatibilty mode

### DIFF
--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -25,7 +25,17 @@ public struct ResultCode : RawRepresentable, Equatable, CustomStringConvertible 
     }
     
     public var description: String {
-        return "\(rawValue) (\(String(cString: sqlite3_errstr(rawValue))))"
+        // sqlite3_errstr was added in SQLite 3.7.15 http://www.sqlite.org/changes.html#version_3_7_15
+        // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+            return "\(rawValue) (\(String(cString: sqlite3_errstr(rawValue))))"
+        #else
+            if #available(iOS 8.2, OSX 10.10, OSXApplicationExtension 10.10, iOSApplicationExtension 8.2, *) {
+                return "\(rawValue) (\(String(cString: sqlite3_errstr(rawValue))))"
+            } else {
+                return "\(rawValue)"
+            }
+        #endif
     }
     
     public static func == (_ lhs: ResultCode, _ rhs: ResultCode) -> Bool {

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -7,7 +7,7 @@ extension NSUUID : DatabaseValueConvertible {
     public var databaseValue: DatabaseValue {
         var uuidBytes = ContiguousArray(repeating: UInt8(0), count: 16)
         return uuidBytes.withUnsafeMutableBufferPointer { buffer in
-            getBytes(buffer.baseAddress)
+            getBytes(buffer.baseAddress!)
             return NSData(bytes: buffer.baseAddress, length: 16).databaseValue
         }
     }

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -7,7 +7,11 @@ extension NSUUID : DatabaseValueConvertible {
     public var databaseValue: DatabaseValue {
         var uuidBytes = ContiguousArray(repeating: UInt8(0), count: 16)
         return uuidBytes.withUnsafeMutableBufferPointer { buffer in
-            getBytes(buffer.baseAddress!)
+            #if swift(>=3.2)
+                getBytes(buffer.baseAddress!)
+            #else
+                getBytes(buffer.baseAddress)
+            #endif
             return NSData(bytes: buffer.baseAddress, length: 16).databaseValue
         }
     }

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -7,11 +7,7 @@ extension NSUUID : DatabaseValueConvertible {
     public var databaseValue: DatabaseValue {
         var uuidBytes = ContiguousArray(repeating: UInt8(0), count: 16)
         return uuidBytes.withUnsafeMutableBufferPointer { buffer in
-            #if swift(>=3.2)
-                getBytes(buffer.baseAddress!)
-            #else
-                getBytes(buffer.baseAddress)
-            #endif
+            getBytes(buffer.baseAddress!)
             return NSData(bytes: buffer.baseAddress, length: 16).databaseValue
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ default: test
 # Requirements
 # ============
 #
-# Xcode 8.3.2, with iOS8.1 Simulator installed
+# Xcode 8.3.3, with iOS8.1 Simulator installed
 # CocoaPods ~> 1.2.0 - https://cocoapods.org
 # Carthage ~> 0.20.1 - https://github.com/carthage/carthage
 # Jazzy ~> 0.7.4 - https://github.com/realm/jazzy
@@ -46,10 +46,10 @@ TEST_ACTIONS = clean build build-for-testing test-without-building
 # xcodebuild destination to run tests on iOS 8.1 (requires a pre-installed simulator)
 MIN_IOS_DESTINATION = "platform=iOS Simulator,name=iPhone 4s,OS=8.1"
 
-# xcodebuild destination to run tests on latest iOS (Xcode 8.3)
-MAX_IOS_DESTINATION = "platform=iOS Simulator,name=iPhone 7,OS=10.3"
+# xcodebuild destination to run tests on latest iOS (Xcode 8.3.3)
+MAX_IOS_DESTINATION = "platform=iOS Simulator,name=iPhone 7,OS=10.3.1"
 ifeq ($(XCODEVERSION),8.3)
-	# xcodebuild destination to run tests on latest iOS (Xcode 8.3)
+	# xcodebuild destination to run tests on latest iOS (Xcode 8.3.3)
 	# above (default) MAX_IOS_DESTINATION is appropriate
 else ifeq ($(XCODEVERSION),8.2)
 	# xcodebuild destination to run tests on latest iOS (Xcode 8.2)

--- a/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
@@ -153,7 +153,7 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         //                          }
         
         let (block1, block2) = { () -> (() -> (), () -> ()) in
-            var dbPool: DatabasePool? = try! makeDatabasePool()
+            var dbPool: DatabasePool? = try! self.makeDatabasePool()
             try! dbPool!.write { db in
                 try db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY)")
             }
@@ -231,7 +231,7 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         //                          dbPool is nil
         
         let (block1, block2) = { () -> (() -> (), () -> ()) in
-            var dbPool: DatabasePool? = try! makeDatabasePool()
+            var dbPool: DatabasePool? = try! self.makeDatabasePool()
             let block1 = { () in
                 _ = s1.wait(timeout: .distantFuture)
                 dbPool = nil

--- a/Tests/GRDBTests/DatabaseQueueReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueReleaseMemoryTests.swift
@@ -68,7 +68,7 @@ class DatabaseQueueReleaseMemoryTests: GRDBTestCase {
         //                          }
         
         let (block1, block2) = { () -> (() -> (), () -> ()) in
-            var dbQueue: DatabaseQueue? = try! makeDatabaseQueue()
+            var dbQueue: DatabaseQueue? = try! self.makeDatabaseQueue()
             try! dbQueue!.write { db in
                 try db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY)")
             }
@@ -146,7 +146,7 @@ class DatabaseQueueReleaseMemoryTests: GRDBTestCase {
         //                          dbQueue is nil
         
         let (block1, block2) = { () -> (() -> (), () -> ()) in
-            var dbQueue: DatabaseQueue? = try! makeDatabaseQueue()
+            var dbQueue: DatabaseQueue? = try! self.makeDatabaseQueue()
             
             let block1 = { () in
                 _ = s1.wait(timeout: .distantFuture)

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -105,7 +105,7 @@ class GRDBTestCase: XCTestCase {
         do { try FileManager.default.removeItem(atPath: dbDirectoryPath) } catch { }
     }
     
-    func assertNoError(file: StaticString = #file, line: UInt = #line, _ test: (Void) throws -> Void) {
+    func assertNoError(file: StaticString = #file, line: UInt = #line, _ test: () throws -> Void) {
         do {
             try test()
         } catch {

--- a/Tests/GRDBTests/MutablePersistableTests.swift
+++ b/Tests/GRDBTests/MutablePersistableTests.swift
@@ -43,11 +43,11 @@ private struct MutablePersistableCustomizedCountry : MutablePersistable {
     var rowID: Int64?
     var isoCode: String
     var name: String
-    let willInsert: (Void) -> Void
-    let willUpdate: (Void) -> Void
-    let willSave: (Void) -> Void
-    let willDelete: (Void) -> Void
-    let willExists: (Void) -> Void
+    let willInsert: () -> Void
+    let willUpdate: () -> Void
+    let willSave: () -> Void
+    let willDelete: () -> Void
+    let willExists: () -> Void
     
     static let databaseTableName = "countries"
     

--- a/Tests/GRDBTests/PersistableTests.swift
+++ b/Tests/GRDBTests/PersistableTests.swift
@@ -54,11 +54,11 @@ private struct PersistableCountry : Persistable {
 private struct PersistableCustomizedCountry : Persistable {
     var isoCode: String
     var name: String
-    let willInsert: (Void) -> Void
-    let willUpdate: (Void) -> Void
-    let willSave: (Void) -> Void
-    let willDelete: (Void) -> Void
-    let willExists: (Void) -> Void
+    let willInsert: () -> Void
+    let willUpdate: () -> Void
+    let willSave: () -> Void
+    let willDelete: () -> Void
+    let willExists: () -> Void
     
     static let databaseTableName = "countries"
     


### PR DESCRIPTION
I think this is a swift compiler regression. I'm fairly sure that GRDB should continue to build without errors in `-swift-version 3` mode. But as GRDB is on the source compatibility suite, not sure if we need to let them know.