### PR TITLE
Introduce request derivation protocols

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		560D924B1C672C4B00F4F92B /* TableRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560D92461C672C4B00F4F92B /* TableRecord.swift */; };
 		560D924C1C672C4B00F4F92B /* TableRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560D92461C672C4B00F4F92B /* TableRecord.swift */; };
 		561667051D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */; };
+		5616AAF1207CD45E00AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF0207CD45E00AC3664 /* RequestProtocols.swift */; };
+		5616AAF2207CD45E00AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF0207CD45E00AC3664 /* RequestProtocols.swift */; };
+		5616AAF3207CD45E00AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF0207CD45E00AC3664 /* RequestProtocols.swift */; };
 		56176C591EACCCC7000F3F2B /* FTS5CustomTokenizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5698AD001DAA8ACA0056AF8C /* FTS5CustomTokenizerTests.swift */; };
 		56176C5A1EACCCC7000F3F2B /* FTS5PatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B964C01DA521450002DA19 /* FTS5PatternTests.swift */; };
 		56176C5B1EACCCC7000F3F2B /* FTS5RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B964C11DA521450002DA19 /* FTS5RecordTests.swift */; };
@@ -766,6 +769,7 @@
 		560D92461C672C4B00F4F92B /* TableRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableRecord.swift; sourceTree = "<group>"; };
 		560FC5101CAEEDF10014AA8E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationNSDecimalNumberTests.swift; sourceTree = "<group>"; };
+		5616AAF0207CD45E00AC3664 /* RequestProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestProtocols.swift; sourceTree = "<group>"; };
 		562393171DECC02000A6B01F /* RowFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowFetchTests.swift; sourceTree = "<group>"; };
 		5623932F1DEDFC5700A6B01F /* AnyCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCursorTests.swift; sourceTree = "<group>"; };
 		5623934D1DEDFEFB00A6B01F /* EnumeratedCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedCursorTests.swift; sourceTree = "<group>"; };
@@ -1274,6 +1278,7 @@
 				56CEB5181EAA328900BFAF62 /* FTS5+QueryInterface.swift */,
 				5605F18C1C6B1A8700235C62 /* QueryInterfaceQuery.swift */,
 				56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */,
+				5616AAF0207CD45E00AC3664 /* RequestProtocols.swift */,
 				5605F1891C6B1A8700235C62 /* SQLCollatedExpression.swift */,
 				566475991D97D8A000FF74B8 /* SQLCollection.swift */,
 				56CEB5411EAA359A00BFAF62 /* SQLExpressible.swift */,
@@ -2160,6 +2165,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				569A98EF2039B6F3008D7DBF /* Fixits-3.0.swift in Sources */,
+				5616AAF3207CD45E00AC3664 /* RequestProtocols.swift in Sources */,
 				56B964BF1DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
 				56D51D061EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				565490CE1D5AE252005622CB /* NSNull.swift in Sources */,
@@ -2321,6 +2327,7 @@
 				56D51D031EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				560D924C1C672C4B00F4F92B /* TableRecord.swift in Sources */,
 				5657AB121D10899D006283EF /* URL.swift in Sources */,
+				5616AAF2207CD45E00AC3664 /* RequestProtocols.swift in Sources */,
 				5659F48B1EA8D94E004A4992 /* Utils.swift in Sources */,
 				56A2387C1B9C75030082EB20 /* Configuration.swift in Sources */,
 				56DAA2DE1DE9C827006E10C8 /* Cursor.swift in Sources */,
