### PR TITLE
Fix buffer overflow in vsscanf date parsing

### DIFF
--- a/GRDB/Core/Support/Foundation/SQLiteDateParser.swift
+++ b/GRDB/Core/Support/Foundation/SQLiteDateParser.swift
@@ -55,7 +55,7 @@ class SQLiteDateParser {
                             withUnsafeMutablePointer(to: &parserComponents.second) { secondP in
                                 parserComponents.nanosecond.withUnsafeMutableBufferPointer { nanosecondBuffer in
                                     withVaList([yearP, monthP, dayP, hourP, minuteP, secondP, nanosecondBuffer.baseAddress!]) { pointer in
-                                        vsscanf(cString, "%4d-%2d-%2d%*1[ T]%2d:%2d:%2d.%10s", pointer)
+                                        vsscanf(cString, "%4d-%2d-%2d%*1[ T]%2d:%2d:%2d.%9s", pointer)
                                     }
                                 }
                             }
@@ -100,7 +100,7 @@ class SQLiteDateParser {
                 withUnsafeMutablePointer(to: &parserComponents.second) { secondP in
                     parserComponents.nanosecond.withUnsafeMutableBufferPointer { nanosecondBuffer in
                         withVaList([hourP, minuteP, secondP, nanosecondBuffer.baseAddress!]) { pointer in
-                            vsscanf(cString, "%2d:%2d:%2d.%10s", pointer)
+                            vsscanf(cString, "%2d:%2d:%2d.%9s", pointer)
                         }
                     }
                 }


### PR DESCRIPTION
The buffer is 10 bytes long including the null terminator so we can only scan 9 characters.