### PR TITLE
Table alteration: add untyped column

### DIFF
--- a/GRDB/QueryInterface/TableDefinition.swift
+++ b/GRDB/QueryInterface/TableDefinition.swift
@@ -495,7 +495,7 @@ public final class TableAlteration {
     /// - returns: An ColumnDefinition that allows you to refine the
     ///   column definition.
     @discardableResult
-    public func add(column name: String, _ type: Database.ColumnType) -> ColumnDefinition {
+    public func add(column name: String, _ type: Database.ColumnType? = nil) -> ColumnDefinition {
         let column = ColumnDefinition(name: name, type: type)
         addedColumns.append(column)
         return column

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -462,14 +462,16 @@ class TableDefinitionTests: GRDBTestCase {
                 t.add(column: "b", .text)
                 t.add(column: "c", .integer).notNull().defaults(to: 1)
                 t.add(column: "d", .text).references("alt")
+                t.add(column: "e")
             }
             
-            assertEqualSQL(sqlQueries[sqlQueries.count - 3], "ALTER TABLE \"test\" ADD COLUMN \"b\" TEXT")
-            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" ADD COLUMN \"c\" INTEGER NOT NULL DEFAULT 1")
-            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"d\" TEXT REFERENCES \"alt\"(\"rowid\")")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 4], "ALTER TABLE \"test\" ADD COLUMN \"b\" TEXT")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 3], "ALTER TABLE \"test\" ADD COLUMN \"c\" INTEGER NOT NULL DEFAULT 1")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" ADD COLUMN \"d\" TEXT REFERENCES \"alt\"(\"rowid\")")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"e\"")
         }
     }
-
+    
     func testDropTable() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in


### PR DESCRIPTION
It is already possible to create a table with untyped columns:

```swift
try db.create(table: "test") { t in
    t.column("a")
}
```

However, it is not possible to add an untyped column:

```swift
try db.alter(table: "test") { t in
    t.add(column: "a") // compiler error
}
```

This PR fixes this hole.