### PR TITLE
Delayed Request Ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ It comes with new features, but also a few breaking changes, and a set of update
 - Request derivation protocols ([#329](https://github.com/groue/GRDB.swift/pull/329)).
 - Preliminary Linux support for the main framework ([#354](https://github.com/groue/GRDB.swift/pull/354)).
 - Automatic table name generation ([#355](https://github.com/groue/GRDB.swift/pull/355)).
+- Delayed Request Ordering ([#365](https://github.com/groue/GRDB.swift/pull/365)).
 
 
 ### Breaking Changes

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -249,6 +249,9 @@
 		565490E41D5AE252005622CB /* TableRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560D92461C672C4B00F4F92B /* TableRecord.swift */; };
 		56553C101C3E906C00522B5C /* GRDBTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623E0901B4AFACC00B20B7F /* GRDBTestCase.swift */; };
 		56553C131C3E906C00522B5C /* GRDB.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC3773F319C8CBB3004FCF85 /* GRDB.framework */; };
+		5656BF4F20C723E300F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF4E20C723E300F98521 /* QueryOrdering.swift */; };
+		5656BF5020C723E300F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF4E20C723E300F98521 /* QueryOrdering.swift */; };
+		5656BF5120C723E300F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF4E20C723E300F98521 /* QueryOrdering.swift */; };
 		5657AAB91D107001006283EF /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		5657AABC1D107001006283EF /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		5657AB0F1D10899D006283EF /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AB0E1D10899D006283EF /* URL.swift */; };
@@ -892,6 +895,7 @@
 		5653EC0B2098738B00F46237 /* SQLGenerationContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLGenerationContext.swift; sourceTree = "<group>"; };
 		565490A01D5A4798005622CB /* GRDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GRDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		56553C181C3E906C00522B5C /* GRDBOSXCrashTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBOSXCrashTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5656BF4E20C723E300F98521 /* QueryOrdering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryOrdering.swift; sourceTree = "<group>"; };
 		5657AAB81D107001006283EF /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		5657AB0E1D10899D006283EF /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		5657AB2F1D108BA9006283EF /* FoundationDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDataTests.swift; sourceTree = "<group>"; };
@@ -1374,6 +1378,7 @@
 				5605F18C1C6B1A8700235C62 /* QueryInterfaceQuery.swift */,
 				56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */,
 				5653EB242094A14400F46237 /* QueryInterfaceRequest+Association.swift */,
+				5656BF4E20C723E300F98521 /* QueryOrdering.swift */,
 				5616AAF0207CD45E00AC3664 /* RequestProtocols.swift */,
 				5605F1891C6B1A8700235C62 /* SQLCollatedExpression.swift */,
 				566475991D97D8A000FF74B8 /* SQLCollection.swift */,
@@ -2308,6 +2313,7 @@
 				566475C01D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				56CEB51F1EAA328900BFAF62 /* FTS5+QueryInterface.swift in Sources */,
 				565490E21D5AE252005622CB /* Record.swift in Sources */,
+				5656BF5120C723E300F98521 /* QueryOrdering.swift in Sources */,
 				565490C11D5AE236005622CB /* FetchRequest.swift in Sources */,
 				5698AD1C1DAAD17F0056AF8C /* FTS5Tokenizer.swift in Sources */,
 				56CEB5171EAA324B00BFAF62 /* FTS3+QueryInterfaceRequest.swift in Sources */,
@@ -2514,6 +2520,7 @@
 				C96C0F2C2084A459006B2981 /* SQLiteDateParser.swift in Sources */,
 				5605F1681C672E4000235C62 /* NSNumber.swift in Sources */,
 				56CEB5041EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
+				5656BF5020C723E300F98521 /* QueryOrdering.swift in Sources */,
 				5605F1741C672E4000235C62 /* StandardLibrary.swift in Sources */,
 				560D92481C672C4B00F4F92B /* PersistableRecord.swift in Sources */,
 				560D92431C672C3E00F4F92B /* StatementColumnConvertible.swift in Sources */,
@@ -2915,6 +2922,7 @@
 				566475BA1D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				5653EB0920944C7C00F46237 /* Association.swift in Sources */,
 				56A238851B9C75030082EB20 /* DatabaseValue.swift in Sources */,
+				5656BF4F20C723E300F98521 /* QueryOrdering.swift in Sources */,
 				5671FC201DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56A238A41B9C753B0082EB20 /* Record.swift in Sources */,
 				56CEB5451EAA359A00BFAF62 /* Column.swift in Sources */,

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -100,7 +100,7 @@ extension Association {
         return mapRequest { $0.filter(predicate) }
     }
     
-    /// Creates an association with the provided *orderings*.
+    /// Creates an association with the provided *orderings promise*.
     ///
     ///     struct Player: TableRecord {
     ///         static let team = belongsTo(Team.self)
@@ -110,7 +110,7 @@ extension Association {
     ///     // FROM player
     ///     // JOIN team ON team.id = player.teamId
     ///     // ORDER BY team.name
-    ///     let association = Player.team.order(Column("name"))
+    ///     let association = Player.team.order { _ in [Column("name")] }
     ///     var request = Player.including(required: association)
     ///
     /// Any previous ordering is replaced:
@@ -120,11 +120,11 @@ extension Association {
     ///     // JOIN team ON team.id = player.teamId
     ///     // ORDER BY team.name
     ///     let association = Player.team
-    ///         .order(Column("color"))
+    ///         .order{ _ in [Column("color")] }
     ///         .reversed()
-    ///         .order(Column("name"))
+    ///         .order{ _ in [Column("name")] }
     ///     var request = Player.including(required: association)
-    public func order(_ orderings: [SQLOrderingTerm]) -> Self {
+    public func order(_ orderings: @escaping (Database) throws -> [SQLOrderingTerm]) -> Self {
         return mapRequest { $0.order(orderings) }
     }
     

--- a/GRDB/QueryInterface/Association/AssociationQuery.swift
+++ b/GRDB/QueryInterface/Association/AssociationQuery.swift
@@ -45,7 +45,7 @@ extension AssociationQuery {
         return query
     }
     
-    func order(_ orderings: [SQLOrderingTerm]) -> AssociationQuery {
+    func order(_ orderings: @escaping (Database) throws -> [SQLOrderingTerm]) -> AssociationQuery {
         return order(QueryOrdering(orderings: orderings))
     }
     

--- a/GRDB/QueryInterface/Association/AssociationRequest.swift
+++ b/GRDB/QueryInterface/Association/AssociationRequest.swift
@@ -24,7 +24,7 @@ extension AssociationRequest {
         return AssociationRequest(query: query.filter(predicate))
     }
     
-    func order(_ orderings: [SQLOrderingTerm]) -> AssociationRequest {
+    func order(_ orderings: @escaping (Database) throws -> [SQLOrderingTerm]) -> AssociationRequest {
         return AssociationRequest(query: query.order(orderings))
     }
     

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -97,20 +97,20 @@ extension QueryInterfaceRequest : DerivableRequest, AggregatingRequest {
         return QueryInterfaceRequest(query: query.having(predicate))
     }
     
-    /// Creates a request with the provided *orderings*.
+    /// Creates a request with the provided *orderings promise*.
     ///
     ///     // SELECT * FROM player ORDER BY name
     ///     var request = Player.all()
-    ///     request = request.order([Column("name")])
+    ///     request = request.order { _ in [Column("name")] }
     ///
     /// Any previous ordering is replaced:
     ///
     ///     // SELECT * FROM player ORDER BY name
     ///     request
-    ///         .order([Column("email")])
+    ///         .order{ _ in [Column("email")] }
     ///         .reversed()
-    ///         .order([Column("name")])
-    public func order(_ orderings: [SQLOrderingTerm]) -> QueryInterfaceRequest<T> {
+    ///         .order{ _ in [Column("name")] }
+    public func order(_ orderings: @escaping (Database) throws -> [SQLOrderingTerm]) -> QueryInterfaceRequest<T> {
         return QueryInterfaceRequest(query: query.order(orderings))
     }
     
@@ -358,6 +358,21 @@ extension TableRecord {
     /// for individual requests with the `TableRecord.select` method.
     public static func order(_ orderings: [SQLOrderingTerm]) -> QueryInterfaceRequest<Self> {
         return all().order(orderings)
+    }
+    
+    /// Creates a request sorted by primary key.
+    ///
+    ///     // SELECT * FROM player ORDER BY id
+    ///     let request = Player.orderByPrimaryKey()
+    ///
+    ///     // SELECT * FROM country ORDER BY code
+    ///     let request = Country.orderByPrimaryKey()
+    ///
+    /// The selection defaults to all columns. This default can be changed for
+    /// all requests by the `TableRecord.databaseSelection` property, or
+    /// for individual requests with the `TableRecord.select` method.
+    public static func orderByPrimaryKey() -> QueryInterfaceRequest<Self> {
+        return all().orderByPrimaryKey()
     }
     
     /// Creates a request sorted according to *sql*.

--- a/GRDB/QueryInterface/QueryOrdering.swift
+++ b/GRDB/QueryInterface/QueryOrdering.swift
@@ -1,0 +1,81 @@
+/// QueryOrdering provides the order clause to QueryInterfaceQuery
+/// and AssociationQuery.
+struct QueryOrdering {
+    private var elements: [Element] = []
+    var isReversed: Bool
+    
+    private enum Element {
+        case orderingTerms((Database) throws -> [SQLOrderingTerm])
+        case queryOrdering(QueryOrdering)
+        
+        var reversed: Element {
+            switch self {
+            case .orderingTerms(let orderings):
+                return .orderingTerms { db in try orderings(db).map { $0.reversed } }
+            case .queryOrdering(let queryOrdering):
+                return .queryOrdering(queryOrdering.reversed)
+            }
+        }
+        
+        func qualified(with alias: TableAlias) -> Element {
+            switch self {
+            case .orderingTerms(let orderings):
+                return .orderingTerms { db in try orderings(db).map { $0.qualifiedOrdering(with: alias) } }
+            case .queryOrdering(let queryOrdering):
+                return .queryOrdering(queryOrdering.qualified(with: alias))
+            }
+        }
+        
+        func resolve(_ db: Database) throws -> [SQLOrderingTerm] {
+            switch self {
+            case .orderingTerms(let orderings):
+                return try orderings(db)
+            case .queryOrdering(let queryOrdering):
+                return try queryOrdering.resolve(db)
+            }
+        }
+    }
+    
+    private init(elements: [Element], isReversed: Bool) {
+        self.elements = elements
+        self.isReversed = isReversed
+    }
+    
+    init() {
+        self.init(
+            elements: [],
+            isReversed: false)
+    }
+    
+    init(orderings: @escaping (Database) throws -> [SQLOrderingTerm]) {
+        self.init(
+            elements: [.orderingTerms(orderings)],
+            isReversed: false)
+    }
+    
+    var reversed: QueryOrdering {
+        return QueryOrdering(
+            elements: elements,
+            isReversed: !isReversed)
+    }
+    
+    func qualified(with alias: TableAlias) -> QueryOrdering {
+        return QueryOrdering(
+            elements: elements.map { $0.qualified(with: alias) },
+            isReversed: isReversed)
+    }
+    
+    func appending(_ ordering: QueryOrdering) -> QueryOrdering {
+        return QueryOrdering(
+            elements: elements + [.queryOrdering(ordering)],
+            isReversed: isReversed)
+    }
+    
+    func resolve(_ db: Database) throws -> [SQLOrderingTerm] {
+        if isReversed {
+            return try elements.flatMap { try $0.reversed.resolve(db) }
+        } else {
+            return try elements.flatMap { try $0.resolve(db) }
+        }
+    }
+}

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -273,6 +273,8 @@
 		5653EC18209873A400F46237 /* SQLExpression+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653EC15209873A400F46237 /* SQLExpression+QueryInterface.swift */; };
 		5653EC1A209873E600F46237 /* SQLGenerationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653EC19209873E600F46237 /* SQLGenerationContext.swift */; };
 		5653EC1B209873E600F46237 /* SQLGenerationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653EC19209873E600F46237 /* SQLGenerationContext.swift */; };
+		5656BF5E20C7248700F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF5C20C7248700F98521 /* QueryOrdering.swift */; };
+		5656BF5F20C7248700F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF5C20C7248700F98521 /* QueryOrdering.swift */; };
 		5657AABA1D107001006283EF /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		5657AABD1D107001006283EF /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		5657AB101D10899D006283EF /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AB0E1D10899D006283EF /* URL.swift */; };
@@ -988,6 +990,7 @@
 		5653EBB320961FE800F46237 /* AssociationBelongsToRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationBelongsToRowScopeTests.swift; sourceTree = "<group>"; };
 		5653EC15209873A400F46237 /* SQLExpression+QueryInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SQLExpression+QueryInterface.swift"; sourceTree = "<group>"; };
 		5653EC19209873E600F46237 /* SQLGenerationContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLGenerationContext.swift; sourceTree = "<group>"; };
+		5656BF5C20C7248700F98521 /* QueryOrdering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryOrdering.swift; sourceTree = "<group>"; };
 		5657AAB81D107001006283EF /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		5657AB0E1D10899D006283EF /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		5657AB2F1D108BA9006283EF /* FoundationDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDataTests.swift; sourceTree = "<group>"; };
@@ -1444,6 +1447,7 @@
 				5605F18C1C6B1A8700235C62 /* QueryInterfaceQuery.swift */,
 				56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */,
 				5653EBA120961FCA00F46237 /* QueryInterfaceRequest+Association.swift */,
+				5656BF5C20C7248700F98521 /* QueryOrdering.swift */,
 				5616AAF8207CD5A900AC3664 /* RequestProtocols.swift */,
 				5605F1891C6B1A8700235C62 /* SQLCollatedExpression.swift */,
 				566475991D97D8A000FF74B8 /* SQLCollection.swift */,
@@ -2185,6 +2189,7 @@
 				56CEB55B1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
 				56BF6D301DEF47DA006039A3 /* Fixits-0-84-0.swift in Sources */,
 				560FC52A1CB003810014AA8E /* DatabaseError.swift in Sources */,
+				5656BF5E20C7248700F98521 /* QueryOrdering.swift in Sources */,
 				56D51D011EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				566475BB1D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				560FC52B1CB003810014AA8E /* DatabaseValue.swift in Sources */,
@@ -2619,6 +2624,7 @@
 				56CEB55E1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
 				56BF6D331DEF47DA006039A3 /* Fixits-0-84-0.swift in Sources */,
 				56AFC9FF1CB1A8BB00F48B96 /* DatabaseValueConvertible.swift in Sources */,
+				5656BF5F20C7248700F98521 /* QueryOrdering.swift in Sources */,
 				56D51D041EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				566475BE1D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				56AFCA001CB1A8BB00F48B96 /* Record.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		5653EB8320961FB200F46237 /* AssociationBelongsToRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653EB6520961FB200F46237 /* AssociationBelongsToRowScopeTests.swift */; };
 		5653EC082098737400F46237 /* SQLGenerationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653EC072098737400F46237 /* SQLGenerationContext.swift */; };
 		5653EC092098737400F46237 /* SQLGenerationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5653EC072098737400F46237 /* SQLGenerationContext.swift */; };
