### PR TITLE
Updates for Swift 4

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -308,23 +308,23 @@ public final class Database {
     }
     
     /// Set by SAVEPOINT/COMMIT/ROLLBACK/RELEASE savepoint statements.
-    private var savepointStack = SavepointStack()
+    fileprivate var savepointStack = SavepointStack()
     
     /// Traces transaction hooks
-    private var transactionHookState: TransactionHookState = .pending
+    fileprivate var transactionHookState: TransactionHookState = .pending
     
     /// Transaction observers
-    private var transactionObservers = [ManagedTransactionObserver]()
-    private var activeTransactionObservers = [ManagedTransactionObserver]()  // subset of transactionObservers, set in updateStatementWillExecute
+    fileprivate var transactionObservers = [ManagedTransactionObserver]()
+    fileprivate var activeTransactionObservers = [ManagedTransactionObserver]()  // subset of transactionObservers, set in updateStatementWillExecute
     
     /// See setupBusyMode()
     private var busyCallback: BusyCallback?
     
     /// Available functions
-    private var functions = Set<DatabaseFunction>()
+    fileprivate var functions = Set<DatabaseFunction>()
     
     /// Available collations
-    private var collations = Set<DatabaseCollation>()
+    fileprivate var collations = Set<DatabaseCollation>()
     
     /// Schema Cache
     var schemaCache: DatabaseSchemaCache    // internal so that it can be tested
@@ -341,8 +341,8 @@ public final class Database {
         case grdb
         case user
     }
