### PR TITLE
Enhancements to logical operators

### DIFF
--- a/GRDB/QueryInterface/Support/SQLOperators.swift
+++ b/GRDB/QueryInterface/Support/SQLOperators.swift
@@ -697,20 +697,12 @@ public func - (lhs: SQLSpecificExpressible, rhs: SQLSpecificExpressible) -> SQLE
 
 // MARK: - Logical Operators (AND, OR, NOT)
 
-extension SQLBinaryOperator {
-    /// The `AND` binary operator
-    static let and = SQLBinaryOperator("AND")
-    
-    /// The `OR` binary operator
-    static let or = SQLBinaryOperator("OR")
-}
-
 /// A logical SQL expression with the `AND` SQL operator.
 ///
 ///     // favorite AND 0
 ///     Column("favorite") && false
 public func && (lhs: SQLSpecificExpressible, rhs: SQLExpressible) -> SQLExpression {
-    return SQLExpressionBinary(.and, lhs.sqlExpression, rhs.sqlExpression)
+    return SQLExpressionAnd([lhs.sqlExpression, rhs.sqlExpression])
 }
 
 /// A logical SQL expression with the `AND` SQL operator.
@@ -718,7 +710,7 @@ public func && (lhs: SQLSpecificExpressible, rhs: SQLExpressible) -> SQLExpressi
 ///     // 0 AND favorite
 ///     false && Column("favorite")
 public func && (lhs: SQLExpressible, rhs: SQLSpecificExpressible) -> SQLExpression {
-    return SQLExpressionBinary(.and, lhs.sqlExpression, rhs.sqlExpression)
+    return SQLExpressionAnd([lhs.sqlExpression, rhs.sqlExpression])
 }
 
 /// A logical SQL expression with the `AND` SQL operator.
@@ -726,7 +718,7 @@ public func && (lhs: SQLExpressible, rhs: SQLSpecificExpressible) -> SQLExpressi
 ///     // email IS NOT NULL AND favorite
 ///     Column("email") != nil && Column("favorite")
 public func && (lhs: SQLSpecificExpressible, rhs: SQLSpecificExpressible) -> SQLExpression {
-    return SQLExpressionBinary(.and, lhs.sqlExpression, rhs.sqlExpression)
+    return SQLExpressionAnd([lhs.sqlExpression, rhs.sqlExpression])
 }
 
 /// A logical SQL expression with the `OR` SQL operator.
@@ -734,7 +726,7 @@ public func && (lhs: SQLSpecificExpressible, rhs: SQLSpecificExpressible) -> SQL
 ///     // favorite OR 1
 ///     Column("favorite") || true
 public func || (lhs: SQLSpecificExpressible, rhs: SQLExpressible) -> SQLExpression {
-    return SQLExpressionBinary(.or, lhs.sqlExpression, rhs.sqlExpression)
+    return SQLExpressionOr([lhs.sqlExpression, rhs.sqlExpression])
 }
 
 /// A logical SQL expression with the `OR` SQL operator.
@@ -742,7 +734,7 @@ public func || (lhs: SQLSpecificExpressible, rhs: SQLExpressible) -> SQLExpressi
 ///     // 0 OR favorite
 ///     true || Column("favorite")
 public func || (lhs: SQLExpressible, rhs: SQLSpecificExpressible) -> SQLExpression {
-    return SQLExpressionBinary(.or, lhs.sqlExpression, rhs.sqlExpression)
+    return SQLExpressionOr([lhs.sqlExpression, rhs.sqlExpression])
 }
 
 /// A logical SQL expression with the `OR` SQL operator.
@@ -750,7 +742,7 @@ public func || (lhs: SQLExpressible, rhs: SQLSpecificExpressible) -> SQLExpressi
 ///     // email IS NULL OR hidden
 ///     Column("email") == nil || Column("hidden")
 public func || (lhs: SQLSpecificExpressible, rhs: SQLSpecificExpressible) -> SQLExpression {
-    return SQLExpressionBinary(.or, lhs.sqlExpression, rhs.sqlExpression)
+    return SQLExpressionOr([lhs.sqlExpression, rhs.sqlExpression])
 }
 
 /// A negated logical SQL expression with the `NOT` SQL operator.
@@ -764,6 +756,34 @@ public func || (lhs: SQLSpecificExpressible, rhs: SQLSpecificExpressible) -> SQL
 ///     !((1...10).contains(Column("id")))
 public prefix func ! (value: SQLSpecificExpressible) -> SQLExpression {
     return value.sqlExpression.negated
+}
+
+public enum SQLLogicalBinaryOperator {
+    case and, or
+}
+
+extension Sequence where Element: SQLExpressible {
+    /// Return an expression by joining all elements with an SQL logical
+    /// operator
+    public func joined(operator: SQLLogicalBinaryOperator) -> SQLExpression {
+        let expressions: [SQLExpression] = map { $0.sqlExpression }
+        switch `operator` {
+        case .and: return SQLExpressionAnd(expressions)
+        case .or: return SQLExpressionOr(expressions)
+        }
+    }
+}
+
+extension Sequence where Element == SQLExpression {
+    /// Return an expression by joining all elements with an SQL logical
+    /// operator
+    public func joined(operator: SQLLogicalBinaryOperator) -> SQLExpression {
+        let expressions = Array(self)
+        switch `operator` {
+        case .and: return SQLExpressionAnd(expressions)
+        case .or: return SQLExpressionOr(expressions)
+        }
+    }
 }
 
 

