### PR TITLE
Bring changes tracking to any record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 Release Notes
 =============
 
+## Next Version
+
+**New**
+
+- The RecordBox class brings changes tracking to any record type ([documentation](https://github.com/groue/GRDB.swift/blob/master/README.md#recordbox-class)):
+    
+    ```swift
+    // A regular record struct
+    struct Player: RowConvertible, MutablePersistable { ... }
+    
+    try dbQueue.inDatabase { db in
+        // Fetch a boxed player
+        if let player = try RecordBox<Player>.fetchOne(db, key: 1) {
+            player.value.score = 300
+            
+            if player.hasPersistentChangedValues {
+                print("player has been modified")
+            }
+            
+            // Does nothing if player has not been modified:
+            try player.updateChanges(db)
+        }
+    }
+    ```
+
+
 ## 2.6.1
 
 Released January 19, 2018 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v2.6.0...v2.6.1)

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -281,6 +281,9 @@
 		5674A7231F30A8DF0095F066 /* MutablePersistableEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A71C1F30A8DF0095F066 /* MutablePersistableEncodableTests.swift */; };
 		5674A72A1F30A9090095F066 /* RowConvertibleDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A7261F30A9090095F066 /* RowConvertibleDecodableTests.swift */; };
 		5674A72D1F30A9090095F066 /* RowConvertibleDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A7261F30A9090095F066 /* RowConvertibleDecodableTests.swift */; };
+		567517C820131B220094BF41 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567517C720131B220094BF41 /* RecordBox.swift */; };
+		567517C920131B220094BF41 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567517C720131B220094BF41 /* RecordBox.swift */; };
+		567517CA20131B220094BF41 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567517C720131B220094BF41 /* RecordBox.swift */; };
 		567A80571D41350C00C7DCEC /* IndexInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567A80521D41350C00C7DCEC /* IndexInfoTests.swift */; };
 		567DAF1C1EAB61ED00FC0928 /* grdb_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 567DAF141EAB61ED00FC0928 /* grdb_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		567DAF1F1EAB61ED00FC0928 /* grdb_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 567DAF141EAB61ED00FC0928 /* grdb_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -289,6 +292,8 @@
 		567DAF391EAB789800FC0928 /* DatabaseLogErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */; };
 		567F45A81F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		567F45AC1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
+		56805210201320E600E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680520F201320E600E87861 /* RecordBoxTests.swift */; };
+		56805211201320E600E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680520F201320E600E87861 /* RecordBoxTests.swift */; };
 		568068311EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568068351EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568735A21CEDE16C009B9116 /* Betty.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 5687359E1CEDE16C009B9116 /* Betty.jpeg */; };
@@ -824,10 +829,12 @@
 		5674A70B1F3087700095F066 /* DatabaseValueConvertibleEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEncodableTests.swift; sourceTree = "<group>"; };
 		5674A71C1F30A8DF0095F066 /* MutablePersistableEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutablePersistableEncodableTests.swift; sourceTree = "<group>"; };
 		5674A7261F30A9090095F066 /* RowConvertibleDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowConvertibleDecodableTests.swift; sourceTree = "<group>"; };
+		567517C720131B220094BF41 /* RecordBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBox.swift; sourceTree = "<group>"; };
 		567A80521D41350C00C7DCEC /* IndexInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexInfoTests.swift; sourceTree = "<group>"; };
 		567DAF141EAB61ED00FC0928 /* grdb_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grdb_config.h; sourceTree = "<group>"; };
 		567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLogErrorTests.swift; sourceTree = "<group>"; };
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
+		5680520F201320E600E87861 /* RecordBoxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordBoxTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		56873BEB1F2CB400004D24B4 /* Fixits-1.2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fixits-1.2.swift"; sourceTree = "<group>"; };
@@ -1451,6 +1458,7 @@
 				56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */,
 				560B3FA41C19DFF800C58EC7 /* Persistable */,
 				56176C9E1EACEDF9000F3F2B /* Record */,
+				5680520F201320E600E87861 /* RecordBoxTests.swift */,
 				5674A7251F30A8EF0095F066 /* RowConvertible */,
 				56176C9C1EACEA8C000F3F2B /* TableMapping */,
 			);
@@ -1506,6 +1514,7 @@
 				560D92441C672C4B00F4F92B /* Persistable.swift */,
 				5674A6F31F307F600095F066 /* Persistable+Encodable.swift */,
 				56A238A11B9C753B0082EB20 /* Record.swift */,
+				567517C720131B220094BF41 /* RecordBox.swift */,
 				56CEB4F01EAA2EFA00BFAF62 /* RowConvertible.swift */,
 				5674A6F21F307F600095F066 /* RowConvertible+Decodable.swift */,
 				56D51CFF1EA789FA0074638A /* RowConvertible+TableMapping.swift */,
@@ -2180,6 +2189,7 @@
 				5671FC261DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56CEB5521EAA359A00BFAF62 /* SQLExpressible.swift in Sources */,
 				565490DB1D5AE252005622CB /* SQLCollatedExpression.swift in Sources */,
+				567517CA20131B220094BF41 /* RecordBox.swift in Sources */,
 				5674A7071F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
 				565490C61D5AE236005622CB /* Statement.swift in Sources */,
 				56CEB5071EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
@@ -2272,6 +2282,7 @@
 				5671FC231DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56D51D031EA789FA0074638A /* RowConvertible+TableMapping.swift in Sources */,
 				560D924C1C672C4B00F4F92B /* TableMapping.swift in Sources */,
