### PR TITLE
Codable support: customize the `userInfo` context dictionary, and the format of JSON columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Release Notes
 ### New
 
 - [#397](https://github.com/groue/GRDB.swift/pull/397): JSON encoding and decoding of codable record properties
+- [#399](https://github.com/groue/GRDB.swift/pull/399): Codable support: customize the `userInfo` context dictionary, and the format of JSON columns
 - [#393](https://github.com/groue/GRDB.swift/pull/393): Upgrade SQLCipher to 3.4.2, enable FTS5 on GRDBCipher and new pod GRDBPlus.
 - [#384](https://github.com/groue/GRDB.swift/pull/384): Improve database value decoding diagnostics
 - Cursors of optimized values (Strint, Int, Date, etc.) have been renamed: FastDatabaseValueCursor and FastNullableDatabaseValueCursor replace the deprecated ColumnCursor and NullableColumnCursor.
@@ -26,6 +27,16 @@ Release Notes
 +    func unsafeReentrantRead<T>(_ block: (Database) throws -> T) rethrows -> T {
  }
 
+ protocol FetchableRecord {
++    static var databaseDecodingUserInfo: [CodingUserInfoKey: Any] { get }
++    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder
+ }
+
+ protocol MutablePersistableRecord: TableRecord {
++    static var databaseEncodingUserInfo: [CodingUserInfoKey: Any] { get }
++    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder
+ }
+
 +final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & StatementColumnConvertible> : Cursor { }
 +@available(*, deprecated, renamed: "FastDatabaseValueCursor")
 +typealias ColumnCursor<Value: DatabaseValueConvertible & StatementColumnConvertible> = FastDatabaseValueCursor<Value>
@@ -39,7 +50,8 @@ Release Notes
 ### Documentation Diff
 
 - [Enabling FTS5 Support](README.md#enabling-fts5-support): Procedure for enabling FTS5 support in GRDB.
-- [Codable Records](README.md#codable-records): Updated documentation, for JSON encoding of codable record properties, and for the reuse of coding keys as database columns.
+- [Codable Records](README.md#codable-records): Updated documentation for JSON columns, tips, and customization options.
+- [Record Customization Options](README.md#record-customization-options): A new chapter that gather all your customization options.
 
 
 ## 3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,12 @@ Release Notes
 
  protocol FetchableRecord {
 +    static var databaseDecodingUserInfo: [CodingUserInfoKey: Any] { get }
-+    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder
++    static func databaseJSONDecoder(for column: String) -> JSONDecoder
  }
 
  protocol MutablePersistableRecord: TableRecord {
 +    static var databaseEncodingUserInfo: [CodingUserInfoKey: Any] { get }
-+    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder
++    static func databaseJSONEncoder(for column: String) -> JSONEncoder
  }
 
 +final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & StatementColumnConvertible> : Cursor { }

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -1,285 +1,264 @@
 import Foundation
 
-private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
-    let decoder: RowDecoder
-    var codingPath: [CodingKey] { return decoder.codingPath }
+// MARK: - RowDecoder
 
-    init(decoder: RowDecoder) {
-        self.decoder = decoder
+/// The decoder that decodes a record from a database row
+private struct RowDecoder<Record: FetchableRecord>: Decoder {
+    var row: Row
+    var codingPath: [CodingKey]
+    var userInfo: [CodingUserInfoKey: Any] { return Record.databaseDecodingUserInfo }
+    
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        return KeyedDecodingContainer(KeyedContainer<Key>(decoder: self))
     }
     
-    /// All the keys the `Decoder` has for this container.
-    ///
-    /// Different keyed containers from the same `Decoder` may return different keys here; it is possible to encode with multiple key types which are not convertible to one another. This should report all keys present which are convertible to the requested type.
-    var allKeys: [Key] {
-        let row = decoder.row
-        let columnNames = Set(row.columnNames)
-        let scopeNames = Set(row.scopesTree.names)
-        return columnNames.union(scopeNames).compactMap { Key(stringValue: $0) }
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        fatalError("unkeyed decoding from database row is not supported")
     }
     
-    /// Returns whether the `Decoder` contains a value associated with the given key.
-    ///
-    /// The value associated with the given key may be a null value as appropriate for the data format.
-    ///
-    /// - parameter key: The key to search for.
-    /// - returns: Whether the `Decoder` has an entry for the given key.
-    func contains(_ key: Key) -> Bool {
-        let row = decoder.row
-        return row.hasColumn(key.stringValue) || (row.scopesTree[key.stringValue] != nil)
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        fatalError("single value decoding from database row is not supported")
     }
     
-    /// Decodes a null value for the given key.
-    ///
-    /// - parameter key: The key that the decoded value is associated with.
-    /// - returns: Whether the encountered value was null.
-    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
-    func decodeNil(forKey key: Key) throws -> Bool {
-        let row = decoder.row
-        return row[key.stringValue] == nil && (row.scopesTree[key.stringValue] == nil)
-    }
-    
-    /// Decodes a value of the given type for the given key.
-    ///
-    /// - parameter type: The type of value to decode.
-    /// - parameter key: The key that the decoded value is associated with.
-    /// - returns: A value of the requested type, if present for the given key and convertible to the requested type.
-    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
-    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
-    /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the given key.
-    func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool { return decoder.row[key.stringValue] }
-    func decode(_ type: Int.Type, forKey key: Key) throws -> Int { return decoder.row[key.stringValue] }
-    func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 { return decoder.row[key.stringValue] }
-    func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 { return decoder.row[key.stringValue] }
-    func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 { return decoder.row[key.stringValue] }
-    func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 { return decoder.row[key.stringValue] }
-    func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt { return decoder.row[key.stringValue] }
-    func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 { return decoder.row[key.stringValue] }
-    func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { return decoder.row[key.stringValue] }
-    func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { return decoder.row[key.stringValue] }
-    func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { return decoder.row[key.stringValue] }
-    func decode(_ type: Float.Type, forKey key: Key) throws -> Float { return decoder.row[key.stringValue] }
-    func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return decoder.row[key.stringValue] }
-    func decode(_ type: String.Type, forKey key: Key) throws -> String { return decoder.row[key.stringValue] }
-    
-    /// Decodes a value of the given type for the given key, if present.
-    ///
-    /// This method returns nil if the container does not have a value
-    /// associated with key, or if the value is null. The difference between
-    /// these states can be distinguished with a contains(_:) call.
-    func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
-        let row = decoder.row
-        let keyName = key.stringValue
-
-        // Column?
-        if let index = row.index(ofColumn: keyName) {
-            // Prefer DatabaseValueConvertible decoding over Decodable.
-            // This allows decoding Date from String, or DatabaseValue from NULL.
-            if let type = T.self as? (DatabaseValueConvertible & StatementColumnConvertible).Type {
-                return type.fastDecodeIfPresent(from: row, atUncheckedIndex: index) as! T?
-            } else if let type = T.self as? DatabaseValueConvertible.Type {
-                return type.decodeIfPresent(from: row, atUncheckedIndex: index) as! T?
-            } else if row.impl.hasNull(atUncheckedIndex: index) {
-                return nil
-            } else {
-                do {
-                    // This decoding will fail for types that decode from keyed
-                    // or unkeyed containers, because we're decoding a single
-                    // value here (string, int, double, data, null). If such an
-                    // error happens, we'll switch to JSON decoding.
-                    let singleValueDecoder = RowSingleValueDecoder(
-                        row: row,
-                        columnIndex: index,
-                        codingPath: codingPath + [key],
-                        userInfo: decoder.userInfo)
-                    return try T(from: singleValueDecoder)
-                } catch is JSONRequiredError {
-                    guard let data = row.dataNoCopy(atIndex: index) else {
-                        fatalConversionError(to: T.self, from: row[index], conversionContext: ValueConversionContext(row).atColumn(index))
-                    }
-                    return try decoder
-                        .JSONDecoder(keyName)
-                        .decode(type.self, from: data)
+    struct KeyedContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+        let decoder: RowDecoder
+        var codingPath: [CodingKey] { return decoder.codingPath }
+        
+        init(decoder: RowDecoder) {
+            self.decoder = decoder
+        }
+        
+        var allKeys: [Key] {
+            let row = decoder.row
+            let columnNames = Set(row.columnNames)
+            let scopeNames = Set(row.scopesTree.names)
+            return columnNames.union(scopeNames).compactMap { Key(stringValue: $0) }
+        }
+        
+        func contains(_ key: Key) -> Bool {
+            let row = decoder.row
+            return row.hasColumn(key.stringValue) || (row.scopesTree[key.stringValue] != nil)
+        }
+        
+        func decodeNil(forKey key: Key) throws -> Bool {
+            let row = decoder.row
+            return row[key.stringValue] == nil && (row.scopesTree[key.stringValue] == nil)
+        }
+        
+        func decode(_ type: Bool.Type,   forKey key: Key) throws -> Bool   { return decoder.row[key.stringValue] }
+        func decode(_ type: Int.Type,    forKey key: Key) throws -> Int    { return decoder.row[key.stringValue] }
+        func decode(_ type: Int8.Type,   forKey key: Key) throws -> Int8   { return decoder.row[key.stringValue] }
+        func decode(_ type: Int16.Type,  forKey key: Key) throws -> Int16  { return decoder.row[key.stringValue] }
+        func decode(_ type: Int32.Type,  forKey key: Key) throws -> Int32  { return decoder.row[key.stringValue] }
+        func decode(_ type: Int64.Type,  forKey key: Key) throws -> Int64  { return decoder.row[key.stringValue] }
+        func decode(_ type: UInt.Type,   forKey key: Key) throws -> UInt   { return decoder.row[key.stringValue] }
+        func decode(_ type: UInt8.Type,  forKey key: Key) throws -> UInt8  { return decoder.row[key.stringValue] }
+        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { return decoder.row[key.stringValue] }
+        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { return decoder.row[key.stringValue] }
+        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { return decoder.row[key.stringValue] }
+        func decode(_ type: Float.Type,  forKey key: Key) throws -> Float  { return decoder.row[key.stringValue] }
+        func decode(_ type: Double.Type, forKey key: Key) throws -> Double { return decoder.row[key.stringValue] }
+        func decode(_ type: String.Type, forKey key: Key) throws -> String { return decoder.row[key.stringValue] }
+        
+        func decodeIfPresent<T>(_ type: T.Type, forKey key: Key) throws -> T? where T : Decodable {
+            let row = decoder.row
+            let keyName = key.stringValue
+            
+            // Column?
+            if let index = row.index(ofColumn: keyName) {
+                // Prefer DatabaseValueConvertible decoding over Decodable.
+                // This allows decoding Date from String, or DatabaseValue from NULL.
+                if let type = T.self as? (DatabaseValueConvertible & StatementColumnConvertible).Type {
+                    return type.fastDecodeIfPresent(from: row, atUncheckedIndex: index) as! T?
+                } else if let type = T.self as? DatabaseValueConvertible.Type {
+                    return type.decodeIfPresent(from: row, atUncheckedIndex: index) as! T?
+                } else if row.impl.hasNull(atUncheckedIndex: index) {
+                    return nil
+                } else {
+                    return try decode(type, fromColumnAtIndex: index, key: key)
                 }
             }
-        }
-        
-        // Scope?
-        if let scopedRow = row.scopesTree[keyName], scopedRow.containsNonNullValue {
-            if let type = T.self as? FetchableRecord.Type {
-                // Prefer FetchableRecord decoding over Decodable.
-                // This allows custom row decoding
-                return (type.init(row: scopedRow) as! T)
-            } else {
-                let scopedDecoder = RowDecoder(
-                    row: scopedRow,
-                    codingPath: codingPath + [key],
-                    userInfo: decoder.userInfo,
-                    JSONDecoder: decoder.JSONDecoder)
-                return try T(from: scopedDecoder)
+            
+            // Scope? (beware left joins, and check if scoped row contains non-null values)
+            if let scopedRow = row.scopesTree[keyName], scopedRow.containsNonNullValue {
+                return try decode(type, fromRow: scopedRow, codingPath: codingPath + [key])
             }
+            
+            // Key is not a column, and not a scope.
+            return nil
         }
         
-        return nil
-    }
-    
-    /// Decodes a value of the given type for the given key.
-    ///
-    /// - parameter type: The type of value to decode.
-    /// - parameter key: The key that the decoded value is associated with.
-    /// - returns: A value of the requested type, if present for the given key and convertible to the requested type.
-    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
-    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
-    /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the given key.
-    func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
-        let row = decoder.row
-        let keyName = key.stringValue
-
-        // Column?
-        if let index = row.index(ofColumn: keyName) {
-            // Prefer DatabaseValueConvertible decoding over Decodable.
-            // This allows decoding Date from String, or DatabaseValue from NULL.
-            if let type = T.self as? (DatabaseValueConvertible & StatementColumnConvertible).Type {
-                return type.fastDecode(from: row, atUncheckedIndex: index) as! T
-            } else if let type = T.self as? DatabaseValueConvertible.Type {
-                return type.decode(from: row, atUncheckedIndex: index) as! T
-            } else {
-                do {
-                    // This decoding will fail for types that decode from keyed
-                    // or unkeyed containers, because we're decoding a single
-                    // value here (string, int, double, data, null). If such an
-                    // error happens, we'll switch to JSON decoding.
-                    let singleValueDecoder = RowSingleValueDecoder(
-                        row: row,
-                        columnIndex: index,
-                        codingPath: codingPath + [key],
-                        userInfo: decoder.userInfo)
-                    return try T(from: singleValueDecoder)
-                } catch is JSONRequiredError {
-                    guard let data = row.dataNoCopy(atIndex: index) else {
-                        fatalConversionError(to: T.self, from: row[index], conversionContext: ValueConversionContext(row).atColumn(index))
-                    }
-                    return try decoder
-                        .JSONDecoder(keyName)
-                        .decode(type.self, from: data)
+        /// Decodes a value of the given type for the given key.
+        ///
+        /// - parameter type: The type of value to decode.
+        /// - parameter key: The key that the decoded value is associated with.
+        /// - returns: A value of the requested type, if present for the given key and convertible to the requested type.
+        /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
+        /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
+        /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the given key.
+        func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
+            let row = decoder.row
+            let keyName = key.stringValue
+            
+            // Column?
+            if let index = row.index(ofColumn: keyName) {
+                // Prefer DatabaseValueConvertible decoding over Decodable.
+                // This allows decoding Date from String, or DatabaseValue from NULL.
+                if let type = T.self as? (DatabaseValueConvertible & StatementColumnConvertible).Type {
+                    return type.fastDecode(from: row, atUncheckedIndex: index) as! T
+                } else if let type = T.self as? DatabaseValueConvertible.Type {
+                    return type.decode(from: row, atUncheckedIndex: index) as! T
+                } else {
+                    return try decode(type, fromColumnAtIndex: index, key: key)
                 }
             }
+            
+            // Scope?
+            if let scopedRow = row.scopesTree[keyName] {
+                return try decode(type, fromRow: scopedRow, codingPath: codingPath + [key])
+            }
+            
+            // Key is not a column, and not a scope.
+            //
+            // Should be throw an error? Well... The use case is the following:
+            //
+            //      // SELECT book.*, author.* FROM book
+            //      // JOIN author ON author.id = book.authorId
+            //      let request = Book.including(required: Book.author)
+            //
+            // Rows loaded from this request don't have any "book" key:
+            //
+            //      let row = try Row.fetchOne(db, request)!
+            //      print(row.debugDescription)
+            //      // ▿ [id:1 title:"Moby-Dick" authorId:2]
+            //      //   unadapted: [id:1 title:"Moby-Dick" authorId:2 id:2 name:"Melville"]
+            //      //   author: [id:2 name:"Melville"]
+            //
+            // And yet we have to decode the "book" key when we decode the
+            // BookInfo type below:
+            //
+            //      struct BookInfo {
+            //          var book: Book // <- decodes from the "book" key
+            //          var author: Author
+            //      }
+            //      let infos = try BookInfos.fetchAll(db, request)
+            //
+            // Our current strategy is to assume that a missing key (such as
+            // "book", which is not the name of a column, and not the name of a
+            // scope) has to be decoded right from the base row.
+            //
+            // Yeah, there may be better ways to handle this.
+            return try decode(type, fromRow: row, codingPath: codingPath + [key])
         }
-
-        // Scope?
-        if let scopedRow = row.scopesTree[keyName] {
+        
+        /// Returns the data stored for the given key as represented in a container keyed by the given key type.
+        ///
+        /// - parameter type: The key type to use for the container.
+        /// - parameter key: The key that the nested container is associated with.
+        /// - returns: A keyed decoding container view into `self`.
+        /// - throws: `DecodingError.typeMismatch` if the encountered stored value is not a keyed container.
+        func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
+            fatalError("not implemented")
+        }
+        
+        func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+            throw DecodingError.typeMismatch(
+                UnkeyedDecodingContainer.self,
+                DecodingError.Context(codingPath: codingPath, debugDescription: "unkeyed decoding is not supported"))
+        }
+        
+        func superDecoder() throws -> Decoder {
+            // Not sure
+            return decoder
+        }
+        
+        func superDecoder(forKey key: Key) throws -> Decoder {
+            fatalError("not implemented")
+        }
+        
+        // Helper methods
+        
+        @inline(__always)
+        private func decode<T>(_ type: T.Type, fromRow row: Row, codingPath: [CodingKey]) throws -> T where T: Decodable {
             if let type = T.self as? FetchableRecord.Type {
                 // Prefer FetchableRecord decoding over Decodable.
-                // This allows custom row decoding
-                return type.init(row: scopedRow) as! T
+                return type.init(row: row) as! T
             } else {
-                let scopedDecoder = RowDecoder(
-                    row: scopedRow,
-                    codingPath: codingPath + [key],
-                    userInfo: decoder.userInfo,
-                    JSONDecoder: decoder.JSONDecoder)
-                return try T(from: scopedDecoder)
+                let decoder = RowDecoder(row: row, codingPath: codingPath)
+                return try T(from: decoder)
             }
         }
         
-        // Base row
-        if let type = T.self as? FetchableRecord.Type {
-            // Prefer FetchableRecord decoding over Decodable.
-            // This allows custom row decoding
-            return type.init(row: row) as! T
-        } else {
-            let baseDecoder = RowDecoder(
-                row: row,
-                codingPath: codingPath + [key],
-                userInfo: decoder.userInfo,
-                JSONDecoder: decoder.JSONDecoder)
-            return try T(from: baseDecoder)
+        @inline(__always)
+        private func decode<T>(_ type: T.Type, fromColumnAtIndex index: Int, key: Key) throws -> T where T: Decodable {
+            let row = decoder.row
+            do {
+                // This decoding will fail for types that decode from keyed
+                // or unkeyed containers, because we're decoding a single
+                // value here (string, int, double, data, null). If such an
+                // error happens, we'll switch to JSON decoding.
+                let columnDecoder = ColumnDecoder<Record>(
+                    row: row,
+                    columnIndex: index,
+                    codingPath: codingPath + [key])
+                return try T(from: columnDecoder)
+            } catch is JSONRequiredError {
+                // Decode from JSON
+                guard let data = row.dataNoCopy(atIndex: index) else {
+                    fatalConversionError(to: T.self, from: row[index], conversionContext: ValueConversionContext(row).atColumn(index))
+                }
+                return try Record
+                    .databaseJSONDecoder(for: key.stringValue)
+                    .decode(type.self, from: data)
+            }
         }
-    }
-    
-    /// Returns the data stored for the given key as represented in a container keyed by the given key type.
-    ///
-    /// - parameter type: The key type to use for the container.
-    /// - parameter key: The key that the nested container is associated with.
-    /// - returns: A keyed decoding container view into `self`.
-    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is not a keyed container.
-    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        fatalError("not implemented")
-    }
-    
-    /// Returns the data stored for the given key as represented in an unkeyed container.
-    ///
-    /// - parameter key: The key that the nested container is associated with.
-    /// - returns: An unkeyed decoding container view into `self`.
-    /// - throws: `DecodingError.typeMismatch` if the encountered stored value is not an unkeyed container.
-    func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
-        throw DecodingError.typeMismatch(
-            UnkeyedDecodingContainer.self,
-            DecodingError.Context(codingPath: codingPath, debugDescription: "unkeyed decoding is not supported"))
-    }
-    
-    /// Returns a `Decoder` instance for decoding `super` from the container associated with the default `super` key.
-    ///
-    /// Equivalent to calling `superDecoder(forKey:)` with `Key(stringValue: "super", intValue: 0)`.
-    ///
-    /// - returns: A new `Decoder` to pass to `super.init(from:)`.
-    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the default `super` key.
-    /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the default `super` key.
-    public func superDecoder() throws -> Decoder {
-        return decoder
-    }
-    
-    /// Returns a `Decoder` instance for decoding `super` from the container associated with the given key.
-    ///
-    /// - parameter key: The key to decode `super` for.
-    /// - returns: A new `Decoder` to pass to `super.init(from:)`.
-    /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
-    /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the given key.
-    public func superDecoder(forKey key: Key) throws -> Decoder {
-        return decoder
     }
 }
 
-private struct RowSingleValueDecodingContainer: SingleValueDecodingContainer {
+// MARK: - ColumnDecoder
+
+/// The decoder that decodes from a database column
+private struct ColumnDecoder<Record: FetchableRecord>: Decoder {
     var row: Row
     var columnIndex: Int
     var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
+    var userInfo: [CodingUserInfoKey: Any] { return Record.databaseDecodingUserInfo }
+    
+    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        // We need to switch to JSON decoding
+        throw JSONRequiredError()
+    }
+    
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        // We need to switch to JSON decoding
+        throw JSONRequiredError()
+    }
+    
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        return self
+    }
+}
 
-    /// Decodes a null value.
-    ///
-    /// - returns: Whether the encountered value was null.
+extension ColumnDecoder: SingleValueDecodingContainer {
     func decodeNil() -> Bool {
         return row.hasNull(atIndex: columnIndex)
     }
-
-    /// Decodes a single value of the given type.
-    ///
-    /// - parameter type: The type to decode as.
-    /// - returns: A value of the requested type.
-    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value cannot be converted to the requested type.
-    /// - throws: `DecodingError.valueNotFound` if the encountered encoded value is null.
-    func decode(_ type: Bool.Type) throws -> Bool { return row[columnIndex] }
-    func decode(_ type: Int.Type) throws -> Int { return row[columnIndex] }
-    func decode(_ type: Int8.Type) throws -> Int8 { return row[columnIndex] }
-    func decode(_ type: Int16.Type) throws -> Int16 { return row[columnIndex] }
-    func decode(_ type: Int32.Type) throws -> Int32 { return row[columnIndex] }
-    func decode(_ type: Int64.Type) throws -> Int64 { return row[columnIndex] }
-    func decode(_ type: UInt.Type) throws -> UInt { return row[columnIndex] }
-    func decode(_ type: UInt8.Type) throws -> UInt8 { return row[columnIndex] }
+    
+    func decode(_ type: Bool.Type  ) throws -> Bool   { return row[columnIndex] }
+    func decode(_ type: Int.Type   ) throws -> Int    { return row[columnIndex] }
+    func decode(_ type: Int8.Type  ) throws -> Int8   { return row[columnIndex] }
+    func decode(_ type: Int16.Type ) throws -> Int16  { return row[columnIndex] }
+    func decode(_ type: Int32.Type ) throws -> Int32  { return row[columnIndex] }
+    func decode(_ type: Int64.Type ) throws -> Int64  { return row[columnIndex] }
+    func decode(_ type: UInt.Type  ) throws -> UInt   { return row[columnIndex] }
+    func decode(_ type: UInt8.Type ) throws -> UInt8  { return row[columnIndex] }
     func decode(_ type: UInt16.Type) throws -> UInt16 { return row[columnIndex] }
     func decode(_ type: UInt32.Type) throws -> UInt32 { return row[columnIndex] }
     func decode(_ type: UInt64.Type) throws -> UInt64 { return row[columnIndex] }
-    func decode(_ type: Float.Type) throws -> Float { return row[columnIndex] }
+    func decode(_ type: Float.Type ) throws -> Float  { return row[columnIndex] }
     func decode(_ type: Double.Type) throws -> Double { return row[columnIndex] }
     func decode(_ type: String.Type) throws -> String { return row[columnIndex] }
-
-    /// Decodes a single value of the given type.
-    ///
-    /// - parameter type: The type to decode as.
-    /// - returns: A value of the requested type.
-    /// - throws: `DecodingError.typeMismatch` if the encountered encoded value cannot be converted to the requested type.
-    /// - throws: `DecodingError.valueNotFound` if the encountered encoded value is null.
+    
     func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
         // Prefer DatabaseValueConvertible decoding over Decodable.
         // This allows decoding Date from String, or DatabaseValue from NULL.
@@ -288,55 +267,8 @@ private struct RowSingleValueDecodingContainer: SingleValueDecodingContainer {
         } else if let type = T.self as? DatabaseValueConvertible.Type {
             return type.decode(from: row, atUncheckedIndex: columnIndex) as! T
         } else {
-            let singleValueDecoder = RowSingleValueDecoder(
-                row: row,
-                columnIndex: columnIndex,
-                codingPath: codingPath,
-                userInfo: userInfo)
-            return try T(from: singleValueDecoder)
+            return try T(from: self)
         }
-    }
-}
-
-private struct RowDecoder: Decoder {
-    var row: Row
-    var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
-    var JSONDecoder: (String) -> JSONDecoder
-    
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
-        return KeyedDecodingContainer(RowKeyedDecodingContainer<Key>(decoder: self))
-    }
-    
-    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        throw JSONRequiredError()
-    }
-    
-    func singleValueContainer() throws -> SingleValueDecodingContainer {
-        throw JSONRequiredError()
-    }
-}
-
-private struct RowSingleValueDecoder: Decoder {
-    var row: Row
-    var columnIndex: Int
-    var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
-    
-    func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
-        throw JSONRequiredError()
-    }
-    
-    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        throw JSONRequiredError()
-    }
-    
-    func singleValueContainer() throws -> SingleValueDecodingContainer {
-        return RowSingleValueDecodingContainer(
-            row: row,
-            columnIndex: columnIndex,
-            codingPath: codingPath,
-            userInfo: userInfo)
     }
 }
 
@@ -346,11 +278,7 @@ private struct JSONRequiredError: Error { }
 extension FetchableRecord where Self: Decodable {
     /// Initializes a record from `row`.
     public init(row: Row) {
-        let decoder = RowDecoder(
-            row: row,
-            codingPath: [],
-            userInfo: Self.databaseDecodingUserInfo,
-            JSONDecoder: Self.databaseJSONDecoder)
+        let decoder = RowDecoder<Self>(row: row, codingPath: [])
         try! self.init(from: decoder)
     }
 }

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -349,8 +349,8 @@ extension FetchableRecord where Self: Decodable {
         let decoder = RowDecoder(
             row: row,
             codingPath: [],
-            userInfo: Self.decodingUserInfo,
-            makeJSONDecoder: Self.makeJSONDecoder)
+            userInfo: Self.databaseDecodingUserInfo,
+            makeJSONDecoder: Self.makeDatabaseJSONDecoder)
         try! self.init(from: decoder)
     }
 }

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -88,14 +88,6 @@ private struct RowDecoder<Record: FetchableRecord>: Decoder {
             return nil
         }
         