@@ -2670,6 +2677,7 @@
 			files = (
 				56873BEC1F2CB400004D24B4 /* Fixits-1.2.swift in Sources */,
 				56BF6D3D1DEF47DA006039A3 /* Fixits-Swift2.swift in Sources */,
+				5616AAF1207CD45E00AC3664 /* RequestProtocols.swift in Sources */,
 				5636E9BC1D22574100B9B05F /* FetchRequest.swift in Sources */,
 				56BB6EA91D3009B100A1CA52 /* SchedulingWatchdog.swift in Sources */,
 				566B91091FA4C3970012D5B0 /* Database+Statements.swift in Sources */,

--- a/GRDB/QueryInterface/RequestProtocols.swift
+++ b/GRDB/QueryInterface/RequestProtocols.swift
@@ -1,0 +1,201 @@
+// MARK: - SelectionRequest
+
+/// The protocol for all requests that can refine their selection.
+public protocol SelectionRequest {
+    /// Creates a request with a new net of selected columns.
+    ///
+    ///     // SELECT id, email FROM players
+    ///     var request = Player.all()
+    ///     request = request.select([Column("id"), Column("email")])
+    ///
+    /// Any previous selection is replaced:
+    ///
+    ///     // SELECT email FROM players
+    ///     request
+    ///         .select([Column("id")])
+    ///         .select([Column("email")])
+    func select(_ selection: [SQLSelectable]) -> Self
+}
+
+extension SelectionRequest {
+    /// Creates a request with a new net of selected columns.
+    ///
+    ///     // SELECT id, email FROM players
+    ///     var request = Player.all()
+    ///     request = request.select(Column("id"), Column("email"))
+    ///
+    /// Any previous selection is replaced:
+    ///
+    ///     // SELECT email FROM players
+    ///     request
+    ///         .select(Column("id"))
+    ///         .select(Column("email"))
+    public func select(_ selection: SQLSelectable...) -> Self {
+        return select(selection)
+    }
+    
+    /// Creates a request with a new net of selected columns.
+    ///
+    ///     // SELECT id, email FROM players
+    ///     var request = Player.all()
+    ///     request = request.select(sql: "id, email")
+    ///
+    /// Any previous selection is replaced:
+    ///
+    ///     // SELECT email FROM players
+    ///     request
+    ///         .select(sql: "id")
+    ///         .select(sql: "email")
+    public func select(sql: String, arguments: StatementArguments? = nil) -> Self {
+        return select(SQLSelectionLiteral(sql, arguments: arguments))
+    }
+}
+
+// MARK: - FilteredRequest
+
+/// The protocol for all requests that can be filtered.
+public protocol FilteredRequest {
+    /// Creates a request with the provided *predicate* added to the
+    /// eventual set of already applied predicates.
+    ///
+    ///     // SELECT * FROM players WHERE email = 'arthur@example.com'
+    ///     var request = Player.all()
+    ///     request = request.filter(Column("email") == "arthur@example.com")
+    func filter(_ predicate: SQLExpressible) -> Self
+    
+    /// Creates a request that matches nothing.
+    ///
+    ///     // SELECT * FROM players WHERE 0
+    ///     var request = Player.all()
+    ///     request = request.none()
+    func none() -> Self
+}
+
+extension FilteredRequest {
+    /// Creates a request with the provided *predicate* added to the
+    /// eventual set of already applied predicates.
+    ///
+    ///     // SELECT * FROM players WHERE email = 'arthur@example.com'
+    ///     var request = Player.all()
+    ///     request = request.filter(sql: "email = ?", arguments: ["arthur@example.com"])
+    public func filter(sql: String, arguments: StatementArguments? = nil) -> Self {
+        return filter(SQLExpressionLiteral(sql, arguments: arguments))
+    }
+}
+
+// MARK: - AggregatingRequest
+
+/// The protocol for all requests that can aggregate.
+public protocol AggregatingRequest {
+    /// Creates a request grouped according to *expressions*.
+    func group(_ expressions: [SQLExpressible]) -> Self
+    
+    /// Creates a request with the provided *predicate* added to the
+    /// eventual set of already applied predicates.
+    func having(_ predicate: SQLExpressible) -> Self
+}
+
+extension AggregatingRequest {
+    /// Creates a request grouped according to *expressions*.
+    public func group(_ expressions: SQLExpressible...) -> Self {
+        return group(expressions)
+    }
+    
+    /// Creates a request with a new grouping.
+    public func group(sql: String, arguments: StatementArguments? = nil) -> Self {
+        // This "expression" is not a real expression. We support raw sql which
+        // actually contains several expressions:
+        //
+        //   request = Player.group(sql: "teamId, level")
+        //
+        // This is why we use the "unsafe" flag, so that the SQLExpressionLiteral
+        // does not output its safe wrapping parenthesis, and generates
+        // invalid SQL.
+        var expression = SQLExpressionLiteral(sql, arguments: arguments)
+        expression.unsafeRaw = true
+        return group(expression)
+    }
+    
+    /// Creates a request with the provided *sql* added to the
+    /// eventual set of already applied predicates.
+    public func having(sql: String, arguments: StatementArguments? = nil) -> Self {
+        return having(SQLExpressionLiteral(sql, arguments: arguments))
+    }
+}
+
+// MARK: - OrderedRequest
+
+/// The protocol for all requests that be ordered.
+public protocol OrderedRequest {
+    /// Creates a request with the provided *orderings*.
+    ///
+    ///     // SELECT * FROM players ORDER BY name
+    ///     var request = Player.all()
+    ///     request = request.order([Column("name")])
+    ///
+    /// Any previous ordering is replaced:
+    ///
+    ///     // SELECT * FROM players ORDER BY name
+    ///     request
+    ///         .order([Column("email")])
+    ///         .reversed()
+    ///         .order([Column("name")])
+    func order(_ orderings: [SQLOrderingTerm]) -> Self
+    
+    /// Creates a request that reverses applied orderings. If no ordering
+    /// was applied, the returned request is identical.
+    ///
+    ///     // SELECT * FROM players ORDER BY name DESC
+    ///     var request = Player.all().order(Column("name"))
+    ///     request = request.reversed()
+    ///
+    ///     // SELECT * FROM players
+    ///     var request = Player.all()
+    ///     request = request.reversed()
+    func reversed() -> Self
+}
+
+extension OrderedRequest {
+    /// Creates a request with the provided *orderings*.
+    ///
+    ///     // SELECT * FROM players ORDER BY name
+    ///     var request = Player.all()
+    ///     request = request.order(Column("name"))
+    ///
+    /// Any previous ordering is replaced:
+    ///
+    ///     // SELECT * FROM players ORDER BY name
+    ///     request
+    ///         .order(Column("email"))
+    ///         .reversed()
+    ///         .order(Column("name"))
+    public func order(_ orderings: SQLOrderingTerm...) -> Self {
+        return order(orderings)
+    }
+    
+    /// Creates a request with the provided *sql* used for sorting.
+    ///
+    ///     // SELECT * FROM players ORDER BY name
+    ///     var request = Player.all()
+    ///     request = request.order(sql: "name")
+    ///
+    /// Any previous ordering is replaced:
+    ///
+    ///     // SELECT * FROM players ORDER BY name
+    ///     request
+    ///         .order(sql: "email")
+    ///         .order(sql: "name")
+    public func order(sql: String, arguments: StatementArguments? = nil) -> Self {
+        // This "expression" is not a real expression. We support raw sql which
+        // actually contains several expressions:
+        //
+        //   request = Player.order(sql: "teamId, level")
+        //
+        // This is why we use the "unsafe" flag, so that the SQLExpressionLiteral
+        // does not output its safe wrapping parenthesis, and generates
+        // invalid SQL.
+        var expression = SQLExpressionLiteral(sql, arguments: arguments)
+        expression.unsafeRaw = true
+        return order([expression])
+    }
+}

--- a/GRDB/QueryInterface/SQLSelectable.swift
+++ b/GRDB/QueryInterface/SQLSelectable.swift
@@ -23,6 +23,48 @@ public protocol SQLSelectable {
     func qualified(by qualifier: SQLTableQualifier) -> Self
 }
 
+// MARK: - SQLSelectionLiteral
+
+struct SQLSelectionLiteral : SQLSelectable {
+    let sql: String
+    let arguments: StatementArguments?
+    
+    init(_ sql: String, arguments: StatementArguments? = nil) {
+        self.sql = sql
+        self.arguments = arguments
+    }
+    
+    func resultColumnSQL(_ arguments: inout StatementArguments?) -> String {
+        if let literalArguments = self.arguments {
+            guard arguments != nil else {
+                // GRDB limitation: we don't know how to look for `?` in sql and
+                // replace them with with literals.
+                fatalError("Not implemented")
+            }
+            arguments! += literalArguments
+        }
+        return sql
+    }
+    
+    func countedSQL(_ arguments: inout StatementArguments?) -> String {
+        fatalError("Selection literals can't be counted. To resolve this error, select one or several SQLExpressionLiteral instead.")
+    }
+    
+    func count(distinct: Bool) -> SQLCount? {
+        fatalError("Selection literals can't be counted. To resolve this error, select one or several SQLExpressionLiteral instead.")
+    }
+    
+    func columnCount(_ db: Database) throws -> Int {
+        fatalError("Selection literals don't known how many columns they contain. To resolve this error, select one or several SQLExpressionLiteral instead.")
+    }
+    
+    func qualified(by qualifier: SQLTableQualifier) -> SQLSelectionLiteral {
+        return self
+    }
+}
+
+// MARK: - SQLTableQualifier
+
 /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
 ///
 /// :nodoc:

--- a/GRDB/QueryInterface/TableDefinition.swift
+++ b/GRDB/QueryInterface/TableDefinition.swift
@@ -360,7 +360,9 @@ public final class TableDefinition {
     ///
     /// - parameter sql: An SQL snippet
     public func check(sql: String) {
-        checkConstraints.append(SQLExpressionLiteral(sql))
+        var expression = SQLExpressionLiteral(sql)
+        expression.unsafeRaw = true // It's safe because this expression can't be composed with others
+        checkConstraints.append(expression)
     }
     
     fileprivate func sql(_ db: Database) throws -> String {
@@ -663,7 +665,9 @@ public final class ColumnDefinition {
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func check(sql: String) -> Self {
-        checkConstraints.append(SQLExpressionLiteral(sql))
+        var expression = SQLExpressionLiteral(sql)
+        expression.unsafeRaw = true // It's safe because this expression can't be composed with others
+        checkConstraints.append(expression)
         return self
     }
     
@@ -695,7 +699,9 @@ public final class ColumnDefinition {
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func defaults(sql: String) -> Self {
-        defaultExpression = SQLExpressionLiteral(sql)
+        var expression = SQLExpressionLiteral(sql)
+        expression.unsafeRaw = true // It's safe because this expression can't be composed with others
+        defaultExpression = expression
         return self
     }
     

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		561667031D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */; };
 		561667061D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */; };
 		561667071D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */; };
+		5616AAF9207CD5A900AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF8207CD5A900AC3664 /* RequestProtocols.swift */; };
+		5616AAFA207CD5A900AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF8207CD5A900AC3664 /* RequestProtocols.swift */; };
 		56176C5F1EACCCC7000F3F2B /* FTS5CustomTokenizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5698AD001DAA8ACA0056AF8C /* FTS5CustomTokenizerTests.swift */; };
 		56176C601EACCCC7000F3F2B /* FTS5PatternTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B964C01DA521450002DA19 /* FTS5PatternTests.swift */; };
 		56176C611EACCCC7000F3F2B /* FTS5RecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B964C11DA521450002DA19 /* FTS5RecordTests.swift */; };
