### PR TITLE
Annotate `DatabaseQueue.write(_:)` with `@discardableResult`

### DIFF
--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -230,6 +230,7 @@ extension DatabaseQueue {
     ///
     /// - parameter block: A block that executes SQL statements.
     /// - throws: An eventual database error, or the error thrown by the block.
+    @discardableResult
     public func write<T>(_ block: (Database) throws -> T) rethrows -> T {
         return try writer.sync { db in
             var result: T? = nil


### PR DESCRIPTION
The returned result from `write(_:)` isn't necessarily needed, for example when just updating, or writing a new record in a database queue. 

e.g. 

```swift
try dbQueue.write { db in 
    try myModel.update(db)
}
```