### PR TITLE
GRDB3 Support for RxGRDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,11 @@ Release Notes
 +    associatedtype RowDecoder
 +    func prepare(_ db: Database) throws -> (SelectStatement, RowAdapter?)
 +    func fetchCount(_ db: Database) throws -> Int
-+    func fetchedRegion(_ db: Database) throws -> DatabaseRegion
++    func databaseRegion(_ db: Database) throws -> DatabaseRegion
 +}
 +extension FetchRequest {
 +    func fetchCount(_ db: Database) throws -> Int
-+    func fetchedRegion(_ db: Database) throws -> DatabaseRegion
++    func databaseRegion(_ db: Database) throws -> DatabaseRegion
 +    func asRequest<T>(of type: T.Type) -> AnyFetchRequest<T>
 +    func adapted(_ adapter: @escaping (Database) throws -> RowAdapter) -> AdaptedFetchRequest<Self>
 +}

--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -16,16 +16,16 @@
 /// You don't create a database region directly. Instead, you use one of
 /// those methods:
 ///
-/// - `SelectStatement.fetchedRegion`:
+/// - `SelectStatement.databaseRegion`:
 ///
 ///     let statement = db.makeSelectStatement("SELECT name, score FROM player")
-///     print(statement.fetchedRegion)
+///     print(statement.databaseRegion)
 ///     // prints "player(name,score)"
 ///
-/// - `Request.fetchedRegion(_:)`
+/// - `Request.databaseRegion(_:)`
 ///
 ///     let request = Player.filter(key: 1)
-///     try print(request.fetchedRegion(db))
+///     try print(request.databaseRegion(db))
 ///     // prints "player(*)[1]"
 ///
 /// Database regions returned by requests can be more precise than regions
@@ -34,11 +34,11 @@
 ///
 ///     // A plain statement
 ///     let statement = db.makeSelectStatement("SELECT * FROM player WHERE id = 1")
-///     statement.fetchedRegion       // "player(*)"
+///     statement.databaseRegion       // "player(*)"
 ///
 ///     // A query interface request that executes the same statement:
 ///     let request = Player.filter(key: 1)
