### PR TITLE
DatabaseWriter.concurrentRead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Release Notes
      func readFromCurrentState(_ block: @escaping (Database) -> Void) throws
  }
 
-+struct Future<Value> {
++class Future<Value> {
 +    func wait() throws -> Value
 +}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,20 @@ Release Notes
 
 ## Next Version
 
+### New
+
+- [#409](https://github.com/groue/GRDB.swift/pull/409): DatabaseWriter.concurrentRead
+
+
 ### API diff
 
 ```diff
+ protocol DatabaseWriter : DatabaseReader {
++    func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T>
++    @available(*, deprecated)
+     func readFromCurrentState(_ block: @escaping (Database) -> Void) throws
+ }
+ 
  extension Cursor {
 +    func isEmpty() throws -> Bool
  }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Release Notes
 +    @available(*, deprecated)
      func readFromCurrentState(_ block: @escaping (Database) -> Void) throws
  }
- 
+
++struct Future<Value> {
++    func wait() throws -> Value
++}
+
  extension Cursor {
 +    func isEmpty() throws -> Bool
  }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,6 +233,8 @@ Starting points:
 - [RxSwiftCommunity/RxDataSources](https://github.com/RxSwiftCommunity/RxDataSources)
 - [ra1028/DifferenceKit](https://github.com/ra1028/DifferenceKit)
 - [tonyarnold/Differ](https://github.com/tonyarnold/Differ)
+- [onmyway133/DeepDiff](https://github.com/onmyway133/DeepDiff)
+- [mcudich/HeckelDiff](https://github.com/mcudich/HeckelDiff)
 
 
 ### FetchedRecordsController Support for Any Request

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -374,6 +374,9 @@ extension DatabasePool : DatabaseReader {
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block, or any DatabaseError that would
     ///   happen while establishing the read access to the database.
+    ///
+    /// :nodoc:
+    @available(*, deprecated)
     public func readFromCurrentState(_ block: @escaping (Database) -> Void) throws {
         // https://www.sqlite.org/isolation.html
         //
@@ -422,7 +425,12 @@ extension DatabasePool : DatabaseReader {
         // Check that we're on the writer queue...
         writer.execute { db in
             // ... and that no transaction is opened.
-            GRDBPrecondition(!db.isInsideTransaction, "readFromCurrentState must not be called from inside a transaction. If this error is raised from a DatabasePool.write block, use DatabasePool.writeWithoutTransaction instead (and use transactions when needed).")
+            GRDBPrecondition(!db.isInsideTransaction, """
+                readFromCurrentState must not be called from inside a transaction. \
+                If this error is raised from a DatabasePool.write block, use \
+                DatabasePool.writeWithoutTransaction instead (and use \
+                transactions when needed).
+                """)
         }
         
         // The semaphore that blocks the writing dispatch queue until snapshot
@@ -456,7 +464,122 @@ extension DatabasePool : DatabaseReader {
             throw readError
         }
     }
-
+    
+    /// See `DatabaseWriter.concurrentRead`.
+    ///
+    /// :nodoc:
+    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
+        // https://www.sqlite.org/isolation.html
+        //
+        // > In WAL mode, SQLite exhibits "snapshot isolation". When a read
+        // > transaction starts, that reader continues to see an unchanging
+        // > "snapshot" of the database file as it existed at the moment in time
+        // > when the read transaction started. Any write transactions that
+        // > commit while the read transaction is active are still invisible to
+        // > the read transaction, because the reader is seeing a snapshot of
+        // > database file from a prior moment in time.
+        //
+        // That's exactly what we need. But what does "when read transaction
+        // starts" mean?
+        //
+        // http://www.sqlite.org/lang_transaction.html
+        //
+        // > Deferred [transaction] means that no locks are acquired on the
+        // > database until the database is first accessed. [...] Locks are not
+        // > acquired until the first read or write operation. [...] Because the
+        // > acquisition of locks is deferred until they are needed, it is
+        // > possible that another thread or process could create a separate
+        // > transaction and write to the database after the BEGIN on the
+        // > current thread has executed.
+        //
+        // Now that's precise enough: SQLite defers "snapshot isolation" until
+        // the first SELECT:
+        //
+        //     Reader                       Writer
+        //     BEGIN DEFERRED TRANSACTION
+        //                                  UPDATE ... (1)
+        //     Here the change (1) is visible
+        //     SELECT ...
+        //                                  UPDATE ... (2)
+        //     Here the change (2) is not visible
+        //
+        // The readFromCurrentState method says that no change should be visible
+        // at all. We thus have to perform a select that establishes the
+        // snapshot isolation before we release the writer queue:
+        //
+        //     Reader                       Writer
+        //     BEGIN DEFERRED TRANSACTION
+        //     SELECT anything
+        //                                  UPDATE ...
+        //     Here the change is not visible by GRDB user
+        
+        // Check that we're on the writer queue...
+        writer.execute { db in
+            // ... and that no transaction is opened.
+            GRDBPrecondition(!db.isInsideTransaction, """
+                concurrentRead must not be called from inside a transaction. \
+                If this error is raised from a DatabasePool.write block, use \
+                DatabasePool.writeWithoutTransaction instead (and use \
+                transactions when needed).
+                """)
+        }
+        
+        // The semaphore that blocks the writing dispatch queue until snapshot
+        // isolation has been established:
+        let isolationSemaphore = DispatchSemaphore(value: 0)
+        
+        // The semaphore that blocks until futureResult is defined:
+        let futureSemaphore = DispatchSemaphore(value: 0)
+        var futureResult: Result<T>? = nil
+        
+        do {
+            try readerPool.get { reader in
+                reader.async { db in
+                    // Open a deferred transaction and access the database in
+                    // order to establish snapshot isolation.
+                    defer { _ = try? db.commit() }
+                    do {
+                        try db.beginTransaction(.deferred)
+                        try db.makeSelectStatement("SELECT rootpage FROM sqlite_master").makeCursor().next()
+                    } catch {
+                        // Snapshot isolation failure
+                        futureResult = .failure(error)
+                        isolationSemaphore.signal()
+                        futureSemaphore.signal()
+                        return
+                    }
+                    
+                    // Release the writer queue
+                    isolationSemaphore.signal()
+                    
+                    // Reset the schema cache before running user code in snapshot isolation
+                    db.schemaCache = SimpleDatabaseSchemaCache()
+                    
+                    // Fetch and release the future
+                    futureResult = Result { try block(db) }
+                    futureSemaphore.signal()
+                }
+            }
+        } catch {
+            return Future { throw error }
+        }
+        
+        // Block the writer queue until snapshot isolation success or error
+        _ = isolationSemaphore.wait(timeout: .distantFuture)
+        
+        return Future {
+            // Block the future until results are fetched
+            _ = futureSemaphore.wait(timeout: .distantFuture)
+            
+            switch futureResult! {
+            case .failure(let error):
+                throw error
+            case .success(let result):
+                return result
+            }
+        }
+    }
+    
     /// Returns a reader that can be used from the current dispatch queue,
     /// if any.
     private var currentReader: SerializedDatabase? {

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 #if SWIFT_PACKAGE
     import CSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -350,6 +350,8 @@ extension DatabasePool : DatabaseReader {
         }
     }
     
+    /// This method is deprecated. Use concurrentRead instead.
+    ///
     /// Asynchronously executes a read-only block in a protected dispatch queue,
     /// wrapped in a deferred transaction.
     ///
@@ -375,9 +377,7 @@ extension DatabasePool : DatabaseReader {
     /// - parameter block: A block that accesses the database.
     /// - throws: The error thrown by the block, or any DatabaseError that would
     ///   happen while establishing the read access to the database.
-    ///
-    /// :nodoc:
-    @available(*, deprecated)
+    @available(*, deprecated, message: "Use concurrentRead instead")
     public func readFromCurrentState(_ block: @escaping (Database) -> Void) throws {
         // https://www.sqlite.org/isolation.html
         //
@@ -466,9 +466,6 @@ extension DatabasePool : DatabaseReader {
         }
     }
     
-    /// See `DatabaseWriter.concurrentRead`.
-    ///
-    /// :nodoc:
     public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
         // https://www.sqlite.org/isolation.html
         //

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -203,6 +203,8 @@ extension DatabaseQueue {
         return try writer.reentrantSync(block)
     }
     
+    /// This method is deprecated. Use concurrentRead instead.
+    ///
     /// Synchronously executes *block*.
     ///
     /// This method must be called from the protected database dispatch queue,
@@ -211,11 +213,7 @@ extension DatabaseQueue {
     /// Starting SQLite 3.8.0 (iOS 8.2+, OSX 10.10+, custom SQLite builds and
     /// SQLCipher), attempts to write in the database from this meethod throw a
     /// DatabaseError of resultCode `SQLITE_READONLY`.
-    ///
-    /// See `DatabaseWriter.readFromCurrentState`.
-    ///
-    /// :nodoc:
-    @available(*, deprecated)
+    @available(*, deprecated, message: "Use concurrentRead instead")
     public func readFromCurrentState(_ block: @escaping (Database) -> Void) {
         // Check that we're on the correct queue...
         writer.execute { db in
@@ -225,9 +223,6 @@ extension DatabaseQueue {
         }
     }
     
-    /// See `DatabaseWriter.concurrentRead`.
-    ///
-    /// :nodoc:
     public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
         // DatabaseQueue can't perform parallel reads.
         let result = Result<T> {

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -34,7 +34,7 @@ public class DatabaseSnapshot : DatabaseReader {
             try db.beginTransaction(.deferred)
             
             // Take snapshot
-            // See DatabasePool.readFromCurrentState for a complete discussion
+            // See DatabasePool.concurrentRead for a complete discussion
             try db.makeSelectStatement("SELECT rootpage FROM sqlite_master").makeCursor().next()
         }
     }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -62,6 +62,8 @@ public protocol DatabaseWriter : DatabaseReader {
     
     // MARK: - Reading from Database
     
+    /// This method is deprecated. Use concurrentRead instead.
+    ///
     /// Synchronously or asynchronously executes a read-only block that takes a
     /// database connection.
     ///
@@ -82,9 +84,7 @@ public protocol DatabaseWriter : DatabaseReader {
     ///         }
     ///         try db.execute("INSERT INTO player ...")
     ///     }
-    ///
-    /// :nodoc:
-    @available(*, deprecated)
+    @available(*, deprecated, message: "Use concurrentRead instead")
     func readFromCurrentState(_ block: @escaping (Database) -> Void) throws
     
     /// Concurrently executes a read-only block that takes a
@@ -282,7 +282,7 @@ public final class AnyDatabaseWriter : DatabaseWriter {
     }
 
     /// :nodoc:
-    @available(*, deprecated)
+    @available(*, deprecated, message: "Use concurrentRead instead")
     public func readFromCurrentState(_ block: @escaping (Database) -> Void) throws {
         try base.readFromCurrentState(block)
     }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -238,11 +238,14 @@ public class Future<Value> {
         _wait = wait
     }
     
-    /// Blocks the current thread until the future value is available.
-    /// Throws an error if the value could not be computed.
+    /// Blocks the current thread until the value is available, and returns it.
     ///
     /// It is a programmer error to call this method several times.
+    ///
+    /// - throws: Any error that prevented the value from becoming available.
     public func wait() throws -> Value {
+        // Not thread-safe and quick and dirty.
+        // Goal is that users learn not to call this method twice.
         GRDBPrecondition(consumed == false, "Future.wait() must be called only once")
         consumed = true
         return try _wait()

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -230,7 +230,8 @@ extension DatabaseWriter {
 }
 
 /// A future value.
-public struct Future<Value> {
+public class Future<Value> {
+    private var consumed = false
     private let _wait: () throws -> Value
     
     init(_ wait: @escaping () throws -> Value) {
@@ -239,7 +240,11 @@ public struct Future<Value> {
     
     /// Blocks the current thread until the future value is available.
     /// Throws an error if the value could not be computed.
+    ///
+    /// It is a programmer error to call this method several times.
     public func wait() throws -> Value {
+        GRDBPrecondition(consumed == false, "Future.wait() must be called only once")
+        consumed = true
         return try _wait()
     }
 }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -98,8 +98,8 @@ public protocol DatabaseWriter : DatabaseReader {
     /// database updates are *not visible* inside the block.
     ///
     /// This method returns as soon as the isolation guarantees described above
-    /// are established. To access the fetched results, you use the wait()
-    /// method of the returned future.
+    /// are established. To access the fetched results, you call the wait()
+    /// method of the returned future, on any dispatch queue.
     ///
     /// In the example below, the number of players is fetched concurrently with
     /// the player insertion. Yet the future is guaranteed to return zero:

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -80,7 +80,44 @@ public protocol DatabaseWriter : DatabaseReader {
     ///         }
     ///         try db.execute("INSERT INTO player ...")
     ///     }
+    ///
+    /// :nodoc:
+    @available(*, deprecated)
     func readFromCurrentState(_ block: @escaping (Database) -> Void) throws
+    
+    /// Concurrently executes a read-only block that takes a
+    /// database connection.
+    ///
+    /// This method must be called from a writing dispatch queue, outside of any
+    /// transaction. You'll get a fatal error otherwise.
+    ///
+    /// The *block* argument is guaranteed to see the database in the last
+    /// committed state at the moment this method is called. Eventual concurrent
+    /// database updates are *not visible* inside the block.
+    ///
+    /// This method returns as soon as the isolation guarantees described above
+    /// are established. To access the fetched results, you use the wait()
+    /// method of the returned future.
+    ///
+    /// In the example below, the number of players is fetched concurrently with
+    /// the player insertion. Yet the future is guaranteed to return zero:
+    ///
+    ///     try writer.writeWithoutTransaction { db in
+    ///         // Delete all players
+    ///         try Player.deleteAll()
+    ///
+    ///         // Count players concurrently
+    ///         let future = writer.concurrentRead { db in
+    ///             return try Player.fetchCount()
+    ///         }
+    ///
+    ///         // Insert a player
+    ///         try Player(...).insert(db)
+    ///
+    ///         // Guaranteed to be zero
+    ///         let count = try future.wait()
+    ///     }
+    func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T>
 }
 
 extension DatabaseWriter {
@@ -148,6 +185,37 @@ extension DatabaseWriter {
         #endif
     }
     
+    // MARK: - Reading from Database
+    
+    /// Default implementation, based on the deprecated readFromCurrentState.
+    ///
+    /// :nodoc:
+    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Result<T>? = nil
+
+        do {
+            try readFromCurrentState { db in
+                result = Result { try block(db) }
+                semaphore.signal()
+            }
+        } catch {
+            result = .failure(error)
+            semaphore.signal()
+        }
+
+        return Future {
+            _ = semaphore.wait(timeout: .distantFuture)
+
+            switch result! {
+            case .failure(let error):
+                throw error
+            case .success(let result):
+                return result
+            }
+        }
+    }
+    
     // MARK: - Claiming Disk Space
     
     /// Rebuilds the database file, repacking it into a minimal amount of
@@ -156,6 +224,18 @@ extension DatabaseWriter {
     /// See https://www.sqlite.org/lang_vacuum.html for more information.
     public func vacuum() throws {
         try writeWithoutTransaction { try $0.execute("VACUUM") }
+    }
+}
+
+public struct Future<T> {
+    private let _wait: () throws -> T
+    
+    init(_ wait: @escaping () throws -> T) {
+        _wait = wait
+    }
+    
+    public func wait() throws -> T {
+        return try _wait()
     }
 }
 
@@ -189,8 +269,14 @@ public final class AnyDatabaseWriter : DatabaseWriter {
     }
 
     /// :nodoc:
+    @available(*, deprecated)
     public func readFromCurrentState(_ block: @escaping (Database) -> Void) throws {
         try base.readFromCurrentState(block)
+    }
+    
+    /// :nodoc:
+    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
+        return base.concurrentRead(block)
     }
 
     // MARK: - Writing in Database

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -1,3 +1,5 @@
+import Dispatch
+
 /// The protocol for all types that can update a database.
 ///
 /// It is adopted by DatabaseQueue and DatabasePool.

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -227,14 +227,17 @@ extension DatabaseWriter {
     }
 }
 
-public struct Future<T> {
-    private let _wait: () throws -> T
+/// A future value.
+public struct Future<Value> {
+    private let _wait: () throws -> Value
     
-    init(_ wait: @escaping () throws -> T) {
+    init(_ wait: @escaping () throws -> Value) {
         _wait = wait
     }
     
-    public func wait() throws -> T {
+    /// Blocks the current thread until the future value is available.
+    /// Throws an error if the value could not be computed.
+    public func wait() throws -> Value {
         return try _wait()
     }
 }

--- a/GRDB/Utils/Result.swift
+++ b/GRDB/Utils/Result.swift
@@ -37,4 +37,13 @@ enum Result<Value> {
             return .failure(error)
         }
     }
+    
+    func unwrap() throws -> Value {
+        switch self {
+        case .success(let value):
+            return value
+        case .failure(let error):
+            throw error
+        }
+    }
 }

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,8 @@
 - [ ] https://github.com/apple/swift-evolution/blob/master/proposals/0075-import-test.md
 - [ ] Avoid code duplication: https://forums.swift.org/t/c-interoperability-combinations-of-library-and-os-versions/14029/4
 - [ ] Allow joining methods on DerivableRequest
+- [ ] DatabaseWriter.assertWriteAccess()
+- [ ] Configuration.crashOnError = true
 - [ ] Support for "INSERT INTO ... SELECT ...". For example:
     
     ```swift

--- a/Tests/GRDBTests/CompilationProtocolTests.swift
+++ b/Tests/GRDBTests/CompilationProtocolTests.swift
@@ -80,6 +80,7 @@ private class UserDatabaseWriter : DatabaseWriter {
     func writeWithoutTransaction<T>(_ block: (Database) throws -> T) rethrows -> T { preconditionFailure() }
     func unsafeReentrantWrite<T>(_ block: (Database) throws -> T) rethrows -> T { preconditionFailure() }
     func readFromCurrentState(_ block: @escaping (Database) -> Void) throws { preconditionFailure() }
+    func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> { preconditionFailure() }
 }
 
 // MARK: - FTS5Tokenizer


### PR DESCRIPTION
This pull requests improves the DatabaseWriter protocol by deprecating the `readFromCurrentState` method, and introducing `concurrentRead` as a replacement.

```swift
protocol DatabaseWriter {
    func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T>
}
```

The problem with the deprecated `readFromCurrentState` is that it is a *synchronous* DatabaseQueue method, and an *asynchronous* DatabasePool method. This makes writing code that target both classes difficult.

`concurrentRead`, instead, returns a `Future` value that client code can wait until the concurrent fetch is completed.

`concurrentRead` aims at helping database observation tools like FetchedRecordsController and RxGRDB: it fetches values from a known database state (right after a transaction has been committed), without blocking the database writer dispatch queue longer than necessary. DatabasePool.concurrentRead, especially, only blocks until snapshot isolation has been established in a concurrent reader.

```swift
try writer.writeWithoutTransaction { db in
    // Delete all players
    try Player.deleteAll()
    
    // Count players concurrently
    let future = writer.concurrentRead { db in
        return try Player.fetchCount()
    }
    
    // Insert a player
    try Player(...).insert(db)
    
    // Guaranteed to be zero
    let count = try future.wait()
}
```