-        /// Decodes a value of the given type for the given key.
-        ///
-        /// - parameter type: The type of value to decode.
-        /// - parameter key: The key that the decoded value is associated with.
-        /// - returns: A value of the requested type, if present for the given key and convertible to the requested type.
-        /// - throws: `DecodingError.typeMismatch` if the encountered encoded value is not convertible to the requested type.
-        /// - throws: `DecodingError.keyNotFound` if `self` does not have an entry for the given key.
-        /// - throws: `DecodingError.valueNotFound` if `self` has a null entry for the given key.
         func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T : Decodable {
             let row = decoder.row
             let keyName = key.stringValue
@@ -151,12 +143,6 @@ private struct RowDecoder<Record: FetchableRecord>: Decoder {
             return try decode(type, fromRow: row, codingPath: codingPath + [key])
         }
         
-        /// Returns the data stored for the given key as represented in a container keyed by the given key type.
-        ///
-        /// - parameter type: The key type to use for the container.
-        /// - parameter key: The key that the nested container is associated with.
-        /// - returns: A keyed decoding container view into `self`.
-        /// - throws: `DecodingError.typeMismatch` if the encountered stored value is not a keyed container.
         func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
             fatalError("not implemented")
         }

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -98,7 +98,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
                         fatalConversionError(to: T.self, from: row[index], conversionContext: ValueConversionContext(row).atColumn(index))
                     }
                     return try decoder