+				567517C920131B220094BF41 /* RecordBox.swift in Sources */,
 				5657AB121D10899D006283EF /* URL.swift in Sources */,
 				5659F48B1EA8D94E004A4992 /* Utils.swift in Sources */,
 				56A2387C1B9C75030082EB20 /* Configuration.swift in Sources */,
@@ -2339,6 +2350,7 @@
 				564448871EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				56A238461B9C74A90082EB20 /* RowFromDictionaryTests.swift in Sources */,
 				569C1EB51CF07DDD0042627B /* SchedulingWatchdogTests.swift in Sources */,
+				56805211201320E600E87861 /* RecordBoxTests.swift in Sources */,
 				562EA82A1F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				564A50C81BFF4B7F00B3A3A2 /* DatabaseCollationTests.swift in Sources */,
 				56E8CE111BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift in Sources */,
@@ -2478,6 +2490,7 @@
 				564448831EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				56D496811D813131008276D7 /* TransactionObserverSavepointsTests.swift in Sources */,
 				56D496AB1D8132CA008276D7 /* DatabasePoolFunctionTests.swift in Sources */,
+				56805210201320E600E87861 /* RecordBoxTests.swift in Sources */,
 				562EA8261F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				56D496691D813086008276D7 /* QueryInterfaceExpressionsTests.swift in Sources */,
 				562393691DEE0CD200A6B01F /* FlattenCursorTests.swift in Sources */,
@@ -2687,6 +2700,7 @@
 				5605F1671C672E4000235C62 /* NSNumber.swift in Sources */,
 				56A238871B9C75030082EB20 /* Row.swift in Sources */,
 				5605F1731C672E4000235C62 /* StandardLibrary.swift in Sources */,
+				567517C820131B220094BF41 /* RecordBox.swift in Sources */,
 				560D92471C672C4B00F4F92B /* Persistable.swift in Sources */,
 				566475A21D9810A400FF74B8 /* SQLSelectable+QueryInterface.swift in Sources */,
 				5674A6E41F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,

--- a/GRDB/Record/RecordBox.swift
+++ b/GRDB/Record/RecordBox.swift
@@ -1,0 +1,88 @@
+/// RecordBox is a subclass of Record that aims at giving any record type the
+/// changes tracking provided by the Record class.
+///
+///     // A Regular record struct
+///     struct Player: RowConvertible, MutablePersistable, Codable {
+///         static let databaseTableName = "players"
+///         var id: Int64?
+///         var name: String
+///         var score: Int
+///         mutating func didInsert(with rowID: Int64, for column: String?) {
+///             id = rowID
+///         }
+///     }
+///
+///     try dbQueue.inDatabase { db in
+///         // Fetch a player record
+///         let playerRecord = try RecordBox<Player>.fetchOne(db, key: 1)!
+///
+///         // Profit from changes tracking
+///         playerRecord.value.score = 300
+///         playerRecord.hasPersistentChangedValues         // true
+///         playerRecord.persistentChangedValues["score"]   // 100 (the old value)
+///     }
+public final class RecordBox<T: RowConvertible & MutablePersistable>: Record {
+    public var value: T
+    
+    public init(value: T) {
+        self.value = value
+        super.init()
+    }
+    
+    // MARK: - RowConvertible
+    
+    public required init(row: Row) {
+        self.value = T(row: row)
+        super.init(row: row)
+    }
+    
+    // MARK: - TableMapping
+    
+    override public class var databaseTableName: String {
+        return T.databaseTableName
+    }
+    
+    override public class var databaseSelection: [SQLSelectable] {
+        return T.databaseSelection
+    }
+    
+    // MARK: - MutablePersistable
+    
+    override public class var persistenceConflictPolicy: PersistenceConflictPolicy {
+        return T.persistenceConflictPolicy
+    }
+    
+    override public func encode(to container: inout PersistenceContainer) {
+        value.encode(to: &container)
+    }
+    
+    override public func didInsert(with rowID: Int64, for column: String?) {
+        value.didInsert(with: rowID, for: column)
+    }
+    
+    override public func insert(_ db: Database) throws {
+        try value.insert(db)
+        hasPersistentChangedValues = false
+    }
+    
+    override public func update(_ db: Database, columns: Set<String>) throws {
+        try value.update(db, columns: columns)
+        hasPersistentChangedValues = false
+    }
+    
+    @discardableResult
+    override public func delete(_ db: Database) throws -> Bool {
+        defer {
+            // Future calls to update() will throw NotFound. Make the user
+            // a favor and make sure this error is thrown even if she checks the
+            // hasPersistentChangedValues flag:
+            hasPersistentChangedValues = true
+        }
+        return try value.delete(db)
+    }
+    
+    public func exists(_ db: Database) throws -> Bool {
+        return try value.exists(db)
+    }
+}
+

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -380,6 +380,12 @@
 		567F45AA1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		567F45AD1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		567F45AE1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
+		5680520C2013209300E87861 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680520A2013209300E87861 /* RecordBox.swift */; };
+		5680520D2013209900E87861 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680520A2013209300E87861 /* RecordBox.swift */; };
+		5680521E2013296F00E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680521C2013296800E87861 /* RecordBoxTests.swift */; };
+		5680521F2013296F00E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680521C2013296800E87861 /* RecordBoxTests.swift */; };
+		568052202013297000E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680521C2013296800E87861 /* RecordBoxTests.swift */; };
+		568052212013297000E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5680521C2013296800E87861 /* RecordBoxTests.swift */; };
 		568068321EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568068331EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568068361EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