@@ -845,6 +847,7 @@
 		560FC5501CB004AD0014AA8E /* sqlcipher.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = sqlcipher.xcodeproj; path = SQLCipher/src/sqlcipher.xcodeproj; sourceTree = "<group>"; };
 		560FC5B01CB00B880014AA8E /* GRDBCipherOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBCipherOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationNSDecimalNumberTests.swift; sourceTree = "<group>"; };
+		5616AAF8207CD5A900AC3664 /* RequestProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestProtocols.swift; sourceTree = "<group>"; };
 		562393171DECC02000A6B01F /* RowFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowFetchTests.swift; sourceTree = "<group>"; };
 		5623932F1DEDFC5700A6B01F /* AnyCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCursorTests.swift; sourceTree = "<group>"; };
 		5623934D1DEDFEFB00A6B01F /* EnumeratedCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedCursorTests.swift; sourceTree = "<group>"; };
@@ -1325,6 +1328,7 @@
 				56CEB5181EAA328900BFAF62 /* FTS5+QueryInterface.swift */,
 				5605F18C1C6B1A8700235C62 /* QueryInterfaceQuery.swift */,
 				56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */,
+				5616AAF8207CD5A900AC3664 /* RequestProtocols.swift */,
 				5605F1891C6B1A8700235C62 /* SQLCollatedExpression.swift */,
 				566475991D97D8A000FF74B8 /* SQLCollection.swift */,
 				56CEB5411EAA359A00BFAF62 /* SQLExpressible.swift */,
