### PR TITLE
Don't call sqlite3_config() unless explicitly required to do so

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -48,7 +48,7 @@ public final class Database {
     /// > for debugging.
     public static var logError: LogErrorFunction? = nil {
         didSet {
-            if let logError = logError {
+            if logError != nil {
                 registerErrorLogCallback { (_, code, message) in
                     guard let logError = Database.logError else { return }
                     guard let message = message.map({ String(cString: $0) }) else { return }

--- a/README.md
+++ b/README.md
@@ -5466,13 +5466,15 @@ See [prepared statements](#prepared-statements) and [DatabaseValue](#databaseval
 
 **SQLite can be configured to invoke a callback function containing an error code and a terse error message whenever anomalies occur.**
 
-It is recommended that you setup, early in the lifetime of your application, the error logging callback:
+This global error callback must be configured early in the lifetime of your application:
 
 ```swift
 Database.logError = { (resultCode, message) in
     NSLog("%@", "SQLite error \(resultCode): \(message)")
 }
 ```
+
+> :warning: **Warning**: Database.logError must be set before any database connection is opened. This includes the connections that your application opens with GRDB, but also connections opened by other tools, such as third-party libraries. Setting it after a connection has been opened is an SQLite misuse, and has no effect.
 
 See [The Error And Warning Log](https://sqlite.org/errlog.html) for more information.
 

--- a/Tests/GRDBTests/DatabaseLogErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseLogErrorTests.swift
@@ -10,23 +10,11 @@ import XCTest
 class DatabaseLogErrorTests: GRDBTestCase {
     
     func testErrorLog() throws {
-        // Remember current log function
-        let currentLogError = Database.logError
-        
-        var lastResultCode: ResultCode? = nil
-        var lastMessage: String? = nil
-        Database.logError = { (resultCode, message) in
-            lastResultCode = resultCode
-            lastMessage = message
-        }
         let dbQueue = try makeDatabaseQueue()
         dbQueue.inDatabase { db in
             _ = try? db.execute("That's not SQL.")
         }
         XCTAssertEqual(lastResultCode!, ResultCode.SQLITE_ERROR)
         XCTAssertEqual(lastMessage!, "near \"That\": syntax error")
-        
-        // Restore current log function
-        Database.logError = currentLogError
     }
 }

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -50,8 +50,17 @@ class GRDBTestCase: XCTestCase {
         return sqlQueries.last!
     }
     
+    var lastResultCode: ResultCode? = nil
+    var lastMessage: String? = nil
+    
     override func setUp() {
         super.setUp()
+        
+        // Must be set prior to any databaase connection
+        Database.logError = { [weak self] (resultCode, message) in
+            self?.lastResultCode = resultCode
+            self?.lastMessage = message
+        }
         
         let dbPoolDirectoryName = "GRDBTestCase-\(ProcessInfo.processInfo.globallyUniqueString)"
         dbDirectoryPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(dbPoolDirectoryName)

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -12,6 +12,10 @@ import XCTest
     @testable import GRDB       // @testable so that we have access to SQLiteConnectionWillClose
 #endif
 
+// Support for Database.logError
+var lastResultCode: ResultCode? = nil
+var lastMessage: String? = nil
+
 class GRDBTestCase: XCTestCase {
     // The default configuration for tests
     var dbConfiguration: Configuration!
@@ -50,16 +54,13 @@ class GRDBTestCase: XCTestCase {
         return sqlQueries.last!
     }
     
-    var lastResultCode: ResultCode? = nil
-    var lastMessage: String? = nil
-    
     override func setUp() {
         super.setUp()
         
         // Must be set prior to any databaase connection
         Database.logError = { [weak self] (resultCode, message) in
-            self?.lastResultCode = resultCode
-            self?.lastMessage = message
+            lastResultCode = resultCode
+            lastMessage = message
         }
         
         let dbPoolDirectoryName = "GRDBTestCase-\(ProcessInfo.processInfo.globallyUniqueString)"


### PR DESCRIPTION
**Context**

GRDB calls the SQLite [sqlite3_config](https://sqlite.org/c3ref/config.html) function in order to configure the global [error log](https://github.com/groue/GRDB.swift/blob/master/README.md#error-log).

Any call to sqlite3_config must happen *before* any connection to any database. In other words, changing the SQLite configuration after a connection has been opened is a *misuse* of SQLite .

**Bug**

GRDB was calling sqlite3_config() once, before opening its first database connection. But issue #283 has revealed that this GRDB practice could conflict with other pieces of code that also open database connections. When GRDB opens its first connection *after* another part of the program has already opened a connection, this sqlite3_config() invocation is a misuse.

**Fix**

This PR fixes this, by only calling sqlite3_config() when the GRDB user configures the error log:

```swift
// Invokes sqlite3_config
Database.logError = { (resultCode, message) in
    NSLog("%@", "SQLite error \(resultCode): \(message)")
}
```

This also mean that the user is now responsible for setting the `Database.logError` *before* any other piece of code would open a connection.