-                        .makeJSONDecoder(keyName)
+                        .JSONDecoder(keyName)
                         .decode(type.self, from: data)
                 }
             }
@@ -115,7 +115,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
                     row: scopedRow,
                     codingPath: codingPath + [key],
                     userInfo: decoder.userInfo,
-                    makeJSONDecoder: decoder.makeJSONDecoder)
+                    JSONDecoder: decoder.JSONDecoder)
                 return try T(from: scopedDecoder)
             }
         }
@@ -160,7 +160,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
                         fatalConversionError(to: T.self, from: row[index], conversionContext: ValueConversionContext(row).atColumn(index))
                     }
                     return try decoder
-                        .makeJSONDecoder(keyName)
+                        .JSONDecoder(keyName)
                         .decode(type.self, from: data)
                 }
             }
@@ -177,7 +177,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
                     row: scopedRow,
                     codingPath: codingPath + [key],
                     userInfo: decoder.userInfo,
-                    makeJSONDecoder: decoder.makeJSONDecoder)
+                    JSONDecoder: decoder.JSONDecoder)
                 return try T(from: scopedDecoder)
             }
         }
@@ -192,7 +192,7 @@ private struct RowKeyedDecodingContainer<Key: CodingKey>: KeyedDecodingContainer
                 row: row,
                 codingPath: codingPath + [key],
                 userInfo: decoder.userInfo,
-                makeJSONDecoder: decoder.makeJSONDecoder)
+                JSONDecoder: decoder.JSONDecoder)
             return try T(from: baseDecoder)
         }
     }