@@ -1977,6 +1981,7 @@
 			files = (
 				56873BED1F2CB400004D24B4 /* Fixits-1.2.swift in Sources */,
 				56BF6D3E1DEF47DA006039A3 /* Fixits-Swift2.swift in Sources */,
+				5616AAF9207CD5A900AC3664 /* RequestProtocols.swift in Sources */,
 				5636E9BD1D22574100B9B05F /* FetchRequest.swift in Sources */,
 				56BB6EAA1D3009B100A1CA52 /* SchedulingWatchdog.swift in Sources */,
 				566B910A1FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
@@ -2368,6 +2373,7 @@
 			files = (
 				56873BF01F2CB400004D24B4 /* Fixits-1.2.swift in Sources */,
 				56BF6D411DEF47DA006039A3 /* Fixits-Swift2.swift in Sources */,
+				5616AAFA207CD5A900AC3664 /* RequestProtocols.swift in Sources */,
 				5636E9C01D22574100B9B05F /* FetchRequest.swift in Sources */,
 				56BB6EAD1D3009B100A1CA52 /* SchedulingWatchdog.swift in Sources */,
 				566B910D1FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
@@ -2827,7 +2833,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -2864,7 +2869,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.GRDBCipherOSXTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -2901,7 +2905,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.GRDBCipherOSXTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -2952,7 +2955,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -2990,7 +2992,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.GRDBCipheriOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -3027,7 +3028,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.GRDBCipheriOSEncryptedTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -3127,7 +3127,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		56071A501DB54ED300CA6E47 /* FetchedRecordsControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B15D0A1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift */; };
 		561667041D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */; };
 		561667081D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */; };
