### PR TITLE
Improve testability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Release Notes
 
 - `Database.isSQLiteInternalTable(_:)` returns whether a table name is an internal SQLite table.
 - `Database.isGRDBInternalTable(_:)` returns whether a table name is an internal GRDB table.
-- `DatabaseMigrator.appliedMigrations(in:)` returns the set of applied migrations identifiers.
+- `DatabaseMigrator.appliedMigrations(in:)` returns the set of applied migrations identifiers in a database.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Release Notes
 
 ## Next Version
 
+### New
+
+- `Database.isSQLiteInternalTable(_:)` returns whether a table name is an internal SQLite table.
+
 ### Breaking Changes
 
 - The Record protocols have been renamed: `RowConvertible` to `FetchableRecord`, `Persistable` to `PersistableRecord`, and `TableMapping` to `TableRecord`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release Notes
 ### New
 
 - `Database.isSQLiteInternalTable(_:)` returns whether a table name is an internal SQLite table.
+- `Database.isGRDBInternalTable(_:)` returns whether a table name is an internal GRDB table.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Release Notes
 
 - `Database.isSQLiteInternalTable(_:)` returns whether a table name is an internal SQLite table.
 - `Database.isGRDBInternalTable(_:)` returns whether a table name is an internal GRDB table.
+- `DatabaseMigrator.appliedMigrations(in:)` returns the set of applied migrations identifiers.
 
 ### Breaking Changes
 

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -30,6 +30,19 @@ extension Database {
         return try Row.fetchOne(self, "SELECT 1 FROM (SELECT sql, type, name FROM sqlite_master UNION SELECT sql, type, name FROM sqlite_temp_master) WHERE type = 'table' AND LOWER(name) = ?", arguments: [tableName.lowercased()]) != nil
     }
     