@@ -893,6 +899,8 @@
 		567DAF141EAB61ED00FC0928 /* grdb_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grdb_config.h; sourceTree = "<group>"; };
 		567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLogErrorTests.swift; sourceTree = "<group>"; };
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
+		5680520A2013209300E87861 /* RecordBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordBox.swift; sourceTree = "<group>"; };
+		5680521C2013296800E87861 /* RecordBoxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordBoxTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		56873BEB1F2CB400004D24B4 /* Fixits-1.2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fixits-1.2.swift"; sourceTree = "<group>"; };
@@ -1476,6 +1484,7 @@
 				56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */,
 				560B3FA41C19DFF800C58EC7 /* Persistable */,
 				56176C9E1EACEDF9000F3F2B /* Record */,
+				5680521C2013296800E87861 /* RecordBoxTests.swift */,
 				5674A7251F30A8EF0095F066 /* RowConvertible */,
 				56176C9C1EACEA8C000F3F2B /* TableMapping */,
 			);
@@ -1531,6 +1540,7 @@
 				560D92441C672C4B00F4F92B /* Persistable.swift */,
 				5674A6F31F307F600095F066 /* Persistable+Encodable.swift */,
 				56A238A11B9C753B0082EB20 /* Record.swift */,
+				5680520A2013209300E87861 /* RecordBox.swift */,
 				56CEB4F01EAA2EFA00BFAF62 /* RowConvertible.swift */,
 				5674A6F21F307F600095F066 /* RowConvertible+Decodable.swift */,
 				56D51CFF1EA789FA0074638A /* RowConvertible+TableMapping.swift */,
@@ -2003,6 +2013,7 @@
 				560FC53D1CB003810014AA8E /* NSNumber.swift in Sources */,
 				560FC53F1CB003810014AA8E /* Row.swift in Sources */,
 				560FC5401CB003810014AA8E /* StandardLibrary.swift in Sources */,
+				5680520C2013209300E87861 /* RecordBox.swift in Sources */,
 				560FC5411CB003810014AA8E /* Persistable.swift in Sources */,
 				566475A31D9810A400FF74B8 /* SQLSelectable+QueryInterface.swift in Sources */,
 				5674A6EA1F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
@@ -2029,6 +2040,7 @@
 				564448841EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				560FC5B21CB031E30014AA8E /* StatementColumnConvertibleFetchTests.swift in Sources */,
 				561667021D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */,
+				5680521E2013296F00E87861 /* RecordBoxTests.swift in Sources */,
 				562EA8271F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				569C1EB31CF07DDD0042627B /* SchedulingWatchdogTests.swift in Sources */,
 				560FC5651CB00B880014AA8E /* RecordPrimaryKeyNoneTests.swift in Sources */,
@@ -2168,6 +2180,7 @@
 				564448851EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				567156241CB16729007DC145 /* RecordMinimalPrimaryKeyRowIDTests.swift in Sources */,
 				567156251CB16729007DC145 /* RowFromDictionaryTests.swift in Sources */,
+				5680521F2013296F00E87861 /* RecordBoxTests.swift in Sources */,
 				562EA8281F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				565F03C41CE5D3AA00DE108F /* RowAdapterTests.swift in Sources */,
 				567156261CB16729007DC145 /* SelectStatementTests.swift in Sources */,
@@ -2377,6 +2390,7 @@
 				56AFCA141CB1A8BB00F48B96 /* StandardLibrary.swift in Sources */,
 				56AFCA151CB1A8BB00F48B96 /* Persistable.swift in Sources */,
 				56AFCA161CB1A8BB00F48B96 /* StatementColumnConvertible.swift in Sources */,
+				5680520D2013209900E87861 /* RecordBox.swift in Sources */,
 				566475A61D9810A400FF74B8 /* SQLSelectable+QueryInterface.swift in Sources */,
 				5657AABD1D107001006283EF /* NSData.swift in Sources */,
 				5674A6E71F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
@@ -2403,6 +2417,7 @@
 				564448881EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				56AFCA341CB1AA9900F48B96 /* RowFromDictionaryTests.swift in Sources */,
 				569C1EB61CF07DDD0042627B /* SchedulingWatchdogTests.swift in Sources */,
+				568052202013297000E87861 /* RecordBoxTests.swift in Sources */,
 				562EA82B1F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				56DAA2D71DE99DAB006E10C8 /* DatabaseCursorTests.swift in Sources */,
 				5698AC4E1DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
@@ -2542,6 +2557,7 @@
 				564448891EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				56AFCA8D1CB1ABC800F48B96 /* RowFromDictionaryTests.swift in Sources */,
 				5657AB541D108BA9006283EF /* FoundationNSNumberTests.swift in Sources */,
+				568052212013297000E87861 /* RecordBoxTests.swift in Sources */,
 				562EA82C1F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				56DAA2D81DE99DAB006E10C8 /* DatabaseCursorTests.swift in Sources */,
 				5698AC4F1DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -131,6 +131,10 @@
 		567DAF3C1EAB789800FC0928 /* DatabaseLogErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */; };
 		567F45AB1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		567F45AF1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
+		568052092013207000E87861 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568052072013206F00E87861 /* RecordBox.swift */; };
+		5680520E201320A200E87861 /* RecordBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568052072013206F00E87861 /* RecordBox.swift */; };
+		5680521A2013295600E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568052182013295100E87861 /* RecordBoxTests.swift */; };
+		5680521B2013295700E87861 /* RecordBoxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568052182013295100E87861 /* RecordBoxTests.swift */; };
 		568068341EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568068381EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		56873BEE1F2CB400004D24B4 /* Fixits-1.2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56873BEB1F2CB400004D24B4 /* Fixits-1.2.swift */; };
