### PR TITLE
Fixing type used in 'Demographics BelongsTo Country' example

### DIFF
--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -221,7 +221,7 @@ struct Country: TableRecord, FetchableRecord {
 }
 
 struct Demographics: TableRecord, FetchableRecord {
-    static let country = belongsTo(Demographics.self)
+    static let country = belongsTo(Country.self)
     ...
 }
 ```


### PR DESCRIPTION
I am reading this for the first time, so I might be wrong, but I strongly suspect the type in the belongsTo() call should be Country?