+    /// Returns whether a table is an internal SQLite table.
+    ///
+    /// For more information, see https://www.sqlite.org/fileformat2.html
+    public func isSQLiteInternalTable(_ tableName: String) -> Bool {
+        // https://www.sqlite.org/fileformat2.html#internal_schema_objects
+        // > The names of internal schema objects always begin with "sqlite_"
+        // > and any table, index, view, or trigger whose name begins with
+        // > "sqlite_" is an internal schema object. SQLite prohibits
+        // > applications from creating objects whose names begin with
+        // > "sqlite_".
+        return tableName.starts(with: "sqlite_")
+    }
+
     /// Returns whether a view exists.
     public func viewExists(_ viewName: String) throws -> Bool {
         // SQlite identifiers are case-insensitive, case-preserving (http://www.alberton.info/dbms_identifiers_and_case_sensitivity.html)

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -32,6 +32,8 @@ extension Database {
     
     /// Returns whether a table is an internal SQLite table.
     ///
+    /// Those are tables whose name begins with "sqlite_".
+    ///
     /// For more information, see https://www.sqlite.org/fileformat2.html
     public func isSQLiteInternalTable(_ tableName: String) -> Bool {
         // https://www.sqlite.org/fileformat2.html#internal_schema_objects
@@ -42,7 +44,14 @@ extension Database {
         // > "sqlite_".
         return tableName.starts(with: "sqlite_")
     }
-
+    
+    /// Returns whether a table is an internal GRDB table.
+    ///
+    /// Those are tables whose name begins with "grdb_".
+    public func isGRDBInternalTable(_ tableName: String) -> Bool {
+        return tableName.starts(with: "grdb_")
+    }
+    
     /// Returns whether a view exists.
     public func viewExists(_ viewName: String) throws -> Bool {
         // SQlite identifiers are case-insensitive, case-preserving (http://www.alberton.info/dbms_identifiers_and_case_sensitivity.html)

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -147,7 +147,7 @@ public struct DatabaseMigrator {
     }
     
     /// Returns the set of applied migration identifiers.
-    public func appliedMigrations(_ reader: DatabaseReader) throws -> Set<String> {
+    public func appliedMigrations(in reader: DatabaseReader) throws -> Set<String> {
         return try reader.read { try appliedMigrations($0) }
     }
     

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -146,6 +146,11 @@ public struct DatabaseMigrator {
         }
     }
     
+    /// Returns the set of applied migration identifiers.
+    public func appliedMigrations(_ reader: DatabaseReader) throws -> Set<String> {
+        return try reader.read { try appliedMigrations($0) }
+    }
+    
     
     // MARK: - Non public
     
@@ -160,13 +165,13 @@ public struct DatabaseMigrator {
         try db.execute("CREATE TABLE IF NOT EXISTS grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
     }
     
-    private func appliedIdentifiers(_ db: Database) throws -> Set<String> {
+    private func appliedMigrations(_ db: Database) throws -> Set<String> {
         return try Set(String.fetchAll(db, "SELECT identifier FROM grdb_migrations"))
     }
     
     private func runMigrations(_ db: Database) throws {
-        let appliedIdentifiers = try self.appliedIdentifiers(db)
-        for migration in migrations where !appliedIdentifiers.contains(migration.identifier) {
+        let appliedMigrations = try self.appliedMigrations(db)
+        for migration in migrations where !appliedMigrations.contains(migration.identifier) {
             try migration.run(db)
         }
     }
@@ -184,13 +189,13 @@ public struct DatabaseMigrator {
         GRDBPrecondition(prefixMigrations.last?.identifier == targetIdentifier, "undefined migration: \(String(reflecting: targetIdentifier))")
         
         // Subsequent migration must not be applied
-        let appliedIdentifiers = try self.appliedIdentifiers(db)
+        let appliedMigrations = try self.appliedMigrations(db)
         if prefixMigrations.count < migrations.count {
             let nextIdentifier = migrations[prefixMigrations.count].identifier
-            GRDBPrecondition(!appliedIdentifiers.contains(nextIdentifier), "database is already migrated beyond migration \(String(reflecting: targetIdentifier))")
+            GRDBPrecondition(!appliedMigrations.contains(nextIdentifier), "database is already migrated beyond migration \(String(reflecting: targetIdentifier))")
         }
         
-        for migration in prefixMigrations where !appliedIdentifiers.contains(migration.identifier) {
+        for migration in prefixMigrations where !appliedMigrations.contains(migration.identifier) {
             try migration.run(db)
         }
     }

--- a/README.md
+++ b/README.md
@@ -3854,6 +3854,15 @@ try migrator.migrate(dbQueue, upTo: "v1")
 // fatal error: database is already migrated beyond migration "v1"
 ```
 
+Check if a migration has been applied:
+
+```swift
+let appliedMigrations = try migrator.appliedMigration(in: dbQueue)
+if appliedMigrations.contains("v2") {
+    // "v2" has been applied
+}
+```
+
 
 ### Advanced Database Schema Changes
 

--- a/README.md
+++ b/README.md
@@ -1647,6 +1647,7 @@ try db.indexes(on: "players")     // [IndexInfo], the indexes defined on the tab
 try db.foreignKeys(on: "players") // [ForeignKeyInfo], the foreign keys defined on the table
 try db.primaryKey("players")      // PrimaryKeyInfo
 try db.table("players", hasUniqueKey: ["email"]) // Bool, true if column(s) is a unique key
+Database.isSQLiteInternalTable("players") // Bool, true if argument is the name of an internal to SQLite table
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1647,7 +1647,8 @@ try db.indexes(on: "players")     // [IndexInfo], the indexes defined on the tab
 try db.foreignKeys(on: "players") // [ForeignKeyInfo], the foreign keys defined on the table
 try db.primaryKey("players")      // PrimaryKeyInfo
 try db.table("players", hasUniqueKey: ["email"]) // Bool, true if column(s) is a unique key
-Database.isSQLiteInternalTable("players") // Bool, true if argument is the name of an internal to SQLite table
+Database.isSQLiteInternalTable(...) // Bool, true if argument is the name of an internal SQLite table
+Database.isGRDBInternalTable(...)   // Bool, true if argument is the name of an internal GRDB table
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -3859,7 +3859,7 @@ Check if a migration has been applied:
 ```swift
 let appliedMigrations = try migrator.appliedMigration(in: dbQueue)
 if appliedMigrations.contains("v2") {
-    // "v2" has been applied
+    // "v2" migration has been applied
 }
 ```
 


### PR DESCRIPTION
This PR brings convenience methods that help testing database contents and migrations:

- `Database.isSQLiteInternalTable(_:)` returns whether a table name is an internal SQLite table.
- `Database.isGRDBInternalTable(_:)` returns whether a table name is an internal GRDB table.
- `DatabaseMigrator.appliedMigrations(in:)` returns the set of applied migrations identifiers in a database.