### PR TITLE
Expressions are no longer PATs

### DIFF
--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -204,17 +204,6 @@ extension DatabaseValue {
     }
 }
 
-// MARK: - SQLSelectable
-
-extension DatabaseValue {
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
-    /// :nodoc:
-    public func qualified(by qualifier: SQLTableQualifier) -> DatabaseValue {
-        return self
-    }
-}
-
 // MARK: - Lossless conversions
 
 extension DatabaseValue {
@@ -359,6 +348,12 @@ extension DatabaseValue {
             // SELECT NOT X'30' -- 1 (because X'30' is turned into the string '0', then into integer 0, which is negated into 1)
             return SQLExpressionNot(self)
         }
+    }
+    
+    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+    /// :nodoc:
+    public func qualifiedExpression(with qualifier: SQLTableQualifier) -> SQLExpression {
+        return self
     }
 }
 

--- a/GRDB/QueryInterface/Column.swift
+++ b/GRDB/QueryInterface/Column.swift
@@ -16,7 +16,6 @@ public struct Column : SQLExpression {
     }
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
     /// :nodoc:
     public func expressionSQL(_ arguments: inout StatementArguments?) -> String {
         if let qualifierName = qualifier?.name {
@@ -26,9 +25,8 @@ public struct Column : SQLExpression {
     }
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
     /// :nodoc:
-    public func qualified(by qualifier: SQLTableQualifier) -> Column {
+    public func qualifiedExpression(with qualifier: SQLTableQualifier) -> SQLExpression {
         if self.qualifier != nil {
             // Never requalify
             return self

--- a/GRDB/QueryInterface/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQLExpression.swift
@@ -60,6 +60,9 @@ public protocol SQLExpression : SQLSpecificExpressible, SQLSelectable, SQLOrderi
     ///
     /// Returns the rowIds matched by the expression.
     func matchedRowIds(rowIdName: String?) -> Set<Int64>? // TODO: this method should take SQLTableQualifier in account
+    
+    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+    func qualifiedExpression(with qualifier: SQLTableQualifier) -> SQLExpression
 }
 
 extension SQLExpression {
@@ -83,6 +86,15 @@ extension SQLExpression {
     /// :nodoc:
     public func matchedRowIds(rowIdName: String?) -> Set<Int64>? {
         return nil
+    }
+    
+    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+    ///
+    /// The default implementation returns qualifiedExpression(with:)
+    ///
+    /// :nodoc:
+    public func qualifiedSelectable(with qualifier: SQLTableQualifier) -> SQLSelectable {
+        return qualifiedExpression(with: qualifier)
     }
 }
 
@@ -137,7 +149,7 @@ struct SQLExpressionNot : SQLExpression {
         return expression
     }
     
-    func qualified(by qualifier: SQLTableQualifier) -> SQLExpressionNot {
-        return SQLExpressionNot(expression.qualified(by: qualifier))
+    func qualifiedExpression(with qualifier: SQLTableQualifier) -> SQLExpression {
+        return SQLExpressionNot(expression.qualifiedExpression(with: qualifier))
     }
 }

--- a/GRDB/QueryInterface/SQLSelectable+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLSelectable+QueryInterface.swift
@@ -65,7 +65,7 @@ extension AllColumns : SQLSelectable {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
     /// :nodoc:
-    public func qualified(by qualifier: SQLTableQualifier) -> AllColumns {
+    public func qualifiedSelectable(with qualifier: SQLTableQualifier) -> SQLSelectable {
         if self.qualifier != nil {
             // Never requalify
             return self
@@ -110,8 +110,8 @@ struct SQLAliasedExpression : SQLSelectable {
         return expression.count(distinct: distinct)
     }
     
-    func qualified(by qualifier: SQLTableQualifier) -> SQLAliasedExpression {
-        return SQLAliasedExpression(expression.qualified(by: qualifier), alias: alias)
+    func qualifiedSelectable(with qualifier: SQLTableQualifier) -> SQLSelectable {
+        return SQLAliasedExpression(expression.qualifiedExpression(with: qualifier), alias: alias)
     }
     
     func columnCount(_ db: Database) throws -> Int {

--- a/GRDB/QueryInterface/SQLSelectable.swift
+++ b/GRDB/QueryInterface/SQLSelectable.swift
@@ -20,7 +20,7 @@ public protocol SQLSelectable {
     func columnCount(_ db: Database) throws -> Int
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    func qualified(by qualifier: SQLTableQualifier) -> Self
+    func qualifiedSelectable(with qualifier: SQLTableQualifier) -> SQLSelectable
 }
 
 // MARK: - SQLSelectionLiteral
@@ -58,7 +58,7 @@ struct SQLSelectionLiteral : SQLSelectable {
         fatalError("Selection literals don't known how many columns they contain. To resolve this error, select one or several SQLExpressionLiteral instead.")
     }
     
-    func qualified(by qualifier: SQLTableQualifier) -> SQLSelectionLiteral {
+    func qualifiedSelectable(with qualifier: SQLTableQualifier) -> SQLSelectable {
         return self
     }
 }

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -87,7 +87,7 @@ extension TableRecord {
     ///     let sql = "SELECT \(Player.selectionSQL(alias: "p")) FROM players AS p"
     public static func selectionSQL(alias: String? = nil) -> String {
         let qualifier = SQLTableQualifier(tableName: databaseTableName, alias: alias ?? databaseTableName)
-        let selection = databaseSelection.map { $0.qualified(by: qualifier) }
+        let selection = databaseSelection.map { $0.qualifiedSelectable(with: qualifier) }
         var arguments: StatementArguments? = nil
         return selection
             .map { $0.resultColumnSQL(&arguments) }
@@ -115,7 +115,7 @@ extension TableRecord {
     public static func numberOfSelectedColumns(_ db: Database) throws -> Int {
         let qualifier = SQLTableQualifier(tableName: databaseTableName, alias: nil)
         return try databaseSelection
-            .map { try $0.qualified(by: qualifier).columnCount(db) }
+            .map { try $0.qualifiedSelectable(with: qualifier).columnCount(db) }
             .reduce(0, +)
     }
 }


### PR DESCRIPTION
The SQLSelectable and SQLExpression protocols that fuel the query interface have turned into PATs (protocol with associated type) in GRDB 2.9.

This has introduced inconvenience for some users, would could no longer easily introduce custom expression types (such as a typed Column type, for @freak4pc - as notified in a private Twitter conversation).

This PR reverts this change: SQLSelectable and SQLExpression are no longer PATs.