### PR TITLE
Implicit transaction in DatabasePool.write and DatabaseQueue.write

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -21,8 +21,8 @@ let SQLITE_TRANSIENT = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_
 ///     let dbQueue = DatabaseQueue(...)
 ///
 ///     // The Database is the `db` in the closure:
-///     try dbQueue.inDatabase { db in
-///         try db.execute(...)
+///     try dbQueue.write { db in
+///         try Player(...).insert(db)
 ///     }
 public final class Database {
     // The Database class is not thread-safe. An instance should always be

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -150,7 +150,9 @@ public final class Database {
     lazy var observationBroker = DatabaseObservationBroker(self)
     
     /// The list of compile options used when building SQLite
-    static let sqliteCompileOptions: Set<String> = DatabaseQueue().inDatabase { try! Set(String.fetchCursor($0, "PRAGMA COMPILE_OPTIONS")) }
+    static let sqliteCompileOptions: Set<String> = DatabaseQueue().inDatabase {
+        try! Set(String.fetchCursor($0, "PRAGMA COMPILE_OPTIONS"))
+    }
     
     // MARK: - Private properties
     
@@ -528,6 +530,25 @@ extension Database {
 }
 
 extension Database {
+    
+    // MARK: - Read-Only Access
+    
+    /// Grants read-only access, starting SQLite 3.8.0
+    func readOnly<T>(_ block: () throws -> T) rethrows -> T {
+        if configuration.readonly {
+            return try block()
+        }
+        
+        // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
+        // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
+        // Assume those pragmas never fail
+        try! execute("PRAGMA query_only = 1")
+        defer { try! execute("PRAGMA query_only = 0") }
+        return try block()
+    }
+}
+
+extension Database {
 
     // MARK: - Transactions & Savepoint
     
@@ -548,7 +569,7 @@ extension Database {
     /// - parameters:
     ///     - kind: The transaction type (default nil). If nil, the transaction
     ///       type is configuration.defaultTransactionKind, which itself
-    ///       defaults to .immediate. See https://www.sqlite.org/lang_transaction.html
+    ///       defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
     ///       for more information.
     ///     - block: A block that executes SQL statements and return either
     ///       .commit or .rollback.
@@ -679,7 +700,7 @@ extension Database {
     ///
     /// - parameter kind: The transaction type (default nil). If nil, the
     ///   transaction type is configuration.defaultTransactionKind, which itself
-    ///   defaults to .immediate. See https://www.sqlite.org/lang_transaction.html
+    ///   defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
     ///   for more information.
     /// - throws: The error thrown by the block.
     public func beginTransaction(_ kind: TransactionKind? = nil) throws {

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -82,7 +82,7 @@ public final class DatabaseFunction: Hashable {
     ///     let dbQueue = DatabaseQueue()
     ///     let fn = DatabaseFunction("mysum", argumentCount: 1, aggregate: MySum.self)
     ///     dbQueue.add(function: fn)
-    ///     try dbQueue.inDatabase { db in
+    ///     try dbQueue.write { db in
     ///         try db.execute("CREATE TABLE test(i)")
     ///         try db.execute("INSERT INTO test(i) VALUES (1)")
     ///         try db.execute("INSERT INTO test(i) VALUES (2)")
@@ -357,7 +357,7 @@ extension DatabaseFunction {
 ///     let dbQueue = DatabaseQueue()
 ///     let fn = DatabaseFunction("mysum", argumentCount: 1, aggregate: MySum.self)
 ///     dbQueue.add(function: fn)
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.write { db in
 ///         try db.execute("CREATE TABLE test(i)")
 ///         try db.execute("INSERT INTO test(i) VALUES (1)")
 ///         try db.execute("INSERT INTO test(i) VALUES (2)")

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -9,7 +9,7 @@ import Foundation
 #endif
 
 /// A DatabasePool grants concurrent accesses to an SQLite database.
-public final class DatabasePool {
+public final class DatabasePool: DatabaseWriter {
     private let writer: SerializedDatabase
     private var readerConfig: Configuration
     private var readerPool: Pool<SerializedDatabase>!
@@ -315,8 +315,8 @@ extension DatabasePool : DatabaseReader {
     ///         while let row = try rows.next() { ... }
     ///     }
     ///
-    /// This method is reentrant. It should be avoided because it fosters
-    /// dangerous concurrency practices.
+    /// This method is reentrant. It is unsafe because it fosters dangerous
+    /// concurrency practices.
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block, or any DatabaseError that would
@@ -334,199 +334,6 @@ extension DatabasePool : DatabaseReader {
             }
         }
     }
-    
-    /// Returns a reader that can be used from the current dispatch queue,
-    /// if any.
-    private var currentReader: SerializedDatabase? {
-        var readers: [SerializedDatabase] = []
-        readerPool.forEach { reader in
-            // We can't check for reader.onValidQueue here because
-            // Pool.forEach() runs its closure argument in some arbitrary
-            // dispatch queue. We thus extract the reader so that we can query
-            // it below.
-            readers.append(reader)
-        }
-        
-        // Now the readers array contains some readers. The pool readers may
-        // already be different, because some other thread may have started
-        // a new read, for example.
-        //
-        // This doesn't matter: the reader we are looking for is already on
-        // its own dispatch queue. If it exists, is still in use, thus still
-        // in the pool, and thus still relevant for our check:
-        return readers.first { $0.onValidQueue }
-    }
-    
-    // MARK: - Functions
-    
-    /// Add or redefine an SQL function.
-    ///
-    ///     let fn = DatabaseFunction("succ", argumentCount: 1) { dbValues in
-    ///         guard let int = Int.fromDatabaseValue(dbValues[0]) else {
-    ///             return nil
-    ///         }
-    ///         return int + 1
-    ///     }
-    ///     dbPool.add(function: fn)
-    ///     try dbPool.read { db in
-    ///         try Int.fetchOne(db, "SELECT succ(1)") // 2
-    ///     }
-    public func add(function: DatabaseFunction) {
-        functions.update(with: function)
-        writer.sync { $0.add(function: function) }
-        readerPool.forEach { reader in
-            reader.sync { $0.add(function: function) }
-        }
-    }
-    
-    /// Remove an SQL function.
-    public func remove(function: DatabaseFunction) {
-        functions.remove(function)
-        writer.sync { $0.remove(function: function) }
-        readerPool.forEach { reader in
-            reader.sync { $0.remove(function: function) }
-        }
-    }
-    
-    // MARK: - Collations
-    
-    /// Add or redefine a collation.
-    ///
-    ///     let collation = DatabaseCollation("localized_standard") { (string1, string2) in
-    ///         return (string1 as NSString).localizedStandardCompare(string2)
-    ///     }
-    ///     dbPool.add(collation: collation)
-    ///     try dbPool.write { db in
-    ///         try db.execute("CREATE TABLE files (name TEXT COLLATE LOCALIZED_STANDARD")
-    ///     }
-    public func add(collation: DatabaseCollation) {
-        collations.update(with: collation)
-        writer.sync { $0.add(collation: collation) }
-        readerPool.forEach { reader in
-            reader.sync { $0.add(collation: collation) }
-        }
-    }
-    
-    /// Remove a collation.
-    public func remove(collation: DatabaseCollation) {
-        collations.remove(collation)
-        writer.sync { $0.remove(collation: collation) }
-        readerPool.forEach { reader in
-            reader.sync { $0.remove(collation: collation) }
-        }
-    }
-}
-
-extension DatabasePool : DatabaseWriter {
-    
-    // MARK: - Writing in Database
-    
-    /// Synchronously executes an update block in a protected dispatch queue,
-    /// wrapped inside a transaction, and returns the result of the block.
-    ///
-    /// Eventual concurrent database updates are postponed until the block
-    /// has executed.
-    ///
-    ///     try dbPool.write { db in
-    ///         try db.execute(...)
-    ///     }
-    ///
-    /// Eventual concurrent reads are guaranteed not to see any changes
-    /// performed in the block until they are all saved in the database.
-    ///
-    /// This method is *not* reentrant.
-    ///
-    /// - parameters block: A block that executes SQL statements and return
-    ///   either .commit or .rollback.
-    /// - throws: The error thrown by the block, or by the wrapping transaction.
-    public func write<T>(_ block: (Database) throws -> T) throws -> T {
-        return try writer.sync { db in
-            var result: T? = nil
-            try db.inTransaction {
-                result = try block(db)
-                return .commit
-            }
-            return result!
-        }
-    }
-    
-    /// Synchronously executes a block that takes a database connection, and
-    /// returns its result.
-    ///
-    /// Eventual concurrent database updates are postponed until the block
-    /// has executed.
-    ///
-    /// Eventual concurrent reads may see changes performed in the block before
-    /// the block completes.
-    ///
-    /// The block is guaranteed to be executed outside of a transaction.
-    ///
-    /// This method is *not* reentrant.
-    ///
-    /// - parameters block: A block that executes SQL statements and return
-    ///   either .commit or .rollback.
-    /// - throws: The error thrown by the block.
-    public func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T {
-        return try writer.sync(block)
-    }
-    
-    /// Synchronously executes a block in a protected dispatch queue, wrapped
-    /// inside a transaction.
-    ///
-    /// Eventual concurrent database updates are postponed until the block
-    /// has executed.
-    ///
-    /// If the block throws an error, the transaction is rollbacked and the
-    /// error is rethrown. If the block returns .rollback, the transaction is
-    /// also rollbacked, but no error is thrown.
-    ///
-    ///     try dbPool.writeInTransaction { db in
-    ///         db.execute(...)
-    ///         return .commit
-    ///     }
-    ///
-    /// Eventual concurrent reads are guaranteed not to see any changes
-    /// performed in the block until they are all saved in the database.
-    ///
-    /// This method is *not* reentrant.
-    ///
-    /// - parameters:
-    ///     - kind: The transaction type (default nil). If nil, the transaction
-    ///       type is configuration.defaultTransactionKind, which itself
-    ///       defaults to .immediate. See https://www.sqlite.org/lang_transaction.html
-    ///       for more information.
-    ///     - block: A block that executes SQL statements and return either
-    ///       .commit or .rollback.
-    /// - throws: The error thrown by the block, or any error establishing the
-    ///   transaction.
-    public func writeInTransaction(_ kind: Database.TransactionKind? = nil, _ block: (Database) throws -> Database.TransactionCompletion) throws {
-        try writer.sync { db in
-            try db.inTransaction(kind) {
-                try block(db)
-            }
-        }
-    }
-    
-    /// Synchronously executes an update block in a protected dispatch queue,
-    /// and returns its result.
-    ///
-    /// Eventual concurrent database updates are postponed until the block
-    /// has executed.
-    ///
-    ///     try dbPool.unsafeReentrantWrite { db in
-    ///         try db.execute(...)
-    ///     }
-    ///
-    /// Eventual concurrent reads may see changes performed in the block before
-    /// the block completes.
-    ///
-    /// This method is reentrant. It should be avoided because it fosters
-    /// dangerous concurrency practices.
-    public func unsafeReentrantWrite<T>(_ block: (Database) throws -> T) rethrows -> T {
-        return try writer.reentrantSync(block)
-    }
-    
-    // MARK: - Reading from Database
     
     /// Asynchronously executes a read-only block in a protected dispatch queue,
     /// wrapped in a deferred transaction.
@@ -633,6 +440,193 @@ extension DatabasePool : DatabaseWriter {
         if let readError = readError {
             // TODO: write a test for this
             throw readError
+        }
+    }
+
+    /// Returns a reader that can be used from the current dispatch queue,
+    /// if any.
+    private var currentReader: SerializedDatabase? {
+        var readers: [SerializedDatabase] = []
+        readerPool.forEach { reader in
+            // We can't check for reader.onValidQueue here because
+            // Pool.forEach() runs its closure argument in some arbitrary
+            // dispatch queue. We thus extract the reader so that we can query
+            // it below.
+            readers.append(reader)
+        }
+        
+        // Now the readers array contains some readers. The pool readers may
+        // already be different, because some other thread may have started
+        // a new read, for example.
+        //
+        // This doesn't matter: the reader we are looking for is already on
+        // its own dispatch queue. If it exists, is still in use, thus still
+        // in the pool, and thus still relevant for our check:
+        return readers.first { $0.onValidQueue }
+    }
+    
+    // MARK: - Writing in Database
+    
+    /// Synchronously executes an update block in a protected dispatch queue,
+    /// wrapped inside a transaction, and returns the result of the block.
+    ///
+    /// Eventual concurrent database updates are postponed until the block
+    /// has executed.
+    ///
+    ///     try dbPool.write { db in
+    ///         try db.execute(...)
+    ///     }
+    ///
+    /// Eventual concurrent reads are guaranteed not to see any changes
+    /// performed in the block until they are all saved in the database.
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameters block: A block that executes SQL statements.
+    /// - throws: The error thrown by the block, or by the wrapping transaction.
+    public func write<T>(_ block: (Database) throws -> T) throws -> T {
+        return try writer.sync { db in
+            var result: T? = nil
+            try db.inTransaction {
+                result = try block(db)
+                return .commit
+            }
+            return result!
+        }
+    }
+    
+    /// Synchronously executes a block that takes a database connection, and
+    /// returns its result.
+    ///
+    /// Eventual concurrent database updates are postponed until the block
+    /// has executed.
+    ///
+    /// Eventual concurrent reads may see changes performed in the block before
+    /// the block completes.
+    ///
+    /// The block is guaranteed to be executed outside of a transaction.
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameters block: A block that executes SQL statements and return
+    ///   either .commit or .rollback.
+    /// - throws: The error thrown by the block.
+    public func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try writer.sync(block)
+    }
+    
+    /// Synchronously executes a block in a protected dispatch queue, wrapped
+    /// inside a transaction.
+    ///
+    /// Eventual concurrent database updates are postponed until the block
+    /// has executed.
+    ///
+    /// If the block throws an error, the transaction is rollbacked and the
+    /// error is rethrown. If the block returns .rollback, the transaction is
+    /// also rollbacked, but no error is thrown.
+    ///
+    ///     try dbPool.writeInTransaction { db in
+    ///         db.execute(...)
+    ///         return .commit
+    ///     }
+    ///
+    /// Eventual concurrent reads are guaranteed not to see any changes
+    /// performed in the block until they are all saved in the database.
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameters:
+    ///     - kind: The transaction type (default nil). If nil, the transaction
+    ///       type is configuration.defaultTransactionKind, which itself
+    ///       defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
+    ///       for more information.
+    ///     - block: A block that executes SQL statements and return either
+    ///       .commit or .rollback.
+    /// - throws: The error thrown by the block, or any error establishing the
+    ///   transaction.
+    public func writeInTransaction(_ kind: Database.TransactionKind? = nil, _ block: (Database) throws -> Database.TransactionCompletion) throws {
+        try writer.sync { db in
+            try db.inTransaction(kind) {
+                try block(db)
+            }
+        }
+    }
+    
+    /// Synchronously executes an update block in a protected dispatch queue,
+    /// and returns its result.
+    ///
+    /// Eventual concurrent database updates are postponed until the block
+    /// has executed.
+    ///
+    ///     try dbPool.unsafeReentrantWrite { db in
+    ///         try db.execute(...)
+    ///     }
+    ///
+    /// Eventual concurrent reads may see changes performed in the block before
+    /// the block completes.
+    ///
+    /// This method is reentrant. It is unsafe because it fosters dangerous
+    /// concurrency practices.
+    public func unsafeReentrantWrite<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try writer.reentrantSync(block)
+    }
+    
+    // MARK: - Functions
+    
+    /// Add or redefine an SQL function.
+    ///
+    ///     let fn = DatabaseFunction("succ", argumentCount: 1) { dbValues in
+    ///         guard let int = Int.fromDatabaseValue(dbValues[0]) else {
+    ///             return nil
+    ///         }
+    ///         return int + 1
+    ///     }
+    ///     dbPool.add(function: fn)
+    ///     try dbPool.read { db in
+    ///         try Int.fetchOne(db, "SELECT succ(1)") // 2
+    ///     }
+    public func add(function: DatabaseFunction) {
+        functions.update(with: function)
+        writer.sync { $0.add(function: function) }
+        readerPool.forEach { reader in
+            reader.sync { $0.add(function: function) }
+        }
+    }
+    
+    /// Remove an SQL function.
+    public func remove(function: DatabaseFunction) {
+        functions.remove(function)
+        writer.sync { $0.remove(function: function) }
+        readerPool.forEach { reader in
+            reader.sync { $0.remove(function: function) }
+        }
+    }
+    
+    // MARK: - Collations
+    
+    /// Add or redefine a collation.
+    ///
+    ///     let collation = DatabaseCollation("localized_standard") { (string1, string2) in
+    ///         return (string1 as NSString).localizedStandardCompare(string2)
+    ///     }
+    ///     dbPool.add(collation: collation)
+    ///     try dbPool.write { db in
+    ///         try db.execute("CREATE TABLE files (name TEXT COLLATE LOCALIZED_STANDARD")
+    ///     }
+    public func add(collation: DatabaseCollation) {
+        collations.update(with: collation)
+        writer.sync { $0.add(collation: collation) }
+        readerPool.forEach { reader in
+            reader.sync { $0.add(collation: collation) }
+        }
+    }
+    
+    /// Remove a collation.
+    public func remove(collation: DatabaseCollation) {
+        collations.remove(collation)
+        writer.sync { $0.remove(collation: collation) }
+        readerPool.forEach { reader in
+            reader.sync { $0.remove(collation: collation) }
         }
     }
 }

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -5,7 +5,7 @@ import UIKit
 #endif
 
 /// A DatabaseQueue serializes access to an SQLite database.
-public final class DatabaseQueue {
+public final class DatabaseQueue: DatabaseWriter {
     private var serializedDatabase: SerializedDatabase
     #if os(iOS)
     private weak var application: UIApplication?
@@ -66,63 +66,6 @@ public final class DatabaseQueue {
         NotificationCenter.default.removeObserver(self)
     }
     #endif
-}
-
-extension DatabaseQueue {
-
-    // MARK: - Database Access
-
-    /// Synchronously executes a block in a protected dispatch queue, and
-    /// returns its result.
-    ///
-    ///     let players = try dbQueue.inDatabase { db in
-    ///         try Player.fetchAll(...)
-    ///     }
-    ///
-    /// This method is *not* reentrant.
-    ///
-    /// - parameter block: A block that accesses the database.
-    /// - throws: The error thrown by the block.
-    public func inDatabase<T>(_ block: (Database) throws -> T) rethrows -> T {
-        return try serializedDatabase.sync { db in
-            var result: T? = nil
-            try db.inTransaction {
-                result = try block(db)
-                return .commit
-            }
-            return result!
-        }
-    }
-    
-    /// Synchronously executes a block in a protected dispatch queue, wrapped
-    /// inside a transaction.
-    ///
-    /// If the block throws an error, the transaction is rollbacked and the
-    /// error is rethrown. If the block returns .rollback, the transaction is
-    /// also rollbacked, but no error is thrown.
-    ///
-    ///     try dbQueue.inTransaction { db in
-    ///         db.execute(...)
-    ///         return .commit
-    ///     }
-    ///
-    /// This method is *not* reentrant.
-    ///
-    /// - parameters:
-    ///     - kind: The transaction type (default nil). If nil, the transaction
-    ///       type is configuration.defaultTransactionKind, which itself
-    ///       defaults to .immediate. See https://www.sqlite.org/lang_transaction.html
-    ///       for more information.
-    ///     - block: A block that executes SQL statements and return either
-    ///       .commit or .rollback.
-    /// - throws: The error thrown by the block.
-    public func inTransaction(_ kind: Database.TransactionKind? = nil, _ block: (Database) throws -> Database.TransactionCompletion) throws {
-        try serializedDatabase.sync { db in
-            try db.inTransaction(kind) {
-                try block(db)
-            }
-        }
-    }
 }
 
 extension DatabaseQueue {
@@ -193,7 +136,7 @@ extension DatabaseQueue {
     }
 #endif
 
-extension DatabaseQueue : DatabaseReader {
+extension DatabaseQueue {
     
     // MARK: - Reading from Database
     
@@ -201,31 +144,35 @@ extension DatabaseQueue : DatabaseReader {
     /// and returns its result.
     ///
     ///     let players = try dbQueue.read { db in
-    ///         try Player.fetchAll(...)
+    ///         try Player.fetchAll(db)
     ///     }
     ///
     /// This method is *not* reentrant.
     ///
-    /// Starting iOS 8.2, OSX 10.10, and with custom SQLite builds and
-    /// SQLCipher, attempts to write in the database throw a DatabaseError whose
-    /// resultCode is `SQLITE_READONLY`.
+    /// Starting SQLite 3.8.0 (iOS 8.2+, OSX 10.10+, custom SQLite builds and
+    /// SQLCipher), attempts to write in the database from this meethod throw a
+    /// DatabaseError of resultCode `SQLITE_READONLY`.
     ///
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block.
     public func read<T>(_ block: (Database) throws -> T) rethrows -> T {
-        // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
-        // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
-        #if GRDBCUSTOMSQLITE || GRDBCIPHER
-            return try serializedDatabase.sync { try readOnly($0, block) }
-        #else
-            if #available(iOS 8.2, OSX 10.10, *) {
-                return try serializedDatabase.sync { try readOnly($0, block) }
-            } else {
-                return try serializedDatabase.sync(block)
-            }
-        #endif
+        return try serializedDatabase.sync { db in
+            try db.readOnly { try block(db) }
+        }
     }
     
+    /// Synchronously executes a block in a protected dispatch queue, and
+    /// returns its result.
+    ///
+    ///     let players = try dbQueue.unsafeRead { db in
+    ///         try Player.fetchAll(db)
+    ///     }
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameter block: A block that accesses the database.
+    /// - throws: The error thrown by the block.
+    ///
     /// :nodoc:
     public func unsafeRead<T>(_ block: (Database) throws -> T) rethrows -> T {
         return try serializedDatabase.sync(block)
@@ -234,15 +181,140 @@ extension DatabaseQueue : DatabaseReader {
     /// Synchronously executes a block in a protected dispatch queue, and
     /// returns its result.
     ///
-    ///     try dbQueue.unsafeReentrantRead { db in
-    ///         try db.execute(...)
+    ///     let players = try dbQueue.unsafeReentrantRead { db in
+    ///         try Player.fetchAll(db)
     ///     }
     ///
-    /// This method is reentrant. It should be avoided because it fosters
-    /// dangerous concurrency practices.
+    /// This method is reentrant. It is unsafe because it fosters dangerous
+    /// concurrency practices.
     ///
     /// :nodoc:
     public func unsafeReentrantRead<T>(_ block: (Database) throws -> T) throws -> T {
+        return try serializedDatabase.reentrantSync(block)
+    }
+    
+    /// Synchronously executes *block*.
+    ///
+    /// This method must be called from the protected database dispatch queue,
+    /// outside of a transaction. You'll get a fatal error otherwise.
+    ///
+    /// Starting SQLite 3.8.0 (iOS 8.2+, OSX 10.10+, custom SQLite builds and
+    /// SQLCipher), attempts to write in the database from this meethod throw a
+    /// DatabaseError of resultCode `SQLITE_READONLY`.
+    ///
+    /// See `DatabaseWriter.readFromCurrentState`.
+    ///
+    /// :nodoc:
+    public func readFromCurrentState(_ block: @escaping (Database) -> Void) {
+        // Check that we're on the correct queue...
+        serializedDatabase.execute { db in
+            // ... and that no transaction is opened.
+            GRDBPrecondition(!db.isInsideTransaction, "readFromCurrentState must not be called from inside a transaction.")
+            db.readOnly { block(db) }
+        }
+    }
+    
+    // MARK: - Writing in Database
+    
+    /// Synchronously executes a block in a protected dispatch queue, wrapped
+    /// inside a transaction.
+    ///
+    /// If the block throws an error, the transaction is rollbacked and the
+    /// error is rethrown.
+    ///
+    ///     try dbQueue.write { db in
+    ///         try Player(...).insert(db)
+    ///     }
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameter block: A block that executes SQL statements.
+    /// - throws: An eventual database error, or the error thrown by the block.
+    public func write<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try serializedDatabase.sync { db in
+            var result: T? = nil
+            try db.inTransaction {
+                result = try block(db)
+                return .commit
+            }
+            return result!
+        }
+    }
+    
+    /// Synchronously executes a block in a protected dispatch queue, wrapped
+    /// inside a transaction.
+    ///
+    /// If the block throws an error, the transaction is rollbacked and the
+    /// error is rethrown. If the block returns .rollback, the transaction is
+    /// also rollbacked, but no error is thrown.
+    ///
+    ///     try dbQueue.inTransaction { db in
+    ///         try Player(...).insert(db)
+    ///         return .commit
+    ///     }
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameters:
+    ///     - kind: The transaction type (default nil). If nil, the transaction
+    ///       type is configuration.defaultTransactionKind, which itself
+    ///       defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
+    ///       for more information.
+    ///     - block: A block that executes SQL statements and return either
+    ///       .commit or .rollback.
+    /// - throws: The error thrown by the block.
+    public func inTransaction(_ kind: Database.TransactionKind? = nil, _ block: (Database) throws -> Database.TransactionCompletion) throws {
+        try serializedDatabase.sync { db in
+            try db.inTransaction(kind) {
+                try block(db)
+            }
+        }
+    }
+    
+    /// Synchronously executes a block in a protected dispatch queue, and
+    /// returns its result.
+    ///
+    ///     let players = try dbQueue.writeWithoutTransaction { db in
+    ///         try Player(...).insert(db)
+    ///     }
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameter block: A block that accesses the database.
+    /// - throws: The error thrown by the block.
+    ///
+    /// :nodoc:
+    public func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try serializedDatabase.sync(block)
+    }
+
+    /// Synchronously executes a block in a protected dispatch queue, and
+    /// returns its result.
+    ///
+    ///     // INSERT INTO players ...
+    ///     let players = try dbQueue.inDatabase { db in
+    ///         try Player(...).insert(db)
+    ///     }
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameter block: A block that accesses the database.
+    /// - throws: The error thrown by the block.
+    public func inDatabase<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try serializedDatabase.sync(block)
+    }
+    
+    /// Synchronously executes a block in a protected dispatch queue, and
+    /// returns its result.
+    ///
+    ///     // INSERT INTO players ...
+    ///     try dbQueue.unsafeReentrantWrite { db in
+    ///         try Player(...).insert(db)
+    ///     }
+    ///
+    /// This method is reentrant. It is unsafe because it fosters dangerous
+    /// concurrency practices.
+    public func unsafeReentrantWrite<T>(_ block: (Database) throws -> T) rethrows -> T {
         return try serializedDatabase.reentrantSync(block)
     }
     
@@ -290,77 +362,3 @@ extension DatabaseQueue : DatabaseReader {
     }
 }
 
-extension DatabaseQueue : DatabaseWriter {
-
-    /// Alias for `inDatabase`. See `DatabaseWriter.write`.
-    ///
-    /// :nodoc:
-    public func write<T>(_ block: (Database) throws -> T) rethrows -> T {
-        return try inDatabase(block)
-    }
-    
-    /// Alias for `inDatabase`. See `DatabaseWriter.writeWithoutTransaction`.
-    ///
-    /// :nodoc:
-    public func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T {
-        return try serializedDatabase.sync(block)
-    }
-    
-    /// Synchronously executes *block*.
-    ///
-    /// Starting iOS 8.2, OSX 10.10, and with custom SQLite builds and
-    /// SQLCipher, attempts to write in the database throw a DatabaseError whose
-    /// resultCode is `SQLITE_READONLY`.
-    ///
-    /// This method must be called from the protected database dispatch queue,
-    /// outside of a transaction. You'll get a fatal error otherwise.
-    ///
-    /// See `DatabaseWriter.readFromCurrentState`.
-    ///
-    /// :nodoc:
-    public func readFromCurrentState(_ block: @escaping (Database) -> Void) {
-        // Check that we're on the correct queue...
-        serializedDatabase.execute { db in
-            // ... and that no transaction is opened.
-            GRDBPrecondition(!db.isInsideTransaction, "readFromCurrentState must not be called from inside a transaction.")
-            
-            // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
-            // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
-            #if GRDBCUSTOMSQLITE || GRDBCIPHER
-                readOnly(db, block)
-            #else
-                if #available(iOS 8.2, OSX 10.10, *) {
-                    readOnly(db, block)
-                } else {
-                    block(db)
-                }
-            #endif
-        }
-    }
-    
-    // MARK: - Unsafe Database Access
-
-    /// Synchronously executes a block in a protected dispatch queue, and
-    /// returns its result.
-    ///
-    ///     try dbQueue.unsafeReentrantWrite { db in
-    ///         try db.execute(...)
-    ///     }
-    ///
-    /// This method is reentrant. It should be avoided because it fosters
-    /// dangerous concurrency practices.
-    public func unsafeReentrantWrite<T>(_ block: (Database) throws -> T) rethrows -> T {
-        return try serializedDatabase.reentrantSync(block)
-    }
-}
-
-private func readOnly<T>(_ db: Database, _ block: (Database) throws -> T) rethrows -> T {
-    guard !db.configuration.readonly else {
-        return try block(db)
-    }
-    
-    // Assume those pragmas never fail
-    try! db.internalCachedUpdateStatement("PRAGMA query_only = 1").execute()
-    defer { try! db.internalCachedUpdateStatement("PRAGMA query_only = 0").execute() }
-    return try block(db)
-}

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -294,6 +294,13 @@ extension DatabaseQueue : DatabaseWriter {
         return try inDatabase(block)
     }
     
+    /// Alias for `inDatabase`. See `DatabaseWriter.writeWithoutTransaction`.
+    ///
+    /// :nodoc:
+    public func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try inDatabase(block)
+    }
+    
     /// Synchronously executes *block*.
     ///
     /// Starting iOS 8.2, OSX 10.10, and with custom SQLite builds and

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -329,7 +329,7 @@ extension DatabaseQueue {
     ///         return int + 1
     ///     }
     ///     dbQueue.add(function: fn)
-    ///     try dbQueue.inDatabase { db in
+    ///     try dbQueue.read { db in
     ///         try Int.fetchOne(db, "SELECT succ(1)") // 2
     ///     }
     public func add(function: DatabaseFunction) {
@@ -349,7 +349,7 @@ extension DatabaseQueue {
     ///         return (string1 as NSString).localizedStandardCompare(string2)
     ///     }
     ///     dbQueue.add(collation: collation)
-    ///     try dbQueue.inDatabase { db in
+    ///     try dbQueue.write { db in
     ///         try db.execute("CREATE TABLE files (name TEXT COLLATE LOCALIZED_STANDARD")
     ///     }
     public func add(collation: DatabaseCollation) {

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -41,7 +41,7 @@ extension DatabaseValueConvertible {
 /// A cursor of database values extracted from a single column.
 /// For example:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let urls: DatabaseValueCursor<URL> = try URL.fetchCursor(db, "SELECT url FROM links")
 ///         while let url = urls.next() { // URL
 ///             print(url)
@@ -81,7 +81,7 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible> : Cursor
 /// A cursor of optional database values extracted from a single column.
 /// For example:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let urls: NullableDatabaseValueCursor<URL> = try Optional<URL>.fetchCursor(db, "SELECT url FROM links")
 ///         while let url = urls.next() { // URL?
 ///             print(url)

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -23,6 +23,12 @@ public protocol DatabaseWriter : DatabaseReader {
     /// Eventual concurrent database updates are postponed until the block
     /// has executed.
     ///
+    /// Eventual concurrent reads are guaranteed not to see any changes
+    /// performed in the block until they are all saved in the database.
+    ///
+    /// The block may, or may not, be wrapped inside a transaction, depending on
+    /// the concrete DatabaseWriter type.
+    ///
     /// This method is *not* reentrant.
     func write<T>(_ block: (Database) throws -> T) rethrows -> T
     
@@ -31,6 +37,9 @@ public protocol DatabaseWriter : DatabaseReader {
     ///
     /// Eventual concurrent database updates are postponed until the block
     /// has executed.
+    ///
+    /// Eventual concurrent reads may see changes performed in the block before
+    /// the block completes.
     ///
     /// This method is reentrant. It should be avoided because it fosters
     /// dangerous concurrency practices.

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -26,11 +26,24 @@ public protocol DatabaseWriter : DatabaseReader {
     /// Eventual concurrent reads are guaranteed not to see any changes
     /// performed in the block until they are all saved in the database.
     ///
-    /// The block may, or may not, be wrapped inside a transaction, depending on
-    /// the concrete DatabaseWriter type.
+    /// The block may, or may not, be wrapped inside a transaction.
     ///
     /// This method is *not* reentrant.
-    func write<T>(_ block: (Database) throws -> T) rethrows -> T
+    func write<T>(_ block: (Database) throws -> T) throws -> T
+    
+    /// Synchronously executes a block that takes a database connection, and
+    /// returns its result.
+    ///
+    /// Eventual concurrent database updates are postponed until the block
+    /// has executed.
+    ///
+    /// Eventual concurrent reads may see changes performed in the block before
+    /// the block completes.
+    ///
+    /// The block is guaranteed to be executed outside of a transaction.
+    ///
+    /// This method is *not* reentrant.
+    func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T
     
     /// Synchronously executes a block that takes a database connection, and
     /// returns its result.
@@ -82,12 +95,12 @@ extension DatabaseWriter {
     ///   the observer lifetime (observation lasts until observer
     ///   is deallocated).
     public func add(transactionObserver: TransactionObserver, extent: Database.TransactionObservationExtent = .observerLifetime) {
-        write { $0.add(transactionObserver: transactionObserver, extent: extent) }
+        writeWithoutTransaction { $0.add(transactionObserver: transactionObserver, extent: extent) }
     }
     
     /// Remove a transaction observer.
     public func remove(transactionObserver: TransactionObserver) {
-        write { $0.remove(transactionObserver: transactionObserver) }
+        writeWithoutTransaction { $0.remove(transactionObserver: transactionObserver) }
     }
 }
 
@@ -128,8 +141,13 @@ public final class AnyDatabaseWriter : DatabaseWriter {
     // MARK: - Writing in Database
 
     /// :nodoc:
-    public func write<T>(_ block: (Database) throws -> T) rethrows -> T {
+    public func write<T>(_ block: (Database) throws -> T) throws -> T {
         return try base.write(block)
+    }
+    
+    /// :nodoc:
+    public func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T {
+        return try base.writeWithoutTransaction(block)
     }
 
     /// :nodoc:

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -566,7 +566,7 @@ extension Row {
 
 /// A cursor of database rows. For example:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let rows: RowCursor = try Row.fetchCursor(db, "SELECT * FROM players")
 ///     }
 public final class RowCursor : Cursor {

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -286,7 +286,7 @@ extension AuthorizedStatement {
 ///
 /// You create SelectStatement with the Database.makeSelectStatement() method:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let statement = try db.makeSelectStatement("SELECT COUNT(*) FROM players WHERE score > ?")
 ///         let moreThanTwentyCount = try Int.fetchOne(statement, arguments: [20])!
 ///         let moreThanThirtyCount = try Int.fetchOne(statement, arguments: [30])!
@@ -372,7 +372,7 @@ extension SelectStatement: AuthorizedStatement { }
 /// A cursor that iterates a database statement without producing any value.
 /// For example:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let statement = db.makeSelectStatement("SELECT * FROM players")
 ///         let cursor: StatementCursor = statement.cursor()
 ///     }

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -74,7 +74,7 @@ extension StatementColumnConvertible {
 /// A cursor of database values extracted from a single column.
 /// For example:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let names: ColumnCursor<String> = try String.fetchCursor(db, "SELECT name FROM players")
 ///         while let name = names.next() { // String
 ///             print(name)
@@ -120,7 +120,7 @@ public final class ColumnCursor<Value: DatabaseValueConvertible & StatementColum
 /// A cursor of optional database values extracted from a single column.
 /// For example:
 ///
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let emails: NullableColumnCursor<String> = try Optional<String>.fetchCursor(db, "SELECT email FROM players")
 ///         while let email = emails.next() { // String?
 ///             print(email ?? "<NULL>")

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -160,7 +160,7 @@
         ///     class MyTokenizer : FTS5CustomTokenizer { ... }
         ///     dbPool.add(tokenizer: MyTokenizer.self)
         public func add<Tokenizer: FTS5CustomTokenizer>(tokenizer: Tokenizer.Type) {
-            write { db in
+            writeWithoutTransaction { db in
                 db.add(tokenizer: Tokenizer.self)
             }
         }

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -125,7 +125,7 @@ public struct DatabaseMigrator {
     ///   migrations should apply.
     /// - throws: An eventual error thrown by the registered migration blocks.
     public func migrate(_ writer: DatabaseWriter) throws {
-        try writer.write { db in
+        try writer.writeWithoutTransaction { db in
             try setupMigrations(db)
             try runMigrations(db)
         }
@@ -140,7 +140,7 @@ public struct DatabaseMigrator {
     /// - targetIdentifier: The identifier of a registered migration.
     /// - throws: An eventual error thrown by the registered migration blocks.
     public func migrate(_ writer: DatabaseWriter, upTo targetIdentifier: String) throws {
-        try writer.write { db in
+        try writer.writeWithoutTransaction { db in
             try setupMigrations(db)
             try runMigrations(db, upTo: targetIdentifier)
         }

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -35,7 +35,7 @@ public protocol FetchableRecord {
 /// A cursor of records. For example:
 ///
 ///     struct Player : FetchableRecord { ... }
-///     try dbQueue.inDatabase { db in
+///     try dbQueue.read { db in
 ///         let players: RecordCursor<Player> = try Player.fetchCursor(db, "SELECT * FROM players")
 ///     }
 public final class RecordCursor<Record: FetchableRecord> : Cursor {

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -182,7 +182,7 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
         // Replace observer so that it tracks a new set of columns,
         // and notify eventual changes
         let initialItems = fetchedItems
-        databaseWriter.write { db in
+        databaseWriter.writeWithoutTransaction { db in
             let observer = FetchedRecordsObserver(region: region, fetchAndNotifyChanges: fetchAndNotifyChanges)
             self.observer = observer
             observer.items = initialItems
@@ -293,7 +293,7 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
         #endif
         
         let initialItems = fetchedItems
-        databaseWriter.write { db in
+        databaseWriter.writeWithoutTransaction { db in
             let fetchAndNotifyChanges = makeFetchAndNotifyChangesFunction(
                 controller: self,
                 fetchAlongside: fetchAlongside,

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -102,7 +102,7 @@ extension TableRecord {
     ///         static let databaseTableName = "players"
     ///     }
     ///
-    ///     try dbQueue.inDatabase { db in
+    ///     try dbQueue.write { db in
     ///         try db.create(table: "players") { t in
     ///             t.column("id", .integer).primaryKey()
     ///             t.column("name", .text)

--- a/README.md
+++ b/README.md
@@ -1266,9 +1266,9 @@ Grape.fromDatabaseValue(row[0])  // nil
 ## Transactions and Savepoints
 
 - [Transactions and Safety](#transactions-and-safety)
-- [Explicit Transactions](#explicit transactions)
+- [Explicit Transactions](#explicit-transactions)
 - [Savepoints](#savepoints)
-- [Transaction Kinds](#transaction kinds)
+- [Transaction Kinds](#transaction-kinds)
 
 
 ### Transactions and Safety

--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,7 @@ If an error is thrown within the transaction body, the transaction is rollbacked
 If you want to insert a transaction between other database statements, you can use the Database.inTransaction() function, or even raw SQL statements:
 
 ```swift
-dbPool.writeWithoutTransaction { db in  // or dbQueue.inDatabase { ... }
+try dbPool.writeWithoutTransaction { db in  // or dbQueue.inDatabase { ... }
     try db.inTransaction {
         ...
         return .commit

--- a/README.md
+++ b/README.md
@@ -6340,12 +6340,12 @@ Those guarantees hold as long as you follow three rules:
     
     ```swift
     // SAFE CONCURRENCY
-    func currentUser(_ db: Database) throws -> User? {
+    func fetchCurrentUser(_ db: Database) throws -> User? {
         return try User.fetchOne(db)
     }
     // dbQueue is a singleton defined somewhere in your app
     let user = try dbQueue.read { db in // or dbPool.read
-        try currentUser(db)
+        try fetchCurrentUser(db)
     }
     
     // UNSAFE CONCURRENCY
@@ -6625,7 +6625,7 @@ DatabaseWriter and DatabaseReader fuel, for example:
     
     Reentrant database accesses make it very easy to break the second [safety rule](#guarantees-and-rules), which says: "group related statements within a single call to a DatabaseQueue or DatabasePool database access method.". Using a reentrant method is pretty much likely the sign of a wrong application architecture that needs refactoring.
     
-    Reentrant methods have been introduced in order to support [RxGRDB](http://github.com/RxSwiftCommunity/RxGRDB), a set of reactive extensions to GRDB based on [RxSwift](https://github.com/ReactiveX/RxSwift) that need precise scheduling.
+    There is a single valid use case for reentrant methods, which is when you are unable to control database access scheduling.
     
 - **`unsafeReentrantWrite`**
     
@@ -6646,7 +6646,7 @@ DatabaseWriter and DatabaseReader fuel, for example:
     
     Reentrant database accesses make it very easy to break the second [safety rule](#guarantees-and-rules), which says: "group related statements within a single call to a DatabaseQueue or DatabasePool database access method.". Using a reentrant method is pretty much likely the sign of a wrong application architecture that needs refactoring.
     
-    Reentrant methods have been introduced in order to support [RxGRDB](http://github.com/RxSwiftCommunity/RxGRDB), a set of reactive extensions to GRDB based on [RxSwift](https://github.com/ReactiveX/RxSwift) that need precise scheduling.
+    There is a single valid use case for reentrant methods, which is when you are unable to control database access scheduling.
 
 
 ### Dealing with External Connections

--- a/README.md
+++ b/README.md
@@ -6607,9 +6607,7 @@ This is the list of database access methods:
 - [DatabaseWriter Protocol](#databasewriter-protocol-methods)
 
 
-#### DatabaseQueue Methods
-
-See [DatabaseQueue](#database-queues)
+#### [DatabaseQueue](#database-queues) Methods
 
 | Method | Opens a Transaction | Notes |
 | ------ | ------------------- | ----- |
@@ -6618,9 +6616,7 @@ See [DatabaseQueue](#database-queues)
 | `inTransaction` | YES | |
 
 
-#### DatabasePool Methods
-
-See [DatabasePool](#database-pools)
+#### [DatabasePool](#database-pools) Methods
 
 | Method | Opens a Transaction | Notes |
 | ------ | ------------------- | ----- |
@@ -6632,18 +6628,14 @@ See [DatabasePool](#database-pools)
 | `makeSnapshot` | YES | Can't be executed from inside a transaction. |
 
 
-#### DatabaseSnapshot Methods
-
-See [DatabaseSnapshot](#database-snapshots)
+#### [DatabaseSnapshot](#database-snapshots) Methods
 
 | Method | Opens a Transaction | Notes |
 | ------ | ------------------- | ----- |
 | `read` | YES | |
 
 
-#### DatabaseReader Protocol Methods
-
-See [DatabaseReader](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/DatabaseReader.html)
+#### [DatabaseReader Protocol](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/DatabaseReader.html) Methods
 
 | Method | Notes |
 | ------ | ----- |
@@ -6652,9 +6644,7 @@ See [DatabaseReader](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/Datab
 | `unsafeReentrantRead` | |
 
 
-#### DatabaseWriter Protocol Methods
-
-See [DatabaseWriter](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/DatabaseWriter.html)
+#### [DatabaseWriter Protocol](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/DatabaseWriter.html) Methods
 
 | Method | Notes |
 | ------ | ----- |

--- a/README.md
+++ b/README.md
@@ -1275,7 +1275,16 @@ Grape.fromDatabaseValue(row[0])  // nil
 
 **Transactions** are a fundamental concept of SQLite that guarantee [data consistency](https://www.sqlite.org/transactional.html) as well as [proper isolation](https://sqlite.org/isolation.html) between application threads and database connections.
 
-These are all important words for a database expert, but not all developers know them very well. That's why GRDB will sometimes open transactions for you, automatically, as a way to enforce its [concurrency guarantees](#concurrency), and provide maximal security for both your application data and application logic. See the [list of database access methods](#list-of-database-access-methods) for an overview.
+These are all important words for a database expert, but not all developers know them very well. That's why GRDB will generally open transactions for you, automatically, as a way to enforce its [concurrency guarantees](#concurrency), and provide maximal security for both your application data and application logic:
+
+```swift
+// BEGIN TRANSACTION
+// INSERT INTO players ...
+// COMMIT
+try dbPool.write { db in
+    try Player(...).insert(db)
+}
+```
 
 **Yet some users need to control exactly when transactions take place.** This is an advanced use case, described below.
 
@@ -6224,7 +6233,6 @@ You can catch those errors and wait for [UIApplicationDelegate.applicationProtec
 - [DatabaseWriter and DatabaseReader Protocols](#databasewriter-and-databasereader-protocols)
 - [Unsafe Concurrency APIs](#unsafe-concurrency-apis)
 - [Dealing with External Connections](#dealing-with-external-connections)
-- [List of Database Access Methods](#list-of-database-access-methods)
 
 
 ### Guarantees and Rules
@@ -6594,64 +6602,6 @@ If you absolutely need multiple connections, then:
 - Become a master of the [WAL mode](https://www.sqlite.org/wal.html)
 - Prepare to setup a [busy handler](https://www.sqlite.org/c3ref/busy_handler.html) with [Configuration.busyMode](http://groue.github.io/GRDB.swift/docs/2.10/Structs/Configuration.html)
 - [Ask questions](https://github.com/groue/GRDB.swift/issues)
-
-
-### List of Database Access Methods
-
-This is the list of database access methods:
-
-- [DatabaseQueue](#databasequeue-methods)
-- [DatabasePool](#databasepool-methods)
-- [DatabaseSnapshot](#databasesnapshot-methods)
-- [DatabaseReader Protocol](#databasereader-protocol-methods)
-- [DatabaseWriter Protocol](#databasewriter-protocol-methods)
-
-
-#### [DatabaseQueue](#database-queues) Methods
-
-| Method | Opens a Transaction | Notes |
-| ------ | ------------------- | ----- |
-| `read` | NO | Guaranteed read-only access from SQLite 3.8.0 (iOS 8.2+, macOS 10.10+). |
-| `inDatabase` | NO | |
-| `inTransaction` | YES | |
-
-
-#### [DatabasePool](#database-pools) Methods
-
-| Method | Opens a Transaction | Notes |
-| ------ | ------------------- | ----- |
-| `write` | YES | |
-| `writeInTransaction` | YES | |
-| `writeWithoutTransaction` | NO | |
-| `read` | YES | |
-| `readFromCurrentState` | YES | Must be executed from a writing block. Can't be executed from inside a transaction. |
-| `makeSnapshot` | YES | Can't be executed from inside a transaction. |
-
-
-#### [DatabaseSnapshot](#database-snapshots) Methods
-
-| Method | Opens a Transaction | Notes |
-| ------ | ------------------- | ----- |
-| `read` | YES | |
-
-
-#### [DatabaseReader Protocol](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/DatabaseReader.html) Methods
-
-| Method | Notes |
-| ------ | ----- |
-| `read` | |
-| `unsafeRead` | |
-| `unsafeReentrantRead` | |
-
-
-#### [DatabaseWriter Protocol](http://groue.github.io/GRDB.swift/docs/2.10/Protocols/DatabaseWriter.html) Methods
-
-| Method | Notes |
-| ------ | ----- |
-| `write` | |
-| `writeWithoutTransaction` | |
-| `unsafeReentrantWrite` | |
-| `readFromCurrentState` | Must be executed from a writing block. Can't be executed from inside a transaction. |
 
 
 ## Performance

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ let dbPool = try DatabasePool(path: "/path/to/database.sqlite")
 [Execute SQL statements](#executing-updates):
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try db.execute("""
         CREATE TABLE places (
           id INTEGER PRIMARY KEY,
@@ -110,7 +110,7 @@ try dbQueue.inDatabase { db in
 [Fetch database rows and values](#fetch-queries):
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     let rows = try Row.fetchCursor(db, "SELECT * FROM places")
     while let row = try rows.next() {
         let title: String = row["title"]
@@ -125,7 +125,7 @@ try dbQueue.inDatabase { db in
 }
 
 // Extraction
-let placeCount = try dbQueue.inDatabase { db in
+let placeCount = try dbQueue.read { db in
     try Int.fetchOne(db, "SELECT COUNT(*) FROM places")!
 }
 ```
@@ -143,7 +143,7 @@ struct Place {
 // snip: turn Place into a "record" by adopting the protocols that
 // provide fetching and persistence methods.
 
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     var berlin = Place(
         id: nil,
         title: "Berlin",
@@ -164,7 +164,7 @@ try dbQueue.inDatabase { db in
 Avoid SQL with the [query interface](#the-query-interface):
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try db.create(table: "places") { t in
         t.column("id", .integer).primaryKey()
         t.column("title", .text).notNull()
@@ -309,7 +309,7 @@ let dbPool = try DatabasePool(path: "/path/to/database.sqlite")
 The differences are:
 
 - Database pools allow concurrent database accesses (this can improve the performance of multithreaded applications).
-- Unless read-only, database pools open your SQLite database in the [WAL mode](https://www.sqlite.org/wal.html).
+- Database pools open your SQLite database in the [WAL mode](https://www.sqlite.org/wal.html) (unless read-only).
 - Database queues support [in-memory databases](https://www.sqlite.org/inmemorydb.html).
 
 **If you are not sure, choose DatabaseQueue.** You will always be able to switch to DatabasePool later.
@@ -331,32 +331,26 @@ let inMemoryDBQueue = DatabaseQueue()
 
 SQLite creates the database file if it does not already exist. The connection is closed when the database queue gets deallocated.
 
-
-**A database queue can be used from any thread.** The `inDatabase` and `inTransaction` methods are synchronous, and block the current thread until your database statements are executed in a protected dispatch queue. They safely serialize the database accesses:
+**A database queue can be used from any thread.** The `write` and `read` methods are synchronous, and block the current thread until your database statements are executed in a protected dispatch queue:
 
 ```swift
-// Execute database statements:
-try dbQueue.inDatabase { db in
+// Modify the database:
+try dbQueue.write { db in
     try db.create(table: "places") { ... }
     try Place(...).insert(db)
 }
 
-// Wrap database statements in a transaction:
-try dbQueue.inTransaction { db in
-    if let place = try Place.fetchOne(db, key: 1) {
-        try place.delete(db)
-    }
-    return .commit
-}
-
 // Read values:
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     let places = try Place.fetchAll(db)
     let placeCount = try Place.fetchCount(db)
 }
+```
 
-// Extract a value from the database:
-let placeCount = try dbQueue.inDatabase { db in
+Database access methods can return values, for easy extraction of database values:
+
+```swift
+let placeCount = try dbQueue.read { db in
     try Place.fetchCount(db)
 }
 ```
@@ -364,6 +358,12 @@ let placeCount = try dbQueue.inDatabase { db in
 **A database queue needs your application to follow rules in order to deliver its safety guarantees.** Please refer to the [Concurrency](#concurrency) chapter.
 
 See [DemoApps/GRDBDemoiOS/AppDatabase.swift](DemoApps/GRDBDemoiOS/GRDBDemoiOS/AppDatabase.swift) for a sample code that sets up a database queue on iOS.
+
+> :muscle: **Note to database experts**: The `write` and `read` database access methods generally help enforcing the [GRDB concurrency guarantees](#concurrency), and are highly recommended, even for skilled developers, because they lift most of the mental burden related to explicit SQLite transactions:
+>
+> `DatabaseQueue.write` wraps your database statements in a transaction, and rollbacks on the first unhandled error. `DatabaseQueue.read` enforces read-only access.
+>
+> When precise transaction handling is required, see [Transactions and Savepoints](#transactions-and-savepoints).
 
 
 ### DatabaseQueue Configuration
@@ -384,9 +384,7 @@ See [Configuration](http://groue.github.io/GRDB.swift/docs/2.10/Structs/Configur
 
 ## Database Pools
 
-**A Database Pool allows concurrent database accesses.**
-
-When more efficient than [database queues](#database-queues), database pools also inherit the subtleties of SQLite's [WAL mode](https://www.sqlite.org/wal.html). If you don't feel comfortable with improving your SQLite skills, use a [database queue](#database-queues) instead.
+**A database pool allows concurrent database accesses.**
 
 ```swift
 import GRDB
@@ -397,22 +395,13 @@ SQLite creates the database file if it does not already exist. The connection is
 
 > :point_up: **Note**: unless read-only, a database pool opens your database in the SQLite "WAL mode". The WAL mode does not fit all situations. Please have a look at https://www.sqlite.org/wal.html.
 
-
-**A database pool can be used from any thread.** The `read`, `write` and `writeInTransaction` methods are synchronous, and block the current thread until your database statements are executed in a protected dispatch queue. They safely isolate the database accesses:
+**A database pool can be used from any thread.** The `write` and `read` methods are synchronous, and block the current thread until your database statements are executed in a protected dispatch queue:
 
 ```swift
-// Execute database statements:
+// Modify the database:
 try dbPool.write { db in
     try db.create(table: "places") { ... }
     try Place(...).insert(db)
-}
-
-// Wrap database statements in a transaction:
-try dbPool.writeInTransaction { db in
-    if let place = try Place.fetchOne(db, key: 1) {
-        try place.delete(db)
-    }
-    return .commit
 }
 
 // Read values:
@@ -420,32 +409,40 @@ try dbPool.read { db in
     let places = try Place.fetchAll(db)
     let placeCount = try Place.fetchCount(db)
 }
+```
 
-// Extract a value from the database:
+Database access methods can return values, for easy extraction of database values:
+
+```swift
 let placeCount = try dbPool.read { db in
     try Place.fetchCount(db)
 }
 ```
 
-Database pools allow several threads to access the database at the same time:
+**A database pool needs your application to follow rules in order to deliver its safety guarantees.** Please refer to the [Concurrency](#concurrency) chapter.
+
+For a sample code that sets up a database pool on iOS, see [DemoApps/GRDBDemoiOS/AppDatabase.swift](DemoApps/GRDBDemoiOS/GRDBDemoiOS/AppDatabase.swift), and replace DatabaseQueue with DatabasePool.
+
+
+### Database Pool Concurrency
+
+Unlike [database queues](#database-queues), pools allow several threads to access the database at the same time:
 
 - When you don't need to modify the database, prefer the `read` method, because several threads can perform reads in parallel.
     
     Reads are generally non-blocking, unless the maximum number of concurrent reads has been reached. In this case, a read has to wait for another read to complete. That maximum number can be [configured](#databasepool-configuration).
 
-- Reads are guaranteed an immutable view of the last committed state of the database, regardless of concurrent writes. This kind of isolation is called "snapshot isolation".
+- Reads are guaranteed an immutable view of the last committed state of the database, regardless of concurrent writes. This kind of isolation is called [snapshot isolation](https://sqlite.org/isolation.html).
 
 - Unlike reads, writes are serialized. There is never more than a single thread that is writing into the database.
 
-- The `write` and `writeInTransaction` methods always run your database statements in a transaction. There is also a `writeWithoutTransaction` method that allows you to precisely control database transactions, at the cost of concurrency subtleties. See the [Concurrency](#concurrency) chapter.
+- The `write` method wraps your database statements in a transaction, and rollbacks on the first unhandled error.
+
+    When precise transaction handling is required, see [Transactions and Savepoints](#transactions-and-savepoints) for more information.
 
 - Database pools can take [snapshots](#database-snapshots) of the database.
 
-See [Differences between Database Queues and Pools](#differences-between-database-queues-and-pools) before you decide to use a database pool. When you're sure, see [Advanced DatabasePool](#advanced-databasepool) for more DatabasePool hotness.
-
-**A database pool needs your application to follow rules in order to deliver its safety guarantees.** Please refer to the [Concurrency](#concurrency) chapter.
-
-For a sample code that sets up a database pool on iOS, see [DemoApps/GRDBDemoiOS/AppDatabase.swift](DemoApps/GRDBDemoiOS/GRDBDemoiOS/AppDatabase.swift), and replace DatabaseQueue with DatabasePool.
+See the [Concurrency](#concurrency) chapter for more details about database pools, and advanced use cases.
 
 
 ### DatabasePool Configuration
@@ -502,7 +499,7 @@ Once granted with a [database connection](#database-connections), the `execute` 
 For example:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try db.execute("""
         CREATE TABLE players (
             id INTEGER PRIMARY KEY,
@@ -551,7 +548,7 @@ let playerId = player.id
 **Rows** are the raw results of SQL queries:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     if let row = try Row.fetchOne(db, "SELECT * FROM wines WHERE id = ?", arguments: [1]) {
         let name: String = row["name"]
         let color: Color = row["color"]
@@ -564,7 +561,7 @@ try dbQueue.inDatabase { db in
 **Values** are the Bool, Int, String, Date, Swift enums, etc. stored in row columns:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     let urls = try URL.fetchCursor(db, "SELECT url FROM wines")
     while let url = try urls.next() {
         print(url)
@@ -576,7 +573,7 @@ try dbQueue.inDatabase { db in
 **Records** are your application objects that can initialize themselves from rows:
 
 ```swift
-let wines = try dbQueue.inDatabase { db in
+let wines = try dbQueue.read { db in
     try Wine.fetchAll(db, "SELECT * FROM wines")
 }
 ```
@@ -623,7 +620,7 @@ try Row.fetchOne(...)    // Row?
 The `fetchAll()` method returns a regular Swift array, that you iterate like all other arrays:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     // [Player]
     let players = try Player.fetchAll(db, "SELECT ...")
     for player in players {
@@ -635,7 +632,7 @@ try dbQueue.inDatabase { db in
 Unlike arrays, cursors returned by `fetchCursor()` load their results step after step:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     // Cursor of Player
     let players = try Player.fetchCursor(db, "SELECT ...")
     while let player = try players.next() {
@@ -650,10 +647,10 @@ Both arrays and cursors can iterate over database results. How do you choose one
     
     ```swift
     // Wrong
-    let cursor = try dbQueue.inDatabase { try Player.fetchCursor($0, ...) }
+    let cursor = try dbQueue.read { try Player.fetchCursor($0, ...) }
     
     // OK
-    let array = try dbQueue.inDatabase { try Player.fetchAll($0, ...) }
+    let array = try dbQueue.read { try Player.fetchAll($0, ...) }
     ```
     
 - **Cursors can be iterated only one time.** Arrays can be iterated many times.
@@ -718,7 +715,7 @@ let hosts = try Set(cursor) // Set<String>
 Fetch **cursors** of rows, **arrays**, or **single** rows (see [fetching methods](#fetching-methods)):
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     try Row.fetchCursor(db, "SELECT ...", arguments: ...) // A Cursor of Row
     try Row.fetchAll(db, "SELECT ...", arguments: ...)    // [Row]
     try Row.fetchOne(db, "SELECT ...", arguments: ...)    // Row?
@@ -731,7 +728,7 @@ try dbQueue.inDatabase { db in
     }
 }
 
-let rows = try dbQueue.inDatabase { db in
+let rows = try dbQueue.read { db in
     try Row.fetchAll(db, "SELECT * FROM players")
 }
 ```
@@ -978,7 +975,7 @@ See the documentation of [`Dictionary.init(_:uniquingKeysWith:)`](https://develo
 Instead of rows, you can directly fetch **[values](#values)**. Like rows, fetch them as **cursors**, **arrays**, or **single** values (see [fetching methods](#fetching-methods)). Values are extracted from the leftmost column of the SQL queries:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     try Int.fetchCursor(db, "SELECT ...", arguments: ...) // A Cursor of Int
     try Int.fetchAll(db, "SELECT ...", arguments: ...)    // [Int]
     try Int.fetchOne(db, "SELECT ...", arguments: ...)    // Int?
@@ -988,7 +985,7 @@ try dbQueue.inDatabase { db in
     try Optional<Int>.fetchAll(db, "SELECT ...", arguments: ...)    // [Int?]
 }
 
-let playerCount = try dbQueue.inDatabase { db in
+let playerCount = try dbQueue.read { db in
     try Int.fetchOne(db, "SELECT COUNT(*) FROM players")!
 }
 ```
@@ -1273,11 +1270,18 @@ Grape.fromDatabaseValue(row[0])  // nil
 
 ### Transactions and Safety
 
-**Transactions** are a fundamental concept of SQLite that guarantee [data consistency](https://www.sqlite.org/transactional.html) as well as [proper isolation](https://sqlite.org/isolation.html) between application threads and database connections.
+**A transaction** is a fundamental tool of SQLite that guarantees [data consistency](https://www.sqlite.org/transactional.html) as well as [proper isolation](https://sqlite.org/isolation.html) between application threads and database connections.
 
-These are all important words for a database expert, but not all developers know them very well. That's why GRDB will generally open transactions for you, automatically, as a way to enforce its [concurrency guarantees](#concurrency), and provide maximal security for both your application data and application logic:
+GRDB generally opens transactions for you, as a way to enforce its [concurrency guarantees](#concurrency), and provide maximal security for both your application data and application logic:
 
 ```swift
+// BEGIN TRANSACTION
+// INSERT INTO players ...
+// COMMIT
+try dbQueue.write { db in
+    try Player(...).insert(db)
+}
+
 // BEGIN TRANSACTION
 // INSERT INTO players ...
 // COMMIT
@@ -1286,35 +1290,64 @@ try dbPool.write { db in
 }
 ```
 
-**Yet some users need to control exactly when transactions take place.** This is an advanced use case, described below.
+Yet you may need to exactly control when transactions take place:
 
 
 ### Explicit Transactions
 
-`DatabaseQueue.inTransaction()` and `DatabasePool.writeInTransaction()` open an SQLite transaction and run their closure argument in a protected dispatch queue. They block the current thread until your database statements are executed:
+`DatabaseQueue.inDatabase()` and `DatabasePool.writeWithoutTransaction()` execute your database statements outside of any transaction:
+
+```swift
+// INSERT INTO players (...)
+try dbQueue.inDatabase { db in
+    try Player(...).insert(db)
+}
+
+// INSERT INTO players (...)
+try dbPool.writeWithoutTransaction { db in
+    try Player(...).insert(db)
+}
+```
+
+> :warning: **Warning**: it is dangerous to write in a database pool outside of a transaction, because concurrent reads may see an inconsistent state of the database:
+>
+> ```swift
+> // UNSAFE CONCURRENCY
+> try dbPool.writeWithoutTransaction { db in
+>     try Credit(destinationAccout, amount).insert(db)
+>     // <- Concurrent dbPool.read sees a partial db update here
+>     try Debit(sourceAccount, amount).insert(db)
+> }
+> ```
+
+To open explicit transactions, use one of the `Database.inTransaction`, `DatabaseQueue.inTransaction`, or `DatabasePool.writeInTransaction` methods:
 
 ```swift
 // BEGIN TRANSACTION
-// INSERT INTO wines (...)
+// INSERT INTO players ...
 // COMMIT
-try dbQueue.inTransaction { db in
-    let wine = Wine(color: .red, name: "Pomerol")
-    try wine.insert(db)
+try dbQueue.inDatabase { db in  // or dbPool.writeWithoutTransaction
+    try db.inTransaction {
+        try Player(...).insert(db)
+        return .commit
+    }
+}
+
+// BEGIN TRANSACTION
+// INSERT INTO players (...)
+// COMMIT
+try dbQueue.inTransaction { db in  // or dbPool.writeInTransaction
+    try Player(...).insert(db)
     return .commit
 }
 ```
 
-If an error is thrown within the transaction body, the transaction is rollbacked and the error is rethrown by the `inTransaction` method. If you return `.rollback` from your closure, the transaction is also rollbacked, but no error is thrown.
+If an error is thrown from the transaction block, the transaction is rollbacked and the error is rethrown by the `inTransaction` method. If you return `.rollback` instead of `.commit`, the transaction is also rollbacked, but no error is thrown.
 
-If you want to insert a transaction between other database statements, you can use the Database.inTransaction() function, or even raw SQL statements:
+You can also perform manual transaction management:
 
 ```swift
-try dbPool.writeWithoutTransaction { db in  // or dbQueue.inDatabase { ... }
-    try db.inTransaction {
-        ...
-        return .commit
-    }
-    
+try dbQueue.inDatabase { db in  // or dbPool.writeWithoutTransaction
     try db.beginTransaction()
     ...
     try db.commit()
@@ -1325,7 +1358,17 @@ try dbPool.writeWithoutTransaction { db in  // or dbQueue.inDatabase { ... }
 }
 ```
 
-You can ask a database if a transaction is currently opened:
+Transactions can't be left opened unless you set the [allowsUnsafeTransactions](http://groue.github.io/GRDB.swift/docs/2.10/Structs/Configuration.html) configuration flag:
+
+```swift
+// fatal error: A transaction has been left opened at the end of a database access
+try dbQueue.inDatabase { db in
+    try db.execute("BEGIN TRANSACTION")
+    // <- no commit or rollback
+}
+```
+
+You can ask if a transaction is currently opened:
 
 ```swift
 func myCriticalMethod(_ db: Database) throws {
@@ -1334,7 +1377,7 @@ func myCriticalMethod(_ db: Database) throws {
 }
 ```
 
-Yet, you have a better option than checking for transactions: critical sections of your application should use savepoints, described below:
+Yet, you have a better option than checking for transactions: critical database sections should use savepoints, described below:
 
 ```swift
 func myCriticalMethod(_ db: Database) throws {
@@ -1351,7 +1394,7 @@ func myCriticalMethod(_ db: Database) throws {
 **Statements grouped in a savepoint can be rollbacked without invalidating a whole transaction:**
 
 ```swift
-try dbQueue.inTransaction { db in
+try dbQueue.write { db in
     try db.inSavepoint { 
         try db.execute("DELETE ...")
         try db.execute("INSERT ...") // need to rollback the delete above if this fails
@@ -1359,13 +1402,12 @@ try dbQueue.inTransaction { db in
     }
     
     // Other savepoints, etc...
-    return .commit
 }
 ```
 
-If an error is thrown within the savepoint body, the savepoint is rollbacked and the error is rethrown by the `inSavepoint` method. If you return `.rollback` from your closure, the body is also rollbacked, but no error is thrown.
+If an error is thrown from the savepoint block, the savepoint is rollbacked and the error is rethrown by the `inSavepoint` method. If you return `.rollback` instead of `.commit`, the savepoint is also rollbacked, but no error is thrown.
 
-**Unlike transactions, savepoints can be nested.** They implicitly open a transaction if no one was opened when the savepoint begins. As such, they behave just like nested transactions. Yet the database changes are only committed to disk when the outermost savepoint is committed:
+**Unlike transactions, savepoints can be nested.** They implicitly open a transaction if no one was opened when the savepoint begins. As such, they behave just like nested transactions. Yet the database changes are only written to disk when the outermost transaction is committed:
 
 ```swift
 try dbQueue.inDatabase { db in
@@ -1381,7 +1423,7 @@ try dbQueue.inDatabase { db in
 }
 ```
 
-SQLite savepoints are more than nested transactions, though. For advanced savepoints uses, use [SQL queries](https://www.sqlite.org/lang_savepoint.html).
+SQLite savepoints are more than nested transactions, though. For advanced uses, use [SQLite savepoint documentation](https://www.sqlite.org/lang_savepoint.html).
 
 
 ### Transaction Kinds
@@ -1391,13 +1433,22 @@ SQLite supports [three kinds of transactions](https://www.sqlite.org/lang_transa
 The transaction kind can be changed in the database configuration, or for each transaction:
 
 ```swift
-// Set the default transaction kind to IMMEDIATE:
+// 1) Default configuration:
+let dbQueue = try DatabaseQueue(path: "...")
+
+// BEGIN DEFERED TRANSACTION ...
+dbQueue.write { db in ... }
+
+// BEGIN EXCLUSIVE TRANSACTION ...
+dbQueue.inTransaction(.exclusive) { db in ... }
+
+// 2) Customized default transaction kind:
 var config = Configuration()
 config.defaultTransactionKind = .immediate
 let dbQueue = try DatabaseQueue(path: "...", configuration: config)
 
 // BEGIN IMMEDIATE TRANSACTION ...
-dbQueue.inTransaction { db in ... }
+dbQueue.write { db in ... }
 
 // BEGIN EXCLUSIVE TRANSACTION ...
 dbQueue.inTransaction(.exclusive) { db in ... }
@@ -1432,7 +1483,7 @@ The `fromDatabaseValue()` factory method returns an instance of your custom type
 There are two kinds of prepared statements: **select statements**, and **update statements**:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     let updateSQL = "INSERT INTO players (name, score) VALUES (:name, :score)"
     let updateStatement = try db.makeUpdateStatement(updateSQL)
     
@@ -1520,7 +1571,7 @@ let reverse = DatabaseFunction("reverse", argumentCount: 1, pure: true) { (value
 }
 dbQueue.add(function: reverse)   // Or dbPool.add(function: ...)
 
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     // "oof"
     try String.fetchOne(db, "SELECT reverse('foo')")!
 }
@@ -1542,7 +1593,7 @@ let averageOf = DatabaseFunction("averageOf", pure: true) { (values: [DatabaseVa
 }
 dbQueue.add(function: averageOf)
 
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     // 2.0
     try Double.fetchOne(db, "SELECT averageOf(1, 2, 3)")!
 }
@@ -1564,7 +1615,7 @@ let sqrt = DatabaseFunction("sqrt", argumentCount: 1, pure: true) { (values: [Da
 dbQueue.add(function: sqrt)
 
 // SQLite error 1 with statement `SELECT sqrt(-1)`: invalid negative number
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     try Double.fetchOne(db, "SELECT sqrt(-1)")!
 }
 ```
@@ -1629,7 +1680,7 @@ let maxLength = DatabaseFunction(
 
 dbQueue.add(function: maxLength)   // Or dbPool.add(function: ...)
 
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     // Some Int
     try Int.fetchOne(db, "SELECT maxLength(name) FROM players")!
 }
@@ -1827,7 +1878,7 @@ let sqliteVersion = String(cString: sqlite3_libversion())
 Raw pointers to database connections and statements are available through the `Database.sqliteConnection` and `Statement.sqliteStatement` properties:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     // The raw pointer to a database connection:
     let sqliteConnection = db.sqliteConnection
 
@@ -1871,7 +1922,7 @@ Records
 **On top of the [SQLite API](#sqlite-api), GRDB provides protocols and a class** that help manipulating database rows as regular objects named "records":
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     if let place = try Place.fetchOne(db, key: 1) {
         place.isFavorite = true
         try place.update(db)
@@ -2025,7 +2076,7 @@ Details follow:
     
     ```swift
     struct Place { ... }
-    try dbQueue.inDatabase { db in
+    try dbQueue.read { db in
         let rows = try Row.fetchAll(db, "SELECT * FROM places")
         let places: [Place] = rows.map { row in
             return Place(
@@ -2043,7 +2094,7 @@ Details follow:
     
     ```swift
     struct Place: FetchableRecord { ... }
-    try dbQueue.inDatabase { db in
+    try dbQueue.read { db in
         let places = try Place.fetchAll(db, "SELECT * FROM places")
     }
     ```
@@ -2062,7 +2113,7 @@ Details follow:
     
     ```swift
     struct Place: TableRecord, FetchableRecord { ... }
-    try dbQueue.inDatabase { db in
+    try dbQueue.read { db in
         let places = try Place.order(Column("title")).fetchAll(db)
         let paris = try Place.fetchOne(key: 1)
     }
@@ -2072,7 +2123,7 @@ Details follow:
     
     ```swift
     struct Place : PersistableRecord { ... }
-    try dbQueue.inDatabase { db in
+    try dbQueue.write { db in
         try Place.delete(db, key: 1)
         try Place(...).insert(db)
     }
@@ -2398,7 +2449,7 @@ extension Player: FetchableRecord, PersistableRecord {
 }
 
 // ...and you can save and fetch players:
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try Player(name: "Arthur", score: 100).insert(db)
     let players = try Player.fetchAll(db)
 }
@@ -2889,7 +2940,7 @@ The Query Interface
 **The query interface lets you write pure Swift instead of SQL:**
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     // Update database schema
     try db.create(table: "wines") { t in ... }
     
@@ -2909,7 +2960,7 @@ You need to open a [database connection](#database-connections) before you can q
 Please bear in mind that the query interface can not generate all possible SQL queries. You may also *prefer* writing SQL, and this is just OK. From little snippets to full queries, your SQL skills are welcome:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     // Update database schema (with SQL)
     try db.execute("CREATE TABLE wines (...)")
     
@@ -4711,7 +4762,7 @@ To split rows, we will use [row adapters](#row-adapters). Row adapters adapt row
 At the very beginning, there is an SQL query:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     let sql = """
         SELECT players.*, teams.*, MAX(rounds.score) AS maxScore
         FROM players
@@ -4874,7 +4925,7 @@ And when your app needs to fetch items, it now reads:
 
 ```swift
 // Fetch items
-let items = try dbQueue.inDatabase { db in
+let items = try dbQueue.read { db in
     try Item.fetchAll(db)
 }
 ```
@@ -4953,7 +5004,7 @@ It is now time to use our request:
 
 ```swift
 // Fetch items
-let items = try dbQueue.inDatabase { db in
+let items = try dbQueue.read { db in
     try Item.fetchAll(db)
 }
 
@@ -5022,7 +5073,7 @@ extension Item {
 }
 
 // Fetch items
-let items = try dbQueue.inDatabase { db in
+let items = try dbQueue.read { db in
     try Item.fetchAll(db)
 }
 
@@ -5174,23 +5225,27 @@ By default, database holds weak references to its transaction observers: they ar
 
 > :point_up: **Note**: the changes that are not notified are changes to internal system tables (such as `sqlite_master`), changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables, and the deletion of duplicate rows triggered by [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) clauses (this last exception might change in a future release of SQLite).
 
-Notified changes are not actually written to disk until `databaseDidCommit` is called. On the other side, `databaseDidRollback` confirms their invalidation:
+Notified changes are not actually written to disk the [transaction](#transactions-and-savepoints) commits, and the until `databaseDidCommit` is called. On the other side, `databaseDidRollback` confirms their invalidation:
 
 ```swift
-try dbQueue.inTransaction { db in
+try dbQueue.write { db in
     try db.execute("INSERT ...") // 1. didChange
     try db.execute("UPDATE ...") // 2. didChange
-    return .commit               // 3. willCommit, 4. didCommit
-}
+}                                // 3. willCommit, 4. didCommit
 
 try dbQueue.inTransaction { db in
     try db.execute("INSERT ...") // 1. didChange
     try db.execute("UPDATE ...") // 2. didChange
     return .rollback             // 3. didRollback
 }
+
+try dbQueue.write { db in
+    try db.execute("INSERT ...") // 1. didChange
+    throw SomeError()            // 2. throw
+}                                // 3. didRollback
 ```
 
-Database statements that are executed outside of an explicit transaction do not drop off the radar:
+Database statements that are executed outside of a transaction do not drop off the radar:
 
 ```swift
 try dbQueue.inDatabase { db in
@@ -5308,7 +5363,7 @@ The `remove(transactionObserver:)` method explicitely stops notifications, at an
 dbQueue.remove(transactionObserver: observer)
 
 // From a database connection:
-dbQueue.inDatabase { db in // or dbPool.write
+dbQueue.inDatabase { db in
     db.remove(transactionObserver: observer)
 }
 ```
@@ -5411,7 +5466,7 @@ When you initialize a fetched records controller, you provide the following mand
 
 ```swift
 class Player : Record { ... }
-let dbQueue = DatabaseQueue(...)    // Or DatabasePool
+let dbQueue = DatabaseQueue(...)    // or DatabasePool
 
 // Using a Request from the Query Interface:
 let controller = FetchedRecordsController(
@@ -5452,18 +5507,26 @@ try controller.performFetch()
 
 In general, FetchedRecordsController is designed to respond to changes at *the database layer*, by [notifying](#the-changes-notifications) when *database rows* change location or values.
 
-Changes are not reflected until they are applied in the database by a successful [transaction](#transactions-and-savepoints). Transactions can be explicit, or implicit:
+Changes are not reflected until they are applied in the database by a successful [transaction](#transactions-and-savepoints):
 
 ```swift
-try dbQueue.inTransaction { db in
+// One transaction
+try dbQueue.write { db in         // or dbPool.write
     try player1.insert(db)
     try player2.insert(db)
-    return .commit         // Explicit transaction
 }
 
-try dbQueue.inDatabase { db in
-    try player1.insert(db) // Implicit transaction
-    try player2.insert(db) // Implicit transaction
+// One transaction
+try dbQueue.inTransaction { db in // or dbPool.writeInTransaction
+    try player1.insert(db)
+    try player2.insert(db)
+    return .commit
+}
+
+// Two transactions
+try dbQueue.inDatabase { db in    // or dbPool.writeWithoutTransaction
+    try player1.insert(db)
+    try player2.insert(db)
 }
 ```
 
@@ -5691,7 +5754,7 @@ When the database itself can be read and modified from [any thread](#database-co
 
 ```swift
 // Change database on the main thread:
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try Player(...).insert(db)
 }
 // Here callbacks have not been called yet.
@@ -5822,7 +5885,7 @@ Here is an example of code that is vulnerable to SQL injection:
 ```swift
 // BAD BAD BAD
 let name = textField.text
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try db.execute("UPDATE students SET name = '\(name)' WHERE id = \(id)")
 }
 ```
@@ -5840,7 +5903,7 @@ To avoid those problems, **never embed raw values in your SQL queries**. The onl
 ```swift
 // Good
 let name = textField.text
-try dbQueue.inDatabase { db in
+try dbQueue.write { db in
     try db.execute(
         "UPDATE students SET name = ? WHERE id = ?",
         arguments: [name, id])
@@ -6001,8 +6064,8 @@ They uncover programmer errors, false assumptions, and prevent misuses. Here are
     
     ```swift
     // fatal error: Database methods are not reentrant.
-    dbQueue.inDatabase { db in
-        dbQueue.inDatabase { db in
+    dbQueue.write { db in
+        dbQueue.write { db in
             ...
         }
     }
@@ -6252,7 +6315,7 @@ GRDB ships with three concurrency modes:
 - :bowtie: **Guarantee 2: reads are always isolated**. This means that they are guaranteed an immutable view of the last committed state of the database, and that you can perform subsequent fetches without fearing eventual concurrent writes to mess with your application logic:
     
     ```swift
-    try dbPool.read { db in // or dbQueue.inDatabase { ... }
+    try dbPool.read { db in // or dbQueue.read
         // Guaranteed to be equal
         let count1 = try Player.fetchCount(db)
         let count2 = try Player.fetchCount(db)
@@ -6281,7 +6344,7 @@ Those guarantees hold as long as you follow three rules:
         return try User.fetchOne(db)
     }
     // dbQueue is a singleton defined somewhere in your app
-    let user = try dbQueue.inDatabase { db in // or dbPool.read { ... }
+    let user = try dbQueue.read { db in // or dbPool.read
         try currentUser(db)
     }
     
@@ -6290,7 +6353,7 @@ Those guarantees hold as long as you follow three rules:
     // the database.
     func currentUser() throws -> User? {
         let dbQueue = try DatabaseQueue(...)
-        return try dbQueue.inDatabase { db in
+        return try dbQueue.read { db in
             try User.fetchOne(db)
         }
     }
@@ -6303,7 +6366,7 @@ Those guarantees hold as long as you follow three rules:
     
     ```swift
     // SAFE CONCURRENCY
-    try dbPool.read { db in  // or dbQueue.inDatabase { ... }
+    try dbPool.read { db in  // or dbQueue.read
         // Guaranteed to be equal:
         let count1 = try Place.fetchCount(db)
         let count2 = try Place.fetchCount(db)
@@ -6339,13 +6402,13 @@ Those guarantees hold as long as you follow three rules:
     
     ```swift
     // SAFE CONCURRENCY
-    try dbPool.write { db in               // or dbQueue.inDatabase { ... }
+    try dbPool.write { db in               // or dbQueue.write
         try Credit(destinationAccout, amount).insert(db)
         try Debit(sourceAccount, amount).insert(db)
     }
     
     // SAFE CONCURRENCY
-    try dbPool.writeInTransaction { db in  // or dbQueue.inTransaction { ... }
+    try dbPool.writeInTransaction { db in  // or dbQueue.inTransaction
         try Credit(destinationAccout, amount).insert(db)
         try Debit(sourceAccount, amount).insert(db)
         return .commit
@@ -6571,7 +6634,7 @@ DatabaseWriter and DatabaseReader fuel, for example:
     Reentrant calls are allowed:
     
     ```swift
-    dbQueue.inDatabase { db1 in
+    dbQueue.write { db1 in
         // No "Database methods are not reentrant" fatal error:
         dbQueue.unsafeReentrantWrite { db2 in
             dbQueue.unsafeReentrantWrite { db3 in
@@ -6635,7 +6698,7 @@ Most GRBD APIs are [synchronous](#database-connections). Spawning them into para
 
 ```swift
 DispatchQueue.global().async { 
-    dbQueue.inDatabase { db in
+    dbQueue.write { db in
         // Perform database work
     }
     DispatchQueue.main.async { 
@@ -6651,18 +6714,25 @@ Performing multiple updates to the database is much faster when executed inside 
 
 ```swift
 // Inefficient
-try dbQueue.inDatabase { db in
+try dbQueue.inDatabase { db in // or dbPool.writeWithoutTransaction
     for player in players {
         try player.insert(db)
     }
 }
 
 // Efficient
-try dbQueue.inTransaction { db in
+try dbQueue.write { db in      // or dbPool.write
     for player in players {
         try player.insert(db)
     }
-    return .Commit
+}
+
+// Efficient
+try dbQueue.inTransaction { db in // or dbPool.writeInTransaction
+    for player in players {
+        try player.insert(db)
+    }
+    return .commit
 }
 ```
 
@@ -6903,7 +6973,7 @@ When you want to debug a request that does not deliver the expected results, you
 Use the `asSQLRequest` method:
 
 ```swift
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     let request = Wine
         .filter(Column("origin") == "Burgundy")
         .order(Column("price")
@@ -6923,7 +6993,7 @@ var config = Configuration()
 config.trace = { print("SQL: \($0)") } // Prints all SQL statements
 let dbQueue = try DatabaseQueue(path: dbPath, configuration: config)
 
-try dbQueue.inDatabase { db in
+try dbQueue.read { db in
     let wines = Wine
         .filter(Column("origin") == "Burgundy")
         .order(Column("price")
@@ -6935,11 +7005,11 @@ try dbQueue.inDatabase { db in
 
 ### Generic parameter 'T' could not be inferred
     
-You may get this error when using DatabaseQueue.inDatabase, DatabasePool.read, or DatabasePool.write:
+You may get this error when using the `read` and `write` methods of database queues and pools:
 
 ```swift
 // Generic parameter 'T' could not be inferred
-let x = try dbQueue.inDatabase { db in
+let x = try dbQueue.read { db in
     let result = try String.fetchOne(db, ...)
     return result
 }
@@ -6951,7 +7021,7 @@ The general workaround is to explicitly declare the type of the closure result:
 
 ```swift
 // General Workaround
-let string = try dbQueue.inDatabase { db -> String? in
+let string = try dbQueue.read { db -> String? in
     let result = try String.fetchOne(db, ...)
     return result
 }
@@ -6961,7 +7031,7 @@ You can also, when possible, write a single-line closure:
 
 ```swift
 // Single-line closure workaround:
-let string = try dbQueue.inDatabase { db in
+let string = try dbQueue.read { db in
     try String.fetchOne(db, ...)
 }
 ```

--- a/Tests/GRDBTests/CompilationProtocolTests.swift
+++ b/Tests/GRDBTests/CompilationProtocolTests.swift
@@ -77,6 +77,7 @@ private class UserDatabaseWriter : DatabaseWriter {
     func add(collation: DatabaseCollation) { }
     func remove(collation: DatabaseCollation) { }
     func write<T>(_ block: (Database) throws -> T) rethrows -> T { preconditionFailure() }
+    func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T { preconditionFailure() }
     func unsafeReentrantWrite<T>(_ block: (Database) throws -> T) rethrows -> T { preconditionFailure() }
     func readFromCurrentState(_ block: @escaping (Database) -> Void) throws { preconditionFailure() }
 }

--- a/Tests/GRDBTests/DatabaseAfterNextTransactionCommitTests.swift
+++ b/Tests/GRDBTests/DatabaseAfterNextTransactionCommitTests.swift
@@ -47,7 +47,7 @@ class DatabaseAfterNextTransactionCommitTests: GRDBTestCase {
         class Witness { }
         
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             var transactionCount = 0
             weak var deallocationWitness: Witness? = nil
             do {
@@ -89,7 +89,7 @@ class DatabaseAfterNextTransactionCommitTests: GRDBTestCase {
         class Witness { }
         
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             var transactionCount = 0
             try db.execute(startSQL)
             

--- a/Tests/GRDBTests/DatabaseErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseErrorTests.swift
@@ -40,7 +40,7 @@ class DatabaseErrorTests: GRDBTestCase {
     func testDatabaseErrorInTopLevelSavepoint() throws {
         let dbQueue = try makeDatabaseQueue()
         do {
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 do {
                     try db.inSavepoint {
                         XCTAssertTrue(db.isInsideTransaction)

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -256,7 +256,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         //                                  dbPool.read // throws
         
         let block1 = { () in
-            try! dbPool.write { db in
+            try! dbPool.writeWithoutTransaction { db in
                 try db.execute("PRAGMA locking_mode=EXCLUSIVE")
                 try db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY)")
                 s1.signal()
@@ -369,7 +369,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             do {
                 _ = s1.wait(timeout: .distantFuture)
                 defer { s2.signal() }
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("DELETE FROM items")
                 }
             } catch {
@@ -419,7 +419,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             do {
                 _ = s1.wait(timeout: .distantFuture)
                 defer { s2.signal() }
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("DELETE FROM items")
                 }
                 try dbPool.checkpoint()
@@ -468,7 +468,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block2 = { () in
             do {
                 _ = s1.wait(timeout: .distantFuture)
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("INSERT INTO items (id) VALUES (NULL)")
                     s2.signal()
                     _ = s3.wait(timeout: .distantFuture)
@@ -515,7 +515,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             do {
                 _ = s1.wait(timeout: .distantFuture)
                 defer { s2.signal() }
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("INSERT INTO items (id) VALUES (NULL)")
                 }
                 try dbPool.checkpoint()
@@ -556,7 +556,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         
         let block1 = { () in
             do {
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("INSERT INTO items (id) VALUES (NULL)")
                     s1.signal()
                     _ = s2.wait(timeout: .distantFuture)
@@ -686,7 +686,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             do {
                 _ = s1.wait(timeout: .distantFuture)
                 defer { s2.signal() }
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("DELETE FROM items")
                 }
             } catch {
@@ -736,7 +736,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             do {
                 _ = s1.wait(timeout: .distantFuture)
                 defer { s2.signal() }
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("DELETE FROM items")
                 }
                 try dbPool.checkpoint()
@@ -780,7 +780,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             do {
                 _ = s1.wait(timeout: .distantFuture)
                 defer { s2.signal() }
-                try dbPool.write { db in
+                try dbPool.writeWithoutTransaction { db in
                     try db.execute("INSERT INTO items (id) VALUES (NULL)")
                 }
                 try dbPool.checkpoint()
@@ -797,7 +797,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
     func testReadFromCurrentStateOpensATransaction() throws {
         let dbPool = try makeDatabasePool()
         let s = DispatchSemaphore(value: 0)
-        try dbPool.write { db in
+        try dbPool.writeWithoutTransaction { db in
             try dbPool.readFromCurrentState { db in
                 XCTAssertTrue(db.isInsideTransaction)
                 do {
@@ -820,7 +820,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         }
         
         // Writer                       Reader
-        // dbPool.write {
+        // dbPool.writeWithoutTransaction {
         // >
         //                              dbPool.readFromCurrentState {
         //                              <
@@ -833,7 +833,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         //                              }
         
         var i: Int! = nil
-        try dbPool.write { db in
+        try dbPool.writeWithoutTransaction { db in
             try dbPool.readFromCurrentState { db in
                 _ = s1.wait(timeout: .distantFuture)
                 i = try! Int.fetchOne(db, "SELECT COUNT(*) FROM persons")!
@@ -849,7 +849,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
     func testReadFromCurrentStateError() throws {
         dbConfiguration.trace = { print($0) }
         let dbPool = try makeDatabasePool()
-        try dbPool.write { db in
+        try dbPool.writeWithoutTransaction { db in
             try db.execute("PRAGMA locking_mode=EXCLUSIVE")
             try db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY)")
             do {

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -31,7 +31,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         
         do {
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 let journalMode = try String.fetchOne(db, "PRAGMA journal_mode = wal")
                 XCTAssertEqual(journalMode, "wal")
                 try db.create(table: "moves") { $0.column("value", .integer) }
@@ -42,7 +42,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block1 = { () in
             let dbQueue = try! self.makeDatabaseQueue(filename: "test.sqlite")
             s0.signal() // Avoid "database is locked" error: don't open the two databases at the same time
-            try! dbQueue.inDatabase { db in
+            try! dbQueue.writeWithoutTransaction { db in
                 try db.execute("BEGIN DEFERRED TRANSACTION")
                 s1.signal()
                 _ = s2.wait(timeout: .distantFuture)
@@ -56,7 +56,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block2 = { () in
             _ = s0.wait(timeout: .distantFuture) // Avoid "database is locked" error: don't open the two databases at the same time
             let dbQueue = try! self.makeDatabaseQueue(filename: "test.sqlite")
-            try! dbQueue.inDatabase { db in
+            try! dbQueue.writeWithoutTransaction { db in
                 _ = s1.wait(timeout: .distantFuture)
                 try db.execute("INSERT INTO moves VALUES (1)")
                 s2.signal()
@@ -93,7 +93,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         
         do {
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 let journalMode = try String.fetchOne(db, "PRAGMA journal_mode = wal")
                 XCTAssertEqual(journalMode, "wal")
                 try db.create(table: "moves") { $0.column("value", .integer) }
@@ -104,7 +104,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block1 = { () in
             let dbQueue = try! self.makeDatabaseQueue(filename: "test.sqlite")
             s0.signal() // Avoid "database is locked" error: don't open the two databases at the same time
-            try! dbQueue.inDatabase { db in
+            try! dbQueue.writeWithoutTransaction { db in
                 _ = s1.wait(timeout: .distantFuture)
                 try db.execute("BEGIN DEFERRED TRANSACTION")
                 s2.signal()
@@ -119,7 +119,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block2 = { () in
             _ = s0.wait(timeout: .distantFuture) // Avoid "database is locked" error: don't open the two databases at the same time
             let dbQueue = try! self.makeDatabaseQueue(filename: "test.sqlite")
-            try! dbQueue.inDatabase { db in
+            try! dbQueue.writeWithoutTransaction { db in
                 try db.execute("BEGIN DEFERRED TRANSACTION")
                 s1.signal()
                 _ = s2.wait(timeout: .distantFuture)
@@ -158,7 +158,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         
         do {
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 let journalMode = try String.fetchOne(db, "PRAGMA journal_mode = wal")
                 XCTAssertEqual(journalMode, "wal")
                 try db.create(table: "moves") { $0.column("value", .integer) }
@@ -169,7 +169,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block1 = { () in
             let dbQueue = try! self.makeDatabaseQueue(filename: "test.sqlite")
             s0.signal() // Avoid "database is locked" error: don't open the two databases at the same time
-            try! dbQueue.inDatabase { db in
+            try! dbQueue.writeWithoutTransaction { db in
                 try db.execute("BEGIN DEFERRED TRANSACTION")
                 s1.signal()
                 _ = s2.wait(timeout: .distantFuture)
@@ -183,7 +183,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block2 = { () in
             _ = s0.wait(timeout: .distantFuture) // Avoid "database is locked" error: don't open the two databases at the same time
             let dbQueue = try! self.makeDatabaseQueue(filename: "test.sqlite")
-            try! dbQueue.inDatabase { db in
+            try! dbQueue.writeWithoutTransaction { db in
                 _ = s1.wait(timeout: .distantFuture)
                 try db.execute("BEGIN DEFERRED TRANSACTION")
                 try db.execute("INSERT INTO moves VALUES (1)")
@@ -215,7 +215,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
     func testReadFromPreviousNonWALDatabase() throws {
         do {
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 try db.execute("CREATE TABLE items (id INTEGER PRIMARY KEY)")
                 try db.execute("INSERT INTO items (id) VALUES (NULL)")
             }
@@ -904,11 +904,11 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             try db.execute("INSERT INTO t DEFAULT VALUES")
         }
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.beginTransaction(.deferred)
         }
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try XCTAssertEqual(Int.fetchOne(db, "SELECT COUNT(*) FROM t")!, 1)
         }
         
@@ -916,7 +916,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             try db.execute("INSERT INTO t DEFAULT VALUES")
         }
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try XCTAssertEqual(Int.fetchOne(db, "SELECT COUNT(*) FROM t")!, 1)
             try db.rollback()
             try XCTAssertEqual(Int.fetchOne(db, "SELECT COUNT(*) FROM t")!, 2)

--- a/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
@@ -148,7 +148,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
         // table exists: false
 
         let block1 = { () in
-            try! dbPool.write { db in
+            try! dbPool.writeWithoutTransaction { db in
                 try db.execute("CREATE TABLE foo(id INTEGER PRIMARY KEY)")
                 // warm cache
                 _ = try db.primaryKey("foo")

--- a/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
@@ -17,7 +17,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
             try db.execute("CREATE INDEX foobar ON items(foo, bar)")
         }
         
-        dbPool.write { db in
+        try dbPool.write { db in
             // Assert that the writer cache is empty
             XCTAssertTrue(db.schemaCache.primaryKey("items") == nil)
             XCTAssertTrue(db.schemaCache.columns(in: "items") == nil)

--- a/Tests/GRDBTests/DatabaseQueueConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueConcurrencyTests.swift
@@ -343,7 +343,7 @@ class ConcurrencyTests: GRDBTestCase {
         var rows1: [Row]?
         var rows2: [Row]?
         queue.async(group: group) {
-            try! dbQueue2.inDatabase { db in
+            try! dbQueue2.writeWithoutTransaction { db in
                 _ = s1.wait(timeout: .distantFuture)
                 rows1 = try Row.fetchAll(db, "SELECT * FROM stuffs")
                 s2.signal()

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -95,11 +95,11 @@ class DatabaseQueueTests: GRDBTestCase {
         dbConfiguration.allowsUnsafeTransactions = true
         let dbQueue = try makeDatabaseQueue()
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.beginTransaction()
         }
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.commit()
         }
     }

--- a/Tests/GRDBTests/DatabaseSavepointTests.swift
+++ b/Tests/GRDBTests/DatabaseSavepointTests.swift
@@ -59,7 +59,7 @@ class DatabaseSavepointTests: GRDBTestCase {
     
     func testIsInsideTransaction() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             XCTAssertFalse(db.isInsideTransaction)
             try db.inTransaction {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -91,7 +91,7 @@ class DatabaseSavepointTests: GRDBTestCase {
 
     func testIsInsideTransactionWithImplicitRollback() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.create(table: "test") { t in
                 t.column("value", .integer).unique()
             }
@@ -112,7 +112,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -143,7 +143,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -173,7 +173,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -210,7 +210,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         observer.reset()
         
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -247,7 +247,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         observer.reset()
         
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -285,7 +285,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         observer.reset()
         
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -329,7 +329,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -359,7 +359,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -389,7 +389,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -426,7 +426,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         observer.reset()
         
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -463,7 +463,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         observer.reset()
         
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)
@@ -501,7 +501,7 @@ class DatabaseSavepointTests: GRDBTestCase {
         observer.reset()
         
         sqlQueries.removeAll()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try insertItem(db, name: "item1")
             try db.inSavepoint {
                 XCTAssertTrue(db.isInsideTransaction)

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -25,7 +25,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
     
     func testSnapshotSeesLatestTransaction() throws {
         let dbPool = try makeDatabasePool()
-        try dbPool.write { db in
+        try dbPool.writeWithoutTransaction { db in
             try db.create(table: "t") { $0.column("id", .integer).primaryKey() }
             try db.execute("INSERT INTO t DEFAULT VALUES")
             let snapshot = try dbPool.makeSnapshot()

--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -302,7 +302,7 @@ class DatabaseTests : GRDBTestCase {
     func testExplicitTransactionManagement() throws {
         let dbQueue = try makeDatabaseQueue()
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.beginTransaction()
             XCTAssertEqual(lastSQLQuery, "BEGIN DEFERRED TRANSACTION")
             try db.rollback()

--- a/Tests/GRDBTests/FTS4TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS4TableBuilderTests.swift
@@ -177,7 +177,7 @@ class FTS4TableBuilderTests: GRDBTestCase {
 
     func testFTS4Options() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.create(virtualTable: "documents", using: FTS4()) { t in
                 t.content = ""
                 t.compress = "zip"

--- a/Tests/GRDBTests/FetchedRecordsControllerTests.swift
+++ b/Tests/GRDBTests/FetchedRecordsControllerTests.swift
@@ -897,7 +897,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         })
         try specificController.performFetch()
 
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("INSERT INTO persons (id, name) VALUES (?, ?)", arguments: [1, "Arthur"])
             try db.execute("INSERT INTO persons (id, name) VALUES (?, ?)", arguments: [2, "Barbara"])
             try db.execute("UPDATE persons SET name = ? WHERE id = ?", arguments: ["Craig", 1])

--- a/Tests/GRDBTests/MutablePersistableRecordPersistenceConflictPolicyTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordPersistenceConflictPolicyTests.swift
@@ -189,7 +189,7 @@ class MutablePersistableRecordPersistenceConflictPolicyTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.create(table: "records") { t in
                 t.column("id", .integer).primaryKey()
                 t.column("email", .text).unique()

--- a/Tests/GRDBTests/SelectStatementTests.swift
+++ b/Tests/GRDBTests/SelectStatementTests.swift
@@ -130,7 +130,7 @@ class SelectStatementTests : GRDBTestCase {
     
     func testRegion() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             class Observer: TransactionObserver {
                 private var didChange = false
                 var triggered = false

--- a/Tests/GRDBTests/TransactionObserverSavepointsTests.swift
+++ b/Tests/GRDBTests/TransactionObserverSavepointsTests.swift
@@ -80,7 +80,7 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE items1 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items2 (id INTEGER PRIMARY KEY)")
             try db.execute("SAVEPOINT sp1")
@@ -112,7 +112,7 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE items1 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items2 (id INTEGER PRIMARY KEY)")
             try db.execute("BEGIN TRANSACTION")
@@ -143,7 +143,7 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE items1 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items2 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items3 (id INTEGER PRIMARY KEY)")
@@ -191,7 +191,7 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE items1 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items2 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items3 (id INTEGER PRIMARY KEY)")
@@ -234,7 +234,7 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE items1 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items2 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items3 (id INTEGER PRIMARY KEY)")
@@ -278,7 +278,7 @@ class TransactionObserverSavepointsTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE items1 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items2 (id INTEGER PRIMARY KEY)")
             try db.execute("CREATE TABLE items3 (id INTEGER PRIMARY KEY)")

--- a/Tests/GRDBTests/TransactionObserverTests.swift
+++ b/Tests/GRDBTests/TransactionObserverTests.swift
@@ -224,7 +224,7 @@ class TransactionObserverTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             let observer = Observer()
             dbQueue.add(transactionObserver: observer, extent: extent)
-            try dbQueue.inDatabase {  db in
+            try dbQueue.writeWithoutTransaction {  db in
                 try db.execute(startSQL)
                 try db.execute(endSQL)
             }
@@ -246,7 +246,7 @@ class TransactionObserverTests: GRDBTestCase {
         for extent in extents {
             let dbQueue = try makeDatabaseQueue()
             let observer = Observer()
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 try db.execute(startSQL)
                 db.add(transactionObserver: observer, extent: extent)
                 try db.execute(endSQL)
@@ -271,7 +271,7 @@ class TransactionObserverTests: GRDBTestCase {
             let observer = Observer()
             weakObserver = observer
             dbQueue.add(transactionObserver: observer)
-            try dbQueue.inDatabase {  db in
+            try dbQueue.writeWithoutTransaction {  db in
                 try db.execute(startSQL)
                 try db.execute(endSQL)
             }
@@ -310,7 +310,7 @@ class TransactionObserverTests: GRDBTestCase {
             let observer = Observer()
             weakObserver = observer
             dbQueue.add(transactionObserver: observer, extent: .observerLifetime)
-            try dbQueue.inDatabase {  db in
+            try dbQueue.writeWithoutTransaction {  db in
                 try db.execute(startSQL)
                 try db.execute(endSQL)
             }
@@ -351,7 +351,7 @@ class TransactionObserverTests: GRDBTestCase {
             dbQueue.add(transactionObserver: observer, extent: .nextTransaction)
         }
         if let observer = weakObserver {
-            try dbQueue.inDatabase {  db in
+            try dbQueue.writeWithoutTransaction {  db in
                 try db.execute(startSQL)
                 try db.execute(endSQL)
             }
@@ -376,7 +376,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer, extent: .nextTransaction)
         
-        try dbQueue.inDatabase {  db in
+        try dbQueue.writeWithoutTransaction {  db in
             try db.execute(startSQL)
             try db.execute(endSQL)
         }
@@ -418,7 +418,7 @@ class TransactionObserverTests: GRDBTestCase {
         dbQueue.add(transactionObserver: witness)
         dbQueue.add(transactionObserver: observer, extent: .nextTransaction)
         
-        try dbQueue.inDatabase {  db in
+        try dbQueue.writeWithoutTransaction {  db in
             try db.execute(startSQL)
             try db.execute(endSQL)
         }
@@ -484,7 +484,7 @@ class TransactionObserverTests: GRDBTestCase {
             }
             
             if let observer = weakObserver {
-                try dbQueue.inDatabase {  db in
+                try dbQueue.writeWithoutTransaction {  db in
                     try db.execute(startSQL)
                     try db.execute(endSQL)
                 }
@@ -546,7 +546,7 @@ class TransactionObserverTests: GRDBTestCase {
             dbQueue.add(transactionObserver: observer3, extent: extent)
             
             do {
-                try dbQueue.inDatabase {  db in
+                try dbQueue.writeWithoutTransaction {  db in
                     try db.execute(startSQL)
                     try db.execute(endSQL)
                 }
@@ -595,7 +595,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             let artist = Artist(id: nil, name: "Gerhard Richter")
             
             //
@@ -626,7 +626,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             let artist = Artist(id: nil, name: "Gerhard Richter")
             try artist.save(db)
             artist.name = "Vincent Fournier"
@@ -662,7 +662,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             let artist = Artist(id: nil, name: "Gerhard Richter")
             try artist.save(db)
             
@@ -694,7 +694,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             let artist = Artist(id: nil, name: "Gerhard Richter")
             try artist.save(db)
             let artwork1 = Artwork(id: nil, artistId: artist.id, title: "Cloud")
@@ -761,7 +761,7 @@ class TransactionObserverTests: GRDBTestCase {
         
         let artist = Artist(id: nil, name: "Gerhard Richter")
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             observer.resetCounts()
             try artist.save(db)
             #if SQLITE_ENABLE_PREUPDATE_HOOK
@@ -784,7 +784,7 @@ class TransactionObserverTests: GRDBTestCase {
         let artwork1 = Artwork(id: nil, artistId: nil, title: "Cloud")
         let artwork2 = Artwork(id: nil, artistId: nil, title: "Ema (Nude on a Staircase)")
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try artist.save(db)
             artwork1.artistId = artist.id
             artwork2.artistId = artist.id
@@ -1116,7 +1116,7 @@ class TransactionObserverTests: GRDBTestCase {
         dbQueue.add(transactionObserver: observer)
         
         do {
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 do {
                     try Artwork(id: nil, artistId: nil, title: "meh").save(db)
                     XCTFail("Expected Error")
@@ -1190,7 +1190,7 @@ class TransactionObserverTests: GRDBTestCase {
         dbQueue.add(transactionObserver: observer)
         
         observer.commitError = NSError(domain: "foo", code: 0, userInfo: nil)
-        dbQueue.inDatabase { db in
+        dbQueue.writeWithoutTransaction { db in
             do {
                 try Artist(id: nil, name: "Gerhard Richter").save(db)
                 XCTFail("Expected Error")
@@ -1246,7 +1246,7 @@ class TransactionObserverTests: GRDBTestCase {
         dbQueue.add(transactionObserver: observer)
         
         do {
-            try dbQueue.inDatabase { db in
+            try dbQueue.writeWithoutTransaction { db in
                 do {
                     try Artwork(id: nil, artistId: nil, title: "meh").save(db)
                     XCTFail("Expected Error")
@@ -1329,7 +1329,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try MinimalRowID.setup(inDatabase: db)
             
             let record = MinimalRowID()
@@ -1357,7 +1357,7 @@ class TransactionObserverTests: GRDBTestCase {
         dbQueue.add(transactionObserver: observer1)
         dbQueue.add(transactionObserver: observer2)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             let artist = Artist(id: nil, name: "Gerhard Richter")
             
             //
@@ -1410,7 +1410,7 @@ class TransactionObserverTests: GRDBTestCase {
         let observer = Observer()
         dbQueue.add(transactionObserver: observer)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             let artist = Artist(id: nil, name: "Gerhard Richter")
             
             //
@@ -1690,7 +1690,7 @@ class TransactionObserverTests: GRDBTestCase {
             }
         }
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             // Don't ignore anything
             do {
                 observer.resetCounts()

--- a/Tests/GRDBTests/TruncateOptimizationTests.swift
+++ b/Tests/GRDBTests/TruncateOptimizationTests.swift
@@ -75,7 +75,7 @@ class TruncateOptimizationTests: GRDBTestCase {
         let observer = DeletionObserver { deletionEvents.append($0) }
         dbQueue.add(transactionObserver: observer, extent: .databaseLifetime)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -100,7 +100,7 @@ class TruncateOptimizationTests: GRDBTestCase {
         let observer = DeletionObserver { deletionEvents.append($0) }
         dbQueue.add(transactionObserver: observer, extent: .databaseLifetime)
         
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             let deleteStatement = try db.makeUpdateStatement("DELETE FROM t")
             
@@ -121,7 +121,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTable() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -133,7 +133,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTable() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -144,7 +144,7 @@ class TruncateOptimizationTests: GRDBTestCase {
 
     func testDropTableWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -157,7 +157,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTableWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -169,7 +169,7 @@ class TruncateOptimizationTests: GRDBTestCase {
 
     func testDropTemporaryTable() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -181,7 +181,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryTable() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -192,7 +192,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryTableWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -205,7 +205,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryTableWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -217,7 +217,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropVirtualTable() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE VIRTUAL TABLE t USING fts3(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -229,7 +229,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropVirtualTable() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE VIRTUAL TABLE t USING fts3(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -240,7 +240,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropVirtualTableWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE VIRTUAL TABLE t USING fts3(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -253,7 +253,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropVirtualTableWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE VIRTUAL TABLE t USING fts3(a)")
             try db.execute("INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
@@ -265,7 +265,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropView() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -278,7 +278,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropView() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -290,7 +290,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -304,7 +304,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -317,7 +317,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryView() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -330,7 +330,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryView() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -342,7 +342,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -356,7 +356,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY VIEW v AS SELECT * FROM t")
             try db.execute("INSERT INTO t VALUES (NULL)")
@@ -369,7 +369,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropIndex() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
@@ -381,7 +381,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropIndex() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
@@ -392,7 +392,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropIndexViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try db.execute("INSERT INTO t VALUES (1)")
@@ -406,7 +406,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropIndexViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try db.execute("INSERT INTO t VALUES (1)")
@@ -419,7 +419,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryIndex() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
@@ -431,7 +431,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryIndex() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
@@ -442,7 +442,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryIndexViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try db.execute("INSERT INTO t VALUES (1)")
@@ -456,7 +456,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryIndexViewWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TEMPORARY TABLE t(a)")
             try db.execute("CREATE INDEX i ON t(a)")
             try db.execute("INSERT INTO t VALUES (1)")
@@ -469,7 +469,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTrigger() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -481,7 +481,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTrigger() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -492,7 +492,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTriggerWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -505,7 +505,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTriggerWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -517,7 +517,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryTrigger() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -529,7 +529,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryTrigger() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -540,7 +540,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     
     func testDropTemporaryTriggerWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
@@ -553,7 +553,7 @@ class TruncateOptimizationTests: GRDBTestCase {
     func testObservedDropTemporaryTriggerWithPreparedStatement() throws {
         let dbQueue = try makeDatabaseQueue()
         dbQueue.add(transactionObserver: UniversalObserver(), extent: .databaseLifetime)
-        try dbQueue.inDatabase { db in
+        try dbQueue.writeWithoutTransaction { db in
             try db.execute("CREATE TABLE t(a)")
             try db.execute("CREATE TEMPORARY TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))


### PR DESCRIPTION
This PR fixes an ergonomic issue with [database pools](https://github.com/groue/GRDB.swift/blob/master/README.md#database-pools) and [queues](https://github.com/groue/GRDB.swift/blob/master/README.md#database-queues), and has them wrap database accesses in a transaction by default.

The problem is clear with database pools: unless writes are wrapped in a transaction, concurrent reads see partial changes. This is positively unsafe:

```swift
// Currently unsafe
try dbPool.write { db
    try Credit(destinationAccout, amount).insert(db)
    // <- Concurrent dbPool.read sees a partial db update here
    try Debit(sourceAccount, amount).insert(db)
}

// Current way to make it safe:
try dbPool.writeInTransaction { db
    try Credit(destinationAccout, amount).insert(db)
    try Debit(sourceAccount, amount).insert(db)
    return .commit
}
```

This subtlety in the concurrent behavior of database pools was abundantly documented. But personal experience with coworkers and frequent feedback from GRDB users have revealed that it was too high a burden to force users to remember to use transactions in nearly all their database pool writes.

The problem is less pressing with database queues, since serialization of database accesses prevent concurrent reads of inconsistent database values. Yet, personal experience again reveals that users perform a constant and conscious effort in order to choose whether to use a transaction or not, or wonder if a transaction-less access hides a potential bug or not.

On top of that, the GRDB 2.0 API makes it painful to both run a transaction and extract values, leading to more opportunities to hesitate between transactions and convenience:

```swift
// Typical GRDB 2.0 code: meh
var count: Int! = nil
dbQueue.inTransaction { db in
    try ...
    count = try Player.fetchCount(db)
    return .commit
}
print(count)
```

Since GRDB is supposed to take care of concurrency difficulties so that developers can profit from the safest behavior without much thinking about it, something has to be done.

---

After this PR is merged:

- `dbQueue.write` and `dbPool.write` run inside a transaction.
- `dbQueue.inTransaction` and `dbPool.writeInTransaction` are still here, in order to support the various SQLite transaction types, and explicit rollbacks.
- `dbQueue.inDatabase`, which does not open a transaction, is now documented as an advanced method.
- A new method `dbPool.writeWithoutTransaction` is introduced, for the advanced use cases that need fine-grained transactions.

```swift
// After this PR is merged:

// BEGIN TRANSACTION
// INSERT INTO credits ...
// INSERT INTO debits ...
// COMMIT
try dbPool.write { db in  // or dbQueue.write
    try Credit(destinationAccout, amount).insert(db)
    try Debit(sourceAccount, amount).insert(db)
}

// BEGIN IMMEDIATE TRANSACTION
// INSERT INTO credits ...
// INSERT INTO debits ...
// COMMIT
try dbPool.writeInTransaction(.immediate) { db in  // or dbQueue.inTransaction
    try Credit(destinationAccout, amount).insert(db)
    try Debit(sourceAccount, amount).insert(db)
    return .commit
}

// INSERT INTO credits ...
// INSERT INTO debits ...
try dbPool.writeWithoutTransaction { db in // or dbQueue.inDatabase
    try Credit(destinationAccout, amount).insert(db)
    // <- Concurrent dbPool.read sees a partial db update here
    try Debit(sourceAccount, amount).insert(db)
}
```
