### PR TITLE
Upgrade SQLite version to 3.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Release Notes
 **New**
 
 - Upgrade custom SQLite builds to [v3.22.0](http://www.sqlite.org/changes.html) (thanks to [@swiftlyfalling](https://github.com/swiftlyfalling/SQLiteLib)).
-- The FTS5 full-text search engine has been enhanced with [initial token querie](https://sqlite.org/fts5.html#carrotq), and FTS5Pattern has gained a new initializer: `FTS5Pattern(matchingPrefixPhrase:)`
+- The FTS5 full-text search engine has been enhanced with [initial token queries](https://sqlite.org/fts5.html#carrotq), and FTS5Pattern has gained a new initializer: `FTS5Pattern(matchingPrefixPhrase:)`
 
 
 ## 2.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Release Notes
 =============
 
+## Next Version
+
+**New**
+
+- Upgrade custom SQLite builds to [v3.22.0](http://www.sqlite.org/changes.html) (thanks to [@swiftlyfalling](https://github.com/swiftlyfalling/SQLiteLib)).
+- The FTS5 full-text search engine has been enhanced with [initial token querie](https://sqlite.org/fts5.html#carrotq), and FTS5Pattern has gained a new initializer: `FTS5Pattern(matchingPrefixPhrase:)`
+
+
 ## 2.7.0
 
 Released January 21, 2018 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v2.6.1...v2.7.0)

--- a/Documentation/CustomSQLiteBuilds.md
+++ b/Documentation/CustomSQLiteBuilds.md
@@ -3,7 +3,7 @@ Custom SQLite Builds
 
 By default, GRDB uses the version of SQLite that ships with the target operating system.
 
-**You can build GRDB with a custom build of [SQLite 3.21.0](https://www.sqlite.org/changes.html).**
+**You can build GRDB with a custom build of [SQLite 3.22.0](https://www.sqlite.org/changes.html).**
 
 A custom SQLite build can activate extra SQLite features, and extra GRDB features as well, such as support for the [FTS5 full-text search engine](../../../#full-text-search), and [SQLite Pre-Update Hooks](../../../#support-for-sqlite-pre-update-hooks).
 

--- a/GRDB/FTS/FTS5Pattern.swift
+++ b/GRDB/FTS/FTS5Pattern.swift
@@ -44,6 +44,19 @@
             try? self.init(rawPattern: "\"" + tokens.joined(separator: " ") + "\"")
         }
         
+        /// Creates a pattern that matches a contiguous string prefix; returns
+        /// nil if no pattern could be built.
+        ///
+        ///     FTS5Pattern(matchingPrefixPhrase: "")        // nil
+        ///     FTS5Pattern(matchingPrefixPhrase: "foo bar") // ^"foo bar"
+        ///
+        /// - parameter string: The string to turn into an FTS5 pattern
+        public init?(matchingPrefixPhrase string: String) {
+            guard let tokens = try? DatabaseQueue().inDatabase({ db in try db.makeTokenizer(.ascii()).nonSynonymTokens(in: string, for: .query) }) else { return nil }
+            guard !tokens.isEmpty else { return nil }
+            try? self.init(rawPattern: "^\"" + tokens.joined(separator: " ") + "\"")
+        }
+
         init(rawPattern: String, allowedColumns: [String] = []) throws {
             // Correctness above all: use SQLite to validate the pattern.
             //

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Installation
 
 See [Encryption](#encryption) for the installation procedure of GRDB with SQLCipher.
 
-See [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) for the installation procedure of GRDB with a customized build of SQLite 3.21.0.
+See [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) for the installation procedure of GRDB with a customized build of SQLite 3.22.0.
 
 
 ## CocoaPods

--- a/README.md
+++ b/README.md
@@ -4399,6 +4399,8 @@ let pattern = FTS5Pattern(matchingAnyTokenIn: query)
 let pattern = FTS5Pattern(matchingAllTokensIn: query)
 // Matches documents that contain "SQLite database"
 let pattern = FTS5Pattern(matchingPhrase: query)
+// Matches documents that start with "SQLite database"
+let pattern = FTS5Pattern(matchingPrefixPhrase: query)
 ```
 
 They return nil when no pattern could be built from the input string:

--- a/Tests/GRDBTests/FTS5PatternTests.swift
+++ b/Tests/GRDBTests/FTS5PatternTests.swift
@@ -17,7 +17,7 @@ class FTS5PatternTests: GRDBTestCase {
                 t.column("author")
                 t.column("body")
             }
-            try db.execute("INSERT INTO books (title, author, body) VALUES (?, ?, ?)", arguments: ["Moby Dick", "Herman Melville", "Call me Ishmael. Some years ago--never mind how long precisely--having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world."])
+            try db.execute("INSERT INTO books (title, author, body) VALUES (?, ?, ?)", arguments: ["Moby-Dick", "Herman Melville", "Call me Ishmael. Some years ago--never mind how long precisely--having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world."])
             try db.execute("INSERT INTO books (title, author, body) VALUES (?, ?, ?)", arguments: ["Red Mars", "Kim Stanley Robinson", "History is not evolution! It is a false analogy! Evolution is a matter of environment and chance, acting over millions of years. But history is a matter of environment and choice, acting within lifetimes, and sometimes within years, or months, or days! History is Lamarckian!"])
             try db.execute("INSERT INTO books (title, author, body) VALUES (?, ?, ?)", arguments: ["Querelle de Brest", "Jean Genet", "L’idée de mer évoque souvent l’idée de mer, de marins. Mer et marins ne se présentent pas alors avec la précision d’une image, le meurtre plutôt fait en nous l’émotion déferler par vagues."])
             try db.execute("INSERT INTO books (title, author, body) VALUES (?, ?, ?)", arguments: ["Éden, Éden, Éden", "Pierre Guyotat", "/ Les soldats, casqués, jambes ouvertes, foulent, muscles retenus, les nouveau-nés emmaillotés dans les châles écarlates, violets : les bébés roulent hors des bras des femmes accroupies sur les tôles mitraillées des G. M. C. ;"])
@@ -153,6 +153,38 @@ class FTS5PatternTests: GRDBTestCase {
                 ]
             for (string, expectedRawPattern, expectedCount) in cases {
                 if let pattern = FTS5Pattern(matchingPhrase: string) {
+                    let rawPattern = String.fromDatabaseValue(pattern.databaseValue)!
+                    XCTAssertEqual(rawPattern, expectedRawPattern)
+                    let count = try Int.fetchOne(db, "SELECT COUNT(*) FROM books WHERE books MATCH ?", arguments: [pattern])!
+                    XCTAssertEqual(count, expectedCount, "Expected pattern \(String(reflecting: rawPattern)) to yield \(expectedCount) results")
+                }
+            }
+        }
+    }
+    
+    func testFTS5PatternWithPrefixPhrase() throws {
+        let wrongInputs = ["", "*", "^", " ", "(", "()", "\"", "?!"]
+        for string in wrongInputs {
+            if let pattern = FTS5Pattern(matchingPrefixPhrase: string) {
+                let rawPattern = String.fromDatabaseValue(pattern.databaseValue)!
+                XCTFail("Unexpected raw pattern \(String(reflecting: rawPattern)) from string \(String(reflecting: string))")
+            }
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            // Couples (pattern, expected raw pattern, expected count of matching rows)
+            let cases = [
+                ("écarlates", "^\"écarlates\"", 0),
+                ("^Moby-dick*", "^\"moby dick\"", 1),
+                ("not evolution", "^\"not evolution\"", 0),
+                ("HISTORY IS", "^\"history is\"", 1),
+                (" \t\nyears \t\nmonths \t\n", "^\"years months\"", 0),
+                ("\"years months days\"", "^\"years months days\"", 0),
+                ("FOOÉı👨👨🏿🇫🇷🇨🇮", "^\"fooÉı👨👨🏿🇫🇷🇨🇮\"", 0),
+                ]
+            for (string, expectedRawPattern, expectedCount) in cases {
+                if let pattern = FTS5Pattern(matchingPrefixPhrase: string) {
                     let rawPattern = String.fromDatabaseValue(pattern.databaseValue)!
                     XCTAssertEqual(rawPattern, expectedRawPattern)
                     let count = try Int.fetchOne(db, "SELECT COUNT(*) FROM books WHERE books MATCH ?", arguments: [pattern])!


### PR DESCRIPTION
Upgrade SQLite version to 3.22.0 ([release notes](https://sqlite.org/changes.html)), and add the new `FTS5Pattern(matchingPrefixPhrase:)` initializer, now that FTS5 supports [initial token queries](https://sqlite.org/fts5.html#carrotq).