-///     try request.fetchedRegion(db) // "player(*)[1]"
+///     try request.databaseRegion(db) // "player(*)[1]"
 public struct DatabaseRegion: CustomStringConvertible, Equatable {
     private let tableRegions: [String: TableRegion]?
     private init(tableRegions: [String: TableRegion]?) {

--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -51,8 +51,9 @@ public struct DatabaseRegion: CustomStringConvertible, Equatable {
         return tableRegions.isEmpty
     }
     
-    /// The full database: (All columns in all tables) × (all rows)
-    static let fullDatabase = DatabaseRegion(tableRegions: nil)
+    /// The region that covers the full database: all columns and all rows
+    /// from all tables.
+    public static let fullDatabase = DatabaseRegion(tableRegions: nil)
     
     /// The empty database region
     public init() {

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -295,7 +295,7 @@ extension AuthorizedStatement {
 ///     }
 public final class SelectStatement : Statement {    
     /// The database region that the statement looks into.
-    public private(set) var fetchedRegion: DatabaseRegion
+    public private(set) var databaseRegion: DatabaseRegion
     
     /// Creates a prepared statement.
     ///
@@ -316,7 +316,7 @@ public final class SelectStatement : Statement {
         prepFlags: Int32,
         authorizer: StatementCompilationAuthorizer) throws
     {
-        self.fetchedRegion = DatabaseRegion()
+        self.databaseRegion = DatabaseRegion()
         try super.init(
             database: database,
             statementStart: statementStart,
@@ -326,7 +326,7 @@ public final class SelectStatement : Statement {
         GRDBPrecondition(authorizer.invalidatesDatabaseSchemaCache == false, "Invalid statement type for query \(String(reflecting: sql)): use UpdateStatement instead.")
         GRDBPrecondition(authorizer.transactionEffect == nil, "Invalid statement type for query \(String(reflecting: sql)): use UpdateStatement instead.")
         
-        self.fetchedRegion = authorizer.region
+        self.databaseRegion = authorizer.databaseRegion
     }
     
     /// The number of columns in the resulting rows.

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -18,7 +18,7 @@ protocol StatementAuthorizer : class {
 /// A class that gathers information about one statement during its compilation.
 final class StatementCompilationAuthorizer : StatementAuthorizer {
     /// What this statements reads
-    var region = DatabaseRegion()
+    var databaseRegion = DatabaseRegion()
     
     /// What this statements writes
     var databaseEventKinds: [DatabaseEventKind] = []
@@ -66,10 +66,10 @@ final class StatementCompilationAuthorizer : StatementAuthorizer {
             guard let columnName = cString2.map({ String(cString: $0) }) else { return SQLITE_OK }
             if columnName.isEmpty {
                 // SELECT COUNT(*) FROM table
-                region.formUnion(DatabaseRegion(table: tableName))
+                databaseRegion.formUnion(DatabaseRegion(table: tableName))
             } else {
                 // SELECT column FROM table
-                region.formUnion(DatabaseRegion(table: tableName, columns: [columnName]))
+                databaseRegion.formUnion(DatabaseRegion(table: tableName, columns: [columnName]))
             }
             return SQLITE_OK
             
@@ -135,7 +135,7 @@ final class StatementCompilationAuthorizer : StatementAuthorizer {
             guard sqlite3_libversion_number() < 3019000 else { return SQLITE_OK }
             guard let cString2 = cString2 else { return SQLITE_OK }
             if sqlite3_stricmp(cString2, "COUNT") == 0 {
-                region = .fullDatabase
+                databaseRegion = .fullDatabase
             }
             return SQLITE_OK
             

--- a/GRDB/Legacy/Fixits-3.0.swift
+++ b/GRDB/Legacy/Fixits-3.0.swift
@@ -36,6 +36,10 @@ extension SelectStatement {
     /// :nodoc:
     @available(*, unavailable, renamed:"databaseRegion")
     public var selectionInfo: DatabaseRegion { preconditionFailure() }
+    
+    /// :nodoc:
+    @available(*, unavailable, renamed:"databaseRegion")
+    public var fetchedRegion: DatabaseRegion { preconditionFailure() }
 }
 
 extension DatabaseEventKind {
@@ -71,4 +75,11 @@ extension Row {
     /// :nodoc:
     @available(*, unavailable, message: "Use row.scopes[name] instead")
     public func scoped(on name: String) -> Row? { preconditionFailure() }
+}
+
+extension FetchRequest {
+    
+    /// :nodoc:
+    @available(*, unavailable, renamed:"databaseRegion(_:)")
+    public func fetchedRegion(_ db: Database) throws -> DatabaseRegion { preconditionFailure() }
 }

--- a/GRDB/Legacy/Fixits-3.0.swift
+++ b/GRDB/Legacy/Fixits-3.0.swift
@@ -34,7 +34,7 @@ extension SelectStatement {
     public typealias SelectionInfo = DatabaseRegion
     
     /// :nodoc:
-    @available(*, unavailable, renamed:"fetchedRegion")
+    @available(*, unavailable, renamed:"databaseRegion")
     public var selectionInfo: DatabaseRegion { preconditionFailure() }
 }
 

--- a/GRDB/QueryInterface/QueryInterfaceQuery.swift
+++ b/GRDB/QueryInterface/QueryInterfaceQuery.swift
@@ -329,37 +329,37 @@ extension QueryInterfaceQuery {
     
     /// The database region that the request looks into.
     /// precondition: self is the result of finalizedQuery
-    func fetchedRegion(_ db: Database) throws -> DatabaseRegion {
+    func databaseRegion(_ db: Database) throws -> DatabaseRegion {
         let statement = try makeSelectStatement(db)
-        let region = statement.fetchedRegion
+        let databaseRegion = statement.databaseRegion
         
         // Can we intersect the region with rowIds?
         //
         // Give up unless request feeds from a single database table
         guard case .table(tableName: let tableName, alias: _) = source else {
             // TODO: try harder
-            return region
+            return databaseRegion
         }
         
         // Give up unless primary key is rowId
         let primaryKeyInfo = try db.primaryKey(tableName)
         guard primaryKeyInfo.isRowID else {
-            return region
+            return databaseRegion
         }
         
         // Give up unless there is a where clause
         guard let filter = try filterPromise.resolve(db) else {
-            return region
+            return databaseRegion
         }
         
         // The filter knows better
         guard let rowIds = filter.matchedRowIds(rowIdName: primaryKeyInfo.rowIDColumn) else {
-            return region
+            return databaseRegion
         }
         
         // Database regions are case-insensitive: use the canonical table name
         let canonicalTableName = try db.canonicalTableName(tableName)
-        return region.tableIntersection(canonicalTableName, rowIds: rowIds)
+        return databaseRegion.tableIntersection(canonicalTableName, rowIds: rowIds)
     }
     
     private var countQuery: QueryInterfaceQuery {

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -38,8 +38,8 @@ extension QueryInterfaceRequest : FetchRequest {
     ///
     /// - parameter db: A database connection.
     /// :nodoc:
-    public func fetchedRegion(_ db: Database) throws -> DatabaseRegion {
-        return try query.finalizedQuery.fetchedRegion(db)
+    public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
+        return try query.finalizedQuery.databaseRegion(db)
     }
 }
 

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -105,7 +105,7 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
         self.itemsAreIdenticalFactory = itemsAreIdenticalFactory
         self.request = ItemRequest(request)
         (self.region, self.itemsAreIdentical) = try databaseWriter.unsafeRead { db in
-            let region = try request.fetchedRegion(db)
+            let region = try request.databaseRegion(db)
             let itemsAreIdentical = try itemsAreIdenticalFactory(db)
             return (region, itemsAreIdentical)
         }
@@ -165,7 +165,7 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
     public func setRequest<Request>(_ request: Request) throws where Request: FetchRequest, Request.RowDecoder == Record {
         self.request = ItemRequest(request)
         (self.region, self.itemsAreIdentical) = try databaseWriter.unsafeRead { db in
-            let region = try request.fetchedRegion(db)
+            let region = try request.databaseRegion(db)
             let itemsAreIdentical = try itemsAreIdenticalFactory(db)
             return (region, itemsAreIdentical)
         }

--- a/README.md
+++ b/README.md
@@ -4105,78 +4105,9 @@ Player.customRequest(...).rx
     })
 ```
 
-- [DatabaseRequest Protocol](#databaserequest-protocol)
-- [SelectStatementRequest Protocol](#selectstatementrequest-protocol)
 - [FetchRequest Protocol](#fetchrequest-protocol)
 - [Building Custom Requests](#building-custom-requests)
 - [Fetching From Custom Requests](#fetching-from-custom-requests)
-
-
-### DatabaseRequest Protocol
-
-**DatabaseRequest** is the highest-level protocol for all types that request database values. It does not tell how values are fetched, but it allows database observation tools ([transaction observers](#transactionobserver-protocol) and [RxGRDB](http://github.com/RxSwiftCommunity/RxGRDB)) the ability to notify changes in the request content.
-
-```swift
-protocol DatabaseRequest {
-    func fetchedRegion(_ db: Database) throws -> DatabaseRegion
-}
-```
-
-**You'll use DatabaseRequest when you want to encapsulate your most complex fetching strategies.**
-
-For example:
-
-```swift
-struct LibraryRequest: DatabaseRequest {
-    func fetchAll(_ db: Database) throws -> [(Author, [Books])] {
-        let authors = try Author.fetchAll(db)
-        let books = try Dictionary(
-            grouping: Book.fetchAll(db),
-            by: { book in book.authorId })
-        return authors.map { author in (author, books[author.id]!) }
-    }
-    
-    func fetchedRegion(_ db: Database) throws -> DatabaseRegion {
-        let authorsRegion = try Author.all().fetchedRegion(db)
-        let booksRegion = try Book.all().fetchedRegion(db)
-        return authorsRegion.union(booksRegion)
-    }
-}
-
-// Track library content with RxGRDB
-let request = LibraryRequest()
-dbQueue.rx
-    .fetchTokens(in: [request])
-    .mapFetch { db in try request.fetchAll(db) }
-    .subscribe(onNext: { library: [(Author, [Books])] in
-        print("Library has changed.")
-    })
-```
-
-See [DatabaseRegion](https://groue.github.io/GRDB.swift/docs/2.10/Structs/DatabaseRegion.html) reference for more information.
-
-
-### SelectStatementRequest Protocol
-
-**SelectStatementRequest** is the protocol for all requests that run a single select statement:
-
-```swift
-protocol SelectStatementRequest: DatabaseRequest {
-    /// A tuple that contains a prepared statement, and an eventual row adapter.
-    func prepare(_ db: Database) throws -> (SelectStatement, RowAdapter?)
-    
-    /// The number of rows fetched by the request.
-    func fetchCount(_ db: Database) throws -> Int
-}
-```
-
-The `prepare` method returns a prepared statement and an optional row adapter. The [prepared statement](#prepared-statements) tells which SQL query should be executed. The row adapter helps presenting the fetched rows in the way expected by the row decoders (see [row adapter](#row-adapters)).
-
-The `fetchCount` method has a default implementation that builds a correct but naive SQL query from the statement returned by `prepare`: `SELECT COUNT(*) FROM (...)`. Adopting types can refine the counting SQL by customizing their `fetchCount` implementation.
-
-The `fetchedRegion` method inherited from [DatabaseRequest](#databaserequest-protocol) is also given a default implementation, based on the statement returned by `prepare`.
-
-There are few use cases for SelectStatementRequest. Usually, your custom requests will adopt its derivative [FetchRequest](#fetchrequest-protocol), introduced below:
 
 
 ### FetchRequest Protocol
@@ -4184,15 +4115,32 @@ There are few use cases for SelectStatementRequest. Usually, your custom request
 **FetchRequest** is the protocol for all requests that run from a single select statement, and know how fetched rows should be interpreted:
 
 ```swift
-protocol FetchRequest: SelectStatementRequest {
+protocol FetchRequest {
     /// The type that tells how fetched rows should be decoded
     associatedtype RowDecoder
+    
+    /// A tuple that contains a prepared statement, and an eventual row adapter.
+    func prepare(_ db: Database) throws -> (SelectStatement, RowAdapter?)
+    
+    /// The number of rows fetched by the request.
+    func fetchCount(_ db: Database) throws -> Int
+    
+    /// Returns the database region that the request looks into.
+    ///
+    /// - parameter db: A database connection.
+    func databaseRegion(_ db: Database) throws -> DatabaseRegion
 }
 ```
 
-The `RowDecoder` associated type can be any type. Yet, not all types have built-in support: see [Fetching From Custom Requests](#fetching-from-custom-requests) below.
+When the `RowDecoder` associated type is [Row](#fetching-rows), or a [value](#value-queries), or a type that conforms to [FetchableRecord], the request can fetch: see [Fetching From Custom Requests](#fetching-from-custom-requests) below.
 
-FetchRequest is adopted, for example, by [query interface requests](#requests):
+The `prepare` method returns a prepared statement and an optional row adapter. The [prepared statement](#prepared-statements) tells which SQL query should be executed. The row adapter helps presenting the fetched rows in the way expected by the row decoders (see [row adapter](#row-adapters)).
+
+The `fetchCount` method has a default implementation that builds a correct but naive SQL query from the statement returned by `prepare`: `SELECT COUNT(*) FROM (...)`. Adopting types can refine the counting SQL by customizing their `fetchCount` implementation.
+
+The `databaseRegion` method is involved in [database observation](#database-changes-observation). It is given a default implementation, based on the statement returned by `prepare`. For more information, see [DatabaseRegion](https://groue.github.io/GRDB.swift/docs/2.10/Structs/DatabaseRegion.html), and [RxGRDB](http://github.com/RxSwiftCommunity/RxGRDB).
+
+The FetchRequest protocol is adopted, for example, by [query interface requests](#requests):
 
 ```swift
 // A FetchRequest whose RowDecoder associated type is Player:
@@ -4202,7 +4150,7 @@ let request = Player.all()
 
 ### Building Custom Requests
 
-**To build custom requests**, you can use one of the built-in requests, derive requests from other requests, or create your own request type that adopts one of the request protocols described above ([FetchRequest](#fetchrequest-protocol), [SelectStatementRequest](#selectstatementrequest-protocol), or [DatabaseRequest](#databaserequest-protocol)). 
+**To build custom requests**, you can use one of the built-in requests, derive requests from other requests, or create your own request type that adopts the [FetchRequest](#fetchrequest-protocol) protocol. 
 
 - [SQLRequest](http://groue.github.io/GRDB.swift/docs/2.10/Structs/SQLRequest.html) is a fetch request built from raw SQL. For example:
     

--- a/README.md
+++ b/README.md
@@ -4125,9 +4125,7 @@ protocol FetchRequest {
     /// The number of rows fetched by the request.
     func fetchCount(_ db: Database) throws -> Int
     
-    /// Returns the database region that the request looks into.
-    ///
-    /// - parameter db: A database connection.
+    /// The database region that the request looks into.
     func databaseRegion(_ db: Database) throws -> DatabaseRegion
 }
 ```

--- a/Tests/GRDBTests/ColumnExpressionTests.swift
+++ b/Tests/GRDBTests/ColumnExpressionTests.swift
@@ -58,11 +58,11 @@ class ColumnExpressionTests: GRDBTestCase {
             }
             
             // Test rowId column identification
-            try XCTAssertEqual(Player.filter(key: 1).fetchedRegion(db).description, "players(id,name,score)[1]")
-            try XCTAssertEqual(Player.filter(Player.Columns.id == 1).fetchedRegion(db).description, "players(id,name,score)[1]")
-            try XCTAssertEqual(Player.filter(1 == Player.Columns.id).fetchedRegion(db).description, "players(id,name,score)[1]")
-            try XCTAssertEqual(Player.filter(Player.Columns.id == 1 || Player.Columns.id == 2).fetchedRegion(db).description, "players(id,name,score)[1,2]")
-            try XCTAssertEqual(Player.filter([1, 2, 3].contains(Player.Columns.id)).fetchedRegion(db).description, "players(id,name,score)[1,2,3]")
+            try XCTAssertEqual(Player.filter(key: 1).databaseRegion(db).description, "players(id,name,score)[1]")
+            try XCTAssertEqual(Player.filter(Player.Columns.id == 1).databaseRegion(db).description, "players(id,name,score)[1]")
+            try XCTAssertEqual(Player.filter(1 == Player.Columns.id).databaseRegion(db).description, "players(id,name,score)[1]")
+            try XCTAssertEqual(Player.filter(Player.Columns.id == 1 || Player.Columns.id == 2).databaseRegion(db).description, "players(id,name,score)[1,2]")
+            try XCTAssertEqual(Player.filter([1, 2, 3].contains(Player.Columns.id)).databaseRegion(db).description, "players(id,name,score)[1,2,3]")
             
             // Test specific column updates
             let player = Player(row: ["id": 1, "name": "Arthur", "score": 1000])
@@ -120,11 +120,11 @@ class ColumnExpressionTests: GRDBTestCase {
             }
             
             // Test rowId column identification
-            try XCTAssertEqual(Player.filter(key: 1).fetchedRegion(db).description, "players(id,name,score)[1]")
-            try XCTAssertEqual(Player.filter(Player.Columns.id == 1).fetchedRegion(db).description, "players(id,name,score)[1]")
-            try XCTAssertEqual(Player.filter(1 == Player.Columns.id).fetchedRegion(db).description, "players(id,name,score)[1]")
-            try XCTAssertEqual(Player.filter(Player.Columns.id == 1 || Player.Columns.id == 2).fetchedRegion(db).description, "players(id,name,score)[1,2]")
-            try XCTAssertEqual(Player.filter([1, 2, 3].contains(Player.Columns.id)).fetchedRegion(db).description, "players(id,name,score)[1,2,3]")
+            try XCTAssertEqual(Player.filter(key: 1).databaseRegion(db).description, "players(id,name,score)[1]")
+            try XCTAssertEqual(Player.filter(Player.Columns.id == 1).databaseRegion(db).description, "players(id,name,score)[1]")
+            try XCTAssertEqual(Player.filter(1 == Player.Columns.id).databaseRegion(db).description, "players(id,name,score)[1]")
+            try XCTAssertEqual(Player.filter(Player.Columns.id == 1 || Player.Columns.id == 2).databaseRegion(db).description, "players(id,name,score)[1,2]")
+            try XCTAssertEqual(Player.filter([1, 2, 3].contains(Player.Columns.id)).databaseRegion(db).description, "players(id,name,score)[1,2,3]")
             
             // Test specific column updates
             let player = Player(row: ["id": 1, "name": "Arthur", "score": 1000])

--- a/Tests/GRDBTests/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionTests.swift
@@ -265,19 +265,19 @@ class DatabaseRegionTests : GRDBTestCase {
                 let statement = try db.makeSelectStatement("SELECT foo.name FROM FOO JOIN BAR ON fooId = foo.id")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["name", "id"])
                     .union(DatabaseRegion(table: "bar", columns: ["fooId"]))
-                XCTAssertEqual(statement.fetchedRegion, expectedRegion)
-                XCTAssertEqual(statement.fetchedRegion.description, "bar(fooId),foo(id,name)")
+                XCTAssertEqual(statement.databaseRegion, expectedRegion)
+                XCTAssertEqual(statement.databaseRegion.description, "bar(fooId),foo(id,name)")
             }
             do {
                 let statement = try db.makeSelectStatement("SELECT COUNT(*) FROM foo")
                 if sqlite3_libversion_number() < 3019000 {
                     let expectedRegion = DatabaseRegion.fullDatabase
-                    XCTAssertEqual(statement.fetchedRegion, expectedRegion)
-                    XCTAssertEqual(statement.fetchedRegion.description, "full database")
+                    XCTAssertEqual(statement.databaseRegion, expectedRegion)
+                    XCTAssertEqual(statement.databaseRegion.description, "full database")
                 } else {
                     let expectedRegion = DatabaseRegion(table: "foo")
-                    XCTAssertEqual(statement.fetchedRegion, expectedRegion)
-                    XCTAssertEqual(statement.fetchedRegion.description, "foo(*)")
+                    XCTAssertEqual(statement.databaseRegion, expectedRegion)
+                    XCTAssertEqual(statement.databaseRegion.description, "foo(*)")
                 }
             }
         }
@@ -295,117 +295,117 @@ class DatabaseRegionTests : GRDBTestCase {
             
             do {
                 let request = Record.all()
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)")
             }
             do {
                 let request = Record.filter(Column("a") == 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)")
             }
             do {
                 let request = Record.filter(Column("id") >= 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)")
             }
             
             do {
                 let request = Record.filter((Column("id") == 1) || (Column("a") == "foo"))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)")
             }
 
             // No rowId
             
             do {
                 let request = Record.filter(Column("id") == nil)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "empty")
+                try XCTAssertEqual(request.databaseRegion(db).description, "empty")
             }
 
             do {
                 let request = Record.filter(Column("id") === nil)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "empty")
+                try XCTAssertEqual(request.databaseRegion(db).description, "empty")
             }
             
             do {
                 let request = Record.filter(nil == Column("id"))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "empty")
+                try XCTAssertEqual(request.databaseRegion(db).description, "empty")
             }
             
             do {
                 let request = Record.filter(nil === Column("id"))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "empty")
+                try XCTAssertEqual(request.databaseRegion(db).description, "empty")
             }
             
             do {
                 let request = Record.filter((Column("id") == 1) && (Column("id") == 2))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "empty")
+                try XCTAssertEqual(request.databaseRegion(db).description, "empty")
             }
             do {
                 let request = Record.filter(key: 1).filter(key: 2)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "empty")
+                try XCTAssertEqual(request.databaseRegion(db).description, "empty")
             }
 
             // Single rowId
             
             do {
                 let request = Record.filter(Column("id") == 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(Column("id") === 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(Column("id") == 1 && Column("a") == "foo")
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(Column.rowID == 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(1 == Column("id"))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(1 === Column("id"))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(1 === Column.rowID)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(key: 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(key: 1).filter(key: 1)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
             do {
                 let request = Record.filter(key: 1).filter(Column("a") == "foo")
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1]")
             }
 
             // Multiple rowIds
             
             do {
                 let request = Record.filter(Column("id") == 1 || Column.rowID == 2)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1,2]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1,2]")
             }
             do {
                 let request = Record.filter((Column("id") == 1 && Column("a") == "foo") || Column.rowID == 2)
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1,2]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1,2]")
             }
             do {
                 let request = Record.filter([1, 2, 3].contains(Column("id")))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1,2,3]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1,2,3]")
             }
             do {
                 let request = Record.filter([1, 2, 3].contains(Column.rowID))
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1,2,3]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1,2,3]")
             }
             do {
                 let request = Record.filter(keys: [1, 2, 3])
-                try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1,2,3]")
+                try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1,2,3]")
             }
         }
     }
@@ -433,14 +433,14 @@ class DatabaseRegionTests : GRDBTestCase {
                     .including(optional: A.b.filter(key: 2))
                     .including(optional: A.c.filter(keys: [1, 2, 3]))
                 // This test will fail when we are able to improve regions of joined requestt
-                try XCTAssertEqual(request.fetchedRegion(db).description, "a(id,name)[1],b(aid,id,name),c(aid,id,name)")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(id,name)[1],b(aid,id,name),c(aid,id,name)")
             }
             do {
                 let request = B.filter(key: 1)
                     .including(optional: B.a.filter(key: 2)
                         .including(optional: A.c.filter(keys: [1, 2, 3])))
                 // This test will fail when we are able to improve regions of joined requestt
-                try XCTAssertEqual(request.fetchedRegion(db).description, "a(id,name),b(aid,id,name)[1],c(aid,id,name)")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(id,name),b(aid,id,name)[1],c(aid,id,name)")
             }
         }
    }
@@ -454,20 +454,20 @@ class DatabaseRegionTests : GRDBTestCase {
             }
             
             let request = Record.filter(keys: [1, 2, 3])
-            try XCTAssertEqual(request.fetchedRegion(db).description, "foo(a,id)[1,2,3]")
+            try XCTAssertEqual(request.databaseRegion(db).description, "foo(a,id)[1,2,3]")
 
             do {
                 let derivedRequest: AnyFetchRequest<Row> = AnyFetchRequest(request)
-                try XCTAssertEqual(derivedRequest.fetchedRegion(db).description, "foo(a,id)[1,2,3]")
+                try XCTAssertEqual(derivedRequest.databaseRegion(db).description, "foo(a,id)[1,2,3]")
             }
             do {
                 let derivedRequest: AdaptedFetchRequest = request.adapted { db in SuffixRowAdapter(fromIndex: 1) }
-                try XCTAssertEqual(derivedRequest.fetchedRegion(db).description, "foo(a,id)[1,2,3]")
+                try XCTAssertEqual(derivedRequest.databaseRegion(db).description, "foo(a,id)[1,2,3]")
             }
             do {
                 // SQL request loses region info
                 let derivedRequest = try SQLRequest(db, request: request)
-                try XCTAssertEqual(derivedRequest.fetchedRegion(db).description, "foo(a,id)")
+                try XCTAssertEqual(derivedRequest.databaseRegion(db).description, "foo(a,id)")
             }
         }
     }
@@ -506,20 +506,20 @@ class DatabaseRegionTests : GRDBTestCase {
             do {
                 let statement = try db.makeSelectStatement("SELECT rowid FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["ROWID"])
-                XCTAssertEqual(statement.fetchedRegion, expectedRegion)
-                XCTAssertEqual(statement.fetchedRegion.description, "foo(ROWID)")
+                XCTAssertEqual(statement.databaseRegion, expectedRegion)
+                XCTAssertEqual(statement.databaseRegion.description, "foo(ROWID)")
             }
             do {
                 let statement = try db.makeSelectStatement("SELECT _ROWID_ FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["ROWID"])
-                XCTAssertEqual(statement.fetchedRegion, expectedRegion)
-                XCTAssertEqual(statement.fetchedRegion.description, "foo(ROWID)")
+                XCTAssertEqual(statement.databaseRegion, expectedRegion)
+                XCTAssertEqual(statement.databaseRegion.description, "foo(ROWID)")
             }
             do {
                 let statement = try db.makeSelectStatement("SELECT oID FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["ROWID"])
-                XCTAssertEqual(statement.fetchedRegion, expectedRegion)
-                XCTAssertEqual(statement.fetchedRegion.description, "foo(ROWID)")
+                XCTAssertEqual(statement.databaseRegion, expectedRegion)
+                XCTAssertEqual(statement.databaseRegion.description, "foo(ROWID)")
             }
         }
     }

--- a/Tests/GRDBTests/SelectStatementTests.swift
+++ b/Tests/GRDBTests/SelectStatementTests.swift
@@ -196,7 +196,7 @@ class SelectStatementTests : GRDBTestCase {
             
             let doubtfulCountFunction = (sqlite3_libversion_number() < 3019000)
             
-            let observers = statements.map { Observer(region: $0.fetchedRegion) }
+            let observers = statements.map { Observer(region: $0.databaseRegion) }
             if doubtfulCountFunction {
                 XCTAssertEqual(observers.map { $0.region.description }, ["table1(a,b,id,id3,id4)","table1(a,id,id3)", "table1(a,id),table2(a,id)", "full database"])
             } else {


### PR DESCRIPTION
This PR simplifies the request protocols introduced by #328, in order to let RxGRDB define its own observation protocol: RxGRDB.DatabaseRegionConvertible.