@@ -609,6 +613,8 @@
 		567DAF141EAB61ED00FC0928 /* grdb_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grdb_config.h; sourceTree = "<group>"; };
 		567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLogErrorTests.swift; sourceTree = "<group>"; };
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
+		568052072013206F00E87861 /* RecordBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordBox.swift; sourceTree = "<group>"; };
+		568052182013295100E87861 /* RecordBoxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordBoxTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		56873BEB1F2CB400004D24B4 /* Fixits-1.2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Fixits-1.2.swift"; sourceTree = "<group>"; };
@@ -1166,6 +1172,7 @@
 				56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */,
 				560B3FA41C19DFF800C58EC7 /* Persistable */,
 				56176C9E1EACEDF9000F3F2B /* Record */,
+				568052182013295100E87861 /* RecordBoxTests.swift */,
 				5674A7251F30A8EF0095F066 /* RowConvertible */,
 				56176C9C1EACEA8C000F3F2B /* TableMapping */,
 			);
@@ -1221,6 +1228,7 @@
 				560D92441C672C4B00F4F92B /* Persistable.swift */,
 				5674A6F31F307F600095F066 /* Persistable+Encodable.swift */,
 				56A238A11B9C753B0082EB20 /* Record.swift */,
+				568052072013206F00E87861 /* RecordBox.swift */,
 				56CEB4F01EAA2EFA00BFAF62 /* RowConvertible.swift */,
 				5674A6F21F307F600095F066 /* RowConvertible+Decodable.swift */,
 				56D51CFF1EA789FA0074638A /* RowConvertible+TableMapping.swift */,
@@ -1722,6 +1730,7 @@
 				F3BA80301CFB289F003DC1BA /* DatabaseMigrator.swift in Sources */,
 				F3BA80361CFB28A4003DC1BA /* TableMapping.swift in Sources */,
 				F3BA80271CFB2891003DC1BA /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
+				5680520E201320A200E87861 /* RecordBox.swift in Sources */,
 				566475A71D9810A400FF74B8 /* SQLSelectable+QueryInterface.swift in Sources */,
 				5657AABE1D107001006283EF /* NSData.swift in Sources */,
 				5674A6E61F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
@@ -1748,6 +1757,7 @@
 				5644488A1EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				F3BA80521CFB2B59003DC1BA /* DatabaseQueueSchemaCacheTests.swift in Sources */,
 				F3BA80BE1CFB2FD1003DC1BA /* DatabasePoolReadOnlyTests.swift in Sources */,
+				5680521B2013295700E87861 /* RecordBoxTests.swift in Sources */,
 				562EA82D1F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				F3BA80C61CFB2FD8003DC1BA /* DatabaseQueueConcurrencyTests.swift in Sources */,
 				F3BA81161CFB305E003DC1BA /* RowConvertible+QueryInterfaceRequestTests.swift in Sources */,
@@ -1957,6 +1967,7 @@
 				F3BA808C1CFB2E75003DC1BA /* DatabaseMigrator.swift in Sources */,
 				F3BA80921CFB2E7A003DC1BA /* TableMapping.swift in Sources */,
 				F3BA80831CFB2E67003DC1BA /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
+				568052092013207000E87861 /* RecordBox.swift in Sources */,
 				566475A41D9810A400FF74B8 /* SQLSelectable+QueryInterface.swift in Sources */,
 				5657AABB1D107001006283EF /* NSData.swift in Sources */,
 				5674A6E51F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
@@ -1983,6 +1994,7 @@
 				564448861EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */,
 				5698ACCB1DA62A2D0056AF8C /* FTS5TokenizerTests.swift in Sources */,
 				56B14E821D4DAE54000BF4A3 /* RowFromDictionaryLiteralTests.swift in Sources */,
