### PR TITLE
Drop full-text synchronization triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Release Notes
     }
     ```
 
+- The `Database.dropFTS4SynchronizationTriggers` & `Database.dropFTS5SynchronizationTriggers` method help cleaning up synchronized full-text table ([documentation](https://github.com/groue/GRDB.swift/blob/master/README.md#deleting-synchronized-full-text-tables))
 
 ## 2.3.1
 

--- a/GRDB/FTS/FTS4.swift
+++ b/GRDB/FTS/FTS4.swift
@@ -111,16 +111,16 @@ public struct FTS4 : VirtualTableModule {
             let oldRowID = "old.\(rowIDColumn.quotedDatabaseIdentifier)"
             
             try db.execute("""
-                CREATE TRIGGER \("__\(contentTable)_bu".quotedDatabaseIdentifier) BEFORE UPDATE ON \(content) BEGIN
+                CREATE TRIGGER \("__\(tableName)_bu".quotedDatabaseIdentifier) BEFORE UPDATE ON \(content) BEGIN
                     DELETE FROM \(ftsTable) WHERE docid=\(oldRowID);
                 END;
-                CREATE TRIGGER \("__\(contentTable)_bd".quotedDatabaseIdentifier) BEFORE DELETE ON \(content) BEGIN
+                CREATE TRIGGER \("__\(tableName)_bd".quotedDatabaseIdentifier) BEFORE DELETE ON \(content) BEGIN
                     DELETE FROM \(ftsTable) WHERE docid=\(oldRowID);
                 END;
-                CREATE TRIGGER \("__\(contentTable)_au".quotedDatabaseIdentifier) AFTER UPDATE ON \(content) BEGIN
+                CREATE TRIGGER \("__\(tableName)_au".quotedDatabaseIdentifier) AFTER UPDATE ON \(content) BEGIN
                     INSERT INTO \(ftsTable)(\(ftsColumns)) VALUES(\(newContentColumns));
                 END;
-                CREATE TRIGGER \("__\(contentTable)_ai".quotedDatabaseIdentifier) AFTER INSERT ON \(content) BEGIN
+                CREATE TRIGGER \("__\(tableName)_ai".quotedDatabaseIdentifier) AFTER INSERT ON \(content) BEGIN
                     INSERT INTO \(ftsTable)(\(ftsColumns)) VALUES(\(newContentColumns));
                 END;
                 """)
@@ -311,5 +311,17 @@ public final class FTS4ColumnDefinition {
     public func asLanguageId() -> Self {
         self.isLanguageId = true
         return self
+    }
+}
+
+extension Database {
+    /// Deletes the synchronization triggers for a synchronized FTS4 table
+    public func dropFTS4SynchronizationTriggers(forTable tableName: String) throws {
+        try execute("""
+            DROP TRIGGER IF EXISTS \("__\(tableName)_bu".quotedDatabaseIdentifier);
+            DROP TRIGGER IF EXISTS \("__\(tableName)_bd".quotedDatabaseIdentifier);
+            DROP TRIGGER IF EXISTS \("__\(tableName)_au".quotedDatabaseIdentifier);
+            DROP TRIGGER IF EXISTS \("__\(tableName)_ai".quotedDatabaseIdentifier);
+            """)
     }
 }

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -111,13 +111,13 @@
                     .joined(separator: ", ")
                 
                 try db.execute("""
-                    CREATE TRIGGER \("__\(contentTable)_ai".quotedDatabaseIdentifier) AFTER INSERT ON \(content) BEGIN
+                    CREATE TRIGGER \("__\(tableName)_ai".quotedDatabaseIdentifier) AFTER INSERT ON \(content) BEGIN
                         INSERT INTO \(ftsTable)(\(ftsColumns)) VALUES (\(newContentColumns));
                     END;
-                    CREATE TRIGGER \("__\(contentTable)_ad".quotedDatabaseIdentifier) AFTER DELETE ON \(content) BEGIN
+                    CREATE TRIGGER \("__\(tableName)_ad".quotedDatabaseIdentifier) AFTER DELETE ON \(content) BEGIN
                         INSERT INTO \(ftsTable)(\(ftsTable), \(ftsColumns)) VALUES('delete', \(oldContentColumns));
                     END;
-                    CREATE TRIGGER \("__\(contentTable)_au".quotedDatabaseIdentifier) AFTER UPDATE ON \(content) BEGIN
+                    CREATE TRIGGER \("__\(tableName)_au".quotedDatabaseIdentifier) AFTER UPDATE ON \(content) BEGIN
                         INSERT INTO \(ftsTable)(\(ftsTable), \(ftsColumns)) VALUES('delete', \(oldContentColumns));
                         INSERT INTO \(ftsTable)(\(ftsColumns)) VALUES (\(newContentColumns));
                     END;
@@ -318,5 +318,16 @@
     extension Column {
         /// The FTS5 rank column
         public static let rank = Column("rank")
+    }
+
+    extension Database {
+        /// Deletes the synchronization triggers for a synchronized FTS4 table
+        public func dropFTS5SynchronizationTriggers(forTable tableName: String) throws {
+            try execute("""
+                DROP TRIGGER IF EXISTS \("__\(tableName)_ai".quotedDatabaseIdentifier);
+                DROP TRIGGER IF EXISTS \("__\(tableName)_ad".quotedDatabaseIdentifier);
+                DROP TRIGGER IF EXISTS \("__\(tableName)_au".quotedDatabaseIdentifier);
+                """)
+        }
     }
 #endif

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -321,7 +321,7 @@
     }
 
     extension Database {
-        /// Deletes the synchronization triggers for a synchronized FTS4 table
+        /// Deletes the synchronization triggers for a synchronized FTS5 table
         public func dropFTS5SynchronizationTriggers(forTable tableName: String) throws {
             try execute("""
                 DROP TRIGGER IF EXISTS \("__\(tableName)_ai".quotedDatabaseIdentifier);

--- a/README.md
+++ b/README.md
@@ -4376,9 +4376,9 @@ Synchronization of Full-text tables with their content table happens by the mean
 
 SQLite automatically deletes those triggers when the content (not full-text) table is dropped.
 
-However, those triggers remain after the full-text table has been deleted. Unless they are deleted, too, they will prevent future insertion, updates, and deletions in the content table, and the creation of a new full-text table.
+However, those triggers remain after the full-text table has been dropped. Unless they are dropped too, they will prevent future insertion, updates, and deletions in the content table, and the creation of a new full-text table.
 
-To delete those triggers, use the `dropFTS4SynchronizationTriggers` or `dropFTS5SynchronizationTriggers` methods:
+To drop those triggers, use the `dropFTS4SynchronizationTriggers` or `dropFTS5SynchronizationTriggers` methods:
 
 ```swift
 // Create tables