-    private lazy var grdbStatementCache: StatementCache = StatementCache(database: self)
-    private lazy var userStatementCache: StatementCache = StatementCache(database: self)
+    fileprivate lazy var grdbStatementCache: StatementCache = StatementCache(database: self)
+    fileprivate lazy var userStatementCache: StatementCache = StatementCache(database: self)
     
     init(path: String, configuration: Configuration, schemaCache: DatabaseSchemaCache) throws {
         // Error log setup must happen before any database connection

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -8,7 +8,7 @@ public final class DatabaseFunction {
     let argumentCount: Int32?
     let pure: Bool
     private let kind: Kind
-    private var nArg: Int32 { return argumentCount ?? -1 }
+    fileprivate var nArg: Int32 { return argumentCount ?? -1 }
     private var eTextRep: Int32 { return (SQLITE_UTF8 | (pure ? SQLITE_DETERMINISTIC : 0)) }
     
     /// Returns an SQL function.

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -187,12 +187,12 @@ public final class DatabasePool {
     
     // MARK: - Not public
     
-    private let writer: SerializedDatabase
+    fileprivate let writer: SerializedDatabase
     private var readerConfig: Configuration
-    private var readerPool: Pool<SerializedDatabase>! = nil // var and nil-initialized so that we can use `self` when creating readerPool in DatabasePool.init()
+    fileprivate var readerPool: Pool<SerializedDatabase>! = nil // var and nil-initialized so that we can use `self` when creating readerPool in DatabasePool.init()
     
-    private var functions = Set<DatabaseFunction>()
-    private var collations = Set<DatabaseCollation>()
+    fileprivate var functions = Set<DatabaseFunction>()
+    fileprivate var collations = Set<DatabaseCollation>()
 }
 
 

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -189,7 +189,7 @@ public final class DatabaseQueue {
     // > behavior is undefined.
     //
     // This is why we use a serialized database:
-    private var serializedDatabase: SerializedDatabase
+    fileprivate var serializedDatabase: SerializedDatabase
 }
 
 

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -434,14 +434,14 @@ extension Row {
     
     // MARK: - Helpers
     
-    private static func statementColumnConvertible<Value: StatementColumnConvertible>(atUncheckedIndex index: Int, in sqliteStatement: SQLiteStatement) -> Value? {
+    fileprivate static func statementColumnConvertible<Value: StatementColumnConvertible>(atUncheckedIndex index: Int, in sqliteStatement: SQLiteStatement) -> Value? {
         guard sqlite3_column_type(sqliteStatement, Int32(index)) != SQLITE_NULL else {
             return nil
         }
         return Value.init(sqliteStatement: sqliteStatement, index: Int32(index))
     }
     
-    private static func statementColumnConvertible<Value: StatementColumnConvertible>(atUncheckedIndex index: Int, in sqliteStatement: SQLiteStatement) -> Value {
+    fileprivate static func statementColumnConvertible<Value: StatementColumnConvertible>(atUncheckedIndex index: Int, in sqliteStatement: SQLiteStatement) -> Value {
         guard sqlite3_column_type(sqliteStatement, Int32(index)) != SQLITE_NULL else {
             // Programmer error
             fatalError("could not convert database value NULL to \(Value.self)")

--- a/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+Decodable.swift
+++ b/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+Decodable.swift
@@ -1,6 +1,6 @@
 private struct DatabaseValueDecodingContainer: SingleValueDecodingContainer {
     let dbValue: DatabaseValue
-    let codingPath: [CodingKey]
+    let codingPath: [CodingKey?]
     
     /// Decodes a null value.
     ///
@@ -51,13 +51,13 @@ private struct DatabaseValueDecodingContainer: SingleValueDecodingContainer {
 private struct DatabaseValueDecoder: Decoder {
     let dbValue: DatabaseValue
     
-    init(dbValue: DatabaseValue, codingPath: [CodingKey]) {
+    init(dbValue: DatabaseValue, codingPath: [CodingKey?]) {
         self.dbValue = dbValue
         self.codingPath = codingPath
     }
     
     // Decoder
-    let codingPath: [CodingKey]
+    let codingPath: [CodingKey?]
     var userInfo: [CodingUserInfoKey : Any] { return [:] }
     
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {

--- a/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+Encodable.swift
+++ b/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+Encodable.swift
@@ -50,7 +50,7 @@ private struct DatabaseValueEncoder : Encoder {
     
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey] { return [] }
+    var codingPath: [CodingKey?] { return [] }
     
     /// Any contextual information set by the user for encoding.
     var userInfo: [CodingUserInfoKey : Any] = [:]

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -370,7 +370,7 @@ public final class FetchedRecordsController<Record: RowConvertible> {
     fileprivate var fetchedItems: [Item<Record>]?
     
     /// The record comparator
-    private var itemsAreIdentical: ItemComparator<Record>
+    fileprivate var itemsAreIdentical: ItemComparator<Record>
     
     /// The record comparator factory (support for request change)
     private let itemsAreIdenticalFactory: ItemComparatorFactory<Record>

--- a/GRDB/Record/Persistable+Encodable.swift
+++ b/GRDB/Record/Persistable+Encodable.swift
@@ -7,7 +7,7 @@ private struct PersistableKeyedEncodingContainer<Key: CodingKey> : KeyedEncoding
     
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey] { return [] }
+    var codingPath: [CodingKey?] { return [] }
     
     /// Encodes the given value for the given key.
     ///
@@ -131,7 +131,7 @@ private struct DatabaseValueEncodingContainer : SingleValueEncodingContainer {
 private struct PersistableEncoder : Encoder {
     /// The path of coding keys taken to get to this point in encoding.
     /// A `nil` value indicates an unkeyed container.
-    var codingPath: [CodingKey]
+    var codingPath: [CodingKey?]
     
     /// Any contextual information set by the user for encoding.
     var userInfo: [CodingUserInfoKey : Any] = [:]
@@ -173,7 +173,7 @@ private struct PersistableEncoder : Encoder {
     /// - precondition: May not be called after a prior `self.unkeyedContainer()` call.
     /// - precondition: May not be called after a value has been encoded through a previous `self.singleValueContainer()` call.
     func singleValueContainer() -> SingleValueEncodingContainer {
-        return DatabaseValueEncodingContainer(key: codingPath.last!, encode: encode)
+        return DatabaseValueEncodingContainer(key: codingPath.last!!, encode: encode)
     }
 }
 


### PR DESCRIPTION
I'm completely new to Swift, but am tinkering with a project that could use your library. I'm trying to get it to build with `swift build`, and I think I've properly sorted out most of the compiler errors with these two commits. The errors that remain:

```
GRDB.swift/GRDB/Record/RowConvertible+Decodable.swift:76:24: error: non-nominal type 'T' does not support explicit initialization

GRDB.swift/GRDB/Record/RowConvertible+Decodable.swift:115:25: error: non-nominal type 'T' does not support explicit initialization

GRDB.swift/GRDB/Record/FetchedRecordsController.swift:515:13: error: argument 'itemsAreIdenticalFactory' must precede argument 'queue'
```

The first two look like they might be a bug in the compiler to me. (It seems the whole point of the `Decodable` protocol is to allow for a generic to initialize from a decoder.) I'm not sure if there's a further type constraint we can add somewhere to get it to work.

I'm also not sure how to fix the last error. If you move the argument, it gives the following error:
`incorrect argument labels in call (have '_:request:itemsAreIdenticalFactory:queue:', expected '_:sql:arguments:queue:')`
I'm not sure where the mixup is in resolving the correct initializer.

Hopefully these commits are helpful.