--- a/GRDB/QueryInterface/Support/SQLOperators.swift
+++ b/GRDB/QueryInterface/Support/SQLOperators.swift
@@ -762,21 +762,30 @@ public enum SQLLogicalBinaryOperator {
     case and, or
 }
 
-extension Sequence where Element: SQLExpressible {
-    /// Return an expression by joining all elements with an SQL logical
-    /// operator
-    public func joined(operator: SQLLogicalBinaryOperator) -> SQLExpression {
-        let expressions: [SQLExpression] = map { $0.sqlExpression }
-        switch `operator` {
-        case .and: return SQLExpressionAnd(expressions)
-        case .or: return SQLExpressionOr(expressions)
-        }
-    }
-}
-
 extension Sequence where Element == SQLExpression {
-    /// Return an expression by joining all elements with an SQL logical
-    /// operator
+    /// Returns an expression by joining all elements with an SQL
+    /// logical operator.
+    ///
+    /// For example:
+    ///
+    ///     // SELECT * FROM players
+    ///     // WHERE (registered
+    ///     //        AND (score >= 1000)
+    ///     //        AND (name IS NOT NULL))
+    ///     let conditions = [
+    ///         Column("registered"),
+    ///         Column("score") >=< 1000,
+    ///         Column("name") != nil]
+    ///     Player.filter(conditions.joined(operator: .and))
+    ///
+    /// When the sequence is empty, `joined(operator: .and)` returns true,
+    /// and `joined(operator: .or)` returns false:
+    ///
+    ///     // SELECT * FROM players WHERE 1
+    ///     Player.filter([].joined(operator: .and))
+    ///
+    ///     // SELECT * FROM players WHERE 0
+    ///     Player.filter([].joined(operator: .or))
     public func joined(operator: SQLLogicalBinaryOperator) -> SQLExpression {
         let expressions = Array(self)
         switch `operator` {

--- a/GRDB/QueryInterface/Support/SQLOperators.swift
+++ b/GRDB/QueryInterface/Support/SQLOperators.swift
@@ -774,7 +774,7 @@ extension Sequence where Element == SQLExpression {
     ///     //        AND (name IS NOT NULL))
     ///     let conditions = [
     ///         Column("registered"),
-    ///         Column("score") >=< 1000,
+    ///         Column("score") >= 1000,
     ///         Column("name") != nil]
     ///     Player.filter(conditions.joined(operator: .and))
     ///

--- a/README.md
+++ b/README.md
@@ -3423,6 +3423,27 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     // SELECT * FROM players WHERE ((NOT verified) OR (score < 1000))
     Player.filter(!verifiedColumn || scoreColumn < 1000)
     ```
+    
+    When you want to join a sequence of expressions with `AND` or `OR` operators, use `joined(operator:)`:
+    
+    ```swift
+    // SELECT * FROM players WHERE (verified AND (score >= 1000) AND (name IS NOT NULL))
+    let conditions = [
+        verifiedColumn,
+        scoreColumn >=< 1000,
+        nameColumn != nil]
+    Player.filter(conditions.joined(operator: .and))
+    ```
+    
+    When the sequence is empty, `joined(operator: .and)` returns true, and `joined(operator: .or)` returns false:
+    
+    ```swift
+    // SELECT * FROM players WHERE 1
+    Player.filter([].joined(operator: .and))
+    
+    // SELECT * FROM players WHERE 0
+    Player.filter([].joined(operator: .or))
+    ```
 
 - `BETWEEN`, `IN`, `NOT IN`
     

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -727,6 +727,40 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT * FROM \"readers\" WHERE (NOT (\"age\" > 18) AND NOT (\"name\" > 'foo'))")
     }
     
+    func testJoinedOperatorAnd() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) AND (\"name\" IS NOT NULL))")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL))")
+    }
+    
+    func testJoinedOperatorOr() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([].joined(operator: .or))),
+            "SELECT * FROM \"readers\" WHERE 0")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .or))),
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .or))),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) OR (\"name\" IS NOT NULL))")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .or))),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL))")
+    }
+
     
     // MARK: - String functions
     


### PR DESCRIPTION
The `joined(operator:)` method lets you join several conditions with the `AND` or `OR` SQL operators:

```swift
// SELECT * FROM players
// WHERE (registered
//        AND (score >= 1000)
//        AND (name IS NOT NULL))
let conditions = [
    Column("registered"),
    Column("score") >= 1000,
    Column("name") != nil]
Player.filter(conditions.joined(operator: .and))
```

When the sequence is empty, `joined(operator: .and)` returns true, and `joined(operator: .or)` returns false:

```swift
// SELECT * FROM players WHERE 1
Player.filter([].joined(operator: .and))

// SELECT * FROM players WHERE 0
Player.filter([].joined(operator: .or))
```