+				5680521A2013295600E87861 /* RecordBoxTests.swift in Sources */,
 				562EA8291F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */,
 				56FF45591D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift in Sources */,
 				56B021CC1D8C0D3900B239BB /* MutablePersistablePersistenceConflictPolicyTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -2587,23 +2587,25 @@ final class RecordBox<T: RowConvertible & MutablePersistable>: Record {
 Given any record type, for example:
 
 ```swift
-// A Regular record struct
+// A regular record struct
 struct Player: RowConvertible, MutablePersistable, Codable {
     static let databaseTableName = "players"
+    
     var id: Int64?
     var name: String
     var score: Int
+    
     mutating func didInsert(with rowID: Int64, for column: String?) {
         id = rowID
     }
 }
 ```
 
-You can fetch boxed players, modify their values, and check if they have been changed:
+You can fetch boxed players, modify their values, and check if they have been changed. For example:
 
 ```swift
 try dbQueue.inDatabase { db in
-    // Fetch a player record
+    // Fetch a boxed player record
     if let player = try RecordBox<Player>.fetchOne(db, key: 1) {
         player.value.score = 300
         

--- a/README.md
+++ b/README.md
@@ -2507,7 +2507,7 @@ final class RecordBox<T: RowConvertible & MutablePersistable>: Record {
 }
 ```
 
-Given any record type, for example:
+As an example, let's start from a regular `Player` record struct:
 
 ```swift
 // A regular record struct
@@ -2524,20 +2524,21 @@ struct Player: RowConvertible, MutablePersistable, Codable {
 }
 ```
 
-You can fetch boxed players, modify their values, and check if they have been changed. For example:
+To track changes, don't fetch raw `Player` records, but fetch `RecordBox<Player>` instead. You can then modify player attributes, and easily check if they have been changed:
 
 ```swift
 try dbQueue.inDatabase { db in
-    // Fetch a boxed player record
-    if let player = try RecordBox<Player>.fetchOne(db, key: 1) {
-        player.value.score = 300
+    // Fetch a boxed player
+    if let boxedPlayer = try RecordBox<Player>.fetchOne(db, key: 1) {
+        // boxedPlayer.value is Player
+        boxedPlayer.value.score = 300
         
-        if player.hasPersistentChangedValues {
+        if boxedPlayer.hasPersistentChangedValues {
             print("player has been modified")
         }
         
         // Does nothing if player has not been modified:
-        try player.updateChanges(db)
+        try boxedPlayer.updateChanges(db)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1846,7 +1846,6 @@ Your custom structs and classes can adopt each protocol individually, and opt in
 - [Changes Tracking](#changes-tracking)
 - [The Implicit RowID Primary Key](#the-implicit-rowid-primary-key)
 - [List of Record Methods](#list-of-record-methods)
-- [The Query Interface](#the-query-interface)
 
 
 ### Inserting Records
@@ -1955,7 +1954,6 @@ Details follow:
 - [Changes Tracking](#changes-tracking)
 - [The Implicit RowID Primary Key](#the-implicit-rowid-primary-key)
 - [List of Record Methods](#list-of-record-methods)
-- [The Query Interface](#the-query-interface)
 
 
 ## Record Protocols Overview
@@ -2117,8 +2115,8 @@ extension Place : RowConvertible {
 See [column values](#column-values) for more information about the `row[]` subscript.
 
 > :point_up: **Note**: for performance reasons, the same row argument to `init(row:)` is reused during the iteration of a fetch query. If you want to keep the row for later use, make sure to store a copy: `self.row = row.copy()`.
-
-**The `init(row:)` initializer can be automatically generated** when your type adopts the standard `Decodable` protocol. See [Codable Records](#codable-records) for more information.
+>
+> :bulb: **Tip**: the `init(row:)` initializer can be automatically generated when your type adopts the standard `Decodable` protocol. See [Codable Records](#codable-records) for more information.
 
 RowConvertible allows adopting types to be fetched from SQL queries:
 
@@ -2219,7 +2217,7 @@ Yes, two protocols instead of one. Both grant exactly the same advantages. Here 
 
 The `encode(to:)` method defines which [values](#values) (Bool, Int, String, Date, Swift enums, etc.) are assigned to database columns.
 
-**`encode(to:)` can be automatically generated** when your type adopts the standard `Encodable` protocol. See [Codable Records](#codable-records) for more information.
+> :bulb: **Tip**: `encode(to:)` can be automatically generated when your type adopts the standard `Encodable` protocol. See [Codable Records](#codable-records) for more information.
 
 The optional `didInsert` method lets the adopting type store its rowID after successful insertion. If your table has an INTEGER PRIMARY KEY column, you are likely to define this method. Otherwise, you can safely ignore it. It is called from a protected dispatch queue, and serialized with all database updates.
 
@@ -2793,7 +2791,7 @@ When SQLite won't let you provide an explicit primary key (as in [full-text](#fu
 
 ## List of Record Methods
 
-This is the list of record methods, along with their required protocols. The [Record Class](#record-class) adopts all these protocols.
+This is the list of record methods, along with their required protocols. The [Record](#record-class) and [RecordBox](#recordbox-class) classes adopt all these protocols, and support [changes tracking](#changes-tracking).
 
 | Method | Protocols | Notes |
 | ------ | --------- | :---: |

--- a/README.md
+++ b/README.md
@@ -2802,7 +2802,7 @@ This is the list of record methods, along with their required protocols. The [Re
 | `record.save(db)` | [Persistable](#persistable-protocol) | |
 | `record.update(db)` | [Persistable](#persistable-protocol) | |
 | `record.update(db, columns: ...)` | [Persistable](#persistable-protocol) | |
-| `record.updateChanges(db)` | [Record](#record-class) & [RecordBox](#recordbox-class) | |
+| `record.updateChanges(db)` | [Record](#record-class), [RecordBox](#recordbox-class) | |
 | **Delete Records** | | |
 | `record.delete(db)` | [Persistable](#persistable-protocol) | |
 | `Type.deleteOne(db, key: ...)` | [Persistable](#persistable-protocol) | <a href="#list-of-record-methods-1">¹</a> |
@@ -2835,8 +2835,8 @@ This is the list of record methods, along with their required protocols. The [Re
 | `Type.fetchOne(statement)` | [RowConvertible](#rowconvertible-protocol) | <a href="#list-of-record-methods-4">⁴</a> |
 | `Type.filter(...).fetchOne(db)` | [RowConvertible](#rowconvertible-protocol) & [TableMapping](#tablemapping-protocol) | <a href="#list-of-record-methods-2">²</a> |
 | **[Track Changes](#changes-tracking)** | | |
-| `record.hasPersistentChangedValues` | [Record](#record-class) & [RecordBox](#recordbox-class) | |
-| `record.persistentChangedValues` | [Record](#record-class) & [RecordBox](#recordbox-class) | |
+| `record.hasPersistentChangedValues` | [Record](#record-class), [RecordBox](#recordbox-class) | |
+| `record.persistentChangedValues` | [Record](#record-class), [RecordBox](#recordbox-class) | |
 
 <a name="list-of-record-methods-1">¹</a> All unique keys are supported: primary keys (single-column, composite, [implicit RowID](#the-implicit-rowid-primary-key)) and unique indexes:
 

--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,9 @@
 GRDB 3.0
 
 - [ ] Make DatabasePool.write safe. See https://github.com/groue/GRDB.swift/commit/5e3c7d9c430df606a1cccfd4983be6b50e778a5c#commitcomment-26988970
+- [ ] Do one of those two:
+    1. Make save() impossible to customize: remove it from Persistable protocol, and remove performSave() from tne public API.
+    2. Open Record.save(), and have RecordBox.save() forward this method to its underlying type.
 - [ ] Make the MutablePersistable.update(_:columns:) method mutating (as support for an updatedDate column)
 - [ ] Introduce some record protocol with an associated primary key type. Restrict filter(key:) methods to this type. Allow distinguishing FooId from BarId types.
 - [ ] Rename Request to FetchRequest, because Request is a bad name: https://github.com/swift-server/http/pull/7#issuecomment-308448528

--- a/Tests/GRDBTests/RecordBoxTests.swift
+++ b/Tests/GRDBTests/RecordBoxTests.swift
@@ -1,0 +1,480 @@
+import XCTest
+#if GRDBCIPHER
+    import GRDBCipher
+#elseif GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    import GRDB
+#endif
+
+private struct Player: RowConvertible, MutablePersistable, Codable {
+    static let databaseTableName = "players"
+    
+    var id: Int64?
+    var name: String?
+    var score: Int?
+    var creationDate: Date?
+    
+    init(id: Int64? = nil, name: String? = nil, score: Int? = nil, creationDate: Date? = nil) {
+        self.id = id
+        self.name = name
+        self.score = score
+        self.creationDate = creationDate
+    }
+    
+    mutating func insert(_ db: Database) throws {
+        if creationDate == nil {
+           creationDate = Date()
+        }
+        try performInsert(db)
+    }
+    
+    mutating func didInsert(with rowID: Int64, for column: String?) {
+        id = rowID
+    }
+}
+
+class RecordBoxTests: GRDBTestCase {
+    override func setup(_ dbWriter: DatabaseWriter) throws {
+        try dbWriter.write { db in
+            try db.create(table: "players") { t in
+                t.column("id", .integer).primaryKey()
+                t.column("name", .text)
+                t.column("score", .integer)
+                t.column("creationDate", .datetime)
+            }
+        }
+    }
+    
+    func testRecordIsEditedAfterInit() {
+        // Create a Record. No fetch has happen, so we don't know if it is
+        // identical to its eventual row in the database. So it is edited.
+        let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+        XCTAssertTrue(player.hasPersistentChangedValues)
+    }
+    
+    func testRecordIsEditedAfterInitFromRow() {
+        // Create a Record from a row. The row may not come from the database.
+        // So it is edited.
+        let row = Row(["name": "Arthur", "score": 41])
+        let player = RecordBox<Player>(row: row)
+        XCTAssertTrue(player.hasPersistentChangedValues)
+    }
+    
+    func testRecordIsNotEditedAfterFullFetch() throws {
+        // Fetch a record from a row that contains all the columns in
+        // persistence container: An update statement, which only saves the
+        // columns in persistence container would perform no change. So the
+        // record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try RecordBox<Player>(value: Player(name: "Arthur", score: 41)).insert(db)
+            let player = try RecordBox<Player>.fetchOne(db, "SELECT * FROM players")!
+            XCTAssertFalse(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testRecordIsNotEditedAfterWiderThanFullFetch() throws {
+        // Fetch a record from a row that contains all the columns in
+        // persistence container, plus extra ones: An update statement,
+        // which only saves the columns in persistence container would
+        // perform no change. So the record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try RecordBox<Player>(value: Player(name: "Arthur", score: 41)).insert(db)
+            let player = try RecordBox<Player>.fetchOne(db, "SELECT *, 1 AS foo FROM players")!
+            XCTAssertFalse(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testRecordIsEditedAfterPartialFetch() throws {
+        // Fetch a record from a row that does not contain all the columns in
+        // persistence container: An update statement saves the columns in
+        // persistence container, so it may perform unpredictable change.
+        // So the record is edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try RecordBox<Player>(value: Player(name: "Arthur", score: 41)).insert(db)
+            let player = try RecordBox<Player>.fetchOne(db, "SELECT name FROM players")!
+            XCTAssertTrue(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testRecordIsNotEditedAfterInsert() throws {
+        // After insertion, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.insert(db)
+            XCTAssertFalse(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testRecordIsEditedAfterValueChange() throws {
+        // Any change in a value exposed in persistence container yields a
+        // record that is edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                let player = RecordBox<Player>(value: Player(name: "Arthur"))
+                try player.insert(db)
+                XCTAssertTrue(player.value.name != nil)
+                player.value.name = "Bobby"           // non-nil vs. non-nil
+                XCTAssertTrue(player.hasPersistentChangedValues)
+            }
+            do {
+                let player = RecordBox<Player>(value: Player(name: "Arthur"))
+                try player.insert(db)
+                XCTAssertTrue(player.value.name != nil)
+                player.value.name = nil               // non-nil vs. nil
+                XCTAssertTrue(player.hasPersistentChangedValues)
+            }
+            do {
+                let player = RecordBox<Player>(value: Player(name: "Arthur"))
+                try player.insert(db)
+                XCTAssertTrue(player.value.score == nil)
+                player.value.score = 41                 // nil vs. non-nil
+                XCTAssertTrue(player.hasPersistentChangedValues)
+            }
+        }
+    }
+    
+    func testRecordIsNotEditedAfterSameValueChange() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                let player = RecordBox<Player>(value: Player(name: "Arthur"))
+                try player.insert(db)
+                XCTAssertTrue(player.value.name != nil)
+                player.value.name = "Arthur"           // non-nil vs. non-nil
+                XCTAssertFalse(player.hasPersistentChangedValues)
+            }
+            do {
+                let player = RecordBox<Player>(value: Player(name: "Arthur"))
+                try player.insert(db)
+                XCTAssertTrue(player.value.score == nil)
+                player.value.score = nil                 // nil vs. nil
+                XCTAssertFalse(player.hasPersistentChangedValues)
+            }
+        }
+    }
+    
+    func testRecordIsNotEditedAfterUpdate() throws {
+        // After update, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.insert(db)
+            player.value.name = "Bobby"
+            try player.update(db)
+            XCTAssertFalse(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testRecordIsNotEditedAfterSave() throws {
+        // After save, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.save(db)
+            XCTAssertFalse(player.hasPersistentChangedValues)
+            player.value.name = "Bobby"
+            XCTAssertTrue(player.hasPersistentChangedValues)
+            try player.save(db)
+            XCTAssertFalse(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testRecordIsEditedAfterPrimaryKeyChange() throws {
+        // After reload, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.insert(db)
+            player.value.id = player.value.id! + 1
+            XCTAssertTrue(player.hasPersistentChangedValues)
+        }
+    }
+    
+    func testCopyTransfersEditedFlag() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            
+            try player.insert(db)
+            XCTAssertFalse(player.hasPersistentChangedValues)
+            XCTAssertFalse(player.copy().hasPersistentChangedValues)
+            
+            player.value.name = "Barbara"
+            XCTAssertTrue(player.hasPersistentChangedValues)
+            XCTAssertTrue(player.copy().hasPersistentChangedValues)
+            
+            player.hasPersistentChangedValues = false
+            XCTAssertFalse(player.hasPersistentChangedValues)
+            XCTAssertFalse(player.copy().hasPersistentChangedValues)
+            
+            player.hasPersistentChangedValues = true
+            XCTAssertTrue(player.hasPersistentChangedValues)
+            XCTAssertTrue(player.copy().hasPersistentChangedValues)
+        }
+    }
+    
+    func testChangesAfterInit() {
+        let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+        let changes = player.persistentChangedValues
+        XCTAssertEqual(changes.count, 4)
+        for (column, old) in changes {
+            switch column {
+            case "id":
+                XCTAssertTrue(old == nil)
+            case "name":
+                XCTAssertTrue(old == nil)
+            case "score":
+                XCTAssertTrue(old == nil)
+            case "creationDate":
+                XCTAssertTrue(old == nil)
+            default:
+                XCTFail("Unexpected column: \(column)")
+            }
+        }
+    }
+    
+    func testChangesAfterInitFromRow() {
+        let player = RecordBox<Player>(row: Row(["name": "Arthur", "score": 41]))
+        let changes = player.persistentChangedValues
+        XCTAssertEqual(changes.count, 4)
+        for (column, old) in changes {
+            switch column {
+            case "id":
+                XCTAssertTrue(old == nil)
+            case "name":
+                XCTAssertTrue(old == nil)
+            case "score":
+                XCTAssertTrue(old == nil)
+            case "creationDate":
+                XCTAssertTrue(old == nil)
+            default:
+                XCTFail("Unexpected column: \(column)")
+            }
+        }
+    }
+    
+    func testChangesAfterFullFetch() throws {
+        // Fetch a record from a row that contains all the columns in
+        // persistence container: An update statement, which only saves the
+        // columns in persistence container would perform no change. So the
+        // record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try RecordBox<Player>(value: Player(name: "Arthur", score: 41)).insert(db)
+            do {
+                let player = try RecordBox<Player>.fetchOne(db, "SELECT * FROM players")!
+                let changes = player.persistentChangedValues
+                XCTAssertEqual(changes.count, 0)
+            }
+            do {
+                let players = try RecordBox<Player>.fetchAll(db, "SELECT * FROM players")
+                let changes = players[0].persistentChangedValues
+                XCTAssertEqual(changes.count, 0)
+            }
+            do {
+                let players = try RecordBox<Player>.fetchCursor(db, "SELECT * FROM players")
+                let changes = try players.next()!.persistentChangedValues
+                XCTAssertEqual(changes.count, 0)
+            }
+            do {
+                let player = try RecordBox<Player>.fetchOne(db, "SELECT * FROM players", adapter: SuffixRowAdapter(fromIndex: 0))!
+                let changes = player.persistentChangedValues
+                XCTAssertEqual(changes.count, 0)
+            }
+        }
+    }
+    
+    func testChangesAfterPartialFetch() throws {
+        // Fetch a record from a row that does not contain all the columns in
+        // persistence container: An update statement saves the columns in
+        // persistence container, so it may perform unpredictable change.
+        // So the record is edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try RecordBox<Player>(value: Player(name: "Arthur", score: 41)).insert(db)
+            let player = try RecordBox<Player>.fetchOne(db, "SELECT name FROM players")!
+            let changes = player.persistentChangedValues
+            XCTAssertEqual(changes.count, 3)
+            for (column, old) in changes {
+                switch column {
+                case "id":
+                    XCTAssertTrue(old == nil)
+                case "score":
+                    XCTAssertTrue(old == nil)
+                case "creationDate":
+                    XCTAssertTrue(old == nil)
+                default:
+                    XCTFail("Unexpected column: \(column)")
+                }
+            }
+        }
+    }
+    
+    func testChangesAfterInsert() throws {
+        // After insertion, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.insert(db)
+            let changes = player.persistentChangedValues
+            XCTAssertEqual(changes.count, 0)
+        }
+    }
+    
+    func testChangesAfterValueChange() throws {
+        // Any change in a value exposed in persistence container yields a
+        // record that is edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur"))
+            try player.insert(db)
+            
+            player.value.name = "Bobby"           // non-nil -> non-nil
+            player.value.score = 41                 // nil -> non-nil
+            player.value.creationDate = nil       // non-nil -> nil
+            let changes = player.persistentChangedValues
+            XCTAssertEqual(changes.count, 3)
+            for (column, old) in changes {
+                switch column {
+                case "name":
+                    XCTAssertEqual(old, "Arthur".databaseValue)
+                case "score":
+                    XCTAssertEqual(old, DatabaseValue.null)
+                case "creationDate":
+                    XCTAssertTrue(Date.fromDatabaseValue(old!) != nil)
+                default:
+                    XCTFail("Unexpected column: \(column)")
+                }
+            }
+        }
+    }
+    
+    func testChangesAfterUpdate() throws {
+        // After update, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.insert(db)
+            player.value.name = "Bobby"
+            try player.update(db)
+            XCTAssertEqual(player.persistentChangedValues.count, 0)
+        }
+    }
+    
+    func testChangesAfterSave() throws {
+        // After save, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.save(db)
+            XCTAssertEqual(player.persistentChangedValues.count, 0)
+            
+            player.value.name = "Bobby"
+            let changes = player.persistentChangedValues
+            XCTAssertEqual(changes.count, 1)
+            for (column, old) in changes {
+                switch column {
+                case "name":
+                    XCTAssertEqual(old, "Arthur".databaseValue)
+                default:
+                    XCTFail("Unexpected column: \(column)")
+                }
+            }
+            try player.save(db)
+            XCTAssertEqual(player.persistentChangedValues.count, 0)
+        }
+    }
+    
+    func testChangesAfterPrimaryKeyChange() throws {
+        // After reload, a record is not edited.
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            try player.insert(db)
+            player.value.id = player.value.id! + 1
+            let changes = player.persistentChangedValues
+            XCTAssertEqual(changes.count, 1)
+            for (column, old) in changes {
+                switch column {
+                case "id":
+                    XCTAssertEqual(old, (player.value.id! - 1).databaseValue)
+                default:
+                    XCTFail("Unexpected column: \(column)")
+                }
+            }
+        }
+    }
+    
+    func testCopyTransfersChanges() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            
+            try player.insert(db)
+            XCTAssertEqual(player.persistentChangedValues.count, 0)
+            XCTAssertEqual(player.copy().persistentChangedValues.count, 0)
+            
+            player.value.name = "Barbara"
+            XCTAssertTrue(player.persistentChangedValues.count > 0)            // TODO: compare actual changes
+            XCTAssertEqual(player.persistentChangedValues.count, player.copy().persistentChangedValues.count)
+            
+            player.hasPersistentChangedValues = false
+            XCTAssertEqual(player.persistentChangedValues.count, 0)
+            XCTAssertEqual(player.copy().persistentChangedValues.count, 0)
+            
+            player.hasPersistentChangedValues = true
+            XCTAssertTrue(player.persistentChangedValues.count > 0)            // TODO: compare actual changes
+            XCTAssertEqual(player.persistentChangedValues.count, player.copy().persistentChangedValues.count)
+        }
+    }
+    
+    func testUpdateChanges() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let player = RecordBox<Player>(value: Player(name: "Arthur", score: 41))
+            
+            do {
+                XCTAssertTrue(player.hasPersistentChangedValues)
+                try player.updateChanges(db)
+                XCTFail("Expected PersistenceError")
+            } catch is PersistenceError { }
+            
+            try player.insert(db)
+            
+            // Nothing to update
+            let initialChangesCount = db.totalChangesCount
+            XCTAssertFalse(player.hasPersistentChangedValues)
+            try player.updateChanges(db)
+            XCTAssertEqual(db.totalChangesCount, initialChangesCount)
+            
+            // Nothing to update
+            player.value.score = 41
+            XCTAssertFalse(player.hasPersistentChangedValues)
+            try player.updateChanges(db)
+            XCTAssertEqual(db.totalChangesCount, initialChangesCount)
+            
+            // Update single column
+            player.value.score = 42
+            XCTAssertEqual(Set(player.persistentChangedValues.keys), ["score"])
+            try player.updateChanges(db)
+            XCTAssertEqual(db.totalChangesCount, initialChangesCount + 1)
+            XCTAssertEqual(lastSQLQuery, "UPDATE \"players\" SET \"score\"=42 WHERE \"id\"=1")
+            
+            // Update two columns
+            player.value.name = "Barbara"
+            player.value.score = 43
+            XCTAssertEqual(Set(player.persistentChangedValues.keys), ["score", "name"])
+            try player.updateChanges(db)
+            XCTAssertEqual(db.totalChangesCount, initialChangesCount + 2)
+            let fetchedPlayer = try RecordBox<Player>.fetchOne(db, key: player.value.id)!
+            XCTAssertEqual(fetchedPlayer.value.name, player.value.name)
+            XCTAssertEqual(fetchedPlayer.value.score, player.value.score)
+        }
+    }
+}


### PR DESCRIPTION
[Changes tracking](https://github.com/groue/GRDB.swift/blob/master/README.md#changes-tracking) is the ability, for a record, to know if it has been modified since it was last fetched or persisted.

Changes tracking is great tool when one has, for example, to synchronize the database with external data, because it avoids performing useless database changes.

Until now, changes tracking was available on the [Record](https://github.com/groue/GRDB.swift/blob/master/README.md#record-class) class only.

This PR brings changes tracking to any record type, by the way of the new generic RecordBox class:

```swift
final class RecordBox<T: RowConvertible & MutablePersistable>: Record {
    var value: T
    init(value: T)
    required init(row: Row)
}
```

For example:

```swift
// A regular record struct
struct Player: RowConvertible, MutablePersistable { ... }

try dbQueue.inDatabase { db in
    // Fetch a boxed player
    if let player = try RecordBox<Player>.fetchOne(db, key: 1) {
        player.value.score = 300
        
        if player.hasPersistentChangedValues {
            print("player has been modified")
        }
        
        // Does nothing if player has not been modified:
        try player.updateChanges(db)
    }
}
```
