### PR TITLE
Database can have a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Release Notes
 
 ## Next Version
 
-- Database dispatch queues now have labels ([#371](https://github.com/groue/GRDB.swift/pull/371)).
+- Database can have a label ([#371](https://github.com/groue/GRDB.swift/pull/371)).
 
 
 ## 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+## Next Version
+
+- Database dispatch queues now have labels ([#371](https://github.com/groue/GRDB.swift/pull/371)).
+
+
 ## 3.0.0
 
 Released June 7, 2018 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v2.10.0...v3.0.0)

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -20,6 +20,53 @@ public struct Configuration {
     /// Default: false
     public var readonly: Bool = false
     
+    /// The database label.
+    ///
+    /// You can query this label at runtime:
+    ///
+    ///     var configuration = Configuration()
+    ///     configuration.label = "MyDatabase"
+    ///     let dbQueue = DatabaseQueue(path: ..., configuration: configuration)
+    ///
+    ///     try dbQueue.read { db in
+    ///         print(db.configuration.label) // Prints "MyDatabase"
+    ///     }
+    ///
+    /// This label is also used to describe the various dispatch queues created
+    /// by GRDB, visible in debugging sessions and crash logs. However those
+    /// dispatch queue labels are intended for debugging only. Their format may
+    /// change between GRDB releases. Applications should not depend on the
+    /// GRDB dispatch queue labels.
+    ///
+    /// If the label is nil, the current GRDB implementation uses those
+    /// dispatch queue labels:
+    ///
+    /// - `GRDB.DatabaseQueue`: the (unique) dispatch queue of a DatabaseQueue
+    /// - `GRDB.DatabasePool.Writer`: the (unique) writer dispatch queue of
+    ///   a DatabasePool
+    /// - `GRDB.DatabasePool.Reader.N`, where N is 1, 2, ...: one of the reader
+    ///   dispatch queue(s) of a DatabasePool. N grows with the number of SQLite
+    ///   connections: it may get bigger than the maximum number of concurrent
+    ///   readers, as SQLite connections get closed and new ones are opened.
+    /// - `GRDB.DatabasePool.Snapshot.N`: the dispatch queue of a
+    ///   DatabaseSnapshot. N grows with the number of snapshots.
+    ///
+    /// If the label is not nil, for example "MyDatabase", the current GRDB
+    /// implementation uses those dispatch queue labels:
+    ///
+    /// - `MyDatabase`: the (unique) dispatch queue of a DatabaseQueue
+    /// - `MyDatabase.Writer`: the (unique) writer dispatch queue of
+    ///   a DatabasePool
+    /// - `MyDatabase.Reader.N`, where N is 1, 2, ...: one of the reader
+    ///   dispatch queue(s) of a DatabasePool. N grows with the number of SQLite
+    ///   connections: it may get bigger than the maximum number of concurrent
+    ///   readers, as SQLite connections get closed and new ones are opened.
+    /// - `MyDatabase.Snapshot.N`: the dispatch queue of a
+    ///   DatabaseSnapshot. N grows with the number of snapshots.
+    ///
+    /// The default label is nil.
+    public var label: String? = nil
+    
     /// A function that is called on every statement executed by the database.
     ///
     /// Default: nil

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -26,7 +26,7 @@ public struct Configuration {
     ///
     ///     var configuration = Configuration()
     ///     configuration.label = "MyDatabase"
-    ///     let dbQueue = DatabaseQueue(path: ..., configuration: configuration)
+    ///     let dbQueue = try DatabaseQueue(path: ..., configuration: configuration)
     ///
     ///     try dbQueue.read { db in
     ///         print(db.configuration.label) // Prints "MyDatabase"
@@ -42,26 +42,26 @@ public struct Configuration {
     /// following dispatch queue labels:
     ///
     /// - `GRDB.DatabaseQueue`: the (unique) dispatch queue of a DatabaseQueue
-    /// - `GRDB.DatabasePool.Writer`: the (unique) writer dispatch queue of
+    /// - `GRDB.DatabasePool.writer`: the (unique) writer dispatch queue of
     ///   a DatabasePool
-    /// - `GRDB.DatabasePool.Reader.N`, where N is 1, 2, ...: one of the reader
+    /// - `GRDB.DatabasePool.reader.N`, where N is 1, 2, ...: one of the reader
     ///   dispatch queue(s) of a DatabasePool. N grows with the number of SQLite
     ///   connections: it may get bigger than the maximum number of concurrent
     ///   readers, as SQLite connections get closed and new ones are opened.
-    /// - `GRDB.DatabasePool.Snapshot.N`: the dispatch queue of a
+    /// - `GRDB.DatabasePool.snapshot.N`: the dispatch queue of a
     ///   DatabaseSnapshot. N grows with the number of snapshots.
     ///
     /// If the database label is not nil, for example "MyDatabase", the current
     /// GRDB implementation uses the following dispatch queue labels:
     ///
     /// - `MyDatabase`: the (unique) dispatch queue of a DatabaseQueue
-    /// - `MyDatabase.Writer`: the (unique) writer dispatch queue of
+    /// - `MyDatabase.writer`: the (unique) writer dispatch queue of
     ///   a DatabasePool
-    /// - `MyDatabase.Reader.N`, where N is 1, 2, ...: one of the reader
+    /// - `MyDatabase.reader.N`, where N is 1, 2, ...: one of the reader
     ///   dispatch queue(s) of a DatabasePool. N grows with the number of SQLite
     ///   connections: it may get bigger than the maximum number of concurrent
     ///   readers, as SQLite connections get closed and new ones are opened.
-    /// - `MyDatabase.Snapshot.N`: the dispatch queue of a
+    /// - `MyDatabase.snapshot.N`: the dispatch queue of a
     ///   DatabaseSnapshot. N grows with the number of snapshots.
     ///
     /// The default label is nil.

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -32,14 +32,14 @@ public struct Configuration {
     ///         print(db.configuration.label) // Prints "MyDatabase"
     ///     }
     ///
-    /// This label is also used to describe the various dispatch queues created
-    /// by GRDB, visible in debugging sessions and crash logs. However those
-    /// dispatch queue labels are intended for debugging only. Their format may
-    /// change between GRDB releases. Applications should not depend on the
-    /// GRDB dispatch queue labels.
+    /// The database label is also used to name the various dispatch queues
+    /// created by GRDB, visible in debugging sessions and crash logs. However
+    /// those dispatch queue labels are intended for debugging only. Their
+    /// format may change between GRDB releases. Applications should not depend
+    /// on the GRDB dispatch queue labels.
     ///
-    /// If the label is nil, the current GRDB implementation uses those
-    /// dispatch queue labels:
+    /// If the database label is nil, the current GRDB implementation uses the
+    /// following dispatch queue labels:
     ///
     /// - `GRDB.DatabaseQueue`: the (unique) dispatch queue of a DatabaseQueue
     /// - `GRDB.DatabasePool.Writer`: the (unique) writer dispatch queue of
@@ -51,8 +51,8 @@ public struct Configuration {
     /// - `GRDB.DatabasePool.Snapshot.N`: the dispatch queue of a
     ///   DatabaseSnapshot. N grows with the number of snapshots.
     ///
-    /// If the label is not nil, for example "MyDatabase", the current GRDB
-    /// implementation uses those dispatch queue labels:
+    /// If the database label is not nil, for example "MyDatabase", the current
+    /// GRDB implementation uses the following dispatch queue labels:
     ///
     /// - `MyDatabase`: the (unique) dispatch queue of a DatabaseQueue
     /// - `MyDatabase.Writer`: the (unique) writer dispatch queue of

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -50,7 +50,7 @@ public final class DatabasePool: DatabaseWriter {
             path: path,
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: (configuration.label ?? "GRDB.DatabasePool") + ".Writer")
+            label: (configuration.label ?? "GRDB.DatabasePool") + ".writer")
         
         // Activate WAL Mode unless readonly
         if !configuration.readonly {
@@ -87,7 +87,7 @@ public final class DatabasePool: DatabaseWriter {
                 path: path,
                 configuration: self.readerConfig,
                 schemaCache: SimpleDatabaseSchemaCache(),
-                label: (self.readerConfig.label ?? "GRDB.DatabasePool") + ".Reader.\(readerCount)")
+                label: (self.readerConfig.label ?? "GRDB.DatabasePool") + ".reader.\(readerCount)")
             reader.sync { self.setupDatabase($0) }
             return reader
         })
@@ -710,7 +710,7 @@ extension DatabasePool {
         let snapshot = try DatabaseSnapshot(
             path: path,
             configuration: writer.configuration,
-            labelSuffix: ".Snapshot.\(snapshotCount.increment())")
+            labelSuffix: ".snapshot.\(snapshotCount.increment())")
         snapshot.read { setupDatabase($0) }
         return snapshot
     }

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -40,7 +40,7 @@ public final class DatabaseQueue: DatabaseWriter {
             path: path,
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: "GRDB.DatabaseQueue")
+            label: configuration.label ?? "GRDB.DatabaseQueue")
     }
     
     /// Opens an in-memory SQLite database.
@@ -56,7 +56,7 @@ public final class DatabaseQueue: DatabaseWriter {
             path: ":memory:",
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: "GRDB.DatabaseQueue")
+            label: configuration.label ?? "GRDB.DatabaseQueue")
     }
     
     #if os(iOS)

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -39,7 +39,8 @@ public final class DatabaseQueue: DatabaseWriter {
         writer = try SerializedDatabase(
             path: path,
             configuration: configuration,
-            schemaCache: SimpleDatabaseSchemaCache())
+            schemaCache: SimpleDatabaseSchemaCache(),
+            label: "GRDB.DatabaseQueue")
     }
     
     /// Opens an in-memory SQLite database.
@@ -54,7 +55,8 @@ public final class DatabaseQueue: DatabaseWriter {
         writer = try! SerializedDatabase(
             path: ":memory:",
             configuration: configuration,
-            schemaCache: SimpleDatabaseSchemaCache())
+            schemaCache: SimpleDatabaseSchemaCache(),
+            label: "GRDB.DatabaseQueue")
     }
     
     #if os(iOS)

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -6,13 +6,13 @@
 /// For more information, read about "snapshot isolation" at https://sqlite.org/isolation.html
 public class DatabaseSnapshot : DatabaseReader {
     private var serializedDatabase: SerializedDatabase
-
+    
     /// The database configuration
     var configuration: Configuration {
         return serializedDatabase.configuration
     }
     
-    init(path: String, configuration: Configuration = Configuration()) throws {
+    init(path: String, configuration: Configuration = Configuration(), labelSuffix: String) throws {
         var configuration = configuration
         configuration.readonly = true
         configuration.allowsUnsafeTransactions = true // Snaphost keeps a long-lived transaction
@@ -21,7 +21,7 @@ public class DatabaseSnapshot : DatabaseReader {
             path: path,
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: "GRDB.DatabaseSnapshot")
+            label: (configuration.label ?? "GRDB.DatabasePool") + labelSuffix)
         
         try serializedDatabase.sync { db in
             // Assert WAL mode

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -20,7 +20,8 @@ public class DatabaseSnapshot : DatabaseReader {
         serializedDatabase = try SerializedDatabase(
             path: path,
             configuration: configuration,
-            schemaCache: SimpleDatabaseSchemaCache())
+            schemaCache: SimpleDatabaseSchemaCache(),
+            label: "GRDB.DatabaseSnapshot")
         
         try serializedDatabase.sync { db in
             // Assert WAL mode

--- a/GRDB/Core/SchedulingWatchdog.swift
+++ b/GRDB/Core/SchedulingWatchdog.swift
@@ -30,8 +30,8 @@ final class SchedulingWatchdog {
         allowedDatabases = [database]
     }
     
-    static func makeSerializedQueue(allowingDatabase database: Database) -> DispatchQueue {
-        let queue = DispatchQueue(label: "GRDB.SerializedDatabase")
+    static func makeSerializedQueue(allowingDatabase database: Database, label: String) -> DispatchQueue {
+        let queue = DispatchQueue(label: label)
         let watchdog = SchedulingWatchdog(allowedDatabase: database)
         queue.setSpecific(key: specificKey, value: watchdog)
         return queue

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -16,7 +16,7 @@ final class SerializedDatabase {
     /// The dispatch queue
     private let queue: DispatchQueue
     
-    init(path: String, configuration: Configuration = Configuration(), schemaCache: DatabaseSchemaCache) throws {
+    init(path: String, configuration: Configuration = Configuration(), schemaCache: DatabaseSchemaCache, label: String) throws {
         // According to https://www.sqlite.org/threadsafe.html
         //
         // > SQLite support three different threading modes:
@@ -38,7 +38,7 @@ final class SerializedDatabase {
         config.threadingMode = .multiThread
         
         db = try Database(path: path, configuration: config, schemaCache: schemaCache)
-        queue = SchedulingWatchdog.makeSerializedQueue(allowingDatabase: db)
+        queue = SchedulingWatchdog.makeSerializedQueue(allowingDatabase: db, label: label)
         self.path = path
         try queue.sync {
             try db.setup()

--- a/GRDB/Utils/ReadWriteBox.swift
+++ b/GRDB/Utils/ReadWriteBox.swift
@@ -18,12 +18,21 @@ final class ReadWriteBox<T> {
         }
     }
     
-    func write(_ block: (inout T) throws -> Void) rethrows {
-        try queue.sync(flags: [.barrier]) {
+    func write<U>(_ block: (inout T) throws -> U) rethrows -> U {
+        return try queue.sync(flags: [.barrier]) {
             try block(&_value)
         }
     }
     
     private var _value: T
     private var queue: DispatchQueue
+}
+
+extension ReadWriteBox where T: Numeric {
+    func increment() -> T {
+        return write { n in
+            n += 1
+            return n
+        }
+    }
 }

--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ var config = Configuration()
 config.readonly = true
 config.foreignKeysEnabled = true // Default is already true
 config.trace = { print($0) }     // Prints all SQL statements
+config.label = "MyDatabase"      // Useful when your app opens multiple databases
 
 let dbQueue = try DatabaseQueue(
     path: "/path/to/database.sqlite",
@@ -525,6 +526,7 @@ var config = Configuration()
 config.readonly = true
 config.foreignKeysEnabled = true // Default is already true
 config.trace = { print($0) }     // Prints all SQL statements
+config.label = "MyDatabase"      // Useful when your app opens multiple databases
 config.maximumReaderCount = 10   // The default is 5
 
 let dbPool = try DatabasePool(

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -951,7 +951,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
             let label = String(utf8String: __dispatch_queue_get_label(nil))
-            XCTAssertEqual(label, "GRDB.DatabasePool.Writer")
+            XCTAssertEqual(label, "GRDB.DatabasePool.writer")
         }
         
         let s1 = DispatchSemaphore(value: 0)
@@ -963,7 +963,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
                 let label = String(utf8String: __dispatch_queue_get_label(nil))
-                XCTAssertEqual(label, "GRDB.DatabasePool.Reader.1")
+                XCTAssertEqual(label, "GRDB.DatabasePool.reader.1")
                 
                 _ = s1.signal()
                 _ = s2.wait(timeout: .distantFuture)
@@ -978,7 +978,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
                 let label = String(utf8String: __dispatch_queue_get_label(nil))
-                XCTAssertEqual(label, "GRDB.DatabasePool.Reader.2")
+                XCTAssertEqual(label, "GRDB.DatabasePool.reader.2")
             }
         }
         let blocks = [block1, block2]
@@ -996,7 +996,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
             let label = String(utf8String: __dispatch_queue_get_label(nil))
-            XCTAssertEqual(label, "Toreador.Writer")
+            XCTAssertEqual(label, "Toreador.writer")
         }
         
         let s1 = DispatchSemaphore(value: 0)
@@ -1008,7 +1008,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
                 let label = String(utf8String: __dispatch_queue_get_label(nil))
-                XCTAssertEqual(label, "Toreador.Reader.1")
+                XCTAssertEqual(label, "Toreador.reader.1")
                 
                 _ = s1.signal()
                 _ = s2.wait(timeout: .distantFuture)
@@ -1023,7 +1023,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
                 let label = String(utf8String: __dispatch_queue_get_label(nil))
-                XCTAssertEqual(label, "Toreador.Reader.2")
+                XCTAssertEqual(label, "Toreador.reader.2")
             }
         }
         let blocks = [block1, block2]

--- a/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
@@ -127,7 +127,6 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
     func testCacheSnapshotIsolation() throws {
         // This test checks that the schema cache follows snapshot isolation.
         // and that writer and readers do not naively share the same cache.
-        dbConfiguration.trace = { print($0) }
         let dbPool = try makeDatabasePool()
         
         // writer                   reader

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Dispatch
 #if GRDBCIPHER
     import GRDBCipher
 #elseif GRDBCUSTOMSQLITE
@@ -101,6 +102,33 @@ class DatabaseQueueTests: GRDBTestCase {
         
         try dbQueue.writeWithoutTransaction { db in
             try db.commit()
+        }
+    }
+    
+    func testDefaultLabel() throws {
+        let dbQueue = try makeDatabaseQueue()
+        XCTAssertEqual(dbQueue.configuration.label, nil)
+        dbQueue.inDatabase { db in
+            XCTAssertEqual(db.configuration.label, nil)
+            
+            // This test CAN break in future releases: the dispatch queue labels
+            // are documented to be a debug-only tool.
+            let label = String(utf8String: __dispatch_queue_get_label(nil))
+            XCTAssertEqual(label, "GRDB.DatabaseQueue")
+        }
+    }
+    
+    func testCustomLabel() throws {
+        dbConfiguration.label = "Toreador"
+        let dbQueue = try makeDatabaseQueue()
+        XCTAssertEqual(dbQueue.configuration.label, "Toreador")
+        dbQueue.inDatabase { db in
+            XCTAssertEqual(db.configuration.label, "Toreador")
+            
+            // This test CAN break in future releases: the dispatch queue labels
+            // are documented to be a debug-only tool.
+            let label = String(utf8String: __dispatch_queue_get_label(nil))
+            XCTAssertEqual(label, "Toreador")
         }
     }
 }

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -130,7 +130,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
             let label = String(utf8String: __dispatch_queue_get_label(nil))
-            XCTAssertEqual(label, "GRDB.DatabasePool.Snapshot.1")
+            XCTAssertEqual(label, "GRDB.DatabasePool.snapshot.1")
         }
         
         let snapshot2 = try dbPool.makeSnapshot()
@@ -140,7 +140,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
             let label = String(utf8String: __dispatch_queue_get_label(nil))
-            XCTAssertEqual(label, "GRDB.DatabasePool.Snapshot.2")
+            XCTAssertEqual(label, "GRDB.DatabasePool.snapshot.2")
         }
     }
     
@@ -155,7 +155,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
             let label = String(utf8String: __dispatch_queue_get_label(nil))
-            XCTAssertEqual(label, "Toreador.Snapshot.1")
+            XCTAssertEqual(label, "Toreador.snapshot.1")
         }
         
         let snapshot2 = try dbPool.makeSnapshot()
@@ -165,7 +165,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
             let label = String(utf8String: __dispatch_queue_get_label(nil))
-            XCTAssertEqual(label, "Toreador.Snapshot.2")
+            XCTAssertEqual(label, "Toreador.snapshot.2")
         }
     }
 }

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -119,4 +119,53 @@ class DatabaseSnapshotTests: GRDBTestCase {
             XCTAssertEqual(try String.fetchAll(db, "SELECT text FROM items ORDER BY text COLLATE reverse"), ["c", "b", "a"])
         }
     }