+		5616AAF6207CD59400AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF4207CD59300AC3664 /* RequestProtocols.swift */; };
+		5616AAF7207CD59400AC3664 /* RequestProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5616AAF4207CD59300AC3664 /* RequestProtocols.swift */; };
 		56176C7E1EACCD2F000F3F2B /* EncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567156701CB18050007DC145 /* EncryptionTests.swift */; };
 		56176C801EACCD31000F3F2B /* EncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567156701CB18050007DC145 /* EncryptionTests.swift */; };
 		562205FA1E420E49005860AC /* DatabasePoolReleaseMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563363CF1C943D13000BE133 /* DatabasePoolReleaseMemoryTests.swift */; };
@@ -548,6 +550,7 @@
 		560D92441C672C4B00F4F92B /* PersistableRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistableRecord.swift; sourceTree = "<group>"; };
 		560D92461C672C4B00F4F92B /* TableRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableRecord.swift; sourceTree = "<group>"; };
 		561667001D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationNSDecimalNumberTests.swift; sourceTree = "<group>"; };
+		5616AAF4207CD59300AC3664 /* RequestProtocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestProtocols.swift; sourceTree = "<group>"; };
 		562393171DECC02000A6B01F /* RowFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowFetchTests.swift; sourceTree = "<group>"; };
 		5623932F1DEDFC5700A6B01F /* AnyCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCursorTests.swift; sourceTree = "<group>"; };
 		5623934D1DEDFEFB00A6B01F /* EnumeratedCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumeratedCursorTests.swift; sourceTree = "<group>"; };
@@ -1001,6 +1004,7 @@
 				56CEB5181EAA328900BFAF62 /* FTS5+QueryInterface.swift */,
 				5605F18C1C6B1A8700235C62 /* QueryInterfaceQuery.swift */,
 				56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */,
+				5616AAF4207CD59300AC3664 /* RequestProtocols.swift */,
 				5605F1891C6B1A8700235C62 /* SQLCollatedExpression.swift */,
 				566475991D97D8A000FF74B8 /* SQLCollection.swift */,
 				56CEB5411EAA359A00BFAF62 /* SQLExpressible.swift */,
@@ -1682,6 +1686,7 @@
 			files = (
 				56873BF11F2CB400004D24B4 /* Fixits-1.2.swift in Sources */,
 				56BF6D421DEF47DA006039A3 /* Fixits-Swift2.swift in Sources */,
+				5616AAF7207CD59400AC3664 /* RequestProtocols.swift in Sources */,
 				5636E9C11D22574100B9B05F /* FetchRequest.swift in Sources */,
 				F3BA801B1CFB2886003DC1BA /* CGFloat.swift in Sources */,
 				566B910E1FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
@@ -1927,6 +1932,7 @@
 			files = (
 				56873BEE1F2CB400004D24B4 /* Fixits-1.2.swift in Sources */,
 				56BF6D3F1DEF47DA006039A3 /* Fixits-Swift2.swift in Sources */,
+				5616AAF6207CD59400AC3664 /* RequestProtocols.swift in Sources */,
 				5636E9BE1D22574100B9B05F /* FetchRequest.swift in Sources */,
 				F3BA80771CFB2E5C003DC1BA /* CGFloat.swift in Sources */,
 				566B910B1FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
@@ -2287,7 +2293,6 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
@@ -2344,7 +2349,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -2382,7 +2386,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.GRDBCustomSQLite.GRDBCustomSQLiteiOSTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -2431,7 +2434,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -2470,7 +2472,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.github.groue.GRDBCustomSQLiteOSXTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
-				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;

--- a/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
@@ -151,7 +151,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (\"name\" = 'Arthur')")
             
             try Person.filter(sql: "id = 1").deleteAll(db)
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE id = 1")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (id = 1)")
             
             try Person.select(Column("name")).deleteAll(db)
             XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\"")