@@ -302,7 +302,7 @@ private struct RowDecoder: Decoder {
     var row: Row
     var codingPath: [CodingKey]
     var userInfo: [CodingUserInfoKey: Any]
-    var makeJSONDecoder: (String) -> JSONDecoder
+    var JSONDecoder: (String) -> JSONDecoder
     
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
         return KeyedDecodingContainer(RowKeyedDecodingContainer<Key>(decoder: self))
@@ -350,7 +350,7 @@ extension FetchableRecord where Self: Decodable {
             row: row,
             codingPath: [],
             userInfo: Self.databaseDecodingUserInfo,
-            makeJSONDecoder: Self.makeDatabaseJSONDecoder)
+            JSONDecoder: Self.databaseJSONDecoder)
         try! self.init(from: decoder)
     }
 }

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -88,13 +88,13 @@ public protocol FetchableRecord {
     ///         // stored in a JSON column
     ///         var achievements: [Achievement]
     ///
-    ///         static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder {
+    ///         static func databaseJSONDecoder(for column: String) -> JSONDecoder {
     ///             let decoder = JSONDecoder()
     ///             decoder.dateDecodingStrategy = .iso8601
     ///             return decoder
     ///         }
     ///     }
-    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder
+    static func databaseJSONDecoder(for column: String) -> JSONDecoder
 }
 
 extension FetchableRecord {
@@ -107,7 +107,7 @@ extension FetchableRecord {
     /// - dataDecodingStrategy: .base64
     /// - dateDecodingStrategy: .millisecondsSince1970
     /// - nonConformingFloatDecodingStrategy: .throw
-    public static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder {
+    public static func databaseJSONDecoder(for column: String) -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dataDecodingStrategy = .base64
         decoder.dateDecodingStrategy = .millisecondsSince1970

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -48,7 +48,7 @@ public protocol FetchableRecord {
     ///     // A FetchableRecord + Decodable record
     ///     struct Player: FetchableRecord, Decodable {
     ///         // Customize the decoder name when decoding a database row
-    ///         static let decodingUserInfo: [CodingUserInfoKey: Any] = [decoderName: "GRDB"]
+    ///         static let decodingUserInfo: [CodingUserInfoKey: Any] = [decoderName: "Database"]
     ///
     ///         init(from decoder: Decoder) throws {
     ///             // Print the decoder name
@@ -57,7 +57,7 @@ public protocol FetchableRecord {
     ///         }
     ///     }
     ///
-    ///     // prints "GRDB"
+    ///     // prints "Database"
     ///     let player = try Player.fetchOne(db, ...)
     ///
     ///     // prints "JSON"

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -36,7 +36,7 @@ public protocol FetchableRecord {
     // MARK: - Decodable Support
     
     /// When the FetchableRecord type also adopts the standard Decodable
-    /// protocol, you can use this dictionnary to customize the decoding process
+    /// protocol, you can use this dictionary to customize the decoding process
     /// from database rows.
     ///
     /// For example:
@@ -66,15 +66,15 @@ public protocol FetchableRecord {
     static var decodingUserInfo: [CodingUserInfoKey: Any] { get }
     
     /// When the FetchableRecord type also adopts the standard Decodable
-    /// protocol, you can use this dictionnary to customize the decoding process
-    /// of nested properties stored as JSON in database columns.
+    /// protocol, you can use this dictionary to customize the decoding process
+    /// of nested properties from JSON database columns.
     ///
     /// For example:
     ///
     ///     // A key that holds a decoder's name
     ///     let decoderName = CodingUserInfoKey(rawValue: "decoderName")!
     ///
-    ///     // A Decodable record
+    ///     // A Decodable type
     ///     struct Achievement: Decodable {
     ///         init(from decoder: Decoder) throws {
     ///             // Print the decoder name

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -30,6 +30,82 @@ public protocol FetchableRecord {
     /// iteration of a fetch query. If you want to keep the row for later use,
     /// make sure to store a copy: `self.row = row.copy()`.
     init(row: Row)
+    
+    /// When the FetchableRecord type also adopts the standard Decodable
+    /// protocol, you can use this dictionnary to customize the decoding process
+    /// from database rows.
+    ///
+    /// For example:
+    ///
+    ///     // A key that holds a decoder's name
+    ///     let decoderName = CodingUserInfoKey(rawValue: "decoderName")!
+    ///
+    ///     // A FetchableRecord + Decodable record
+    ///     struct Player: FetchableRecord, Decodable {
+    ///         // Customize the decoder name when dedoding a database row
+    ///         static let decodingUserInfo: [CodingUserInfoKey: Any] = [decoderName: "GRDB"]
+    ///
+    ///         init(from decoder: Decoder) throws {
+    ///             // Print the decoder name
+    ///             print(decoder.userInfo[decoderName])
+    ///             ...
+    ///         }
+    ///     }
+    ///
+    ///     // prints "GRDB"
+    ///     let player = try Player.fetchOne(db, ...)
+    ///
+    ///     // prints "JSON"
+    ///     let decoder = JSONDecoder()
+    ///     decoder.userInfo = [decoderName: "JSON"]
+    ///     let player = try decoder.decode(Player.self, from: ...)
+    static var decodingUserInfo: [CodingUserInfoKey: Any] { get }
+    
+    /// When the FetchableRecord type also adopts the standard Decodable
+    /// protocol, you can use this dictionnary to customize the decoding process
+    /// of nested properties stored as JSON in database columns.
+    ///
+    /// For example:
+    ///
+    ///     // A key that holds a decoder's name
+    ///     let decoderName = CodingUserInfoKey(rawValue: "decoderName")!
+    ///
+    ///     // A Decodable record
+    ///     struct Achievement: Decodable {
+    ///         init(from decoder: Decoder) throws {
+    ///             // Print the decoder name
+    ///             print(decoder.userInfo[decoderName])
+    ///             ...
+    ///         }
+    ///     }
+    ///
+    ///     // A FetchableRecord + Decodable record
+    ///     struct Player: FetchableRecord, Decodable {
+    ///         // Achievement is stored as JSON in the "achievement" database column
+    ///         var achievement: Achievement
+    ///
+    ///         // Customize the decoder name when dedoding a JSON column
+    ///         static let JSONDecodingUserInfo: [CodingUserInfoKey: Any] = [decoderName: "JSON database column"]
+    ///     }
+    ///
+    ///     // prints "JSON database column"
+    ///     let player = try Player.fetchOne(db, ...)
+    ///
+    ///     // prints "Raw JSON"
+    ///     let decoder = JSONDecoder()
+    ///     decoder.userInfo = [decoderName: "Raw JSON"]
+    ///     let achievement = try decoder.decode(Achievement.self, from: ...)
+    static var JSONDecodingUserInfo: [CodingUserInfoKey: Any] { get }
+}
+
+extension FetchableRecord {
+    public static var decodingUserInfo: [CodingUserInfoKey: Any] {
+        return [:]
+    }
+    
+    public static var JSONDecodingUserInfo: [CodingUserInfoKey: Any] {
+        return [:]
+    }
 }
 
 /// A cursor of records. For example:

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -24,12 +24,16 @@
 /// FetchableRecord is adopted by Record.
 public protocol FetchableRecord {
     
+    // MARK: - Row Decoding
+    
     /// Creates a record from `row`.
     ///
     /// For performance reasons, the row argument may be reused during the
     /// iteration of a fetch query. If you want to keep the row for later use,
     /// make sure to store a copy: `self.row = row.copy()`.
     init(row: Row)
+    
+    // MARK: - Decodable Support
     
     /// When the FetchableRecord type also adopts the standard Decodable
     /// protocol, you can use this dictionnary to customize the decoding process

--- a/GRDB/Record/PersistableRecord+Encodable.swift
+++ b/GRDB/Record/PersistableRecord+Encodable.swift
@@ -13,12 +13,6 @@ private class RecordEncoder<Record: MutablePersistableRecord>: Encoder {
         _persistenceContainer = PersistenceContainer()
     }
     
-    /// Helper method
-    @inline(__always)
-    fileprivate func encode(_ value: DatabaseValueConvertible?, forKey key: CodingKey) {
-        _persistenceContainer[key.stringValue] = value
-    }
-    
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
         let container = KeyedContainer<Key>(recordEncoder: self)
         return KeyedEncodingContainer(container)
@@ -32,7 +26,13 @@ private class RecordEncoder<Record: MutablePersistableRecord>: Encoder {
         fatalError("single value encoding is not supported")
     }
     
-    struct KeyedContainer<Key: CodingKey> : KeyedEncodingContainerProtocol {
+    /// Helper method
+    @inline(__always)
+    fileprivate func encode(_ value: DatabaseValueConvertible?, forKey key: CodingKey) {
+        _persistenceContainer[key.stringValue] = value
+    }
+    
+    private struct KeyedContainer<Key: CodingKey> : KeyedEncodingContainerProtocol {
         var recordEncoder: RecordEncoder
         var userInfo: [CodingUserInfoKey: Any] { return Record.databaseEncodingUserInfo }
         

--- a/GRDB/Record/PersistableRecord+Encodable.swift
+++ b/GRDB/Record/PersistableRecord+Encodable.swift
@@ -13,6 +13,12 @@ private class RecordEncoder<Record: MutablePersistableRecord>: Encoder {
         _persistenceContainer = PersistenceContainer()
     }
     
+    /// Helper method
+    @inline(__always)
+    fileprivate func encode(_ value: DatabaseValueConvertible?, forKey key: CodingKey) {
+        _persistenceContainer[key.stringValue] = value
+    }
+    
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
         let container = KeyedContainer<Key>(recordEncoder: self)
         return KeyedEncodingContainer(container)
@@ -35,12 +41,6 @@ private class RecordEncoder<Record: MutablePersistableRecord>: Encoder {
         // Wait for somebody hitting this fatal error so that we can write a
         // meaningful regression test.
         fatalError("single value encoding is not supported")
-    }
-    
-    /// Helper method
-    @inline(__always)
-    fileprivate func encode(_ value: DatabaseValueConvertible?, forKey key: CodingKey) {
-        _persistenceContainer[key.stringValue] = value
     }
     
     private struct KeyedContainer<Key: CodingKey> : KeyedEncodingContainerProtocol {

--- a/GRDB/Record/PersistableRecord+Encodable.swift
+++ b/GRDB/Record/PersistableRecord+Encodable.swift
@@ -23,6 +23,17 @@ private class RecordEncoder<Record: MutablePersistableRecord>: Encoder {
     }
     
     func singleValueContainer() -> SingleValueEncodingContainer {
+        // @itaiferber on https://forums.swift.org/t/how-to-encode-objects-of-unknown-type/12253/11
+        //
+        // > Encoding a value into a single-value container is equivalent to
+        // > encoding the value directly into the encoder, with the primary
+        // > difference being the above: encoding into the encoder writes the
+        // > contents of a type into the encoder, while encoding to a
+        // > single-value container gives the encoder a chance to intercept the
+        // > type as a whole.
+        //
+        // Wait for somebody hitting this fatal error so that we can write a
+        // meaningful regression test.
         fatalError("single value encoding is not supported")
     }
     

--- a/GRDB/Record/PersistableRecord+Encodable.swift
+++ b/GRDB/Record/PersistableRecord+Encodable.swift
@@ -423,8 +423,8 @@ private typealias DatabaseValuePersistenceEncoder = (_ value: DatabaseValueConve
 
 extension MutablePersistableRecord where Self: Encodable {
     public func encode(to container: inout PersistenceContainer) {
-        let userInfo = Self.encodingUserInfo
-        let makeJSONEncoder = Self.makeJSONEncoder
+        let userInfo = Self.databaseEncodingUserInfo
+        let makeJSONEncoder = Self.makeDatabaseJSONEncoder
         
         // The inout container parameter won't enter an escaping closure since
         // SE-0035: https://github.com/apple/swift-evolution/blob/master/proposals/0035-limit-inout-capture.md

--- a/GRDB/Record/PersistableRecord+Encodable.swift
+++ b/GRDB/Record/PersistableRecord+Encodable.swift
@@ -1,284 +1,27 @@
 import Foundation
 
-private struct PersistableRecordKeyedEncodingContainer<Key: CodingKey> : KeyedEncodingContainerProtocol {
-    let encode: DatabaseValuePersistenceEncoder
-    var userInfo: [CodingUserInfoKey: Any]
-    var JSONEncoder: (String) -> JSONEncoder
+// MARK: - RecordEncoder
 
-    init(
-        encode: @escaping DatabaseValuePersistenceEncoder,
-        userInfo: [CodingUserInfoKey: Any],
-        JSONEncoder: @escaping (String) -> JSONEncoder)
-    {
-        self.encode = encode
-        self.userInfo = userInfo
-        self.JSONEncoder = JSONEncoder
-    }
-    
-    /// The path of coding keys taken to get to this point in encoding.
-    /// A `nil` value indicates an unkeyed container.
+/// The encoder that encodes a record into GRDB's PersistenceContainer
+private class RecordEncoder<Record: MutablePersistableRecord>: Encoder {
     var codingPath: [CodingKey] { return [] }
+    var userInfo: [CodingUserInfoKey: Any] { return Record.databaseEncodingUserInfo }
+    private var _persistenceContainer: PersistenceContainer
+    var persistenceContainer: PersistenceContainer { return _persistenceContainer }
     
-    /// Encodes the given value for the given key.
-    ///
-    /// - parameter value: The value to encode.
-    /// - parameter key: The key to associate the value with.
-    /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
-    mutating func encode(_ value: Bool, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Int, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Int8, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Int16, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Int32, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Int64, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: UInt, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: UInt8, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: UInt16, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: UInt32, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: UInt64, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Float, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: Double, forKey key: Key) throws { encode(value, key.stringValue) }
-    mutating func encode(_ value: String, forKey key: Key) throws { encode(value, key.stringValue) }
-
-    /// Encodes the given value for the given key.
-    ///
-    /// - parameter value: The value to encode.
-    /// - parameter key: The key to associate the value with.
-    /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
-    mutating func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
-        if let dbValueConvertible = value as? DatabaseValueConvertible {
-            // Prefer DatabaseValueConvertible encoding over Decodable.
-            // This allows us to encode Date as String, for example.
-            encode(dbValueConvertible.databaseValue, key.stringValue)
-        } else {
-            do {
-                // This encoding will fail for types that encode into keyed
-                // or unkeyed containers, because we're encoding a single
-                // value here (string, int, double, data, null). If such an
-                // error happens, we'll switch to JSON encoding.
-                let encoder = DatabaseValueEncoder(
-                    key: key,
-                    encode: encode,
-                    userInfo: userInfo,
-                    JSONEncoder: JSONEncoder)
-                try value.encode(to: encoder)
-            } catch is JSONRequiredError {
-                // Encode to JSON
-                let jsonData = try JSONEncoder(key.stringValue).encode(value)
-                
-                // Store JSON String in the database for easier debugging and
-                // database inspection. Thanks to SQLite weak typing, we won't
-                // have any trouble decoding this string into data when we
-                // eventually perform JSON decoding.
-                // TODO: possible optimization: avoid this conversion to string, and store raw data bytes as an SQLite string
-                let jsonString = String(data: jsonData, encoding: .utf8)! // force unwrap because json data is guaranteed to convert to String
-                encode(jsonString, key.stringValue)
-            }
-        }
+    init() {
+        _persistenceContainer = PersistenceContainer()
     }
     
-    // Provide explicit encoding of optionals, because default implementation does not encode nil values.
-    mutating func encodeNil(forKey key: Key) throws { encode(nil, key.stringValue) }
-    mutating func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Int?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Float?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: Double?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent(_ value: String?, forKey key: Key) throws { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    mutating func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable { if let value = value { try encode(value, forKey: key) } else { try encodeNil(forKey: key) } }
-    
-    /// Stores a keyed encoding container for the given key and returns it.
-    ///
-    /// - parameter keyType: The key type to use for the container.
-    /// - parameter key: The key to encode the container for.
-    /// - returns: A new keyed encoding container.
-    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
-        fatalError("Not implemented")
-    }
-    
-    /// Stores an unkeyed encoding container for the given key and returns it.
-    ///
-    /// - parameter key: The key to encode the container for.
-    /// - returns: A new unkeyed encoding container.
-    mutating func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
-        fatalError("Not implemented")
-    }
-    
-    /// Stores a new nested container for the default `super` key and returns a new `Encoder` instance for encoding `super` into that container.
-    ///
-    /// Equivalent to calling `superEncoder(forKey:)` with `Key(stringValue: "super", intValue: 0)`.
-    ///
-    /// - returns: A new `Encoder` to pass to `super.encode(to:)`.
-    mutating func superEncoder() -> Encoder {
-        fatalError("Not implemented")
-    }
-    
-    /// Stores a new nested container for the given key and returns a new `Encoder` instance for encoding `super` into that container.
-    ///
-    /// - parameter key: The key to encode `super` for.
-    /// - returns: A new `Encoder` to pass to `super.encode(to:)`.
-    mutating func superEncoder(forKey key: Key) -> Encoder {
-        fatalError("Not implemented")
-    }
-}
-
-private struct DatabaseValueEncodingContainer : SingleValueEncodingContainer {
-    var codingPath: [CodingKey] { return [key] }
-    var key: CodingKey
-    var encode: DatabaseValuePersistenceEncoder
-    var userInfo: [CodingUserInfoKey: Any]
-    var JSONEncoder: (String) -> JSONEncoder
-
-    init(
-        key: CodingKey,
-        encode: @escaping DatabaseValuePersistenceEncoder,
-        userInfo: [CodingUserInfoKey: Any],
-        JSONEncoder: @escaping (String) -> JSONEncoder)
-    {
-        self.key = key
-        self.encode = encode
-        self.userInfo = userInfo
-        self.JSONEncoder = JSONEncoder
-    }
-    
-    /// Encodes a null value.
-    ///
-    /// - throws: `EncodingError.invalidValue` if a null value is invalid in the current context for this format.
-    /// - precondition: May not be called after a previous `self.encode(_:)` call.
-    func encodeNil() throws { encode(nil, key.stringValue) }
-    
-    /// Encodes a single value of the given type.
-    ///
-    /// - parameter value: The value to encode.
-    /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
-    /// - precondition: May not be called after a previous `self.encode(_:)` call.
-    func encode(_ value: Bool) throws { encode(value, key.stringValue) }
-    func encode(_ value: Int) throws { encode(value, key.stringValue) }
-    func encode(_ value: Int8) throws { encode(value, key.stringValue) }
-    func encode(_ value: Int16) throws { encode(value, key.stringValue) }
-    func encode(_ value: Int32) throws { encode(value, key.stringValue) }
-    func encode(_ value: Int64) throws { encode(value, key.stringValue) }
-    func encode(_ value: UInt) throws { encode(value, key.stringValue) }
-    func encode(_ value: UInt8) throws { encode(value, key.stringValue) }
-    func encode(_ value: UInt16) throws { encode(value, key.stringValue) }
-    func encode(_ value: UInt32) throws { encode(value, key.stringValue) }
-    func encode(_ value: UInt64) throws { encode(value, key.stringValue) }
-    func encode(_ value: Float) throws { encode(value, key.stringValue) }
-    func encode(_ value: Double) throws { encode(value, key.stringValue) }
-    func encode(_ value: String) throws { encode(value, key.stringValue) }
-    
-    /// Encodes a single value of the given type.
-    ///
-    /// - parameter value: The value to encode.
-    /// - throws: `EncodingError.invalidValue` if the given value is invalid in the current context for this format.
-    /// - precondition: May not be called after a previous `self.encode(_:)` call.
-    func encode<T>(_ value: T) throws where T : Encodable {
-        if let dbValueConvertible = value as? DatabaseValueConvertible {
-            // Prefer DatabaseValueConvertible encoding over Decodable.
-            // This allows us to encode Date as String, for example.
-            encode(dbValueConvertible.databaseValue, key.stringValue)
-        } else {
-            do {
-                // This encoding will fail for types that encode into keyed
-                // or unkeyed containers, because we're encoding a single
-                // value here (string, int, double, data, null). If such an
-                // error happens, we'll switch to JSON encoding.
-                let encoder = DatabaseValueEncoder(
-                    key: key,
-                    encode: encode,
-                    userInfo: userInfo,
-                    JSONEncoder: JSONEncoder)
-                try value.encode(to: encoder)
-            } catch is JSONRequiredError {
-                // Encode to JSON
-                let jsonData = try JSONEncoder(key.stringValue).encode(value)
-                
-                // Store JSON String in the database for easier debugging and
-                // database inspection. Thanks to SQLite weak typing, we won't
-                // have any trouble decoding this string into data when we
-                // eventually perform JSON decoding.
-                // TODO: possible optimization: avoid this conversion to string, and store raw data bytes as an SQLite string
-                let jsonString = String(data: jsonData, encoding: .utf8)! // force unwrap because json data is guaranteed to convert to String
-                encode(jsonString, key.stringValue)
-            }
-        }
-    }
-}
-
-private struct DatabaseValueEncoder: Encoder {
-    var codingPath: [CodingKey] { return [key] }
-    var key: CodingKey
-    var encode: DatabaseValuePersistenceEncoder
-    var userInfo: [CodingUserInfoKey: Any]
-    var JSONEncoder: (String) -> JSONEncoder
-
-    init(
-        key: CodingKey,
-        encode: @escaping DatabaseValuePersistenceEncoder,
-        userInfo: [CodingUserInfoKey: Any],
-        JSONEncoder: @escaping (String) -> JSONEncoder)
-    {
-        self.key = key
-        self.encode = encode
-        self.userInfo = userInfo
-        self.JSONEncoder = JSONEncoder
-    }
-
-    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        // Keyed values require JSON encoding: we need to throw
-        // JSONRequiredError. Since we can't throw right from here, let's
-        // delegate the job to a dedicated container.
-        return KeyedEncodingContainer(JSONRequiredKeyedContainer(
-            codingPath: codingPath,
-            userInfo: userInfo))
-    }
-    
-    func unkeyedContainer() -> UnkeyedEncodingContainer {
-        // Keyed values require JSON encoding: we need to throw
-        // JSONRequiredError. Since we can't throw right from here, let's
-        // delegate the job to a dedicated container.
-        return JSONRequiredUnkeyedContainer(
-            codingPath: codingPath,
-            userInfo: userInfo)
-    }
-    
-    func singleValueContainer() -> SingleValueEncodingContainer {
-        return DatabaseValueEncodingContainer(
-            key: key,
-            encode: encode,
-            userInfo: userInfo,
-            JSONEncoder: JSONEncoder)
-    }
-}
-
-private struct PersistableRecordEncoder: Encoder {
-    var codingPath: [CodingKey] = []
-    var encode: DatabaseValuePersistenceEncoder
-    var userInfo: [CodingUserInfoKey: Any]
-    var JSONEncoder: (String) -> JSONEncoder
-
-    init(
-        encode: @escaping DatabaseValuePersistenceEncoder,
-        userInfo: [CodingUserInfoKey: Any],
-        JSONEncoder: @escaping (String) -> JSONEncoder)
-    {
-        self.encode = encode
-        self.userInfo = userInfo
-        self.JSONEncoder = JSONEncoder
+    /// Helper method
+    @inline(__always)
+    fileprivate func encode(_ value: DatabaseValueConvertible?, forKey key: CodingKey) {
+        _persistenceContainer[key.stringValue] = value
     }
     
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
-        return KeyedEncodingContainer(PersistableRecordKeyedEncodingContainer<Key>(
-            encode: encode,
-            userInfo: userInfo,
-            JSONEncoder: JSONEncoder))
+        let container = KeyedContainer<Key>(recordEncoder: self)
+        return KeyedEncodingContainer(container)
     }
     
     func unkeyedContainer() -> UnkeyedEncodingContainer {
@@ -286,161 +29,293 @@ private struct PersistableRecordEncoder: Encoder {
     }
     
     func singleValueContainer() -> SingleValueEncodingContainer {
-        fatalError("unkeyed encoding is not supported")
+        fatalError("single value encoding is not supported")
+    }
+    
+    struct KeyedContainer<Key: CodingKey> : KeyedEncodingContainerProtocol {
+        var recordEncoder: RecordEncoder
+        var userInfo: [CodingUserInfoKey: Any] { return Record.databaseEncodingUserInfo }
+        
+        init(recordEncoder: RecordEncoder) {
+            self.recordEncoder = recordEncoder
+        }
+        
+        var codingPath: [CodingKey] { return [] }
+        
+        func encode(_ value: Bool,   forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Int,    forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Int8,   forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Int16,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Int32,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Int64,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: UInt,   forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: UInt8,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: UInt16, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: UInt32, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: UInt64, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Float,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: Double, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encode(_ value: String, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        
+        func encode<T>(_ value: T, forKey key: Key) throws where T : Encodable {
+            if let value = value as? DatabaseValueConvertible {
+                // Prefer DatabaseValueConvertible encoding over Decodable.
+                // This allows us to encode Date as String, for example.
+                recordEncoder.encode(value.databaseValue, forKey: key)
+            } else {
+                do {
+                    // This encoding will fail for types that encode into keyed
+                    // or unkeyed containers, because we're encoding a single
+                    // value here (string, int, double, data, null). If such an
+                    // error happens, we'll switch to JSON encoding.
+                    let encoder = ColumnEncoder(recordEncoder: recordEncoder, key: key)
+                    try value.encode(to: encoder)
+                } catch is JSONRequiredError {
+                    // Encode to JSON
+                    let jsonData = try Record.databaseJSONEncoder(for: key.stringValue).encode(value)
+                    
+                    // Store JSON String in the database for easier debugging and
+                    // database inspection. Thanks to SQLite weak typing, we won't
+                    // have any trouble decoding this string into data when we
+                    // eventually perform JSON decoding.
+                    // TODO: possible optimization: avoid this conversion to string, and store raw data bytes as an SQLite string
+                    let jsonString = String(data: jsonData, encoding: .utf8)! // force unwrap because json data is guaranteed to convert to String
+                    recordEncoder.encode(jsonString, forKey: key)
+                }
+            }
+        }
+        
+        func encodeNil(forKey key: Key) throws { recordEncoder.encode(nil, forKey: key) }
+        
+        func encodeIfPresent(_ value: Bool?,   forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Int?,    forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Int8?,   forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Int16?,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Int32?,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Int64?,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: UInt?,   forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: UInt8?,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Float?,  forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: Double?, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        func encodeIfPresent(_ value: String?, forKey key: Key) throws { recordEncoder.encode(value, forKey: key) }
+        
+        func encodeIfPresent<T>(_ value: T?, forKey key: Key) throws where T : Encodable {
+            if let value = value {
+                try encode(value, forKey: key)
+            } else {
+                recordEncoder.encode(nil, forKey: key)
+            }
+        }
+        
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+            fatalError("Not implemented")
+        }
+        
+        func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+            fatalError("Not implemented")
+        }
+        
+        func superEncoder() -> Encoder {
+            fatalError("Not implemented")
+        }
+        
+        func superEncoder(forKey key: Key) -> Encoder {
+            fatalError("Not implemented")
+        }
     }
 }
 
-private struct JSONRequiredEncoder: Encoder {
-    var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
+// MARK: - ColumnEncoder
+
+/// The encoder that encodes into a database column
+private struct ColumnEncoder<Record: MutablePersistableRecord>: Encoder {
+    var recordEncoder: RecordEncoder<Record>
+    var key: CodingKey
+    var codingPath: [CodingKey] { return [key] }
+    var userInfo: [CodingUserInfoKey: Any] { return Record.databaseEncodingUserInfo }
     
-    init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey: Any]) {
-        self.codingPath = codingPath
-        self.userInfo = userInfo
+    init(recordEncoder: RecordEncoder<Record>, key: CodingKey) {
+        self.recordEncoder = recordEncoder
+        self.key = key
     }
     
     func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
-        return KeyedEncodingContainer(JSONRequiredKeyedContainer(
-            codingPath: codingPath,
-            userInfo: userInfo))
+        // Keyed values require JSON encoding: we need to throw
+        // JSONRequiredError. Since we can't throw right from here, let's
+        // delegate the job to a dedicated container.
+        let container = JSONRequiredEncoder<Record>.KeyedContainer<Key>(codingPath: codingPath)
+        return KeyedEncodingContainer(container)
     }
     
     func unkeyedContainer() -> UnkeyedEncodingContainer {
-        return JSONRequiredUnkeyedContainer(
-            codingPath: codingPath,
-            userInfo: userInfo)
+        // Keyed values require JSON encoding: we need to throw
+        // JSONRequiredError. Since we can't throw right from here, let's
+        // delegate the job to a dedicated container.
+        return JSONRequiredEncoder<Record>(codingPath: codingPath)
     }
     
     func singleValueContainer() -> SingleValueEncodingContainer {
-        return JSONRequiredSingleValueContainer()
-    }
-}
-
-private struct JSONRequiredKeyedContainer<KeyType: CodingKey>: KeyedEncodingContainerProtocol {
-    var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
-
-    func encodeNil(forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Bool, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Int, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Int8, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Int16, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Int32, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Int64, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt8, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt16, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt32, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt64, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Float, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: Double, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode(_ value: String, forKey key: KeyType) throws { throw JSONRequiredError() }
-    func encode<T>(_ value: T, forKey key: KeyType) throws where T : Encodable { throw JSONRequiredError() }
-
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: KeyType) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        return KeyedEncodingContainer(JSONRequiredKeyedContainer<NestedKey>(
-            codingPath: codingPath + [key],
-            userInfo: userInfo))
-    }
-    
-    func nestedUnkeyedContainer(forKey key: KeyType) -> UnkeyedEncodingContainer {
-        return JSONRequiredUnkeyedContainer(
-            codingPath: codingPath,
-            userInfo: userInfo)
-    }
-    
-    func superEncoder() -> Encoder {
-        return JSONRequiredEncoder(codingPath: codingPath, userInfo: userInfo)
-    }
-    
-    func superEncoder(forKey key: KeyType) -> Encoder {
-        return JSONRequiredEncoder(codingPath: codingPath, userInfo: userInfo)
-    }
-}
-
-private struct JSONRequiredUnkeyedContainer: UnkeyedEncodingContainer {
-    var codingPath: [CodingKey]
-    var userInfo: [CodingUserInfoKey: Any]
-    var count: Int { return 0 }
-    
-    func encodeNil() throws { throw JSONRequiredError() }
-    func encode(_ value: Bool) throws { throw JSONRequiredError() }
-    func encode(_ value: Int) throws { throw JSONRequiredError() }
-    func encode(_ value: Int8) throws { throw JSONRequiredError() }
-    func encode(_ value: Int16) throws { throw JSONRequiredError() }
-    func encode(_ value: Int32) throws { throw JSONRequiredError() }
-    func encode(_ value: Int64) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt8) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt16) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt32) throws { throw JSONRequiredError() }
-    func encode(_ value: UInt64) throws { throw JSONRequiredError() }
-    func encode(_ value: Float) throws { throw JSONRequiredError() }
-    func encode(_ value: Double) throws { throw JSONRequiredError() }
-    func encode(_ value: String) throws { throw JSONRequiredError() }
-    func encode<T>(_ value: T) throws where T : Encodable { throw JSONRequiredError() }
-    
-    func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-        return KeyedEncodingContainer(JSONRequiredKeyedContainer<NestedKey>(
-            codingPath: codingPath,
-            userInfo: userInfo))
-    }
-    
-    func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
         return self
     }
+}
+
+extension ColumnEncoder: SingleValueEncodingContainer {
+    func encodeNil() throws { recordEncoder.encode(nil, forKey: key) }
     
-    func superEncoder() -> Encoder {
-        return JSONRequiredEncoder(codingPath: codingPath, userInfo: userInfo)
+    func encode(_ value: Bool  ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Int   ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Int8  ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Int16 ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Int32 ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Int64 ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: UInt  ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: UInt8 ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: UInt16) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: UInt32) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: UInt64) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Float ) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: Double) throws { recordEncoder.encode(value, forKey: key) }
+    func encode(_ value: String) throws { recordEncoder.encode(value, forKey: key) }
+    
+    func encode<T>(_ value: T) throws where T : Encodable {
+        if let value = value as? DatabaseValueConvertible {
+            // Prefer DatabaseValueConvertible encoding over Decodable.
+            // This allows us to encode Date as String, for example.
+            recordEncoder.encode(value.databaseValue, forKey: key)
+        } else {
+            do {
+                // This encoding will fail for types that encode into keyed
+                // or unkeyed containers, because we're encoding a single
+                // value here (string, int, double, data, null). If such an
+                // error happens, we'll switch to JSON encoding.
+                let encoder = ColumnEncoder(recordEncoder: recordEncoder, key: key)
+                try value.encode(to: encoder)
+            } catch is JSONRequiredError {
+                // Encode to JSON
+                let jsonData = try Record.databaseJSONEncoder(for: key.stringValue).encode(value)
+                
+                // Store JSON String in the database for easier debugging and
+                // database inspection. Thanks to SQLite weak typing, we won't
+                // have any trouble decoding this string into data when we
+                // eventually perform JSON decoding.
+                // TODO: possible optimization: avoid this conversion to string, and store raw data bytes as an SQLite string
+                let jsonString = String(data: jsonData, encoding: .utf8)! // force unwrap because json data is guaranteed to convert to String
+                recordEncoder.encode(jsonString, forKey: key)
+            }
+        }
     }
 }
 
-private struct JSONRequiredSingleValueContainer: SingleValueEncodingContainer {
-    var codingPath: [CodingKey] { return [] }
-
-    mutating func encodeNil() throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Bool) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: String) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Double) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Float) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Int) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Int8) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Int16) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Int32) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: Int64) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: UInt) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: UInt8) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: UInt16) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: UInt32) throws { throw JSONRequiredError() }
-    mutating func encode(_ value: UInt64) throws { throw JSONRequiredError() }
-    mutating func encode<T>(_ value: T) throws where T : Encodable { throw JSONRequiredError() }
-}
+// MARK: - JSONRequiredEncoder
 
 /// The error that triggers JSON encoding
 private struct JSONRequiredError: Error { }
 