--- a/README.md
+++ b/README.md
@@ -4372,7 +4372,7 @@ See also [WWDC Companion](https://github.com/groue/WWDCCompanion), a sample app 
 
 #### Deleting Synchronized Full-Text Tables
 
-Synchronization of Full-text tables with their content table happens by the mean of SQL triggers.
+Synchronization of full-text tables with their content table happens by the mean of SQL triggers.
 
 SQLite automatically deletes those triggers when the content (not full-text) table is dropped.
 

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -219,5 +219,64 @@ class FTS5TableBuilderTests: GRDBTestCase {
             XCTAssertEqual(try Int.fetchOne(db, "SELECT COUNT(*) FROM ft_documents WHERE ft_documents MATCH ?", arguments: ["bar"])!, 1)
         }
     }
+
+    func testFTS5SynchronizationCleanup() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "documents") { t in
+                t.column("id", .integer).primaryKey()
+                t.column("content", .text)
+            }
+            try db.execute("INSERT INTO documents (content) VALUES (?)", arguments: ["foo"])
+            try db.create(virtualTable: "ft_documents", using: FTS5()) { t in
+                t.synchronize(withTable: "documents")
+                t.column("content")
+            }
+            
+            try db.drop(table: "ft_documents")
+            try db.dropFTS5SynchronizationTriggers(forTable: "ft_documents")
+            
+            // It is possible to modify the content table
+            try db.execute("UPDATE documents SET content = ?", arguments: ["bar"])
+            try db.execute("INSERT INTO documents (content) VALUES (?)", arguments: ["foo"])
+            try db.execute("DELETE FROM documents WHERE content = ?", arguments: ["foo"])
+            
+            // It is possible to recreate the FT table
+            try db.create(virtualTable: "ft_documents", using: FTS5()) { t in
+                t.synchronize(withTable: "documents")
+                t.column("content")
+            }
+        }
+    }
+
+    func testFTS5SynchronizationCleanupWithLegacySupport() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "documents") { t in
+                t.column("id", .integer).primaryKey()
+                t.column("content", .text)
+            }
+            try db.execute("INSERT INTO documents (content) VALUES (?)", arguments: ["foo"])
+            try db.create(virtualTable: "ft_documents", using: FTS5()) { t in
+                t.synchronize(withTable: "documents")
+                t.column("content")
+            }
+            
+            try db.drop(table: "ft_documents")
+            try db.dropFTS5SynchronizationTriggers(forTable: "documents") // legacy GRDB <= 2.3.1
+            try db.dropFTS5SynchronizationTriggers(forTable: "ft_documents")
+            
+            // It is possible to modify the content table
+            try db.execute("UPDATE documents SET content = ?", arguments: ["bar"])
+            try db.execute("INSERT INTO documents (content) VALUES (?)", arguments: ["foo"])
+            try db.execute("DELETE FROM documents WHERE content = ?", arguments: ["foo"])
+            
+            // It is possible to recreate the FT table
+            try db.create(virtualTable: "ft_documents", using: FTS5()) { t in
+                t.synchronize(withTable: "documents")
+                t.column("content")
+            }
+        }
+    }
 }
 #endif


### PR DESCRIPTION
This PR allows to clean up the database after an external content full-text table has been dropped.

See the new documentation chapter [Deleting Synchronized Full-Text Tables ](https://github.com/groue/GRDB.swift/blob/23f2e0371e711996b91986d653bec67e5d889d1d/README.md#deleting-synchronized-full-text-tables) for more information.