+    
+    func testDefaultLabel() throws {
+        let dbPool = try makeDatabasePool()
+        
+        let snapshot1 = try dbPool.makeSnapshot()
+        snapshot1.unsafeRead { db in
+            XCTAssertEqual(db.configuration.label, nil)
+            
+            // This test CAN break in future releases: the dispatch queue labels
+            // are documented to be a debug-only tool.
+            let label = String(utf8String: __dispatch_queue_get_label(nil))
+            XCTAssertEqual(label, "GRDB.DatabasePool.Snapshot.1")
+        }
+        
+        let snapshot2 = try dbPool.makeSnapshot()
+        snapshot2.unsafeRead { db in
+            XCTAssertEqual(db.configuration.label, nil)
+            
+            // This test CAN break in future releases: the dispatch queue labels
+            // are documented to be a debug-only tool.
+            let label = String(utf8String: __dispatch_queue_get_label(nil))
+            XCTAssertEqual(label, "GRDB.DatabasePool.Snapshot.2")
+        }
+    }
+    
+    func testCustomLabel() throws {
+        dbConfiguration.label = "Toreador"
+        let dbPool = try makeDatabasePool()
+        
+        let snapshot1 = try dbPool.makeSnapshot()
+        snapshot1.unsafeRead { db in
+            XCTAssertEqual(db.configuration.label, "Toreador")
+            
+            // This test CAN break in future releases: the dispatch queue labels
+            // are documented to be a debug-only tool.
+            let label = String(utf8String: __dispatch_queue_get_label(nil))
+            XCTAssertEqual(label, "Toreador.Snapshot.1")
+        }
+        
+        let snapshot2 = try dbPool.makeSnapshot()
+        snapshot2.unsafeRead { db in
+            XCTAssertEqual(db.configuration.label, "Toreador")
+            
+            // This test CAN break in future releases: the dispatch queue labels
+            // are documented to be a debug-only tool.
+            let label = String(utf8String: __dispatch_queue_get_label(nil))
+            XCTAssertEqual(label, "Toreador.Snapshot.2")
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces database labels:

```swift
var configuration = Configuration()
configuration.label = "MyDatabase"
let dbQueue = try DatabaseQueue(path: ..., configuration: configuration)
```

You can query this label at runtime:

```swift
try dbQueue.read { db in
    print(db.configuration.label) // Prints "MyDatabase"
}
```

The database label is also used to name the various dispatch queues created by GRDB, visible in debugging sessions and crash logs. However those dispatch queue labels are intended for debugging only. Their format may change between GRDB releases. Applications should not depend on the GRDB dispatch queue labels.

If the database label is nil, the current GRDB implementation uses the following dispatch queue labels:

- `GRDB.DatabaseQueue`: the (unique) dispatch queue of a DatabaseQueue
- `GRDB.DatabasePool.writer`: the (unique) writer dispatch queue of a DatabasePool
- `GRDB.DatabasePool.reader.N`, where N is 1, 2, ...: one of the reader dispatch queue(s) of a DatabasePool. N grows with the number of SQLite connections: it may get bigger than the maximum number of concurrent readers, as SQLite connections get closed and new ones are opened.
- `GRDB.DatabasePool.snapshot.N`: the dispatch queue of a DatabaseSnapshot. N grows with the number of snapshots.

If the database label is not nil, for example "MyDatabase", the current GRDB implementation uses the following dispatch queue labels:

- `MyDatabase`: the (unique) dispatch queue of a DatabaseQueue
- `MyDatabase.writer`: the (unique) writer dispatch queue of a DatabasePool
- `MyDatabase.reader.N`, where N is 1, 2, ...: one of the reader dispatch queue(s) of a DatabasePool. N grows with the number of SQLite connections: it may get bigger than the maximum number of concurrent readers, as SQLite connections get closed and new ones are opened.
- `MyDatabase.snapshot.N`: the dispatch queue of a DatabaseSnapshot. N grows with the number of snapshots.
