### PR TITLE
Query Interface: set the selection and the fetched type in a single method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,17 @@ Release Notes
 
 ### New
 
-- [#397](https://github.com/groue/GRDB.swift/pull/397): JSON encoding and decoding of codable record properties
-- [#399](https://github.com/groue/GRDB.swift/pull/399): Codable support: customize the `userInfo` context dictionary, and the format of JSON columns
+- [#397](https://github.com/groue/GRDB.swift/pull/397): Codable records: JSON encoding and decoding of codable record properties
+- [#399](https://github.com/groue/GRDB.swift/pull/399): Codable records: customize the `userInfo` context dictionary, and the format of JSON columns
+- [#401](https://github.com/groue/GRDB.swift/pull/401): Query Interface: set the selection and the fetched type in a single method call
 - [#393](https://github.com/groue/GRDB.swift/pull/393): Upgrade SQLCipher to 3.4.2, enable FTS5 on GRDBCipher and new pod GRDBPlus.
 - [#384](https://github.com/groue/GRDB.swift/pull/384): Improve database value decoding diagnostics
 - Cursors of optimized values (Strint, Int, Date, etc.) have been renamed: FastDatabaseValueCursor and FastNullableDatabaseValueCursor replace the deprecated ColumnCursor and NullableColumnCursor.
 
 
 ### API diff
+
+Fixes:
 
 ```diff
  class DatabaseQueue {
@@ -26,7 +29,11 @@ Release Notes
 -    func unsafeReentrantRead<T>(_ block: (Database) throws -> T) throws -> T {
 +    func unsafeReentrantRead<T>(_ block: (Database) throws -> T) rethrows -> T {
  }
+```
 
+Enhancements to Codable support:
+
+```diff
  protocol FetchableRecord {
 +    static var databaseDecodingUserInfo: [CodingUserInfoKey: Any] { get }
 +    static func databaseJSONDecoder(for column: String) -> JSONDecoder
@@ -36,7 +43,27 @@ Release Notes
 +    static var databaseEncodingUserInfo: [CodingUserInfoKey: Any] { get }
 +    static func databaseJSONEncoder(for column: String) -> JSONEncoder
  }
+```
 
+Query Interface: set the selection and the fetched type in a single method call:
+
+```diff
+ extension QueryInterfaceRequest {
++    func select<RowDecoder>(_ selection: [SQLSelectable], as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder>
++    func select<RowDecoder>(_ selection: SQLSelectable..., as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder>
++    func select<RowDecoder>(sql: String, arguments: StatementArguments? = nil, as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder>
+ }
+ 
+ extension TableRecord {
++    static func select<RowDecoder>(_ selection: [SQLSelectable], as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder>
++    static func select<RowDecoder>(_ selection: SQLSelectable..., as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder>
++    static func select<RowDecoder>(sql: String, arguments: StatementArguments? = nil, as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder>
+ }
+```
+
+Deprecations:
+
+```diff
 +final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & StatementColumnConvertible> : Cursor { }
 +@available(*, deprecated, renamed: "FastDatabaseValueCursor")
 +typealias ColumnCursor<Value: DatabaseValueConvertible & StatementColumnConvertible> = FastDatabaseValueCursor<Value>
@@ -52,6 +79,7 @@ Release Notes
 - [Enabling FTS5 Support](README.md#enabling-fts5-support): Procedure for enabling FTS5 support in GRDB.
 - [Codable Records](README.md#codable-records): Updated documentation for JSON columns, tips, and customization options.
 - [Record Customization Options](README.md#record-customization-options): A new chapter that gather all your customization options.
+- [Fetching from Requests](README.md#fetching-from-requests): Enhanced documentation about requests that don't fetch their origin record (such as aggregates, or associated records).
 
 
 ## 3.2.0

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -59,7 +59,7 @@ public protocol Association: DerivableRequest {
 }
 
 extension Association {
-    /// Creates an association with a new set of selected columns.
+    /// Creates an association which selects *selection*.
     ///
     ///     struct Player: TableRecord {
     ///         static let team = belongsTo(Team.self)

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -47,7 +47,7 @@ extension QueryInterfaceRequest : DerivableRequest, AggregatingRequest {
     
     // MARK: Request Derivation
 
-    /// Creates a request with a new set of selected columns.
+    /// Creates a request which selects *selection*.
     ///
     ///     // SELECT id, email FROM player
     ///     var request = Player.all()
@@ -63,6 +63,42 @@ extension QueryInterfaceRequest : DerivableRequest, AggregatingRequest {
         return QueryInterfaceRequest(query: query.select(selection))
     }
     
+    /// Creates a request which selects *selection*, and fetches values of
+    /// type *type*.
+    ///
+    ///     try dbQueue.read { db in
+    ///         // SELECT max(score) FROM player
+    ///         let request = Player.all().select([max(Column("score"))], as: Int.self)
+    ///         let maxScore: Int? = try request.fetchOne(db)
+    ///     }
+    public func select<RowDecoder>(_ selection: [SQLSelectable], as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder> {
+        return QueryInterfaceRequest<RowDecoder>(query: query.select(selection))
+    }
+    
+    /// Creates a request which selects *selection*, and fetches values of
+    /// type *type*.
+    ///
+    ///     try dbQueue.read { db in
+    ///         // SELECT max(score) FROM player
+    ///         let request = Player.all().select(max(Column("score")), as: Int.self)
+    ///         let maxScore: Int? = try request.fetchOne(db)
+    ///     }
+    public func select<RowDecoder>(_ selection: SQLSelectable..., as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder> {
+        return select(selection, as: type)
+    }
+    
+    /// Creates a request which selects *sql*, and fetches values of
+    /// type *type*.
+    ///
+    ///     try dbQueue.read { db in
+    ///         // SELECT max(score) FROM player
+    ///         let request = Player.all().select(sql: "max(score)", as: Int.self)
+    ///         let maxScore: Int? = try request.fetchOne(db)
+    ///     }
+    public func select<RowDecoder>(sql: String, arguments: StatementArguments? = nil, as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder> {
+        return select(SQLSelectionLiteral(sql, arguments: arguments), as: type)
+    }
+
     /// Creates a request which returns distinct rows.
     ///
     ///     // SELECT DISTINCT * FROM player
@@ -256,6 +292,42 @@ extension TableRecord {
         return all().select(sql: sql, arguments: arguments)
     }
     
+    /// Creates a request which selects *selection*, and fetches values of
+    /// type *type*.
+    ///
+    ///     try dbQueue.read { db in
+    ///         // SELECT max(score) FROM player
+    ///         let request = Player.select([max(Column("score"))], as: Int.self)
+    ///         let maxScore: Int? = try request.fetchOne(db)
+    ///     }
+    public static func select<RowDecoder>(_ selection: [SQLSelectable], as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder> {
+        return all().select(selection, as: type)
+    }
+    
+    /// Creates a request which selects *selection*, and fetches values of
+    /// type *type*.
+    ///
+    ///     try dbQueue.read { db in
+    ///         // SELECT max(score) FROM player
+    ///         let request = Player.select(max(Column("score")), as: Int.self)
+    ///         let maxScore: Int? = try request.fetchOne(db)
+    ///     }
+    public static func select<RowDecoder>(_ selection: SQLSelectable..., as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder> {
+        return all().select(selection, as: type)
+    }
+    
+    /// Creates a request which selects *sql*, and fetches values of
+    /// type *type*.
+    ///
+    ///     try dbQueue.read { db in
+    ///         // SELECT max(score) FROM player
+    ///         let request = Player.select(sql: "max(score)", as: Int.self)
+    ///         let maxScore: Int? = try request.fetchOne(db)
+    ///     }
+    public static func select<RowDecoder>(sql: String, arguments: StatementArguments? = nil, as type: RowDecoder.Type) -> QueryInterfaceRequest<RowDecoder> {
+        return all().select(sql: sql, arguments: arguments, as: type)
+    }
+
     /// Creates a request with the provided *predicate*.
     ///
     ///     // SELECT * FROM player WHERE email = 'arthur@example.com'

--- a/GRDB/QueryInterface/RequestProtocols.swift
+++ b/GRDB/QueryInterface/RequestProtocols.swift
@@ -2,7 +2,7 @@
 
 /// The protocol for all requests that can refine their selection.
 public protocol SelectionRequest {
-    /// Creates a request with a new set of selected columns.
+    /// Creates a request which selects *selection*.
     ///
     ///     // SELECT id, email FROM player
     ///     var request = Player.all()
@@ -18,7 +18,7 @@ public protocol SelectionRequest {
 }
 
 extension SelectionRequest {
-    /// Creates a request with a new set of selected columns.
+    /// Creates a request which selects *selection*.
     ///
     ///     // SELECT id, email FROM player
     ///     var request = Player.all()
@@ -34,7 +34,7 @@ extension SelectionRequest {
         return select(selection)
     }
     
-    /// Creates a request with a new set of selected columns.
+    /// Creates a request which selects *sql*.
     ///
     ///     // SELECT id, email FROM player
     ///     var request = Player.all()

--- a/README.md
+++ b/README.md
@@ -3654,7 +3654,7 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     
     The hidden `rowid` column can be selected as well [when you need it](#the-implicit-rowid-primary-key).
 
-- `select(...)` and `select(..., as:)` defines the selected columns. See [Columns Selected by a Request].
+- `select(...)` and `select(..., as:)` define the selected columns. See [Columns Selected by a Request].
     
     ```swift
     // SELECT name FROM player
@@ -3820,14 +3820,14 @@ let request = Player.all()
 
 **The selection can be changed for each individual requests, or for all requests built from a given type.**
 
-When the selection of a particular request does not fit the origin record, use the `select(...)` or `select(..., as:)` method (see [Fetching from Requests] for detailed information):
+The `select(...)` and `select(..., as:)` methods change the selection of a single request (see [Fetching from Requests] for detailed information):
 
 ```swift
 let request = Player.select(max(Column("score")))
 let maxScore: Int? = try Int.fetchOne(db, request)
 ```
 
-To specify the default selection for a record type, define the `databaseSelection` property:
+The default selection for a record type is controlled by the `databaseSelection` property:
 
 ```swift
 struct RestrictedPlayer : TableRecord {

--- a/TODO.md
+++ b/TODO.md
@@ -40,7 +40,13 @@
     // new
     request.select(Column("name"), as: String.self)
     ```
-
+- [ ] select values from a JSON column:
+    
+    ```swift
+    let nesteds = try Record
+        .select(Column("nested"), as: Nested.self)
+        .fetchAll(db)
+    ```
 
 Swift 4.2
 

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -220,6 +220,123 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             "SELECT \"name\" FROM \"readers\"")
     }
     
+    func testSelectAs() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute("INSERT INTO readers (name, age) VALUES (?, ?)", arguments: ["Arthur", 42])
+            
+            // select(..., as: String.self)
+            do {
+                // Type.select(..., as:)
+                do {
+                    // variadic
+                    do {
+                        let value = try Reader
+                            .select(Col.name, as: String.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, "Arthur")
+                    }
+                    // array
+                    do {
+                        let value = try Reader
+                            .select([Col.name], as: String.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, "Arthur")
+                    }
+                    // raw sql without argument
+                    do {
+                        let value = try Reader
+                            .select(sql: "name", as: String.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, "Arthur")
+                    }
+                }
+                // request.select(..., as:)
+                do {
+                    // variadic
+                    do {
+                        let value = try Reader
+                            .all()
+                            .select(Col.name, as: String.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, "Arthur")
+                    }
+                    // array
+                    do {
+                        let value = try Reader
+                            .all()
+                            .select([Col.name], as: String.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, "Arthur")
+                    }
+                    // raw sql without argument
+                    do {
+                        let value = try Reader
+                            .all()
+                            .select(sql: "name", as: String.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, "Arthur")
+                    }
+                }
+            }
+            
+            // select(..., as: Row.self)
+            do {
+                // Type.select(..., as:)
+                do {
+                    // variadic
+                    do {
+                        let value = try Reader
+                            .select(Col.name, Col.age, as: Row.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, ["name": "Arthur", "age": 42])
+                    }
+                    // array
+                    do {
+                        let value = try Reader
+                            .select([Col.name, Col.age], as: Row.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, ["name": "Arthur", "age": 42])
+                    }
+                    // raw sql with named argument
+                    do {
+                        let value = try Reader
+                            .select(sql: "name, :age AS age", arguments: ["age": 22], as: Row.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, ["name": "Arthur", "age": 22])
+                    }
+                }
+                // request.select(..., as:)
+                do {
+                    // variadic
+                    do {
+                        let value = try Reader
+                            .all()
+                            .select(Col.name, Col.age, as: Row.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, ["name": "Arthur", "age": 42])
+                    }
+                    // array
+                    do {
+                        let value = try Reader
+                            .all()
+                            .select([Col.name, Col.age], as: Row.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, ["name": "Arthur", "age": 42])
+                    }
+                    // raw sql with positional argument
+                    do {
+                        let value = try Reader
+                            .all()
+                            .select(sql: "name, ? AS age", arguments: [22], as: Row.self)
+                            .fetchOne(db)!
+                        XCTAssertEqual(value, ["name": "Arthur", "age": 22])
+                    }
+                }
+            }
+        }
+    }
+    
     
     // MARK: - Distinct
     


### PR DESCRIPTION
This PR introduces the new `select(..., as:...)` method:

```swift
// new
let request = Player.select(max(Column("score")), as: Int.self)
```

This new method does not bring any new functionality. It is 100% equivalent to the already available `select(...).asRequest(of:...)`:

```swift
// old way to do it
let request = Player
    .select(max(Column("score")))
    .asRequest(of: Int.self)
```

The goal of this PR is to help building apis that return requests (instead of returning fetched values). For example:

```swift
struct Player: Codable, FetchableRecord, PersistableRecord {
    var uuid: UUID
    var name: String
    var score: Int
    
    private enum CodingKeys: String, CodingKey, ColumnExpression {
        case uuid, name, score
    }
    
    static var maximumScore: QueryInterfaceRequest<Int> {
        // new
        return select(max(CodingKeys.score)), as: Int.self)
    }
    
    static func uuid(forName name: String) -> QueryInterfaceRequest<UUID> {
        // new
        return filter(CodingKeys.name == name)
            .select(CodingKeys.uuid, as: UUID.self)
    }
}

// Fetch
dbQueue.read { db in
    let maximumScore: Int? = try Player.maximumScore.fetchOne(db)
    let uuid: UUID? = try Player.uuid(forName: "Arthur").fetchOne(db)
}

// Observe with RxGRDB
Player.maximumScore.rx
    .fetchOne(in: dbQueue)
    .subscribe(onNext: { maximumScore: Int? in
        print("maximum score has changed")
    })
```