--- a/Tests/GRDBTests/QueryInterfaceExtensibilityTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExtensibilityTests.swift
@@ -112,7 +112,7 @@ class QueryInterfaceExtensibilityTests: GRDBTestCase {
             default:
                 XCTFail("Expected data blob")
             }
-            XCTAssertEqual(self.lastSQLQuery, "SELECT CAST(\"text\" AS BLOB) FROM \"records\"")
+            XCTAssertEqual(self.lastSQLQuery, "SELECT (CAST(\"text\" AS BLOB)) FROM \"records\"")
         }
     }
 }

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -237,21 +237,21 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(sql: "id <> 1")),
-            "SELECT * FROM \"readers\" WHERE id <> 1")
+            "SELECT * FROM \"readers\" WHERE (id <> 1)")
     }
     
     func testFilterLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(sql: "id <> ?", arguments: [1])),
-            "SELECT * FROM \"readers\" WHERE id <> 1")
+            "SELECT * FROM \"readers\" WHERE (id <> 1)")
     }
     
     func testFilterLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(sql: "id <> :id", arguments: ["id": 1])),
-            "SELECT * FROM \"readers\" WHERE id <> 1")
+            "SELECT * FROM \"readers\" WHERE (id <> 1)")
     }
     
     func testFilter() throws {
@@ -316,21 +316,21 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(sql: "min(age) > 18")),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING min(age) > 18")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (min(age) > 18)")
     }
     
     func testHavingLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(sql: "min(age) > ?", arguments: [18])),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING min(age) > 18")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (min(age) > 18)")
     }
     
     func testHavingLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(sql: "min(age) > :age", arguments: ["age": 18])),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING min(age) > 18")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (min(age) > 18)")
     }
     
     func testHaving() throws {

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -166,21 +166,21 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(sql: "id <> 1")),
-            "SELECT * FROM \"readers\" WHERE id <> 1")
+            "SELECT * FROM \"readers\" WHERE (id <> 1)")
     }
     
     func testFilterLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(sql: "id <> ?", arguments: [1])),
-            "SELECT * FROM \"readers\" WHERE id <> 1")
+            "SELECT * FROM \"readers\" WHERE (id <> 1)")
     }
     
     func testFilterLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(sql: "id <> :id", arguments: ["id": 1])),
-            "SELECT * FROM \"readers\" WHERE id <> 1")
+            "SELECT * FROM \"readers\" WHERE (id <> 1)")
     }
     
     func testFilter() throws {


### PR DESCRIPTION
This PR introduces the four protocols SelectionRequest, FilteredRequest, AggregatingRequest, and OrderedRequest, which provide basic request derivation API. QueryInterfaceRequest adopts those protocols:

```swift
let request = Player.select(...).filter(...).group(...).order(...)
```

This PR is a step towards the Associations API, where QueryInterfaceRequest will no longer be the only type that provides the `select` and `filter` methods:

```swift
// soon
let frenchAuthors = Book.author.filter(Column("countryCode") == "FR")
let frenchBooks: [Book] = try Book.joined(required: frenchAuthors).fetchAll(db)
```

Also in this PR: `request.select(sql: "...")` does no longer selects a `SQLExpressionLiteral`, but a `SQLSelectionLiteral` instead (a new, internal type). The new `SQLExpressionLiteral` will raise a fatal error when GRDB wants to know the number of selected columns, instead of letting `SQLExpressionLiteral` return an ill-advised 1. This fix will make handling of joined requests, where counting columns is important, more robust.