-private typealias DatabaseValuePersistenceEncoder = (_ value: DatabaseValueConvertible?, _ key: String) -> Void
+/// The encoder that always ends up with a JSONRequiredError
+private struct JSONRequiredEncoder<Record: MutablePersistableRecord>: Encoder {
+    var codingPath: [CodingKey]
+    var userInfo: [CodingUserInfoKey: Any] { return Record.databaseEncodingUserInfo }
+    
+    init(codingPath: [CodingKey]) {
+        self.codingPath = codingPath
+    }
+    
+    func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key : CodingKey {
+        let container = KeyedContainer<Key>(codingPath: codingPath)
+        return KeyedEncodingContainer(container)
+    }
+    
+    func unkeyedContainer() -> UnkeyedEncodingContainer {
+        return self
+    }
+    
+    func singleValueContainer() -> SingleValueEncodingContainer {
+        return self
+    }
+    
+    struct KeyedContainer<KeyType: CodingKey>: KeyedEncodingContainerProtocol {
+        var codingPath: [CodingKey]
+        var userInfo: [CodingUserInfoKey: Any] { return Record.databaseEncodingUserInfo }
+        
+        func encodeNil(forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Bool,   forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Int,    forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Int8,   forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Int16,  forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Int32,  forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Int64,  forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: UInt,   forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: UInt8,  forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: UInt16, forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: UInt32, forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: UInt64, forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Float,  forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: Double, forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode(_ value: String, forKey key: KeyType) throws { throw JSONRequiredError() }
+        func encode<T>(_ value: T, forKey key: KeyType) throws where T : Encodable { throw JSONRequiredError() }
+        
+        func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: KeyType) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+            let container = KeyedContainer<NestedKey>(codingPath: codingPath + [key])
+            return KeyedEncodingContainer(container)
+        }
+        
+        func nestedUnkeyedContainer(forKey key: KeyType) -> UnkeyedEncodingContainer {
+            return JSONRequiredEncoder(codingPath: codingPath)
+        }
+        
+        func superEncoder() -> Encoder {
+            return JSONRequiredEncoder(codingPath: codingPath)
+        }
+        
+        func superEncoder(forKey key: KeyType) -> Encoder {
+            return JSONRequiredEncoder(codingPath: codingPath)
+        }
+    }
+}
+
+extension JSONRequiredEncoder: SingleValueEncodingContainer {
+    func encodeNil() throws { throw JSONRequiredError() }
+    func encode(_ value: Bool  ) throws { throw JSONRequiredError() }
+    func encode(_ value: Int   ) throws { throw JSONRequiredError() }
+    func encode(_ value: Int8  ) throws { throw JSONRequiredError() }
+    func encode(_ value: Int16 ) throws { throw JSONRequiredError() }
+    func encode(_ value: Int32 ) throws { throw JSONRequiredError() }
+    func encode(_ value: Int64 ) throws { throw JSONRequiredError() }
+    func encode(_ value: UInt  ) throws { throw JSONRequiredError() }
+    func encode(_ value: UInt8 ) throws { throw JSONRequiredError() }
+    func encode(_ value: UInt16) throws { throw JSONRequiredError() }
+    func encode(_ value: UInt32) throws { throw JSONRequiredError() }
+    func encode(_ value: UInt64) throws { throw JSONRequiredError() }
+    func encode(_ value: Float ) throws { throw JSONRequiredError() }
+    func encode(_ value: Double) throws { throw JSONRequiredError() }
+    func encode(_ value: String) throws { throw JSONRequiredError() }
+    func encode<T>(_ value: T) throws where T : Encodable { throw JSONRequiredError() }
+}
+
+extension JSONRequiredEncoder: UnkeyedEncodingContainer {
+    var count: Int { return 0 }
+    
+    mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
+        let container = KeyedContainer<NestedKey>(codingPath: codingPath)
+        return KeyedEncodingContainer(container)
+    }
+    
+    mutating func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        return self
+    }
+    
+    mutating func superEncoder() -> Encoder {
+        return self
+    }
+}
 
 extension MutablePersistableRecord where Self: Encodable {
     public func encode(to container: inout PersistenceContainer) {
-        let userInfo = Self.databaseEncodingUserInfo
-        let JSONEncoder = Self.databaseJSONEncoder
-        
-        // The inout container parameter won't enter an escaping closure since
-        // SE-0035: https://github.com/apple/swift-evolution/blob/master/proposals/0035-limit-inout-capture.md
-        //
-        // So let's use it in a non-escaping closure:
-        func encode(_ encode: DatabaseValuePersistenceEncoder) {
-            withoutActuallyEscaping(encode) { escapableEncode in
-                let encoder = PersistableRecordEncoder(
-                    encode: escapableEncode,
-                    userInfo: userInfo,
-                    JSONEncoder: JSONEncoder)
-                try! self.encode(to: encoder)
-            }
-        }
-        encode { (value, key) in
-            container[key] = value
-        }
+        let encoder = RecordEncoder<Self>()
+        try! encode(to: encoder)
+        container = encoder.persistenceContainer
     }
 }

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -323,7 +323,75 @@ public protocol MutablePersistableRecord : TableRecord {
     
     // MARK: - Encodable Support
     
+    /// When the PersistableRecord type also adopts the standard Encodable
+    /// protocol, you can use this dictionary to customize the encoding process
+    /// to database rows.
+    ///
+    /// For example:
+    ///
+    ///     // A key that holds a encoder's name
+    ///     let encoderName = CodingUserInfoKey(rawValue: "encoderName")!
+    ///
+    ///     // A PersistableRecord + Encodable record
+    ///     struct Player: PersistableRecord, Encodable {
+    ///         // Customize the encoder name when dedoding a database row
+    ///         static let encodingUserInfo: [CodingUserInfoKey: Any] = [encoderName: "GRDB"]
+    ///
+    ///         func encode(to encoder: Encoder) throws {
+    ///             // Print the encoder name
+    ///             print(encoder.userInfo[encoderName])
+    ///             ...
+    ///         }
+    ///     }
+    ///
+    ///     let player = Player(...)
+    ///
+    ///     // prints "GRDB"
+    ///     try player.insert(db)
+    ///
+    ///     // prints "JSON"
+    ///     let encoder = JSONEncoder()
+    ///     encoder.userInfo = [encoderName: "JSON"]
+    ///     let data = try encoder.encode(player)
     static var encodingUserInfo: [CodingUserInfoKey: Any] { get }
+    
+    /// When the PersistableRecord type also adopts the standard Encodable
+    /// protocol, you can use this dictionary to customize the encoding process
+    /// of nested properties to JSON database columns.
+    ///
+    /// For example:
+    ///
+    ///     // A key that holds a encoder's name
+    ///     let encoderName = CodingUserInfoKey(rawValue: "encoderName")!
+    ///
+    ///     // An Encodable type
+    ///     struct Achievement: Decodable {
+    ///         func encode(to encoder: Encoder) throws {
+    ///             // Print the encoder name
+    ///             print(encoder.userInfo[decoderName])
+    ///             ...
+    ///         }
+    ///     }
+    ///
+    ///     // A PersistableRecord + Encodable record
+    ///     struct Player: PersistableRecord, Encodable {
+    ///         // Achievement is stored as JSON in the "achievement" database column
+    ///         var achievement: Achievement
+    ///
+    ///         // Customize the decoder name when dedoding a JSON column
+    ///         static let JSONEncodingUserInfo: [CodingUserInfoKey: Any] = [decoderName: "JSON database column"]
+    ///     }
+    ///
+    ///     let achievement = Achievement(...)
+    ///     let player = Player(achievement: achievement)
+    ///
+    ///     // prints "JSON database column"
+    ///     try player.insert(db)
+    ///
+    ///     // prints "Raw JSON"
+    ///     let encoder = JSONEncoder()
+    ///     encoder.userInfo = [encoderName: "Raw JSON"]
+    ///     let achievementData = try encoder.encode(achievement)
     static var JSONEncodingUserInfo: [CodingUserInfoKey: Any] { get }
 }
 

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Database.ConflictResolution {
     var invalidatesLastInsertedRowID: Bool {
         switch self {

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -320,6 +320,21 @@ public protocol MutablePersistableRecord : TableRecord {
     /// - returns: Whether the primary key matches a row in the database.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     func exists(_ db: Database) throws -> Bool
+    
+    // MARK: - Encodable Support
+    
+    static var encodingUserInfo: [CodingUserInfoKey: Any] { get }
+    static var JSONEncodingUserInfo: [CodingUserInfoKey: Any] { get }
+}
+
+extension MutablePersistableRecord {
+    public static var encodingUserInfo: [CodingUserInfoKey: Any] {
+        return [:]
+    }
+    
+    public static var JSONEncodingUserInfo: [CodingUserInfoKey: Any] {
+        return [:]
+    }
 }
 
 extension MutablePersistableRecord {

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -380,13 +380,13 @@ public protocol MutablePersistableRecord : TableRecord {
     ///         // stored in a JSON column
     ///         var achievements: [Achievement]
     ///
-    ///         static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder {
+    ///         static func databaseJSONEncoder(for column: String) -> JSONEncoder {
     ///             let encoder = JSONEncoder()
     ///             encoder.dateEncodingStrategy = .iso8601
     ///             return encoder
     ///         }
     ///     }
-    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder
+    static func databaseJSONEncoder(for column: String) -> JSONEncoder
 }
 
 extension MutablePersistableRecord {
@@ -400,7 +400,7 @@ extension MutablePersistableRecord {
     /// - dateEncodingStrategy: .millisecondsSince1970
     /// - nonConformingFloatEncodingStrategy: .throw
     /// - outputFormatting: .sortedKeys (iOS 11.0+, macOS 10.13+, watchOS 4.0+)
-    public static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder {
+    public static func databaseJSONEncoder(for column: String) -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dataEncodingStrategy = .base64
         encoder.dateEncodingStrategy = .millisecondsSince1970

--- a/README.md
+++ b/README.md
@@ -2620,11 +2620,18 @@ struct Player: Codable, FetchableRecord, PersistableRecord {
     static func filter(name: String) -> QueryInterfaceRequest<Player> {
         return filter(CodingKeys.name == name)
     }
+    
+    static var maximumScore: QueryInterfaceRequest<Int> {
+        return select(max(CodingKeys.score))
+    }
 }
 
-let arthur = try dbQueue.read { db in
+try dbQueue.read { db in
     // SELECT * FROM player WHERE name = 'Arthur'
-    try Player.filter(name: "Arthur").fetchOne($0)
+    let arthur = try Player.filter(name: "Arthur").fetchOne($0) // Player?
+    
+    // SELECT MAX(score) FROM player
+    let maxScore = try Player.maximumScore.fetchOne(db)         // Int?
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -3100,8 +3100,6 @@ Since those use cases are not well handled by FetchableRecord, don't try to impl
 Instead, please have a look at the [CustomizedDecodingOfDatabaseRows](Playgrounds/CustomizedDecodingOfDatabaseRows.playground/Contents.swift) playground. You'll run some sample code, and learn how to escape FetchableRecord when you need. And remember that leaving FetchableRecord will not deprive you of [query interface requests](#requests) and generally all SQL generation features of the [TableRecord] and [PersistableRecord] protocols.
 
 
-
-
 ## Examples of Record Definitions
 
 We will show below how to declare a record type for the following database table:
@@ -7574,7 +7572,7 @@ This protocol has been renamed [FetchableRecord] in GRDB 3.0.
 
 This protocol has been renamed [TableRecord] in GRDB 3.0.
 
-### Customized Decoding of Database Rows
+#### Customized Decoding of Database Rows
 
 This chapter has been renamed [Beyond FetchableRecord].
 

--- a/README.md
+++ b/README.md
@@ -2622,7 +2622,7 @@ struct Player: Codable, FetchableRecord, PersistableRecord {
     }
     
     static var maximumScore: QueryInterfaceRequest<Int> {
-        return select(max(CodingKeys.score))
+        return select(max(CodingKeys.score)).asRequest(of: Int.self)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -2667,11 +2667,11 @@ You can customize the JSON format by implementing those methods:
 
 ```swift
 protocol FetchableRecord {
-    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder
+    static func databaseJSONDecoder(for column: String) -> JSONDecoder
 }
 
 protocol MutablePersistableRecord {
-    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder
+    static func databaseJSONEncoder(for column: String) -> JSONEncoder
 }
 ```
 
@@ -2683,13 +2683,13 @@ struct Player: Codable, FetchableRecord, PersistableRecord {
     var score: Int
     var achievements: [Achievement] // stored in a JSON column
     
-    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder {
+    static func databaseJSONDecoder(for column: String) -> JSONDecoder {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return decoder
     }
     
-    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder {
+    static func databaseJSONEncoder(for column: String) -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = .sortedKeys

--- a/README.md
+++ b/README.md
@@ -2628,7 +2628,7 @@ struct Player: Codable, FetchableRecord, PersistableRecord {
 
 try dbQueue.read { db in
     // SELECT * FROM player WHERE name = 'Arthur'
-    let arthur = try Player.filter(name: "Arthur").fetchOne($0) // Player?
+    let arthur = try Player.filter(name: "Arthur").fetchOne(db) // Player?
     
     // SELECT MAX(score) FROM player
     let maxScore = try Player.maximumScore.fetchOne(db)         // Int?

--- a/README.md
+++ b/README.md
@@ -2060,13 +2060,11 @@ Your custom structs and classes can adopt each protocol individually, and opt in
 - [TableRecord Protocol](#tablerecord-protocol)
 - [PersistableRecord Protocol](#persistablerecord-protocol)
     - [Persistence Methods](#persistence-methods)
-    - [Customizing the Persistence Methods](#customizing-the-persistence-methods)
+    - [Customizing the Persistence Methods]
 - [Codable Records](#codable-records)
 - [Record Class](#record-class)
 - [Record Comparison]
-- [Conflict Resolution](#conflict-resolution)
-- [The Implicit RowID Primary Key](#the-implicit-rowid-primary-key)
-- [Customized Decoding of Database Rows](#customized-decoding-of-database-rows)
+- [Record Customization Options]
 
 **Records in a Glance**
 
@@ -2175,9 +2173,7 @@ Details follow:
 - [Codable Records](#codable-records)
 - [Record Class](#record-class)
 - [Record Comparison]
-- [Conflict Resolution](#conflict-resolution)
-- [The Implicit RowID Primary Key](#the-implicit-rowid-primary-key)
-- [Customized Decoding of Database Rows](#customized-decoding-of-database-rows)
+- [Record Customization Options]
 - [Examples of Record Definitions](#examples-of-record-definitions)
 - [List of Record Methods](#list-of-record-methods)
 
@@ -2322,7 +2318,7 @@ See [fetching methods](#fetching-methods) for information about the `fetchCursor
 
 > :point_up: **Note**: for performance reasons, the same row argument to `init(row:)` is reused during the iteration of a fetch query. If you want to keep the row for later use, make sure to store a copy: `self.row = row.copy()`.
 
-> :point_up: **Note**: The `FetchableRecord.init(row:)` initializer fits the needs of most applications. But some application are more demanding than others. When FetchableRecord does not exactly provide the support you need, have a look at the [Customized Decoding of Database Rows](#customized-decoding-of-database-rows) chapter.
+> :point_up: **Note**: The `FetchableRecord.init(row:)` initializer fits the needs of most applications. But some application are more demanding than others. When FetchableRecord does not exactly provide the support you need, have a look at the [Beyond FetchableRecord] chapter.
 
 
 ## TableRecord Protocol
@@ -2336,7 +2332,7 @@ protocol TableRecord {
 }
 ```
 
-The `databaseSelection` type property is optional, and documented in the [Columns Selected by a Request](#columns-selected-by-a-request) chapter.
+The `databaseSelection` type property is optional, and documented in the [Columns Selected by a Request] chapter.
 
 The `databaseTableName` type property is the name of a database table. By default, it is derived from the type name:
 
@@ -2605,34 +2601,10 @@ try dbQueue.write { db in
 }
 ```
 
-When a record contains a codable property that is not a simple [value](#values) (Bool, Int, String, Date, Swift enums, etc.), that value is encoded and decoded as a **JSON string**. For example:
+> :point_up: **Note**: Some codable values have a different way to encode and decode themselves in a standard archive vs. a database column. For example, [Date](#date-and-datecomponents) saves itself as a numerical timestamp (archive) or a string (database). When such an ambiguity happens, GRDB always favors customized database encoding and decoding.
 
-```swift
-enum AchievementColor: String, Codable {
-    case bronze, silver, gold
-}
+> :point_up: **Note**: When your Codable record provides a custom implementation for `Decodable.init(from:)` or `Encodable.encode(to:)`, you may want to provide a `userInfo` context dictionary: see [The userInfo Dictionary].
 
-struct Achievement: Codable {
-     var name: String
-     var color: AchievementColor
-}
-
-struct Player: Codable, FetchableRecord, PersistableRecord {
-    var name: String
-    var score: Int
-    var achievements: [Achievement] // encoded as JSON
-}
-
-try dbQueue.write { db in
-    // INSERT INTO player (name, score, achievements)
-    // VALUES (
-    //   'Arthur',
-    //   100,
-    //   '[{"color":"gold","name":"Use Codable Records"}]')
-    let achievement = Achievement(name: "Use Codable Records", color: .gold)
-    try Player(name: "Arthur", score: 100, achievements: [achievement]).insert(db)
-}
-```
 
 If you declare an explicit `CodingKeys` enum ([what is this?](https://developer.apple.com/documentation/foundation/archives_and_serialization/encoding_and_decoding_custom_types)), you can use coding keys as [query interface](#the-query-interface) columns, just by adding conformance to the ColumnExpression protocol:
 
@@ -2640,10 +2612,9 @@ If you declare an explicit `CodingKeys` enum ([what is this?](https://developer.
 struct Player: Codable, FetchableRecord, PersistableRecord {
     var name: String
     var score: Int
-    var achievements: [Achievement]
     
     private enum CodingKeys: String, CodingKey, ColumnExpression {
-        case name, score, achievements
+        case name, score
     }
     
     static func filter(name: String) -> QueryInterfaceRequest<Player> {
@@ -2657,12 +2628,122 @@ let arthur = try dbQueue.read { db in
 }
 ```
 
-> :point_up: **Note**: Some codable values have a different way to encode and decode themselves in a standard archive vs. a database column. For example, [Date](#date-and-datecomponents) saves itself as a numerical timestamp (archive) or a string (database). When such an ambiguity happens, GRDB always favors customized database encoding and decoding.
 
-> :point_up: **Note about JSON support**: GRDB uses the standard [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder) and [JSONEncoder](https://developer.apple.com/documentation/foundation/jsonencoder) from Foundation. Data values are handled with the `.base64` strategy, Date with the `.millisecondsSince1970` strategy, and non conforming floats with the `.throw` strategy. Check Foundation documentation for more information.
+### JSON Columns
 
-> :point_up: **Note about JSON support**: JSON encoding uses the `.sortedKeys` option when available (iOS 11.0+, macOS 10.13+, watchOS 4.0+). In previous operating system versions, the ordering of JSON keys may be unstable, and this may negatively impact [Record Comparison].
+When a [Codable record](#codable-records) contains a property that is not a simple [value](#values) (Bool, Int, String, Date, Swift enums, etc.), that value is encoded and decoded as a **JSON string**. For example:
 
+```swift
+enum AchievementColor: String, Codable {
+    case bronze, silver, gold
+}
+
+struct Achievement: Codable {
+     var name: String
+     var color: AchievementColor
+     var date: Date
+}
+
+struct Player: Codable, FetchableRecord, PersistableRecord {
+    var name: String
+    var score: Int
+    var achievements: [Achievement] // stored in a JSON column
+}
+
+try dbQueue.write { db in
+    // INSERT INTO player (name, score, achievements)
+    // VALUES (
+    //   'Arthur',
+    //   100,
+    //   '[{"color":"gold","name":"Use Codable Records"}]')
+    let achievement = Achievement(name: "Use Codable Records", color: .gold)
+    try Player(name: "Arthur", score: 100, achievements: [achievement]).insert(db)
+}
+```
+
+GRDB uses the standard [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder) and [JSONEncoder](https://developer.apple.com/documentation/foundation/jsonencoder) from Foundation. By default, Data values are handled with the `.base64` strategy, Date with the `.millisecondsSince1970` strategy, and non conforming floats with the `.throw` strategy.
+
+You can customize the JSON format by implementing those methods:
+
+```swift
+protocol FetchableRecord {
+    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder
+}
+
+protocol MutablePersistableRecord {
+    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder
+}
+```
+
+For example, here is how the Player type can customize the json format of its "achievements" JSON column:
+
+```swift
+struct Player: Codable, FetchableRecord, PersistableRecord {
+    var name: String
+    var score: Int
+    var achievements: [Achievement] // stored in a JSON column
+    
+    static func makeDatabaseJSONDecoder(for column: String) -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+    
+    static func makeDatabaseJSONEncoder(for column: String) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .sortedKeys
+        return encoder
+    }
+}
+```
+
+> :bulb: **Tip**: Make sure you set the JSONEncoder `sortedKeys` option, available from iOS 11.0+, macOS 10.13+, and watchOS 4.0+. This option makes sure that the JSON output is stable, and this helps [Record Comparison] yield the expected results.
+
+
+### The userInfo Dictionary
+
+Your [Codable records](#codable-records) can be stored in the database, but they may also have other purposes. In this case, you may need to customize their implementations of `Decodable.init(from:)` and `Encodable.encode(to:)`, depending on the context.
+
+The recommended way to provide such context is the `userInfo` dictionary. Implement those properties:
+
+```swift
+protocol FetchableRecord {
+    static var databaseDecodingUserInfo: [CodingUserInfoKey: Any] { get }
+}
+
+protocol MutablePersistableRecord {
+    static var databaseEncodingUserInfo: [CodingUserInfoKey: Any] { get }
+}
+```
+
+For example, here is how the Player type can customize its decoding:
+
+```swift
+// A key that holds a decoder's name
+let decoderName = CodingUserInfoKey(rawValue: "decoderName")!
+
+struct Player: FetchableRecord, Decodable {
+    init(from decoder: Decoder) throws {
+        // Print the decoder name
+        print(decoder.userInfo[decoderName])
+        ...
+    }
+}
+
+// prints "JSON"
+let decoder = JSONDecoder()
+decoder.userInfo = [decoderName: "JSON"]
+let player = try decoder.decode(Player.self, from: ...)
+
+extension Player: FetchableRecord {
+    // Customize the decoder name when decoding a database row
+    static let databaseDecodingUserInfo: [CodingUserInfoKey: Any] = [decoderName: "Database"]
+}
+
+// prints "Database"
+let player = try Player.fetchOne(db, ...)
+```
 
 
 ## Record Class
@@ -2798,7 +2879,20 @@ player.databaseChanges    // ["score": 750]
 For an efficient algorithm which synchronizes the content of a database table with a JSON payload, check [JSONSynchronization.playground](Playgrounds/JSONSynchronization.playground/Contents.swift).
 
 
-## Conflict Resolution
+## Record Customization Options
+
+GRDB records come with many default behaviors, that are designed to fit most situations. Many of those defaults can be customized for your specific needs:
+
+- [Columns Selected by a Request]: define which columns are selected by requests such as `Player.fetchAll(db)`.
+- [Customizing the Persistence Methods]: define what happens when you call a persistance method such as `player.insert(db)`
+- [Conflict Resolution]: Run `INSERT OR REPLACE` queries, and generally define what happens when a persistence method violates a unique index.
+- [The Implicit RowID Primary Key]: all about the special `rowid` column.
+- [JSON Columns]: control the format of JSON columns.
+- [The userInfo Dictionary]: adapt your Codable implementation for the database.
+- [Beyond FetchableRecord]: the FetchableRecord protocol is not the end of the story.
+
+
+### Conflict Resolution
 
 **Insertions and updates can create conflicts**: for example, a query may attempt to insert a duplicate row that violates a unique index.
 
@@ -2808,7 +2902,7 @@ The [five different policies](https://www.sqlite.org/lang_conflict.html) are: ab
 
 **SQLite let you specify conflict policies at two different places:**
 
-- At the table level
+- In the definition of the database table:
     
     ```swift
     // CREATE TABLE player (
@@ -2826,7 +2920,7 @@ The [five different policies](https://www.sqlite.org/lang_conflict.html) are: ab
     try db.execute("INSERT INTO player (email) VALUES (?)", arguments: ["arthur@example.com"])
     ```
     
-- At the query level:
+- In each modification query:
     
     ```swift
     // CREATE TABLE player (
@@ -2843,16 +2937,16 @@ The [five different policies](https://www.sqlite.org/lang_conflict.html) are: ab
     try db.execute("INSERT OR REPLACE INTO player (email) VALUES (?)", arguments: ["arthur@example.com"])
     ```
 
-When you want to handle conflicts at the query level, specify a custom `persistenceConflictPolicy` in your type that adopts the MutablePersistableRecord or PersistableRecord protocol. It will alter the INSERT and UPDATE queries run by the `insert`, `update` and `save` [persistence methods](#persistence-methods):
+When you want to handle conflicts at the query level, specify a custom `persistenceConflictPolicy` in your type that adopts the PersistableRecord protocol. It will alter the INSERT and UPDATE queries run by the `insert`, `update` and `save` [persistence methods](#persistence-methods):
 
 ```swift
 protocol MutablePersistableRecord {
-    /// The policy that handles SQLite conflicts when records are inserted
-    /// or updated.
+    /// The policy that handles SQLite conflicts when records are
+    /// inserted or updated.
     ///
-    /// This property is optional: its default value uses the ABORT policy
-    /// for both insertions and updates, and has GRDB generate regular
-    /// INSERT and UPDATE queries.
+    /// This property is optional: its default value uses the ABORT
+    /// policy for both insertions and updates, so that GRDB generate
+    /// regular INSERT and UPDATE queries.
     static var persistenceConflictPolicy: PersistenceConflictPolicy { get }
 }
 
@@ -2868,13 +2962,13 @@ try player.insert(db)
 
 > :point_up: **Note**: the `ignore` policy does not play well at all with the `didInsert` method which notifies the rowID of inserted records. Choose your poison:
 >
-> - if you specify the `ignore` policy at the table level, don't implement the `didInsert` method: it will be called with some random id in case of failed insert.
+> - if you specify the `ignore` policy in the database table definition, don't implement the `didInsert` method: it will be called with some random id in case of failed insert.
 > - if you specify the `ignore` policy at the query level, the `didInsert` method is never called.
 >
-> :warning: **Warning**: [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) may delete rows so that inserts and updates can succeed. Those deletions are not reported to [transaction observers](#transactionobserver-protocol) (this might change in a future release of SQLite).
+> :point_up: **Note**: The `replace` policy may have to delete rows so that inserts and updates can succeed. Those deletions are not reported to [transaction observers](#transactionobserver-protocol) (this might change in a future release of SQLite).
 
 
-## The Implicit RowID Primary Key
+### The Implicit RowID Primary Key
 
 **All SQLite tables have a primary key.** Even when the primary key is not explicit:
 
@@ -2906,7 +3000,7 @@ try Book.deleteOne(db, key: 1)
 ```
 
 
-### Exposing the RowID Column
+#### Exposing the RowID Column
 
 **By default, a record type that wraps a table without any explicit primary key doesn't know about the hidden rowid column.**
 
@@ -2991,7 +3085,7 @@ When SQLite won't let you provide an explicit primary key (as in [full-text](#fu
     ```
 
 
-## Customized Decoding of Database Rows
+### Beyond FetchableRecord
 
 **Some GRDB users eventually discover that the [FetchableRecord] protocol does not fit all situations.** Use cases that are not well handled by FetchableRecord include:
 
@@ -3004,6 +3098,8 @@ When SQLite won't let you provide an explicit primary key (as in [full-text](#fu
 Since those use cases are not well handled by FetchableRecord, don't try to implement them on top of this protocol: you'll just fight the framework.
 
 Instead, please have a look at the [CustomizedDecodingOfDatabaseRows](Playgrounds/CustomizedDecodingOfDatabaseRows.playground/Contents.swift) playground. You'll run some sample code, and learn how to escape FetchableRecord when you need. And remember that leaving FetchableRecord will not deprive you of [query interface requests](#requests) and generally all SQL generation features of the [TableRecord] and [PersistableRecord] protocols.
+
+
 
 
 ## Examples of Record Definitions
@@ -3321,7 +3417,6 @@ So don't miss the [SQL API](#sqlite-api).
 
 - [Database Schema](#database-schema)
 - [Requests](#requests)
-    - [Columns Selected by a Request](#columns-selected-by-a-request)
 - [Expressions](#expressions)
     - [SQL Operators](#sql-operators)
     - [SQL Functions](#sql-functions)
@@ -3553,15 +3648,7 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     
     The hidden `rowid` column can be selected as well [when you need it](#the-implicit-rowid-primary-key).
 
-- `select(expression, ...)` defines the selected columns.
-    
-    ```swift
-    // SELECT id, name FROM player
-    Player.select(idColumn, nameColumn)
-    
-    // SELECT MAX(score) AS maxScore FROM player
-    Player.select(max(scoreColumn).aliased("maxScore"))
-    ```
+- `select(...)` defines the selected columns. See [Columns Selected by a Request].
 
 - `distinct()` performs uniquing.
     
@@ -4290,7 +4377,7 @@ try request.fetchAll(db)    // [Player]
 
 See [fetching methods](#fetching-methods) for information about the `fetchCursor`, `fetchAll` and `fetchOne` methods.
 
-The RowDecoder type associated with the FetchRequest does not have to be Row, DatabaseValueConvertible, or FetchableRecord. See the [Customized Decoding of Database Rows](#customized-decoding-of-database-rows) chapter for more information.
+The RowDecoder type associated with the FetchRequest does not have to be Row, DatabaseValueConvertible, or FetchableRecord. See the [Beyond FetchableRecord] chapter for more information.
 
 
 ## Migrations
@@ -5228,7 +5315,7 @@ Our introduction above has introduced important techniques. It uses [row adapter
 But we may want to make it more usable and robust:
 
 1. It's generally easier to consume records than raw rows.
-2. Joined records not always need all columns from a table (see `TableRecord.databaseSelection` in [Columns Selected by a Request](#columns-selected-by-a-request)).
+2. Joined records not always need all columns from a table (see `TableRecord.databaseSelection` in [Columns Selected by a Request]).
 3. Building row adapters is long and error prone.
 
 To address the first bullet, let's define a record that holds our player, optional team, and maximum score. Since it can decode database rows, it adopts the [FetchableRecord] protocol:
@@ -7487,7 +7574,19 @@ This protocol has been renamed [FetchableRecord] in GRDB 3.0.
 
 This protocol has been renamed [TableRecord] in GRDB 3.0.
 
+### Customized Decoding of Database Rows
+
+This chapter has been renamed [Beyond FetchableRecord].
+
+[Beyond FetchableRecord]: #beyond-fetchablerecord
+[Columns Selected by a Request]: #columns-selected-by-a-request
+[Conflict Resolution]: #conflict-resolution
+[Customizing the Persistence Methods]: #customizing-the-persistence-methods
+[The Implicit RowID Primary Key]: #the-implicit-rowid-primary-key
+[The userInfo Dictionary]: #the-userinfo-dictionary
+[JSON Columns]: #json-columns
 [FetchableRecord]: #fetchablerecord-protocol
 [PersistableRecord]: #persistablerecord-protocol
 [Record Comparison]: #record-comparison
+[Record Customization Options]: #record-customization-options
 [TableRecord]: #tablerecord-protocol

--- a/Tests/GRDBTests/DatabaseSavepointTests.swift
+++ b/Tests/GRDBTests/DatabaseSavepointTests.swift
@@ -95,7 +95,6 @@ class DatabaseSavepointTests: GRDBTestCase {
             try db.create(table: "test") { t in
                 t.column("value", .integer).unique()
             }
-            print(self.lastSQLQuery)
             try db.execute("BEGIN TRANSACTION")
             XCTAssertTrue(db.isInsideTransaction)
             try db.execute("INSERT INTO test (value) VALUES (?)", arguments: [1])

--- a/Tests/GRDBTests/DatabaseValueConversionTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConversionTests.swift
@@ -57,9 +57,6 @@ class DatabaseValueConversionTests : GRDBTestCase {
         do {
             // test T.fetchOne
             let sqliteConversion = try T.fetchOne(db, sql)
-            if let s = sqliteConversion as? String {
-                print(s.utf8.map { $0 })
-            }
             XCTAssert(
                 sqliteConversion == expectedSQLiteConversion,
                 "unexpected SQLite conversion: \(stringRepresentation(sqliteConversion)) instead of \(stringRepresentation(expectedSQLiteConversion))",

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -830,11 +830,11 @@ extension FetchableRecordDecodableTests {
     
     class CustomizedRecord: Record {
         override class var decodingUserInfo: [CodingUserInfoKey: Any] {
-            return [testKeyRoot: "root", testKeyNested: "nested"]
+            return [testKeyRoot: "GRDB root", testKeyNested: "GRDB column or scope"]
         }
         
         override class var JSONDecodingUserInfo: [CodingUserInfoKey: Any] {
-            return [testKeyRoot: "unused", testKeyNested: "JSON nested"]
+            return [testKeyRoot: "JSON root", testKeyNested: "JSON column"]
         }
         
         required init(from decoder: Decoder) throws {
@@ -892,14 +892,20 @@ extension FetchableRecordDecodableTests {
             func test(_ record: Record) {
                 XCTAssertNil(record.key)
                 XCTAssertNil(record.context)
+                
+                // scope
                 XCTAssertEqual(record.nestedKeyed.name, "foo")
-                XCTAssertEqual(record.nestedKeyed.key, "nestedKeyed") // scope
+                XCTAssertEqual(record.nestedKeyed.key, "nestedKeyed")
                 XCTAssertNil(record.nestedKeyed.context)
+                
+                // column
                 XCTAssertEqual(record.nestedSingle.name, "bar")
-                XCTAssertEqual(record.nestedSingle.key, "nestedSingle") // column
+                XCTAssertEqual(record.nestedSingle.key, "nestedSingle")
                 XCTAssertNil(record.nestedSingle.context)
+                
+                // JSON column
                 XCTAssertEqual(record.nestedUnkeyed.name, "baz")
-                XCTAssertNil(record.nestedUnkeyed.key) // JSON reset
+                XCTAssertNil(record.nestedUnkeyed.key)
                 XCTAssertNil(record.nestedUnkeyed.context)
             }
             
@@ -923,14 +929,20 @@ extension FetchableRecordDecodableTests {
             func test(_ record: Record) {
                 XCTAssertNil(record.key)
                 XCTAssertNil(record.context)
+                
+                // JSON column
                 XCTAssertEqual(record.nestedKeyed.name, "foo")
-                XCTAssertNil(record.nestedKeyed.key) // JSON reset
+                XCTAssertNil(record.nestedKeyed.key)
                 XCTAssertNil(record.nestedKeyed.context)
+                
+                // column
                 XCTAssertEqual(record.nestedSingle.name, "bar")
-                XCTAssertEqual(record.nestedSingle.key, "nestedSingle") // column
+                XCTAssertEqual(record.nestedSingle.key, "nestedSingle")
                 XCTAssertNil(record.nestedSingle.context)
+                
+                // JSON column
                 XCTAssertEqual(record.nestedUnkeyed.name, "baz")
-                XCTAssertNil(record.nestedUnkeyed.key) // JSON reset
+                XCTAssertNil(record.nestedUnkeyed.key)
                 XCTAssertNil(record.nestedUnkeyed.context)
             }
             
@@ -951,16 +963,22 @@ extension FetchableRecordDecodableTests {
         try dbQueue.read { db in
             func test(_ record: CustomizedRecord) {
                 XCTAssertNil(record.key)
-                XCTAssertEqual(record.context, "root")
+                XCTAssertEqual(record.context, "GRDB root")
+                
+                // scope
                 XCTAssertEqual(record.nestedKeyed.name, "foo")
-                XCTAssertEqual(record.nestedKeyed.key, "nestedKeyed") // scope
-                XCTAssertEqual(record.nestedKeyed.context, "nested")
+                XCTAssertEqual(record.nestedKeyed.key, "nestedKeyed")
+                XCTAssertEqual(record.nestedKeyed.context, "GRDB column or scope")
+                
+                // column
                 XCTAssertEqual(record.nestedSingle.name, "bar")
-                XCTAssertEqual(record.nestedSingle.key, "nestedSingle") // column
-                XCTAssertNil(record.nestedSingle.context)
+                XCTAssertEqual(record.nestedSingle.key, "nestedSingle")
+                XCTAssertEqual(record.nestedSingle.context, "GRDB column or scope")
+                
+                // JSON column
                 XCTAssertEqual(record.nestedUnkeyed.name, "baz")
-                XCTAssertNil(record.nestedUnkeyed.key) // JSON reset
-                XCTAssertEqual(record.nestedUnkeyed.context, "JSON nested")
+                XCTAssertNil(record.nestedUnkeyed.key)
+                XCTAssertEqual(record.nestedUnkeyed.context, "JSON column")
             }
             
             let adapter = SuffixRowAdapter(fromIndex: 1).addingScopes(["nestedKeyed": RangeRowAdapter(0..<1)])
@@ -982,16 +1000,22 @@ extension FetchableRecordDecodableTests {
         try dbQueue.read { db in
             func test(_ record: CustomizedRecord) {
                 XCTAssertNil(record.key)
-                XCTAssertEqual(record.context, "root")
+                XCTAssertEqual(record.context, "GRDB root")
+                
+                // JSON column
                 XCTAssertEqual(record.nestedKeyed.name, "foo")
-                XCTAssertNil(record.nestedKeyed.key) // JSON reset
-                XCTAssertEqual(record.nestedKeyed.context, "JSON nested")
+                XCTAssertNil(record.nestedKeyed.key)
+                XCTAssertEqual(record.nestedKeyed.context, "JSON column")
+                
+                // column
                 XCTAssertEqual(record.nestedSingle.name, "bar")
-                XCTAssertEqual(record.nestedSingle.key, "nestedSingle") // column
-                XCTAssertNil(record.nestedSingle.context)
+                XCTAssertEqual(record.nestedSingle.key, "nestedSingle")
+                XCTAssertEqual(record.nestedSingle.context, "GRDB column or scope")
+
+                // JSON column
                 XCTAssertEqual(record.nestedUnkeyed.name, "baz")
-                XCTAssertNil(record.nestedUnkeyed.key) // JSON reset
-                XCTAssertEqual(record.nestedUnkeyed.context, "JSON nested")
+                XCTAssertNil(record.nestedUnkeyed.key)
+                XCTAssertEqual(record.nestedUnkeyed.context, "JSON column")
             }
             
             let request = SQLRequest<Void>(

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -840,13 +840,15 @@ extension FetchableRecordDecodableTests {
             context = decoder.userInfo[testKeyRoot] as? String
         }
 
-        static var decodingUserInfo: [CodingUserInfoKey: Any] {
-            return [testKeyRoot: "GRDB root", testKeyNested: "GRDB column or scope"]
-        }
+        static let decodingUserInfo: [CodingUserInfoKey: Any] = [
+            testKeyRoot: "GRDB root",
+            testKeyNested: "GRDB column or scope"]
         
         static func makeJSONDecoder(for column: String) -> JSONDecoder {
             let decoder = JSONDecoder()
-            decoder.userInfo = [testKeyRoot: "JSON root", testKeyNested: "JSON column: \(column)"]
+            decoder.userInfo = [
+                testKeyRoot: "JSON root",
+                testKeyNested: "JSON column: \(column)"]
             return decoder
         }
     }

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -840,7 +840,7 @@ extension FetchableRecordDecodableTests {
             context = decoder.userInfo[testKeyRoot] as? String
         }
 
-        static let decodingUserInfo: [CodingUserInfoKey: Any] = [
+        static let databaseDecodingUserInfo: [CodingUserInfoKey: Any] = [
             testKeyRoot: "GRDB root",
             testKeyNested: "GRDB column or scope"]
         

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -844,7 +844,7 @@ extension FetchableRecordDecodableTests {
             testKeyRoot: "GRDB root",
             testKeyNested: "GRDB column or scope"]
         
-        static func makeJSONDecoder(for column: String) -> JSONDecoder {
+        static func databaseJSONDecoder(for column: String) -> JSONDecoder {
             let decoder = JSONDecoder()
             decoder.userInfo = [
                 testKeyRoot: "JSON root",

--- a/Tests/GRDBTests/MutablePersistableRecordEncodableTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordEncodableTests.swift
@@ -566,7 +566,7 @@ extension MutablePersistableRecordEncodableTests {
             case nestedKeyed, nestedSingle, nestedUnkeyed, key, context
         }
         
-        static let encodingUserInfo: [CodingUserInfoKey: Any] = [
+        static let databaseEncodingUserInfo: [CodingUserInfoKey: Any] = [
             testKeyRoot: "GRDB root",
             testKeyNested: "GRDB nested"]
         

--- a/Tests/GRDBTests/MutablePersistableRecordEncodableTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordEncodableTests.swift
@@ -570,7 +570,7 @@ extension MutablePersistableRecordEncodableTests {
             testKeyRoot: "GRDB root",
             testKeyNested: "GRDB nested"]
         
-        static func makeJSONEncoder(for column: String) -> JSONEncoder {
+        static func databaseJSONEncoder(for column: String) -> JSONEncoder {
             let encoder = JSONEncoder()
             encoder.outputFormatting = .sortedKeys
             encoder.userInfo = [

--- a/Tests/GRDBTests/MutablePersistableRecordEncodableTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordEncodableTests.swift
@@ -480,7 +480,7 @@ extension MutablePersistableRecordEncodableTests {
 private let testKeyRoot = CodingUserInfoKey(rawValue: "test1")!
 private let testKeyNested = CodingUserInfoKey(rawValue: "test2")!
 
-@available(OSX 10.13, *)
+@available(OSX 10.13, iOS 11.0, *)
 extension MutablePersistableRecordEncodableTests {
     struct NestedKeyed: Encodable {
         var name: String

--- a/Tests/GRDBTests/PersistableRecordTests.swift
+++ b/Tests/GRDBTests/PersistableRecordTests.swift
@@ -1009,9 +1009,8 @@ extension PersistableRecordTests {
                 XCTFail("Could not find record in db")
                 return
             }
-
-            print(fetchModel.numbers.first!)
-             XCTAssertEqual(model.numbers, fetchModel.numbers)
+            
+            XCTAssertEqual(model.numbers, fetchModel.numbers)
         }
     }
     


### PR DESCRIPTION
This PR brings four customization points for Codable record types:

```diff
 protocol FetchableRecord {
+    static var databaseDecodingUserInfo: [CodingUserInfoKey: Any] { get }
+    static func databaseJSONDecoder(for column: String) -> JSONDecoder
 }

 protocol MutablePersistableRecord: TableRecord {
+    static var databaseEncodingUserInfo: [CodingUserInfoKey: Any] { get }
+    static func databaseJSONEncoder(for column: String) -> JSONEncoder
 }
```

The userInfo dictionaries address the feature request #324 by @samritchie.

The JSON encoder/decoders allow you to customize the format of JSON columns introduced in #397 (so that you can change the format of dates embedded in JSON, for example).