### PR TITLE
Allow observation of complex fetching strategies

### DIFF
--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -12,27 +12,27 @@ public struct QueryInterfaceRequest<T> {
 extension QueryInterfaceRequest : FetchRequest {
     public typealias RowDecoder = T
     
-    /// A tuple that contains a prepared statement that is ready to be
+    /// Returns a tuple that contains a prepared statement that is ready to be
     /// executed, and an eventual row adapter.
     ///
     /// - parameter db: A database connection.
-    ///
+    /// - returns: A prepared statement and an eventual row adapter.
     /// :nodoc:
     public func prepare(_ db: Database) throws -> (SelectStatement, RowAdapter?) {
         return try query.prepare(db)
     }
     
-    /// The number of rows fetched by the request.
+    /// Returns the number of rows fetched by the request.
     ///
     /// - parameter db: A database connection.
-    ///
     /// :nodoc:
     public func fetchCount(_ db: Database) throws -> Int {
         return try query.fetchCount(db)
     }
     
-    /// The database region that the request looks into.
+    /// Returns the database region that the request looks into.
     ///
+    /// - parameter db: A database connection.
     /// :nodoc:
     public func fetchedRegion(_ db: Database) throws -> DatabaseRegion {
         return try query.fetchedRegion(db)

--- a/README.md
+++ b/README.md
@@ -3796,12 +3796,12 @@ protocol FetchRequest: SelectStatementRequest {
 }
 ```
 
-The `RowDecoder` associated type tells a request how to decode rows. It can be any type, but not all types have built-in support. See [Fetching From Custom Requests](#fetching-from-custom-requests) below.
+The `RowDecoder` associated type can be any type. Yet, not all types have built-in support: see [Fetching From Custom Requests](#fetching-from-custom-requests) below.
 
 FetchRequest is adopted, for example, by [query interface requests](#requests):
 
 ```swift
-// A FetchRequest whose RowDecoder associated type is Player.
+// A FetchRequest whose RowDecoder associated type is Player:
 let request = Player.all()
 ```
 


### PR DESCRIPTION
This PR refactors the FetchRequest protocol, and introduces two new protocols: `DatabaseRequest` and `SelectStatementRequest`:

```swift
public protocol DatabaseRequest {
    func fetchedRegion(_ db: Database) throws -> DatabaseRegion
}

public protocol SelectStatementRequest: DatabaseRequest {
    func prepare(_ db: Database) throws -> (SelectStatement, RowAdapter?)
    func fetchCount(_ db: Database) throws -> Int
}

public protocol FetchRequest: SelectStatementRequest {
    associatedtype RowDecoder
}
```

The goal of this PR is to allow one to encapsulate complex fetching strategies into a dedicated type, and yet profit from database observation tools like [RxGRDB](http://github.com/RxSwiftCommunity/RxGRDB).

This used to be impossible because only requests that execute a single database statement were properly supported. Now complex requests are supported as well:

```swift
struct LibraryRequest: DatabaseRequest {
    /// Fetch the library content
    func fetchAll(_ db: Database) throws -> [(Author, [Books])] {
        let authors = try Author.fetchAll(db)
        let books = try Dictionary(
            grouping: Book.fetchAll(db),
            by: { book in book.authorId })
        return authors.map { author in (author, books[author.id]!) }
    }
    
    /// Support database observation by tracking the full authors and books tables
    func fetchedRegion(_ db: Database) throws -> DatabaseRegion {
        let authorsRegion = try Author.all().fetchedRegion(db)
        let booksRegion = try Book.all().fetchedRegion(db)
        return authorsRegion.union(booksRegion)
    }
}

// Track library content with RxGRDB
let request = LibraryRequest()
dbQueue.rx
    .fetchTokens(in: [request])
    .mapFetch { db in try request.fetchAll(db) }
    .subscribe(onNext: { library: [(Author, [Books])] in
        print("Library has changed.")
    })
```
