### PR TITLE
Reversing unordered requests

### DIFF
--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -137,8 +137,7 @@ extension QueryInterfaceRequest : SelectionRequest, FilteredRequest, Aggregating
     ///         .order([Column("name")])
     public func order(_ orderings: [SQLOrderingTerm]) -> QueryInterfaceRequest<T> {
         var query = self.query
-        query.orderings = orderings
-        query.isReversed = false
+        query.ordering = QueryOrdering(orderings: orderings)
         return QueryInterfaceRequest(query: query)
     }
     
@@ -149,7 +148,7 @@ extension QueryInterfaceRequest : SelectionRequest, FilteredRequest, Aggregating
     ///     request = request.reversed()
     public func reversed() -> QueryInterfaceRequest<T> {
         var query = self.query
-        query.isReversed = !query.isReversed
+        query.ordering = query.ordering.reversed()
         return QueryInterfaceRequest(query: query)
     }
     

--- a/README.md
+++ b/README.md
@@ -3547,10 +3547,10 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     Player.order(scoreColumn.desc, nameColumn).reversed()
     ```
     
-    If no ordering was specified, the result is ordered by rowID in reverse order.
+    If no ordering was already specified, this method has no effect:
     
     ```swift
-    // SELECT * FROM players ORDER BY _rowid_ DESC
+    // SELECT * FROM players
     Player.all().reversed()
     ```
 
@@ -3578,6 +3578,7 @@ Player                          // SELECT * FROM players
     .filter(nameColumn != nil)  // WHERE (name IS NOT NULL)
     .filter(emailColumn != nil) //        AND (email IS NOT NULL)
     .order(nameColumn)          // - ignored -
+    .reversed()                 // - ignored -
     .order(scoreColumn)         // ORDER BY score
     .limit(20, offset: 40)      // - ignored -
     .limit(10)                  // LIMIT 10

--- a/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
@@ -172,7 +172,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
                 XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" ORDER BY \"name\" DESC LIMIT 1 OFFSET 2")
                 
                 try Person.limit(1, offset: 2).reversed().deleteAll(db)
-                XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" ORDER BY \"rowid\" DESC LIMIT 1 OFFSET 2")
+                XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" LIMIT 1 OFFSET 2")
             }
         }
     }

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -417,7 +417,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.reversed()),
-            "SELECT * FROM \"readers\" ORDER BY \"rowid\" DESC")
+            "SELECT * FROM \"readers\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.age).reversed()),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC")


### PR DESCRIPTION
This PR has the `request.reversed()` method do nothing unless an ordering was already applied:

```swift
// Unchanged: SELECT * FROM players ORDER BY score DESC
Player.order(Column("score")).reversed()

// New: SELECT * FROM players
Player.all().reversed()
```

In previous versions, `reversed()` would sort by descending rowId (inspiration drawn from ActiveRecord). Unfortunately, this made-up ordering is not guaranteed to be the exact opposite of the default SQLite ordering. And [associations](https://github.com/groue/GRDB.swift/pull/319) will soon need a stricter model of what "reversing" a request means.

So let's go back to [basics](https://www.sqlite.org/lang_select.html#orderby):

> If a SELECT statement that returns more than one row does not have an ORDER BY clause, the order in which the rows are returned is undefined.

Reversing an undefined order gives another undefined order.