### PR TITLE
Common API for requests and associations derivation

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -657,6 +657,8 @@
 		56E5D82D1B4D438800430942 /* GRDB-Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2393C61ABE35F8003FF113 /* GRDB-Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		56E8CE0E1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E8CE0C1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift */; };
 		56E8CE111BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E8CE0F1BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift */; };
+		56EA63C5209C7CE3009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63C4209C7CE3009715B8 /* DerivableRequestTests.swift */; };
+		56EA63C6209C7CE3009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63C4209C7CE3009715B8 /* DerivableRequestTests.swift */; };
 		56EA86951C91DFE7002BB4DF /* DatabaseReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */; };
 		56EA869F1C932597002BB4DF /* DatabasePoolReadOnlyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA869D1C932597002BB4DF /* DatabasePoolReadOnlyTests.swift */; };
 		56EB0AB31BCD787300A3DC55 /* DataMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EB0AB11BCD787300A3DC55 /* DataMemoryTests.swift */; };
@@ -1098,6 +1100,7 @@
 		56E5D7F91B4D422D00430942 /* GRDBOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		56E8CE0C1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleFetchTests.swift; sourceTree = "<group>"; };
 		56E8CE0F1BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementColumnConvertibleFetchTests.swift; sourceTree = "<group>"; };
+		56EA63C4209C7CE3009715B8 /* DerivableRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivableRequestTests.swift; sourceTree = "<group>"; };
 		56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseReaderTests.swift; sourceTree = "<group>"; };
 		56EA869D1C932597002BB4DF /* DatabasePoolReadOnlyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabasePoolReadOnlyTests.swift; sourceTree = "<group>"; };
 		56EB0AB11BCD787300A3DC55 /* DataMemoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataMemoryTests.swift; sourceTree = "<group>"; };
@@ -1348,6 +1351,7 @@
 			children = (
 				5653EABF20944B1300F46237 /* Association */,
 				56B6EF55208CB4E3002F0ACB /* ColumnExpressionTests.swift */,
+				56EA63C4209C7CE3009715B8 /* DerivableRequestTests.swift */,
 				56300B601C53C42C005A543B /* FetchableRecord+QueryInterfaceRequestTests.swift */,
 				56300B671C53D25E005A543B /* QueryInterfaceExpressionsTests.swift */,
 				5698AC021D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift */,
@@ -2561,6 +2565,7 @@
 				562756471E963AAC0035B653 /* DatabaseWriterTests.swift in Sources */,
 				569531381C919DF700CF1A2B /* DatabasePoolFunctionTests.swift in Sources */,
 				56A238481B9C74A90082EB20 /* RowCopiedFromStatementTests.swift in Sources */,
+				56EA63C6209C7CE3009715B8 /* DerivableRequestTests.swift in Sources */,
 				5674A71A1F3087710095F066 /* DatabaseValueConvertibleDecodableTests.swift in Sources */,
 				5698AC071D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift in Sources */,
 				56C3F7561CF9F12400F6A361 /* DatabaseSavepointTests.swift in Sources */,
@@ -2722,6 +2727,7 @@
 				56D4966B1D81309E008276D7 /* MutablePersistableRecordDeleteTests.swift in Sources */,
 				56D4965B1D81304E008276D7 /* FoundationNSDecimalNumberTests.swift in Sources */,
 				562756431E963AAC0035B653 /* DatabaseWriterTests.swift in Sources */,
+				56EA63C5209C7CE3009715B8 /* DerivableRequestTests.swift in Sources */,
 				56D496BF1D8135D4008276D7 /* TableDefinitionTests.swift in Sources */,
 				5674A7171F3087710095F066 /* DatabaseValueConvertibleDecodableTests.swift in Sources */,
 				56D496801D813131008276D7 /* StatementColumnConvertibleFetchTests.swift in Sources */,

