### PR TITLE
Fix database pool use of FTS5 tokenizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+## Next Version
+
+### Fixed
+
+- [#414](https://github.com/groue/GRDB.swift/pull/414): Fix database pool use of FTS5 tokenizers
+
+
 ## 3.3.0
 
 Released September 16, 2018 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v3.3.0-beta1...v3.3.0)

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -150,19 +150,4 @@
             }
         }
     }
-    
-    extension DatabasePool {
-        
-        // MARK: - Custom FTS5 Tokenizers
-        
-        /// Add a custom FTS5 tokenizer.
-        ///
-        ///     class MyTokenizer : FTS5CustomTokenizer { ... }
-        ///     dbPool.add(tokenizer: MyTokenizer.self)
-        public func add<Tokenizer: FTS5CustomTokenizer>(tokenizer: Tokenizer.Type) {
-            writeWithoutTransaction { db in
-                db.add(tokenizer: Tokenizer.self)
-            }
-        }
-    }
 #endif

--- a/Tests/GRDBTests/FTS5CustomTokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5CustomTokenizerTests.swift
@@ -223,7 +223,7 @@ class FTS5CustomTokenizerTests: GRDBTestCase {
     }
 
     func testStopWordsTokenizerDatabasePool() throws {
-        let dbPool = try makeDatabaseQueue()
+        let dbPool = try makeDatabasePool()
         dbPool.add(tokenizer: StopWordsTokenizer.self)
         
         try dbPool.write { db in


### PR DESCRIPTION
There was a bug in DatabasePool: [custom FTS5 tokenizers](https://github.com/groue/GRDB.swift/blob/master/Documentation/FTS5Tokenizers.md) were not available during database reads, and full-text searches would fail with an error.

This pull request fixes this bug.