+		5656BF5A20C7247100F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF5820C7247100F98521 /* QueryOrdering.swift */; };
+		5656BF5B20C7247100F98521 /* QueryOrdering.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656BF5820C7247100F98521 /* QueryOrdering.swift */; };
 		5657AABB1D107001006283EF /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		5657AABE1D107001006283EF /* NSData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AAB81D107001006283EF /* NSData.swift */; };
 		5657AB111D10899D006283EF /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AB0E1D10899D006283EF /* URL.swift */; };
@@ -658,6 +660,7 @@
 		5653EB6420961FB200F46237 /* AssociationBelongsToDecodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationBelongsToDecodableRecordTests.swift; sourceTree = "<group>"; };
 		5653EB6520961FB200F46237 /* AssociationBelongsToRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationBelongsToRowScopeTests.swift; sourceTree = "<group>"; };
 		5653EC072098737400F46237 /* SQLGenerationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLGenerationContext.swift; sourceTree = "<group>"; };
+		5656BF5820C7247100F98521 /* QueryOrdering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryOrdering.swift; sourceTree = "<group>"; };
 		5657AAB81D107001006283EF /* NSData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSData.swift; sourceTree = "<group>"; };
 		5657AB0E1D10899D006283EF /* URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		5657AB2F1D108BA9006283EF /* FoundationDataTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDataTests.swift; sourceTree = "<group>"; };
@@ -1088,6 +1091,7 @@
 				5605F18C1C6B1A8700235C62 /* QueryInterfaceQuery.swift */,
 				56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */,
 				5653EB5320961F7D00F46237 /* QueryInterfaceRequest+Association.swift */,