--- a/GRDB/QueryInterface/Association/AssociationRequest.swift
+++ b/GRDB/QueryInterface/Association/AssociationRequest.swift
@@ -37,7 +37,7 @@ extension AssociationRequest {
     
     func joining<A: Association>(_ joinOperator: AssociationJoinOperator, _ association: A)
         -> AssociationRequest
-        where A.LeftAssociated == T
+        where A.OriginRowDecoder == T
     {
         let join = AssociationJoin(
             joinOperator: joinOperator,

--- a/GRDB/QueryInterface/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyAssociation.swift
@@ -1,10 +1,5 @@
-public struct HasManyAssociation<Origin, Destination> : Association, TableRequest where
-    Origin: TableRecord,
-    Destination: TableRecord
-{
-    fileprivate let foreignKeyRequest: ForeignKeyRequest
-    
-    // Association conformance
+public struct HasManyAssociation<Origin, Destination>: Association {
+    fileprivate let joinConditionRequest: ForeignKeyJoinConditionRequest
 
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
@@ -25,7 +20,7 @@ public struct HasManyAssociation<Origin, Destination> : Association, TableReques
     
     /// :nodoc:
     public func joinCondition(_ db: Database) throws -> JoinCondition {
-        return try ForeignKeyJoinConditionRequest(foreignKeyRequest: foreignKeyRequest, originIsLeft: false).fetch(db)
+        return try joinConditionRequest.fetch(db)
     }
     
     /// :nodoc:
@@ -34,17 +29,17 @@ public struct HasManyAssociation<Origin, Destination> : Association, TableReques
         association.request = transform(request)
         return association
     }
-    
-    // TableRequest conformance
-    
+}
+
+extension HasManyAssociation: TableRequest where Destination: TableRecord {
     /// :nodoc:
     public var databaseTableName: String { return Destination.databaseTableName }
 }
 
 extension TableRecord {
-    // TODO: Make it public if and only if we really want to build an association from any request
-    static func hasMany<Destination>(
-        _ request: QueryInterfaceRequest<Destination>,
+    /// TODO
+    public static func hasMany<Destination>(
+        _ destination: Destination.Type,
         key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> HasManyAssociation<Self, Destination>
@@ -55,20 +50,13 @@ extension TableRecord {
             destinationTable: databaseTableName,
             foreignKey: foreignKey)
         
-        return HasManyAssociation(
+        let joinConditionRequest = ForeignKeyJoinConditionRequest(
             foreignKeyRequest: foreignKeyRequest,
+            originIsLeft: false)
+        
+        return HasManyAssociation(
+            joinConditionRequest: joinConditionRequest,
             key: key ?? Destination.databaseTableName,
-            request: AssociationRequest(request))
-    }
-    
-    /// TODO
-    public static func hasMany<Destination>(
-        _ destination: Destination.Type,
-        key: String? = nil,
-        using foreignKey: ForeignKey? = nil)
-        -> HasManyAssociation<Self, Destination>
-        where Destination: TableRecord
-    {
-        return hasMany(Destination.all(), key: key, using: foreignKey)
+            request: AssociationRequest(Destination.all()))
     }
 }

--- a/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
@@ -1,7 +1,7 @@
 extension QueryInterfaceRequest where RowDecoder: TableRecord {
     func joining<A: Association>(_ joinOperator: AssociationJoinOperator, _ association: A)
         -> QueryInterfaceRequest<RowDecoder>
-        where A.LeftAssociated == RowDecoder
+        where A.OriginRowDecoder == RowDecoder
     {
         let join = AssociationJoin(
             joinOperator: joinOperator,
@@ -16,28 +16,28 @@ extension QueryInterfaceRequest where RowDecoder: TableRecord {
     /// Creates a request that includes an association. The columns of the
     /// associated record are selected. The returned association does not
     /// require that the associated database table contains a matching row.
-    public func including<A: Association>(optional association: A) -> QueryInterfaceRequest<RowDecoder> where A.LeftAssociated == RowDecoder {
+    public func including<A: Association>(optional association: A) -> QueryInterfaceRequest<RowDecoder> where A.OriginRowDecoder == RowDecoder {
         return joining(.optional, association)
     }
     
     /// Creates a request that includes an association. The columns of the
     /// associated record are selected. The returned association requires
     /// that the associated database table contains a matching row.
-    public func including<A: Association>(required association: A) -> QueryInterfaceRequest<RowDecoder> where A.LeftAssociated == RowDecoder {
+    public func including<A: Association>(required association: A) -> QueryInterfaceRequest<RowDecoder> where A.OriginRowDecoder == RowDecoder {
         return joining(.required, association)
     }
     
     /// Creates a request that includes an association. The columns of the
     /// associated record are not selected. The returned association does not
     /// require that the associated database table contains a matching row.
-    public func joining<A: Association>(optional association: A) -> QueryInterfaceRequest<RowDecoder> where A.LeftAssociated == RowDecoder {
+    public func joining<A: Association>(optional association: A) -> QueryInterfaceRequest<RowDecoder> where A.OriginRowDecoder == RowDecoder {
         return joining(.optional, association.select([]))
     }
     
     /// Creates a request that includes an association. The columns of the
     /// associated record are not selected. The returned association requires
     /// that the associated database table contains a matching row.
-    public func joining<A: Association>(required association: A) -> QueryInterfaceRequest<RowDecoder> where A.LeftAssociated == RowDecoder {
+    public func joining<A: Association>(required association: A) -> QueryInterfaceRequest<RowDecoder> where A.OriginRowDecoder == RowDecoder {
         return joining(.required, association.select([]))
     }
 }
@@ -56,7 +56,7 @@ extension MutablePersistableRecord {
     ///
     ///     let team: Team = ...
     ///     let players = try team.players.fetchAll(db) // [Player]
-    public func request<A: Association>(for association: A) -> QueryInterfaceRequest<A.RightAssociated> where A.LeftAssociated == Self {
+    public func request<A: Association>(for association: A) -> QueryInterfaceRequest<A.RowDecoder> where A.OriginRowDecoder == Self {
         return association.request(from: self)
     }
 }
@@ -68,28 +68,28 @@ extension TableRecord {
     /// Creates a request that includes an association. The columns of the
     /// associated record are selected. The returned association does not
     /// require that the associated database table contains a matching row.
-    public static func including<A: Association>(optional association: A) -> QueryInterfaceRequest<Self> where A.LeftAssociated == Self {
+    public static func including<A: Association>(optional association: A) -> QueryInterfaceRequest<Self> where A.OriginRowDecoder == Self {
         return all().including(optional: association)
     }
     
     /// Creates a request that includes an association. The columns of the
     /// associated record are selected. The returned association requires
     /// that the associated database table contains a matching row.
-    public static func including<A: Association>(required association: A) -> QueryInterfaceRequest<Self> where A.LeftAssociated == Self {
+    public static func including<A: Association>(required association: A) -> QueryInterfaceRequest<Self> where A.OriginRowDecoder == Self {
         return all().including(required: association)
     }
     
     /// Creates a request that includes an association. The columns of the
     /// associated record are not selected. The returned association does not
     /// require that the associated database table contains a matching row.
-    public static func joining<A: Association>(optional association: A) -> QueryInterfaceRequest<Self> where A.LeftAssociated == Self {
+    public static func joining<A: Association>(optional association: A) -> QueryInterfaceRequest<Self> where A.OriginRowDecoder == Self {
         return all().joining(optional: association)
     }
     
     /// Creates a request that includes an association. The columns of the
     /// associated record are not selected. The returned association requires
     /// that the associated database table contains a matching row.
-    public static func joining<A: Association>(required association: A) -> QueryInterfaceRequest<Self> where A.LeftAssociated == Self {
+    public static func joining<A: Association>(required association: A) -> QueryInterfaceRequest<Self> where A.OriginRowDecoder == Self {
         return all().joining(required: association)
     }
 }

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -43,7 +43,7 @@ extension QueryInterfaceRequest : FetchRequest {
     }
 }
 
-extension QueryInterfaceRequest : SelectionRequest, FilteredRequest, AggregatingRequest, OrderedRequest {
+extension QueryInterfaceRequest : DerivableRequest, AggregatingRequest {
     
     // MARK: Request Derivation
 
@@ -192,7 +192,7 @@ extension QueryInterfaceRequest: TableRequest where RowDecoder: TableRecord {
     }
 }
 
-extension QueryInterfaceRequest where RowDecoder: MutablePersistableRecord {
+extension QueryInterfaceRequest where T: MutablePersistableRecord {
     
     // MARK: Deleting
     

--- a/GRDB/QueryInterface/RequestProtocols.swift
+++ b/GRDB/QueryInterface/RequestProtocols.swift
@@ -324,10 +324,7 @@ extension OrderedRequest {
 
 /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
 ///
-/// The base protocol for all requests that can be refined:
-///
-///     extension DerivableRequest where RowDecoder: Player {
-///     }
+/// The base protocol for all requests that can be refined.
 public protocol DerivableRequest: SelectionRequest, FilteredRequest, OrderedRequest {
     associatedtype RowDecoder
 }

--- a/GRDB/QueryInterface/RequestProtocols.swift
+++ b/GRDB/QueryInterface/RequestProtocols.swift
@@ -319,3 +319,15 @@ extension OrderedRequest {
         return order([expression])
     }
 }
+
+// MARK: - DerivableRequest
+
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+///
+/// The base protocol for all requests that can be refined:
+///
+///     extension DerivableRequest where RowDecoder: Player {
+///     }
+public protocol DerivableRequest: SelectionRequest, FilteredRequest, OrderedRequest {
+    associatedtype RowDecoder
+}

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -824,6 +824,10 @@
 		56DAA2DF1DE9C827006E10C8 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DAA2DA1DE9C827006E10C8 /* Cursor.swift */; };
 		56E06F131E859068008AE2A4 /* Fixits-0.102.0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E06F051E859064008AE2A4 /* Fixits-0.102.0.swift */; };
 		56E06F161E85906C008AE2A4 /* Fixits-0.102.0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E06F051E859064008AE2A4 /* Fixits-0.102.0.swift */; };
+		56EA63CC209C7F31009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63CB209C7F31009715B8 /* DerivableRequestTests.swift */; };
+		56EA63CD209C7F31009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63CB209C7F31009715B8 /* DerivableRequestTests.swift */; };
+		56EA63CE209C7F31009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63CB209C7F31009715B8 /* DerivableRequestTests.swift */; };
+		56EA63CF209C7F31009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63CB209C7F31009715B8 /* DerivableRequestTests.swift */; };
 		56F26C241CEE3F34007969C4 /* RowAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565F03C11CE5D3AA00DE108F /* RowAdapterTests.swift */; };
 		56F3E74A1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
 		56F3E74B1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
@@ -1164,6 +1168,7 @@
 		56E06F051E859064008AE2A4 /* Fixits-0.102.0.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fixits-0.102.0.swift"; sourceTree = "<group>"; };
 		56E8CE0C1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleFetchTests.swift; sourceTree = "<group>"; };
 		56E8CE0F1BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementColumnConvertibleFetchTests.swift; sourceTree = "<group>"; };
+		56EA63CB209C7F31009715B8 /* DerivableRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DerivableRequestTests.swift; sourceTree = "<group>"; };
 		56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseReaderTests.swift; sourceTree = "<group>"; };
 		56EA869D1C932597002BB4DF /* DatabasePoolReadOnlyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabasePoolReadOnlyTests.swift; sourceTree = "<group>"; };
 		56EB0AB11BCD787300A3DC55 /* DataMemoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataMemoryTests.swift; sourceTree = "<group>"; };
@@ -1416,6 +1421,7 @@
 			children = (
 				5653EBA420961FD300F46237 /* Association */,
 				56B6EF62208CB762002F0ACB /* ColumnExpressionTests.swift */,
+				56EA63CB209C7F31009715B8 /* DerivableRequestTests.swift */,
 				56300B601C53C42C005A543B /* FetchableRecord+QueryInterfaceRequestTests.swift */,
 				56300B671C53D25E005A543B /* QueryInterfaceExpressionsTests.swift */,
 				5698AC021D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift */,
@@ -2263,6 +2269,7 @@
 				560FC56C1CB00B880014AA8E /* UpdateStatementTests.swift in Sources */,
 				5653EBE020961FE800F46237 /* AssociationBelongsToSQLTests.swift in Sources */,
 				560FC56D1CB00B880014AA8E /* DatabaseMigratorTests.swift in Sources */,
+				56EA63CC209C7F31009715B8 /* DerivableRequestTests.swift in Sources */,
 				560FC5701CB00B880014AA8E /* DatabasePoolCollationTests.swift in Sources */,
 				560FC5711CB00B880014AA8E /* RecordPrimaryKeySingleTests.swift in Sources */,
 				560FC5721CB00B880014AA8E /* StatementColumnConvertibleTests.swift in Sources */,
@@ -2424,6 +2431,7 @@
 				5671562F1CB16729007DC145 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				5653EBE120961FE800F46237 /* AssociationBelongsToSQLTests.swift in Sources */,
 				567156301CB16729007DC145 /* StatementColumnConvertibleTests.swift in Sources */,
+				56EA63CD209C7F31009715B8 /* DerivableRequestTests.swift in Sources */,
 				56C3F7551CF9F12400F6A361 /* DatabaseSavepointTests.swift in Sources */,
 				5672DE5B1CDB72520022BA81 /* DatabaseQueueBackupTests.swift in Sources */,
 				56B021CB1D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift in Sources */,
@@ -2695,6 +2703,7 @@
 				56AFCA3E1CB1AA9900F48B96 /* DatabasePoolCollationTests.swift in Sources */,
 				5653EBE220961FE800F46237 /* AssociationBelongsToSQLTests.swift in Sources */,
 				56FF455B1D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift in Sources */,
+				56EA63CE209C7F31009715B8 /* DerivableRequestTests.swift in Sources */,
 				56AFCA3F1CB1AA9900F48B96 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				56AFCA411CB1AA9900F48B96 /* StatementColumnConvertibleTests.swift in Sources */,
 				56AFCA421CB1AA9900F48B96 /* DatabasePoolFunctionTests.swift in Sources */,
@@ -2856,6 +2865,7 @@
 				56AFCA931CB1ABC800F48B96 /* UpdateStatementTests.swift in Sources */,
 				5653EBE320961FE800F46237 /* AssociationBelongsToSQLTests.swift in Sources */,
 				56AFCA941CB1ABC800F48B96 /* DatabaseMigratorTests.swift in Sources */,
+				56EA63CF209C7F31009715B8 /* DerivableRequestTests.swift in Sources */,
 				5657AB641D108BA9006283EF /* FoundationNSURLTests.swift in Sources */,
 				56FF455C1D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift in Sources */,
 				56AFCA971CB1ABC800F48B96 /* DatabasePoolCollationTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -318,6 +318,8 @@
 		56DAA2E01DE9C827006E10C8 /* Cursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DAA2DA1DE9C827006E10C8 /* Cursor.swift */; };
 		56E06F141E859069008AE2A4 /* Fixits-0.102.0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E06F051E859064008AE2A4 /* Fixits-0.102.0.swift */; };
 		56E06F171E85906D008AE2A4 /* Fixits-0.102.0.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E06F051E859064008AE2A4 /* Fixits-0.102.0.swift */; };
+		56EA63C9209C7F1E009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63C7209C7F1E009715B8 /* DerivableRequestTests.swift */; };
+		56EA63CA209C7F1E009715B8 /* DerivableRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EA63C7209C7F1E009715B8 /* DerivableRequestTests.swift */; };
 		56ED8A7F1DAB8D6800BD0ABC /* FTS5WrapperTokenizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56ED8A7E1DAB8D6800BD0ABC /* FTS5WrapperTokenizerTests.swift */; };
 		56ED8A801DAB8D6800BD0ABC /* FTS5WrapperTokenizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56ED8A7E1DAB8D6800BD0ABC /* FTS5WrapperTokenizerTests.swift */; };
 		56F3E74C1E66F83A00BF0F01 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */; };
@@ -827,6 +829,7 @@
 		56E06F051E859064008AE2A4 /* Fixits-0.102.0.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Fixits-0.102.0.swift"; sourceTree = "<group>"; };
 		56E8CE0C1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleFetchTests.swift; sourceTree = "<group>"; };
 		56E8CE0F1BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementColumnConvertibleFetchTests.swift; sourceTree = "<group>"; };
+		56EA63C7209C7F1E009715B8 /* DerivableRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DerivableRequestTests.swift; sourceTree = "<group>"; };
 		56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseReaderTests.swift; sourceTree = "<group>"; };
 		56EA869D1C932597002BB4DF /* DatabasePoolReadOnlyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabasePoolReadOnlyTests.swift; sourceTree = "<group>"; };
 		56EB0AB11BCD787300A3DC55 /* DataMemoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataMemoryTests.swift; sourceTree = "<group>"; };
@@ -1062,6 +1065,7 @@
 			children = (
 				5653EB5620961F8900F46237 /* Association */,
 				56B6EF5E208CB746002F0ACB /* ColumnExpressionTests.swift */,
+				56EA63C7209C7F1E009715B8 /* DerivableRequestTests.swift */,
 				56300B601C53C42C005A543B /* FetchableRecord+QueryInterfaceRequestTests.swift */,
 				56300B671C53D25E005A543B /* QueryInterfaceExpressionsTests.swift */,
 				5698AC021D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift */,
@@ -1938,6 +1942,7 @@
 				F3BA80F81CFB3021003DC1BA /* StatementArgumentsTests.swift in Sources */,
 				5653EB7D20961FB200F46237 /* AssociationBelongsToSQLTests.swift in Sources */,
 				5698AC0A1D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift in Sources */,
+				56EA63CA209C7F1E009715B8 /* DerivableRequestTests.swift in Sources */,
 				F3BA80E91CFB3016003DC1BA /* RowAdapterTests.swift in Sources */,
 				562393371DEDFC5700A6B01F /* AnyCursorTests.swift in Sources */,
 				5674A7161F3087710095F066 /* DatabaseValueConvertibleDecodableTests.swift in Sources */,
@@ -2209,6 +2214,7 @@
 				F3BA80E61CFB3012003DC1BA /* DatabaseFunctionTests.swift in Sources */,
 				5653EB7C20961FB200F46237 /* AssociationBelongsToSQLTests.swift in Sources */,
 				5698ACDA1DA925430056AF8C /* RowTestCase.swift in Sources */,
+				56EA63C9209C7F1E009715B8 /* DerivableRequestTests.swift in Sources */,
 				F3BA811D1CFB305F003DC1BA /* TableRecord+QueryInterfaceRequestTests.swift in Sources */,
 				F3BA80AD1CFB2FA6003DC1BA /* DataMemoryTests.swift in Sources */,
 				5698ACB91DA6285E0056AF8C /* FTS3TokenizerTests.swift in Sources */,

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+#if GRDBCIPHER
+import GRDBCipher
+#elseif GRDBCUSTOMSQLITE
+import GRDBCustomSQLite
+#else
+import GRDB
+#endif
+
+private struct Author: FetchableRecord, PersistableRecord, Codable {
+    var id: Int64
+    var name: String
+    var country: String
+    
+    static let databaseTableName = "author"
+    static let books = hasMany(Book.self)
+    var books: QueryInterfaceRequest<Book> {
+        return request(for: Author.books)
+    }
+}
+private struct Book: FetchableRecord, PersistableRecord, Codable {
+    var id: Int64
+    var authorId: Int64
+    var title: String
+    
+    static let databaseTableName = "book"
+    static let author = belongsTo(Author.self)
+    var author: QueryInterfaceRequest<Author> {
+        return request(for: Book.author)
+    }
+}
+
+private var libraryMigrator: DatabaseMigrator = {
+    var migrator = DatabaseMigrator()
+    migrator.registerMigration("library") { db in
+        try db.create(table: "author") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("name", .text).notNull()
+            t.column("country", .text).notNull()
+        }
+        try db.create(table: "book") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("authorId", .integer).notNull().references("author")
+            t.column("title", .text).notNull()
+        }
+    }
+    migrator.registerMigration("fixture") { db in
+        try Author(id: 1, name: "Melville", country: "US").insert(db)
+        try Author(id: 2, name: "Proust", country: "FR").insert(db)
+        try Book(id: 1, authorId: 1, title: "Moby-Dick").insert(db)
+        try Book(id: 2, authorId: 2, title: "Du côté de chez Swann").insert(db)
+        try Book(id: 3, authorId: 2, title: "Le Côté de Guermantes").insert(db)
+    }
+    return migrator
+}()
+
+// One extension...
+extension DerivableRequest where RowDecoder == Author {
+    func filter(country: String) -> Self {
+        return filter(Column("country") == country)
+    }
+}
+
+class DerivableRequestTests: GRDBTestCase {
+    func testDerivation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try libraryMigrator.migrate(dbQueue)
+        try dbQueue.inDatabase { db in
+            // ... for two requests (1)
+            let frenchAuthorNames = try Author.all()
+                .filter(country: "FR")
+                .fetchAll(db)
+                .map { $0.name }
+            XCTAssertEqual(frenchAuthorNames, ["Proust"])
+            
+            // ... for two requests (2)
+            let frenchBookTitles = try Book
+                .joining(required: Book.author.filter(country: "FR"))
+                .order(Column("title"))
+                .fetchAll(db)
+                .map { $0.title }
+            XCTAssertEqual(frenchBookTitles, ["Du côté de chez Swann", "Le Côté de Guermantes"])
+        }
+    }
+}

--- a/Tests/GRDBTests/SQLRequestTests.swift
+++ b/Tests/GRDBTests/SQLRequestTests.swift
@@ -65,7 +65,7 @@ class SQLRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let request = CustomRequest()
-            let sqlRequest = try SQLRequest(db, request: request)
+            let sqlRequest = try SQLRequest<Row>(db, request: request)
             XCTAssertEqual(sqlRequest.sql, "SELECT ? AS a, ? AS b")
             XCTAssertEqual(sqlRequest.arguments, [1, "foo"])
             XCTAssertEqual(try sqlRequest.fetchOne(db)!, ["a": 1, "b": "foo"])


### PR DESCRIPTION
This PR introduces `DerivableRequest`, a protocol that lets you enrich the query interface API. Write one extension, derive both requests and associations:

```swift
// One extension...
extension DerivableRequest where RowDecoder == Author {
    func filter(country: String) -> Self {
        return filter(Column("country") == country)
    }
}

// Apply to a request
let frenchAuthors = Author.all().filter(country: "FR")

// Apply to an association
let frenchBooks = Book.joining(required: Book.author.filter(country: "FR"))
```
