### PR TITLE
Row scopes collection, breadth-first scope search

### DIFF
--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1096,6 +1096,32 @@ extension Row {
             }
             return Row(base: row, adapter: adapter)
         }
+        
+        /// Returns the row associated with the given scope, by performing a
+        /// breadth-first search in this row's scopes and the scopes of its
+        /// scoped rows, recursively.
+        public func lookup(_ name: String) -> Row? {
+            struct Node {
+                let row: Row
+                let name: String
+            }
+            
+            var fifo: [Node] = scopes.map { (name, adapter) in
+                Node(row: Row(base: row, adapter: adapter), name: name)
+            }
+            
+            while !fifo.isEmpty {
+                let node = fifo.removeFirst()
+                if node.name == name {
+                    return node.row
+                }
+                for (name, scopedRow) in node.row.scopes {
+                    fifo.append(Node(row: scopedRow, name: name))
+                }
+            }
+            
+            return nil
+        }
     }
 }
 

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -511,7 +511,7 @@ extension Row {
     // MARK: - Scopes
     
     /// Returns a view of the scopes defined by row adapters
-    var scopes: RowScopes {
+    public var scopes: RowScopes {
         return impl.scopes
     }
     
@@ -1007,7 +1007,7 @@ public struct RowScopes: Collection {
     private let row: Row
     private let scopes: [String: LayoutedRowAdapter]
     
-    var names: Dictionary<String, LayoutedRowAdapter>.Keys {
+    public var names: Dictionary<String, LayoutedRowAdapter>.Keys {
         return scopes.keys
     }
     

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -483,7 +483,7 @@ extension Row {
     /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
     /// for more information.
     public subscript<Record: FetchableRecord>(_ scope: String) -> Record {
-        guard let scopedRow = scopes[scope] else {
+        guard let scopedRow = scopesTree[scope] else {
             // Programmer error
             fatalError("no such scope: \(scope)")
         }
@@ -499,7 +499,7 @@ extension Row {
     /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
     /// for more information.
     public subscript<Record: FetchableRecord>(_ scope: String) -> Record? {
-        guard let scopedRow = scopes[scope], scopedRow.containsNonNullValue else {
+        guard let scopedRow = scopesTree[scope], scopedRow.containsNonNullValue else {
             return nil
         }
         return Record(row: scopedRow)

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -514,7 +514,7 @@ extension Row {
     ///
     /// For example:
     ///
-    ///     // Define a tree of scopes
+    ///     // Define a tree of nested scopes
     ///     let adapter = ScopeAdapter([
     ///         "foo": RangeRowAdapter(0..<1),
     ///         "bar": RangeRowAdapter(1..<2).addingScopes([
@@ -524,12 +524,12 @@ extension Row {
     ///     let sql = "SELECT 1 AS foo, 2 AS bar, 3 AS baz"
     ///     let row = try Row.fetchOne(db, sql, adapter: adapter)!
     ///
-    ///     row.scopes.count // 2
-    ///     row.scopes.names // ["foo", "bar"]
+    ///     row.scopes.count  // 2
+    ///     row.scopes.names  // ["foo", "bar"]
     ///
-    ///     row.scopesTree["foo"] // [foo:1]
-    ///     row.scopesTree["bar"] // [bar:2]
-    ///     row.scopesTree["baz"] // nil
+    ///     row.scopes["foo"] // [foo:1]
+    ///     row.scopes["bar"] // [bar:2]
+    ///     row.scopes["baz"] // nil
     public var scopes: ScopesView {
         return impl.scopes
     }
@@ -538,7 +538,7 @@ extension Row {
     ///
     /// For example:
     ///
-    ///     // Define a tree of scopes
+    ///     // Define a tree of nested scopes
     ///     let adapter = ScopeAdapter([
     ///         "foo": RangeRowAdapter(0..<1),
     ///         "bar": RangeRowAdapter(1..<2).addingScopes([
@@ -1051,7 +1051,7 @@ extension Row {
     ///
     /// For example:
     ///
-    ///     // Define a tree of scopes
+    ///     // Define a tree of nested scopes
     ///     let adapter = ScopeAdapter([
     ///         "foo": RangeRowAdapter(0..<1),
     ///         "bar": RangeRowAdapter(1..<2).addingScopes([
@@ -1061,12 +1061,12 @@ extension Row {
     ///     let sql = "SELECT 1 AS foo, 2 AS bar, 3 AS baz"
     ///     let row = try Row.fetchOne(db, sql, adapter: adapter)!
     ///
-    ///     row.scopes.count // 2
-    ///     row.scopes.names // ["foo", "bar"]
+    ///     row.scopes.count  // 2
+    ///     row.scopes.names  // ["foo", "bar"]
     ///
-    ///     row.scopesTree["foo"] // [foo:1]
-    ///     row.scopesTree["bar"] // [bar:2]
-    ///     row.scopesTree["baz"] // nil
+    ///     row.scopes["foo"] // [foo:1]
+    ///     row.scopes["bar"] // [bar:2]
+    ///     row.scopes["baz"] // nil
     public struct ScopesView: Collection {
         public typealias Index = Dictionary<String, LayoutedRowAdapter>.Index
         private let row: Row
@@ -1126,7 +1126,7 @@ extension Row {
     ///
     /// For example:
     ///
-    ///     // Define a tree of scopes
+    ///     // Define a tree of nested scopes
     ///     let adapter = ScopeAdapter([
     ///         "foo": RangeRowAdapter(0..<1),
     ///         "bar": RangeRowAdapter(1..<2).addingScopes([
@@ -1158,11 +1158,6 @@ extension Row {
         /// breadth-first search in this row's scopes and the scopes of its
         /// scoped rows, recursively.
         public subscript(_ name: String) -> Row? {
-            struct Node {
-                let name: String
-                let row: Row
-            }
-            
             var fifo = Array(scopes)
             while !fifo.isEmpty {
                 let node = fifo.removeFirst()
@@ -1171,7 +1166,6 @@ extension Row {
                 }
                 fifo.append(contentsOf: node.row.scopes)
             }
-            
             return nil
         }
     }

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1160,11 +1160,11 @@ extension Row {
         public subscript(_ name: String) -> Row? {
             var fifo = Array(scopes)
             while !fifo.isEmpty {
-                let node = fifo.removeFirst()
-                if node.name == name {
-                    return node.row
+                let scope = fifo.removeFirst()
+                if scope.name == name {
+                    return scope.row
                 }
-                fifo.append(contentsOf: node.row.scopes)
+                fifo.append(contentsOf: scope.row.scopes)
             }
             return nil
         }

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -475,10 +475,6 @@ struct AdaptedRowImpl : RowImpl {
         self.mapping = adapter.mapping
     }
     
-    var unadaptedRow: Row {
-        return base.unadapted
-    }
-    
     var count: Int {
         return mapping.layoutColumns.count
     }
@@ -487,8 +483,8 @@ struct AdaptedRowImpl : RowImpl {
         return base.isFetched
     }
     
-    var scopes: RowScopes {
-        return RowScopes(row: base, scopes: adapter.scopes)
+    var scopes: Row.Scopes {
+        return Row.Scopes(row: base, scopes: adapter.scopes)
     }
     
     func hasNull(atUncheckedIndex index: Int) -> Bool {
@@ -524,7 +520,16 @@ struct AdaptedRowImpl : RowImpl {
         return mapping.layoutIndex(ofColumn: name)
     }
     
-    func copy(_ row: Row) -> Row {
+    func copiedRow(_ row: Row) -> Row {
         return Row(base: base.copy(), adapter: adapter)
+    }
+
+    func unscopedRow(_ row: Row) -> Row {
+        assert(adapter.mapping.scopes.isEmpty)
+        return Row(base: base, adapter: adapter.mapping)
+    }
+    
+    func unadaptedRow(_ row: Row) -> Row {
+        return base.unadapted
     }
 }

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -487,6 +487,10 @@ struct AdaptedRowImpl : RowImpl {
         return base.isFetched
     }
     
+    var scopes: RowScopes {
+        return RowScopes(row: base, scopes: adapter.scopes)
+    }
+    
     func hasNull(atUncheckedIndex index: Int) -> Bool {
         let mappedIndex = mapping.baseColumnIndex(atMappingIndex: index)
         return base.impl.hasNull(atUncheckedIndex: mappedIndex)
@@ -518,17 +522,6 @@ struct AdaptedRowImpl : RowImpl {
     
     func index(ofColumn name: String) -> Int? {
         return mapping.layoutIndex(ofColumn: name)
-    }
-    
-    func scoped(on name: String) -> Row? {
-        guard let adapter = adapter.scopes[name] else {
-            return nil
-        }
-        return Row(base: base, adapter: adapter)
-    }
-    
-    var scopeNames: Set<String> {
-        return Set(adapter.scopes.keys)
     }
     
     func copy(_ row: Row) -> Row {

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -14,10 +14,10 @@ import Foundation
 ///         "c": adapters[2],
 ///         "d": adapters[3]])
 ///     let row = try Row.fetchOne(db, sql, adapter: adapter)
-///     row.scoped(on: "a") // [1]
-///     row.scoped(on: "b") // [2, 3, 4]
-///     row.scoped(on: "c") // [5, 6]
-///     row.scoped(on: "d") // [7, 8]
+///     row.scopes["a"] // [1]
+///     row.scopes["b"] // [2, 3, 4]
+///     row.scopes["c"] // [5, 6]
+///     row.scopes["d"] // [7, 8]
 public func splittingRowAdapters(columnCounts: [Int]) -> [RowAdapter] {
     guard !columnCounts.isEmpty else {
         // Identity adapter
@@ -366,10 +366,10 @@ public struct RangeRowAdapter : RowAdapter {
 ///     let row = try Row.fetchOne(db, sql, adapter: adapter)!
 ///
 ///     // Scoped rows:
-///     if let fooRow = row.scoped(on: "foo") {
+///     if let fooRow = row.scopes["foo"] {
 ///         fooRow["value"]    // "foo"
 ///     }
-///     if let barRow = row.scopeed(on: "bar") {
+///     if let barRow = row.scopes["bar"] {
 ///         barRow["value"]    // "bar"
 ///     }
 public struct ScopeAdapter : RowAdapter {
@@ -386,8 +386,8 @@ public struct ScopeAdapter : RowAdapter {
     ///
     ///     let adapter = ScopeAdapter(["suffix": SuffixRowAdapter(fromIndex: 1)])
     ///     let row = try Row.fetchOne(db, "SELECT 1, 2, 3", adapter: adapter)!
-    ///     row                      // [1, 2, 3]
-    ///     row.scoped(on: "suffix") // [2, 3]
+    ///     row                  // [1, 2, 3]
+    ///     row.scopes["suffix"] // [2, 3]
     ///
     /// - parameter scopes: A dictionary that maps scope names to
     ///   row adapters.
@@ -403,8 +403,8 @@ public struct ScopeAdapter : RowAdapter {
     ///     let baseAdapter = RangeRowAdapter(0..<1)
     ///     let adapter = ScopeAdapter(base: baseAdapter, scopes: ["suffix": SuffixRowAdapter(fromIndex: 1)])
     ///     let row = try Row.fetchOne(db, "SELECT 1, 2, 3", adapter: adapter)!
-    ///     row                       // [1]
-    ///     row.scoped(on: "initial") // [2, 3]
+    ///     row                   // [1]
+    ///     row.scopes["initial"] // [2, 3]
     ///
     /// If the base adapter already defines scopes, the given scopes replace
     /// eventual existing scopes with the same name.

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -483,8 +483,8 @@ struct AdaptedRowImpl : RowImpl {
         return base.isFetched
     }
     
-    var scopes: Row.Scopes {
-        return Row.Scopes(row: base, scopes: adapter.scopes)
+    var scopes: Row.ScopesView {
+        return Row.ScopesView(row: base, scopes: adapter.scopes)
     }
     
     func hasNull(atUncheckedIndex index: Int) -> Bool {

--- a/GRDB/Legacy/Fixits-3.0.swift
+++ b/GRDB/Legacy/Fixits-3.0.swift
@@ -58,3 +58,13 @@ extension MutablePersistableRecord {
     @available(*, unavailable, renamed: "databaseEquals")
     public func databaseEqual(_ record: Self) -> Bool { preconditionFailure() }
 }
+
+extension Row {
+    /// :nodoc:
+    @available(*, unavailable, message: "Use row.scopes.names instead")
+    var scopeNames: Set<String> { preconditionFailure() }
+
+    /// :nodoc:
+    @available(*, unavailable, message: "Use row.scopes[name] instead")
+    public func scoped(on name: String) -> Row? { preconditionFailure() }
+}

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -13,7 +13,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
     var allKeys: [Key] {
         let row = decoder.row
         let columnNames = Set(row.columnNames)
-        let scopeNames = Set(row.scopes.names)
+        let scopeNames = Set(row.scopesTree.names)
         return columnNames.union(scopeNames).compactMap { Key(stringValue: $0) }
     }
     
@@ -25,7 +25,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
     /// - returns: Whether the `Decoder` has an entry for the given key.
     func contains(_ key: Key) -> Bool {
         let row = decoder.row
-        return row.hasColumn(key.stringValue) || (row.scopes[key.stringValue] != nil)
+        return row.hasColumn(key.stringValue) || (row.scopesTree[key.stringValue] != nil)
     }
     
     /// Decodes a null value for the given key.
@@ -35,7 +35,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
     /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
     func decodeNil(forKey key: Key) throws -> Bool {
         let row = decoder.row
-        return row[key.stringValue] == nil && (row.scopes[key.stringValue] == nil)
+        return row[key.stringValue] == nil && (row.scopesTree[key.stringValue] == nil)
     }
     
     /// Decodes a value of the given type for the given key.
@@ -69,7 +69,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
     func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
         let row = decoder.row
         
-        // Try column
+        // Column?
         if row.hasColumn(key.stringValue) {
             let dbValue: DatabaseValue = row[key.stringValue]
             if let type = T.self as? DatabaseValueConvertible.Type {
@@ -83,9 +83,15 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
             }
         }
         
-        // Fallback on scope
-        if let scopedRow = row.scopes[key.stringValue], scopedRow.containsNonNullValue {
-            return try T(from: RowDecoder(row: scopedRow, codingPath: codingPath + [key]))
+        // Scope?
+        if let scopedRow = row.scopesTree[key.stringValue], scopedRow.containsNonNullValue {
+            if let type = T.self as? FetchableRecord.Type {
+                // Prefer FetchableRecord decoding over Decodable.
+                // This allows custom row decoding
+                return (type.init(row: scopedRow) as! T)
+            } else {
+                return try T(from: RowDecoder(row: scopedRow, codingPath: codingPath + [key]))
+            }
         }
         
         return nil
@@ -102,7 +108,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
         let row = decoder.row
         
-        // Try column
+        // Column?
         if row.hasColumn(key.stringValue) {
             let dbValue: DatabaseValue = row[key.stringValue]
             if let type = T.self as? DatabaseValueConvertible.Type {
@@ -114,13 +120,25 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
             }
         }
         
-        // Fallback on scope
-        if let scopedRow = row.scopes[key.stringValue] {
-            return try T(from: RowDecoder(row: scopedRow, codingPath: codingPath + [key]))
+        // Scope?
+        if let scopedRow = row.scopesTree[key.stringValue] {
+            if let type = T.self as? FetchableRecord.Type {
+                // Prefer FetchableRecord decoding over Decodable.
+                // This allows custom row decoding
+                return type.init(row: scopedRow) as! T
+            } else {
+                return try T(from: RowDecoder(row: scopedRow, codingPath: codingPath + [key]))
+            }
         }
         
-        let path = (codingPath.map { $0.stringValue } + [key.stringValue]).joined(separator: ".")
-        fatalError("No such column or scope: \(path)")
+        // Base row
+        if let type = T.self as? FetchableRecord.Type {
+            // Prefer FetchableRecord decoding over Decodable.
+            // This allows custom row decoding
+            return type.init(row: row) as! T
+        } else {
+            return try T(from: RowDecoder(row: row, codingPath: codingPath + [key]))
+        }
     }
     
     /// Returns the data stored for the given key as represented in a container keyed by the given key type.
@@ -255,3 +273,4 @@ extension FetchableRecord where Self: Decodable {
         try! self.init(from: RowDecoder(row: row, codingPath: []))
     }
 }
+

--- a/README.md
+++ b/README.md
@@ -1813,13 +1813,13 @@ let adapter = ScopeAdapter([
 let row = try Row.fetchOne(db, "SELECT 0 AS a, 1 AS b, 2 AS c, 3 AS d", adapter: adapter)!
 ```
 
-ScopeAdapter does not change the columns and values of the fetched row. Instead, it defines *scopes*, which you access with the `Row.scoped(on:)` method. This method returns an optional Row, which is nil if the scope is missing.
+ScopeAdapter does not change the columns and values of the fetched row. Instead, it defines *scopes*, which you access with `Row.scopes[]`. This subscript returns an optional Row, which is nil if the scope is missing.
 
 ```swift
-row                       // [a:0 b:1 c:2 d:3]
-row.scoped(on: "left")    // [a:0 b:1]
-row.scoped(on: "right")   // [c:2 d:3]
-row.scoped(on: "missing") // nil
+row                   // [a:0 b:1 c:2 d:3]
+row.scopes["left"]    // [a:0 b:1]
+row.scopes["right"]   // [c:2 d:3]
+row.scopes["missing"] // nil
 ```
 
 Scopes can be nested:
@@ -1835,13 +1835,13 @@ let adapter = ScopeAdapter([
     ])
 let row = try Row.fetchOne(db, "SELECT 0 AS a, 1 AS b, 2 AS c, 3 AS d", adapter: adapter)!
 
-let leftRow = row.scoped(on: "left")!
-leftRow.scoped(on: "left")  // [a:0]
-leftRow.scoped(on: "right") // [b:1]
+let leftRow = row.scopes["left"]!
+leftRow.scopes["left"]  // [a:0]
+leftRow.scopes["right"] // [b:1]
 
-let rightRow = row.scoped(on: "right")!
-rightRow.scoped(on: "left")  // [c:2]
-rightRow.scoped(on: "right") // [d:3]
+let rightRow = row.scopes["right"]!
+rightRow.scopes["left"]  // [c:2]
+rightRow.scopes["right"] // [d:3]
 ```
 
 Any adapter can be extended with scopes:
@@ -1853,7 +1853,7 @@ let adapter = ScopeAdapter(base: baseAdapter, scopes: [
 let row = try Row.fetchOne(db, "SELECT 0 AS a, 1 AS b, 2 AS c, 3 AS d", adapter: adapter)!
 
 row // [a:0 b:1]
-row.scoped(on: "remainder") // [c:2 d:3]
+row.scopes["remainder"] // [c:2 d:3]
 ```
 
 

--- a/Tests/GRDBTests/JoinSupportTests.swift
+++ b/Tests/GRDBTests/JoinSupportTests.swift
@@ -95,7 +95,7 @@ private struct FlatModel: FetchableRecord {
         self.t2Left = row[Scopes.t2Left]
         self.t2Right = row[Scopes.t2Right]
         self.t3 = row[Scopes.t3]
-        self.t5count = row.scoped(on: Scopes.suffix)!["t5count"]
+        self.t5count = row.scopes[Scopes.suffix]!["t5count"]
     }
     
     static func all() -> AdaptedFetchRequest<SQLRequest<FlatModel>> {
@@ -299,11 +299,11 @@ class JoinSupportTests: GRDBTestCase {
                 "t1id": 1, "name": "A3",
                 // t5count
                 "t5count": 5])
-            XCTAssertEqual(rows[0].scoped(on: "t1")!, ["id": 1, "name": "A1"])
-            XCTAssertEqual(rows[0].scoped(on: "t2Left")!, ["id": 1, "t1id": 1, "name": "left"])
-            XCTAssertEqual(rows[0].scoped(on: "t2Right")!, ["id": 2, "t1id": 1, "name": "right"])
-            XCTAssertEqual(rows[0].scoped(on: "t3")!, ["t1id": 1, "name": "A3"])
-            XCTAssertEqual(rows[0].scoped(on: "suffix")!, ["t5count": 5])
+            XCTAssertEqual(rows[0].scopes["t1"]!, ["id": 1, "name": "A1"])
+            XCTAssertEqual(rows[0].scopes["t2Left"]!, ["id": 1, "t1id": 1, "name": "left"])
+            XCTAssertEqual(rows[0].scopes["t2Right"]!, ["id": 2, "t1id": 1, "name": "right"])
+            XCTAssertEqual(rows[0].scopes["t3"]!, ["t1id": 1, "name": "A3"])
+            XCTAssertEqual(rows[0].scopes["suffix"]!, ["t5count": 5])
             
             XCTAssertEqual(rows[1].unscoped, [
                 // t1.*
@@ -316,11 +316,11 @@ class JoinSupportTests: GRDBTestCase {
                 "t1id": nil, "name": nil,
                 // t5count
                 "t5count": 2])
-            XCTAssertEqual(rows[1].scoped(on: "t1")!, ["id": 2, "name": "A2"])
-            XCTAssertEqual(rows[1].scoped(on: "t2Left")!, ["id": 3, "t1id": 2, "name": "left"])
-            XCTAssertEqual(rows[1].scoped(on: "t2Right")!, ["id": nil, "t1id": nil, "name": nil])
-            XCTAssertEqual(rows[1].scoped(on: "t3")!, ["t1id": nil, "name": nil])
-            XCTAssertEqual(rows[1].scoped(on: "suffix")!, ["t5count": 2])
+            XCTAssertEqual(rows[1].scopes["t1"]!, ["id": 2, "name": "A2"])
+            XCTAssertEqual(rows[1].scopes["t2Left"]!, ["id": 3, "t1id": 2, "name": "left"])
+            XCTAssertEqual(rows[1].scopes["t2Right"]!, ["id": nil, "t1id": nil, "name": nil])
+            XCTAssertEqual(rows[1].scopes["t3"]!, ["t1id": nil, "name": nil])
+            XCTAssertEqual(rows[1].scopes["suffix"]!, ["t5count": 2])
             
             XCTAssertEqual(rows[2].unscoped, [
                 // t1.*
@@ -333,11 +333,11 @@ class JoinSupportTests: GRDBTestCase {
                 "t1id": nil, "name": nil,
                 // t5count
                 "t5count": 0])
-            XCTAssertEqual(rows[2].scoped(on: "t1")!, ["id": 3, "name": "A3"])
-            XCTAssertEqual(rows[2].scoped(on: "t2Left")!, ["id": nil, "t1id": nil, "name": nil])
-            XCTAssertEqual(rows[2].scoped(on: "t2Right")!, ["id": nil, "t1id": nil, "name": nil])
-            XCTAssertEqual(rows[2].scoped(on: "t3")!, ["t1id": nil, "name": nil])
-            XCTAssertEqual(rows[2].scoped(on: "suffix")!, ["t5count": 0])
+            XCTAssertEqual(rows[2].scopes["t1"]!, ["id": 3, "name": "A3"])
+            XCTAssertEqual(rows[2].scopes["t2Left"]!, ["id": nil, "t1id": nil, "name": nil])
+            XCTAssertEqual(rows[2].scopes["t2Right"]!, ["id": nil, "t1id": nil, "name": nil])
+            XCTAssertEqual(rows[2].scopes["t3"]!, ["t1id": nil, "name": nil])
+            XCTAssertEqual(rows[2].scopes["suffix"]!, ["t5count": 0])
         }
     }
     

--- a/Tests/GRDBTests/JoinSupportTests.swift
+++ b/Tests/GRDBTests/JoinSupportTests.swift
@@ -110,7 +110,24 @@ private struct FlatModel: FetchableRecord {
                 Scopes.t2Left: adapters[1],
                 Scopes.t2Right: adapters[2],
                 Scopes.t3: adapters[3],
-                Scopes.suffix: adapters[4]]) // The only test for adapters[4]
+                Scopes.suffix: adapters[4]])
+        }
+    }
+    
+    static func hierarchicalAll() -> AdaptedFetchRequest<SQLRequest<CodableFlatModel>> {
+        return SQLRequest<CodableFlatModel>(testedSQL).adapted { db in
+            let adapters = try splittingRowAdapters(columnCounts: [
+                T1.numberOfSelectedColumns(db),
+                T2.numberOfSelectedColumns(db),
+                T2.numberOfSelectedColumns(db),
+                T3.numberOfSelectedColumns(db)])
+            return ScopeAdapter([
+                Scopes.t1: adapters[0],
+                "t2": ScopeAdapter(base: EmptyRowAdapter(), scopes: [
+                    Scopes.t2Left: adapters[1],
+                    Scopes.t2Right: adapters[2]]),
+                Scopes.t3: adapters[3],
+                Scopes.suffix: adapters[4]])
         }
     }
 }
@@ -133,6 +150,22 @@ private struct CodableFlatModel: FetchableRecord, Codable {
                 CodingKeys.t1.stringValue: adapters[0],
                 CodingKeys.t2Left.stringValue: adapters[1],
                 CodingKeys.t2Right.stringValue: adapters[2],
+                CodingKeys.t3.stringValue: adapters[3]])
+        }
+    }
+    
+    static func hierarchicalAll() -> AdaptedFetchRequest<SQLRequest<CodableFlatModel>> {
+        return SQLRequest<CodableFlatModel>(testedSQL).adapted { db in
+            let adapters = try splittingRowAdapters(columnCounts: [
+                T1.numberOfSelectedColumns(db),
+                T2.numberOfSelectedColumns(db),
+                T2.numberOfSelectedColumns(db),
+                T3.numberOfSelectedColumns(db)])
+            return ScopeAdapter([
+                CodingKeys.t1.stringValue: adapters[0],
+                "t2": ScopeAdapter(base: EmptyRowAdapter(), scopes: [
+                    CodingKeys.t2Left.stringValue: adapters[1],
+                    CodingKeys.t2Right.stringValue: adapters[2]]),
                 CodingKeys.t3.stringValue: adapters[3]])
         }
     }
@@ -377,10 +410,82 @@ class JoinSupportTests: GRDBTestCase {
         }
     }
     
+    func testFlatModelFromHierarchicalRequest() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let models = try FlatModel.hierarchicalAll().fetchAll(db)
+            XCTAssertEqual(models.count, 3)
+            
+            XCTAssertEqual(models[0].t1.id, 1)
+            XCTAssertEqual(models[0].t1.name, "A1")
+            XCTAssertEqual(models[0].t2Left!.id, 1)
+            XCTAssertEqual(models[0].t2Left!.t1id, 1)
+            XCTAssertEqual(models[0].t2Left!.name, "left")
+            XCTAssertEqual(models[0].t2Right!.id, 2)
+            XCTAssertEqual(models[0].t2Right!.t1id, 1)
+            XCTAssertEqual(models[0].t2Right!.name, "right")
+            XCTAssertEqual(models[0].t3!.t1id, 1)
+            XCTAssertEqual(models[0].t3!.name, "A3")
+            XCTAssertEqual(models[0].t5count, 5)
+            
+            XCTAssertEqual(models[1].t1.id, 2)
+            XCTAssertEqual(models[1].t1.name, "A2")
+            XCTAssertEqual(models[1].t2Left!.id, 3)
+            XCTAssertEqual(models[1].t2Left!.t1id, 2)
+            XCTAssertEqual(models[1].t2Left!.name, "left")
+            XCTAssertNil(models[1].t2Right)
+            XCTAssertNil(models[1].t3)
+            XCTAssertEqual(models[1].t5count, 2)
+            
+            XCTAssertEqual(models[2].t1.id, 3)
+            XCTAssertEqual(models[2].t1.name, "A3")
+            XCTAssertNil(models[2].t2Left)
+            XCTAssertNil(models[2].t2Right)
+            XCTAssertNil(models[2].t3)
+            XCTAssertEqual(models[2].t5count, 0)
+        }
+    }
+    
     func testCodableFlatModel() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let models = try CodableFlatModel.all().fetchAll(db)
+            XCTAssertEqual(models.count, 3)
+            
+            XCTAssertEqual(models[0].t1.id, 1)
+            XCTAssertEqual(models[0].t1.name, "A1")
+            XCTAssertEqual(models[0].t2Left!.id, 1)
+            XCTAssertEqual(models[0].t2Left!.t1id, 1)
+            XCTAssertEqual(models[0].t2Left!.name, "left")
+            XCTAssertEqual(models[0].t2Right!.id, 2)
+            XCTAssertEqual(models[0].t2Right!.t1id, 1)
+            XCTAssertEqual(models[0].t2Right!.name, "right")
+            XCTAssertEqual(models[0].t3!.t1id, 1)
+            XCTAssertEqual(models[0].t3!.name, "A3")
+            XCTAssertEqual(models[0].t5count, 5)
+            
+            XCTAssertEqual(models[1].t1.id, 2)
+            XCTAssertEqual(models[1].t1.name, "A2")
+            XCTAssertEqual(models[1].t2Left!.id, 3)
+            XCTAssertEqual(models[1].t2Left!.t1id, 2)
+            XCTAssertEqual(models[1].t2Left!.name, "left")
+            XCTAssertNil(models[1].t2Right)
+            XCTAssertNil(models[1].t3)
+            XCTAssertEqual(models[1].t5count, 2)
+            
+            XCTAssertEqual(models[2].t1.id, 3)
+            XCTAssertEqual(models[2].t1.name, "A3")
+            XCTAssertNil(models[2].t2Left)
+            XCTAssertNil(models[2].t2Right)
+            XCTAssertNil(models[2].t3)
+            XCTAssertEqual(models[2].t5count, 0)
+        }
+    }
+    
+    func testCodableFlatModelFromHierarchicalRequest() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let models = try CodableFlatModel.hierarchicalAll().fetchAll(db)
             XCTAssertEqual(models.count, 3)
             
             XCTAssertEqual(models[0].t1.id, 1)

--- a/Tests/GRDBTests/RowAdapterTests.swift
+++ b/Tests/GRDBTests/RowAdapterTests.swift
@@ -287,20 +287,19 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
-            if let scopedRow = row.scopes["sub1"] {
-                XCTAssertEqual(scopedRow, ["id": 1, "val": "foo1"])
-            } else {
-                XCTFail()
-            }
+            XCTAssertEqual(row.scopes["sub1"]!, ["id": 1, "val": "foo1"])
+            XCTAssertTrue(row.scopes["sub1"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
             
-            if let scopedRow = row.scopes["sub2"] {
-                XCTAssertEqual(scopedRow, ["id": 2, "val": "foo2"])
-            } else {
-                XCTFail()
-            }
+            XCTAssertEqual(row.scopes["sub2"]!, ["id": 2, "val": "foo2"])
+            XCTAssertTrue(row.scopes["sub2"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub2"])
+
+            XCTAssertTrue(row.scopes["SUB1"] == nil)
+            XCTAssertTrue(row.scopes.lookup("SUB1") == nil)
             
-            XCTAssertTrue(row.scopes["SUB1"] == nil)     // case-insensitivity is not really required here, and case-sensitivity helps the implementation because it allows the use of a dictionary. So let's enforce this with a public test.
             XCTAssertTrue(row.scopes["missing"] == nil)
+            XCTAssertTrue(row.scopes.lookup("missing") == nil)
         }
     }
 
@@ -329,20 +328,19 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
-            if let scopedRow = row.scopes["sub1"] {
-                XCTAssertEqual(scopedRow, ["id": 1, "val": "foo1"])
-            } else {
-                XCTFail()
-            }
+            XCTAssertEqual(row.scopes["sub1"]!, ["id": 1, "val": "foo1"])
+            XCTAssertTrue(row.scopes["sub1"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
             
-            if let scopedRow = row.scopes["sub2"] {
-                XCTAssertEqual(scopedRow, ["id": 2, "val": "foo2"])
-            } else {
-                XCTFail()
-            }
+            XCTAssertEqual(row.scopes["sub2"], ["id": 2, "val": "foo2"])
+            XCTAssertTrue(row.scopes["sub2"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub2"])
 
-            XCTAssertTrue(row.scopes["SUB1"] == nil)     // case-insensitivity is not really required here, and case-sensitivity helps the implementation because it allows the use of a dictionary. So let's enforce this with a public test.
+            XCTAssertTrue(row.scopes["SUB1"] == nil)
+            XCTAssertTrue(row.scopes.lookup("SUB1") == nil)
+            
             XCTAssertTrue(row.scopes["missing"] == nil)
+            XCTAssertTrue(row.scopes.lookup("missing") == nil)
         }
     }
 
@@ -375,23 +373,17 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
-            if let scopedRow = row.scopes["sub0"] {
-                XCTAssertEqual(scopedRow, ["id": 0, "val": "foo0"])
-            } else {
-                XCTFail()
-            }
+            XCTAssertEqual(row.scopes["sub0"], ["id": 0, "val": "foo0"])
+            XCTAssertTrue(row.scopes["sub0"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub0"), row.scopes["sub0"])
+
+            XCTAssertEqual(row.scopes["sub1"], ["id": 1, "val": "foo1"])
+            XCTAssertTrue(row.scopes["sub1"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
             
-            if let scopedRow = row.scopes["sub1"] {
-                XCTAssertEqual(scopedRow, ["id": 1, "val": "foo1"])
-            } else {
-                XCTFail()
-            }
-            
-            if let scopedRow = row.scopes["sub2"] {
-                XCTAssertEqual(scopedRow, ["id": 2, "val": "foo2"])
-            } else {
-                XCTFail()
-            }
+            XCTAssertEqual(row.scopes["sub2"], ["id": 2, "val": "foo2"])
+            XCTAssertTrue(row.scopes["sub2"]!.scopes.isEmpty)
+            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub2"])
         }
     }
 
@@ -419,30 +411,27 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
-            if let scopedRow = row.scopes["sub1"] {
-                XCTAssertEqual(scopedRow.unscoped, ["id": 1, "val": "foo1"])
-                
-                XCTAssertEqual(Set(scopedRow.scopes.names), ["sub2"])
-                XCTAssertEqual(scopedRow.scopes.count, 1)
-                for (name, subScopedRow) in scopedRow.scopes {
-                    if name == "sub2" {
-                        XCTAssertEqual(subScopedRow, ["id": 2, "val": "foo2"])
-                    } else {
-                        XCTFail()
-                    }
-                }
-                
-                if let subScopedRow = scopedRow.scopes["sub2"] {
+            let scopedRow = row.scopes["sub1"]!
+            XCTAssertEqual(scopedRow.unscoped, ["id": 1, "val": "foo1"])
+            
+            XCTAssertEqual(Set(scopedRow.scopes.names), ["sub2"])
+            XCTAssertEqual(scopedRow.scopes.count, 1)
+            for (name, subScopedRow) in scopedRow.scopes {
+                if name == "sub2" {
                     XCTAssertEqual(subScopedRow, ["id": 2, "val": "foo2"])
                 } else {
                     XCTFail()
                 }
-            } else {
-                XCTFail()
             }
+            
+            XCTAssertEqual(scopedRow.scopes["sub2"]!, ["id": 2, "val": "foo2"])
+            XCTAssertTrue(scopedRow.scopes["sub2"]!.scopes.isEmpty)
             
             // sub2 is only defined in sub1
             XCTAssertTrue(row.scopes["sub2"] == nil)
+            
+            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
+            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub1"]!.scopes["sub2"])
         }
     }
 
@@ -492,31 +481,28 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
-            if let scopedRow = row.scopes["sub1"] {
-                XCTAssertEqual(scopedRow.unscoped, ["a1": 1, "a2": 2, "a3": 3])
-
-                XCTAssertEqual(Set(scopedRow.scopes.names), ["sub2"])
-                XCTAssertEqual(scopedRow.scopes.count, 1)
-                for (name, subScopedRow) in scopedRow.scopes {
-                    if name == "sub2" {
-                        XCTAssertEqual(subScopedRow, ["a1": 1, "a2": 2, "a3": 3])
-                    } else {
-                        XCTFail()
-                    }
-                }
-                
-                if let subScopedRow = scopedRow.scopes["sub2"] {
+            let scopedRow = row.scopes["sub1"]!
+            XCTAssertEqual(scopedRow.unscoped, ["a1": 1, "a2": 2, "a3": 3])
+            
+            XCTAssertEqual(Set(scopedRow.scopes.names), ["sub2"])
+            XCTAssertEqual(scopedRow.scopes.count, 1)
+            for (name, subScopedRow) in scopedRow.scopes {
+                if name == "sub2" {
                     XCTAssertEqual(subScopedRow, ["a1": 1, "a2": 2, "a3": 3])
-                    XCTAssertTrue(subScopedRow.scopes.isEmpty)
                 } else {
                     XCTFail()
                 }
-            } else {
-                XCTFail()
             }
+            
+            let subScopedRow = scopedRow.scopes["sub2"]!
+            XCTAssertEqual(subScopedRow, ["a1": 1, "a2": 2, "a3": 3])
+            XCTAssertTrue(subScopedRow.scopes.isEmpty)
             
             // sub2 is only defined in sub1
             XCTAssertTrue(row.scopes["sub2"] == nil)
+            
+            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
+            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub1"]!.scopes["sub2"])
         }
     }
 
@@ -603,31 +589,28 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
-            if let scopedRow = row.scopes["sub1"] {
-                XCTAssertEqual(scopedRow.unscoped, ["a1": 1, "a2": 2])
-                
-                XCTAssertEqual(Set(scopedRow.scopes.names), ["sub2"])
-                XCTAssertEqual(scopedRow.scopes.count, 1)
-                for (name, subScopedRow) in scopedRow.scopes {
-                    if name == "sub2" {
-                        XCTAssertEqual(subScopedRow, ["a1": 1, "a2": 2])
-                    } else {
-                        XCTFail()
-                    }
-                }
-                
-                if let subScopedRow = scopedRow.scopes["sub2"] {
+            let scopedRow = row.scopes["sub1"]!
+            XCTAssertEqual(scopedRow.unscoped, ["a1": 1, "a2": 2])
+            
+            XCTAssertEqual(Set(scopedRow.scopes.names), ["sub2"])
+            XCTAssertEqual(scopedRow.scopes.count, 1)
+            for (name, subScopedRow) in scopedRow.scopes {
+                if name == "sub2" {
                     XCTAssertEqual(subScopedRow, ["a1": 1, "a2": 2])
-                    XCTAssertTrue(subScopedRow.scopes.isEmpty)
                 } else {
                     XCTFail()
                 }
-            } else {
-                XCTFail()
             }
+            
+            let subScopedRow = scopedRow.scopes["sub2"]!
+            XCTAssertEqual(subScopedRow, ["a1": 1, "a2": 2])
+            XCTAssertTrue(subScopedRow.scopes.isEmpty)
             
             // sub2 is only defined in sub1
             XCTAssertTrue(row.scopes["sub2"] == nil)
+            
+            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
+            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub1"]!.scopes["sub2"])
         }
     }
 
@@ -658,11 +641,9 @@ class AdapterRowTests : RowTestCase {
                     }
                 }
                 
-                if let scopedRow = copiedRow.scopes["sub"] {
-                    XCTAssertEqual(scopedRow, ["a": 1])
-                } else {
-                    XCTFail()
-                }
+                XCTAssertEqual(copiedRow.scopes["sub"]!, ["a": 1])
+                XCTAssertTrue(copiedRow.scopes["sub"]!.scopes.isEmpty)
+                XCTAssertEqual(copiedRow.scopes.lookup("sub")!, ["a": 1])
             } else {
                 XCTFail()
             }

--- a/Tests/GRDBTests/RowAdapterTests.swift
+++ b/Tests/GRDBTests/RowAdapterTests.swift
@@ -287,19 +287,21 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
+            XCTAssertEqual(row.scopesTree.names, ["sub1", "sub2"])
+            
             XCTAssertEqual(row.scopes["sub1"]!, ["id": 1, "val": "foo1"])
             XCTAssertTrue(row.scopes["sub1"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
+            XCTAssertEqual(row.scopesTree["sub1"], row.scopes["sub1"])
             
             XCTAssertEqual(row.scopes["sub2"]!, ["id": 2, "val": "foo2"])
             XCTAssertTrue(row.scopes["sub2"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub2"])
+            XCTAssertEqual(row.scopesTree["sub2"], row.scopes["sub2"])
 
             XCTAssertTrue(row.scopes["SUB1"] == nil)
-            XCTAssertTrue(row.scopes.lookup("SUB1") == nil)
+            XCTAssertTrue(row.scopesTree["SUB1"] == nil)
             
             XCTAssertTrue(row.scopes["missing"] == nil)
-            XCTAssertTrue(row.scopes.lookup("missing") == nil)
+            XCTAssertTrue(row.scopesTree["missing"] == nil)
         }
     }
 
@@ -328,19 +330,21 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
+            XCTAssertEqual(row.scopesTree.names, ["sub1", "sub2"])
+            
             XCTAssertEqual(row.scopes["sub1"]!, ["id": 1, "val": "foo1"])
             XCTAssertTrue(row.scopes["sub1"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
+            XCTAssertEqual(row.scopesTree["sub1"], row.scopes["sub1"])
             
             XCTAssertEqual(row.scopes["sub2"], ["id": 2, "val": "foo2"])
             XCTAssertTrue(row.scopes["sub2"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub2"])
+            XCTAssertEqual(row.scopesTree["sub2"], row.scopes["sub2"])
 
             XCTAssertTrue(row.scopes["SUB1"] == nil)
-            XCTAssertTrue(row.scopes.lookup("SUB1") == nil)
+            XCTAssertTrue(row.scopesTree["SUB1"] == nil)
             
             XCTAssertTrue(row.scopes["missing"] == nil)
-            XCTAssertTrue(row.scopes.lookup("missing") == nil)
+            XCTAssertTrue(row.scopesTree["missing"] == nil)
         }
     }
 
@@ -373,17 +377,19 @@ class AdapterRowTests : RowTestCase {
                 }
             }
             
+            XCTAssertEqual(row.scopesTree.names, ["sub0", "sub1", "sub2"])
+            
             XCTAssertEqual(row.scopes["sub0"], ["id": 0, "val": "foo0"])
             XCTAssertTrue(row.scopes["sub0"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub0"), row.scopes["sub0"])
+            XCTAssertEqual(row.scopesTree["sub0"], row.scopes["sub0"])
 
             XCTAssertEqual(row.scopes["sub1"], ["id": 1, "val": "foo1"])
             XCTAssertTrue(row.scopes["sub1"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
+            XCTAssertEqual(row.scopesTree["sub1"], row.scopes["sub1"])
             
             XCTAssertEqual(row.scopes["sub2"], ["id": 2, "val": "foo2"])
             XCTAssertTrue(row.scopes["sub2"]!.scopes.isEmpty)
-            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub2"])
+            XCTAssertEqual(row.scopesTree["sub2"], row.scopes["sub2"])
         }
     }
 
@@ -430,8 +436,9 @@ class AdapterRowTests : RowTestCase {
             // sub2 is only defined in sub1
             XCTAssertTrue(row.scopes["sub2"] == nil)
             
-            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
-            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub1"]!.scopes["sub2"])
+            XCTAssertEqual(row.scopesTree.names, ["sub1", "sub2"])
+            XCTAssertEqual(row.scopesTree["sub1"], row.scopes["sub1"])
+            XCTAssertEqual(row.scopesTree["sub2"], row.scopes["sub1"]!.scopes["sub2"])
         }
     }
 
@@ -501,8 +508,9 @@ class AdapterRowTests : RowTestCase {
             // sub2 is only defined in sub1
             XCTAssertTrue(row.scopes["sub2"] == nil)
             
-            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
-            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub1"]!.scopes["sub2"])
+            XCTAssertEqual(row.scopesTree.names, ["sub1", "sub2"])
+            XCTAssertEqual(row.scopesTree["sub1"], row.scopes["sub1"])
+            XCTAssertEqual(row.scopesTree["sub2"], row.scopes["sub1"]!.scopes["sub2"])
         }
     }
 
@@ -609,8 +617,9 @@ class AdapterRowTests : RowTestCase {
             // sub2 is only defined in sub1
             XCTAssertTrue(row.scopes["sub2"] == nil)
             
-            XCTAssertEqual(row.scopes.lookup("sub1"), row.scopes["sub1"])
-            XCTAssertEqual(row.scopes.lookup("sub2"), row.scopes["sub1"]!.scopes["sub2"])
+            XCTAssertEqual(row.scopesTree.names, ["sub1", "sub2"])
+            XCTAssertEqual(row.scopesTree["sub1"], row.scopes["sub1"])
+            XCTAssertEqual(row.scopesTree["sub2"], row.scopes["sub1"]!.scopes["sub2"])
         }
     }
 
@@ -641,9 +650,11 @@ class AdapterRowTests : RowTestCase {
                     }
                 }
                 
+                XCTAssertEqual(Set(copiedRow.scopes.names), ["sub"])
                 XCTAssertEqual(copiedRow.scopes["sub"]!, ["a": 1])
                 XCTAssertTrue(copiedRow.scopes["sub"]!.scopes.isEmpty)
-                XCTAssertEqual(copiedRow.scopes.lookup("sub")!, ["a": 1])
+                XCTAssertEqual(copiedRow.scopesTree.names, ["sub"])
+                XCTAssertEqual(copiedRow.scopesTree["sub"]!, ["a": 1])
             } else {
                 XCTFail()
             }

--- a/Tests/GRDBTests/RowCopiedFromStatementTests.swift
+++ b/Tests/GRDBTests/RowCopiedFromStatementTests.swift
@@ -251,7 +251,7 @@ class RowCopiedFromStatementTests: RowTestCase {
             let row = try Row.fetchOne(db, "SELECT 'foo' AS nAmE, 1 AS foo")!
             XCTAssertTrue(row.scopes.isEmpty)
             XCTAssertTrue(row.scopes["missing"] == nil)
-            XCTAssertTrue(row.scopes.lookup("missing") == nil)
+            XCTAssertTrue(row.scopesTree["missing"] == nil)
         }
     }
 

--- a/Tests/GRDBTests/RowCopiedFromStatementTests.swift
+++ b/Tests/GRDBTests/RowCopiedFromStatementTests.swift
@@ -251,6 +251,7 @@ class RowCopiedFromStatementTests: RowTestCase {
             let row = try Row.fetchOne(db, "SELECT 'foo' AS nAmE, 1 AS foo")!
             XCTAssertTrue(row.scopes.isEmpty)
             XCTAssertTrue(row.scopes["missing"] == nil)
+            XCTAssertTrue(row.scopes.lookup("missing") == nil)
         }
     }
 

--- a/Tests/GRDBTests/RowCopiedFromStatementTests.swift
+++ b/Tests/GRDBTests/RowCopiedFromStatementTests.swift
@@ -245,11 +245,12 @@ class RowCopiedFromStatementTests: RowTestCase {
         }
     }
 
-    func testVariants() throws {
+    func testScopes() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let row = try Row.fetchOne(db, "SELECT 'foo' AS nAmE, 1 AS foo")!
-            XCTAssertTrue(row.scoped(on: "missing") == nil)
+            XCTAssertTrue(row.scopes.isEmpty)
+            XCTAssertTrue(row.scopes["missing"] == nil)
         }
     }
 

--- a/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
@@ -210,7 +210,7 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         let row: Row = ["a": 0, "b": 1, "c": 2]
         XCTAssertTrue(row.scopes.isEmpty)
         XCTAssertTrue(row.scopes["missing"] == nil)
-        XCTAssertTrue(row.scopes.lookup("missing") == nil)
+        XCTAssertTrue(row.scopesTree["missing"] == nil)
     }
     
     func testCopy() {

--- a/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
@@ -210,6 +210,7 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         let row: Row = ["a": 0, "b": 1, "c": 2]
         XCTAssertTrue(row.scopes.isEmpty)
         XCTAssertTrue(row.scopes["missing"] == nil)
+        XCTAssertTrue(row.scopes.lookup("missing") == nil)
     }
     
     func testCopy() {

--- a/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
@@ -206,9 +206,10 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         XCTAssertTrue(row.hasColumn("FOO"))
     }
     
-    func testSubRows() {
+    func testScopes() {
         let row: Row = ["a": 0, "b": 1, "c": 2]
-        XCTAssertTrue(row.scoped(on: "missing") == nil)
+        XCTAssertTrue(row.scopes.isEmpty)
+        XCTAssertTrue(row.scopes["missing"] == nil)
     }
     
     func testCopy() {

--- a/Tests/GRDBTests/RowFromDictionaryTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryTests.swift
@@ -200,6 +200,7 @@ class RowFromDictionaryTests : RowTestCase {
         let row = Row(["a": 0, "b": 1, "c": 2])
         XCTAssertTrue(row.scopes.isEmpty)
         XCTAssertTrue(row.scopes["missing"] == nil)
+        XCTAssertTrue(row.scopes.lookup("missing") == nil)
     }
     
     func testCopy() {

--- a/Tests/GRDBTests/RowFromDictionaryTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryTests.swift
@@ -200,7 +200,7 @@ class RowFromDictionaryTests : RowTestCase {
         let row = Row(["a": 0, "b": 1, "c": 2])
         XCTAssertTrue(row.scopes.isEmpty)
         XCTAssertTrue(row.scopes["missing"] == nil)
-        XCTAssertTrue(row.scopes.lookup("missing") == nil)
+        XCTAssertTrue(row.scopesTree["missing"] == nil)
     }
     
     func testCopy() {

--- a/Tests/GRDBTests/RowFromDictionaryTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryTests.swift
@@ -196,9 +196,10 @@ class RowFromDictionaryTests : RowTestCase {
         XCTAssertTrue(row.hasColumn("FOO"))
     }
     
-    func testSubRows() {
+    func testScopes() {
         let row = Row(["a": 0, "b": 1, "c": 2])
-        XCTAssertTrue(row.scoped(on: "missing") == nil)
+        XCTAssertTrue(row.scopes.isEmpty)
+        XCTAssertTrue(row.scopes["missing"] == nil)
     }
     
     func testCopy() {

--- a/Tests/GRDBTests/RowFromStatementTests.swift
+++ b/Tests/GRDBTests/RowFromStatementTests.swift
@@ -308,14 +308,15 @@ class RowFromStatementTests : RowTestCase {
         }
     }
 
-    func testVariants() throws {
+    func testScopes() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             var rowFetched = false
             let rows = try Row.fetchCursor(db, "SELECT 'foo' AS nAmE, 1 AS foo")
             while let row = try rows.next() {
                 rowFetched = true
-                XCTAssertTrue(row.scoped(on: "missing") == nil)
+                XCTAssertTrue(row.scopes.isEmpty)
+                XCTAssertTrue(row.scopes["missing"] == nil)
             }
             XCTAssertTrue(rowFetched)
         }

--- a/Tests/GRDBTests/RowFromStatementTests.swift
+++ b/Tests/GRDBTests/RowFromStatementTests.swift
@@ -317,6 +317,7 @@ class RowFromStatementTests : RowTestCase {
                 rowFetched = true
                 XCTAssertTrue(row.scopes.isEmpty)
                 XCTAssertTrue(row.scopes["missing"] == nil)
+                XCTAssertTrue(row.scopes.lookup("missing") == nil)
             }
             XCTAssertTrue(rowFetched)
         }

--- a/Tests/GRDBTests/RowFromStatementTests.swift
+++ b/Tests/GRDBTests/RowFromStatementTests.swift
@@ -317,7 +317,7 @@ class RowFromStatementTests : RowTestCase {
                 rowFetched = true
                 XCTAssertTrue(row.scopes.isEmpty)
                 XCTAssertTrue(row.scopes["missing"] == nil)
-                XCTAssertTrue(row.scopes.lookup("missing") == nil)
+                XCTAssertTrue(row.scopesTree["missing"] == nil)
             }
             XCTAssertTrue(rowFetched)
         }


### PR DESCRIPTION
This PR enhances row scopes. The changes only impact hard-core users, GRDB internals, and pave the way to associations in GRDB3.

[**Row scopes**](https://github.com/groue/GRDB.swift/blob/master/README.md#scopeadapter) are now accessed through a dedicated collection:

```swift
// Define a tree of nested scopes
let adapter = ScopeAdapter([
    "foo": RangeRowAdapter(0..<1),
    "bar": RangeRowAdapter(1..<2).addingScopes([
        "baz" : RangeRowAdapter(2..<3)])])

// Fetch
let sql = "SELECT 1 AS foo, 2 AS bar, 3 AS baz"
let row = try Row.fetchOne(db, sql, adapter: adapter)!

row.scopes.count  // 2
row.scopes.names  // ["foo", "bar"]

row.scopes["foo"] // [foo:1]
row.scopes["bar"] // [bar:2]
row.scopes["baz"] // nil

for (name, scopedRow) in row.scopes {
    print(name, scopedRow)
}
```

The **tree of nested scopes** has its own dedicated view as well, that performs a breadth-first search of scope names:

```swift
row.scopesTree.names  // ["foo", "bar", "baz"]

row.scopesTree["foo"] // [foo:1]
row.scopesTree["bar"] // [bar:2]
row.scopesTree["baz"] // [baz:3]
```

This breadth-first search in the tree of nested scopes is now used when extracting records from rows. This will be paramount for [associations](https://github.com/groue/GRDB.swift/pull/319) ergonomics, so that the user can decode *flat* records from *hierarchical* scopes:

```swift
// From this hierarchical request made from associations...
let request = Book
    .including(required: Book.author
        .including(optional: Author.country))
    .including(optional: Bool.coverImage)

// ... you will decode flat records like the one below:
struct BookInfo: FetchableRecord, Decodable {
    var book: Book
    var author: Author
    var country: Country?
    var coverImage: CoverImage?
}
let bookInfos = try BookInfo.fetchAll(db, request) // [BookInfo]

// ... or perform explicit row decoding:
let rows = try Row.fetchCursor(db, request)
while let row = try rows.next() {
    let book = Book(row: row)
    let author: Author = row["author"]
    let country: Country? = row["country"]
    let coverImage: CoverImage? = row["coverImage"]
}
```