+				5656BF5820C7247100F98521 /* QueryOrdering.swift */,
 				5616AAF4207CD59300AC3664 /* RequestProtocols.swift */,
 				5605F1891C6B1A8700235C62 /* SQLCollatedExpression.swift */,
 				566475991D97D8A000FF74B8 /* SQLCollection.swift */,
@@ -1858,6 +1862,7 @@
 				F3BA80201CFB288C003DC1BA /* Date.swift in Sources */,
 				56A8C2351D1914540096E9D4 /* UUID.swift in Sources */,
 				56BF6D341DEF47DA006039A3 /* Fixits-0-84-0.swift in Sources */,
+				5656BF5B20C7247100F98521 /* QueryOrdering.swift in Sources */,
 				56D51D051EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				F3BA80151CFB2876003DC1BA /* DatabaseWriter.swift in Sources */,
 				F3BA800A1CFB286A003DC1BA /* Configuration.swift in Sources */,
@@ -2130,6 +2135,7 @@
 				F3BA807C1CFB2E61003DC1BA /* Date.swift in Sources */,
 				56A8C2321D1914540096E9D4 /* UUID.swift in Sources */,
 				56BF6D311DEF47DA006039A3 /* Fixits-0-84-0.swift in Sources */,
+				5656BF5A20C7247100F98521 /* QueryOrdering.swift in Sources */,
 				56D51D021EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				F3BA80711CFB2E55003DC1BA /* DatabaseWriter.swift in Sources */,
 				F3BA80661CFB2E55003DC1BA /* Configuration.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -2360,8 +2360,8 @@ try Document.fetchOne(db, key: 1)            // Document?
 For multiple-column primary keys and unique keys defined by unique indexes, provide a dictionary:
 
 ```swift
-// SELECT * FROM citizenship WHERE playerID = 1 AND countryISOCode = 'FR'
-try Citizenship.fetchOne(db, key: ["playerID": 1, "countryISOCode": "FR"]) // Citizenship?
+// SELECT * FROM citizenship WHERE citizenId = 1 AND countryCode = 'FR'
+try Citizenship.fetchOne(db, key: ["citizenId": 1, "countryCode": "FR"]) // Citizenship?
 ```
 
 
@@ -3547,8 +3547,8 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     // SELECT * FROM country WHERE isoCode IN ('FR', 'US')
     Country.filter(keys: ["FR", "US"])
     
-    // SELECT * FROM citizenship WHERE playerID = 1 AND countryISOCode = 'FR'
-    Citizenship.filter(key: ["playerID": 1, "countryISOCode": "FR"])
+    // SELECT * FROM citizenship WHERE citizenId = 1 AND countryCode = 'FR'
+    Citizenship.filter(key: ["citizenId": 1, "countryCode": "FR"])
     
     // SELECT * FROM player WHERE email = 'arthur@example.com'
     Player.filter(key: ["email": "arthur@example.com"])
@@ -3598,6 +3598,19 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     ```swift
     // SELECT * FROM player ORDER BY name
     Player.order(scoreColumn).order(nameColumn)
+    ```
+
+    `orderByPrimaryKey()` sorts by primary key:
+    
+    ```swift
+    // SELECT * FROM player ORDER BY id
+    Player.orderByPrimaryKey()
+    
+    // SELECT * FROM country ORDER BY code
+    Country.orderByPrimaryKey()
+    
+    // SELECT * FROM citizenship ORDER BY citizenId, countryCode
+    Citizenship.orderByPrimaryKey()
     ```
 
 - `reversed()` reverses the eventual orderings.
@@ -3970,8 +3983,8 @@ try Document.fetchOne(db, key: 1)            // Document?
 For multiple-column primary keys and unique keys defined by unique indexes, provide a dictionary:
 
 ```swift
-// SELECT * FROM citizenship WHERE playerID = 1 AND countryISOCode = 'FR'
-try Citizenship.fetchOne(db, key: ["playerID": 1, "countryISOCode": "FR"]) // Citizenship?
+// SELECT * FROM citizenship WHERE citizenId = 1 AND countryCode = 'FR'
+try Citizenship.fetchOne(db, key: ["citizenId": 1, "countryCode": "FR"]) // Citizenship?
 
 // SELECT * FROM player WHERE email = 'arthur@example.com'
 try Player.fetchOne(db, key: ["email": "arthur@example.com"])              // Player?
@@ -3996,8 +4009,8 @@ let country = try request.fetchOne(db)   // Country?
 let request = Country.filter(keys: ["FR", "US"])
 let countries = try request.fetchAll(db) // [Country]
 
-// SELECT * FROM citizenship WHERE playerID = 1 AND countryISOCode = 'FR'
-let request = Citizenship.filter(key: ["playerID": 1, "countryISOCode": "FR"])
+// SELECT * FROM citizenship WHERE citizenId = 1 AND countryCode = 'FR'
+let request = Citizenship.filter(key: ["citizenId": 1, "countryCode": "FR"])
 let citizenship = request.fetchOne(db)   // Citizenship?
 
 // SELECT * FROM player WHERE email = 'arthur@example.com'
@@ -4086,8 +4099,8 @@ try Document.deleteOne(db, key: 1)
 For multiple-column primary keys and unique keys defined by unique indexes, provide a dictionary:
 
 ```swift
-// DELETE FROM citizenship WHERE playerID = 1 AND countryISOCode = 'FR'
-try Citizenship.deleteOne(db, key: ["playerID": 1, "countryISOCode": "FR"])
+// DELETE FROM citizenship WHERE citizenId = 1 AND countryCode = 'FR'
+try Citizenship.deleteOne(db, key: ["citizenId": 1, "countryCode": "FR"])
 
 // DELETE FROM player WHERE email = 'arthur@example.com'
 Player.deleteOne(db, key: ["email": "arthur@example.com"])
@@ -5775,7 +5788,7 @@ let controller = FetchedRecordsController(
 // Using SQL, and eventual arguments:
 let controller = FetchedRecordsController<Player>(
     dbQueue,
-    sql: "SELECT * FROM player ORDER BY name WHERE countryIsoCode = ?",
+    sql: "SELECT * FROM player ORDER BY name WHERE countryCode = ?",
     arguments: ["FR"])
 ```
 

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -379,7 +379,19 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             XCTAssertTrue(fetchedRecord.id == record.id)
         }
     }
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = MinimalRowID.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"minimalRowIDs\" ORDER BY \"id\"")
+        }
+    }
+    
 
     // MARK: - Fetch With Primary Key
     

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
@@ -395,8 +395,20 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.UUID == record.UUID)
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = MinimalSingle.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"minimalSingles\" ORDER BY \"UUID\"")
+        }
+    }
+    
+    
     // MARK: - Fetch With Primary Key
     
     func testFetchCursorWithPrimaryKeys() throws {

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -462,8 +462,20 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = Person.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT *, \"rowid\" FROM \"persons\" ORDER BY \"rowid\"")
+        }
+    }
+    
+    
     // MARK: - Fetch With Primary Key
     
     func testFetchCursorWithPrimaryKeys() throws {

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
@@ -415,8 +415,20 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.native == record.native)
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = Citizenship.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"citizenships\" ORDER BY \"personName\", \"countryName\"")
+        }
+    }
+    
+    
     // MARK: - Exists
 
     func testExistsWithNilPrimaryKeyReturnsFalse() throws {

--- a/Tests/GRDBTests/RecordPrimaryKeyNoneTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyNoneTests.swift
@@ -116,8 +116,20 @@ class RecordPrimaryKeyNoneTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.email == record.email)
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = Item.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"items\" ORDER BY \"rowid\"")
+        }
+    }
+    
+    
     // MARK: - Fetch With Primary Key
     
     func testFetchCursorWithPrimaryKeys() throws {

--- a/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
@@ -458,8 +458,20 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = Person.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"persons\" ORDER BY \"id\"")
+        }
+    }
+    
+    
     // MARK: - Fetch With Primary Key
     
     func testFetchCursorWithPrimaryKeys() throws {

--- a/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
@@ -406,8 +406,20 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.name == record.name)
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = Pet.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"pets\" ORDER BY \"UUID\"")
+        }
+    }
+    
+    
     // MARK: - Fetch With Primary Key
     
     func testFetchCursorWithPrimaryKeys() throws {

--- a/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
@@ -401,8 +401,20 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.email == record.email)
         }
     }
-
-
+    
+    
+    // MARK: - Order By Primary Key
+    
+    func testOrderByPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request = Email.orderByPrimaryKey()
+            let sqlRequest = try SQLRequest(db, request: request)
+            XCTAssertEqual(sqlRequest.sql, "SELECT * FROM \"emails\" ORDER BY \"email\"")
+        }
+    }
+    
+    
     // MARK: - Fetch With Primary Key
     
     func testFetchCursorWithPrimaryKeys() throws {


### PR DESCRIPTION
This PR introduces the `orderByPrimaryKey()` method which sorts by primary key:

```swift
// SELECT * FROM player ORDER BY id
Player.orderByPrimaryKey()

// SELECT * FROM country ORDER BY code
Country.orderByPrimaryKey()

// SELECT * FROM citizenship ORDER BY citizenId, countryCode
Citizenship.orderByPrimaryKey()
```
