### PR TITLE
Refining Association Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Release Notes
 =============
 
+## Next Version
+
+### New
+
+- [#422](https://github.com/groue/GRDB.swift/pull/422): Refining Association Requests
+
+
 ## 3.3.1
 
 Released September 23, 2018 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v3.3.0...v3.3.1)

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -22,6 +22,7 @@ GRDB Associations
     - [Sorting Associations]
     - [Columns Selected by an Association]
     - [Table Aliases]
+    - [Refining Association Requests]
 - [Fetching Values from Associations]
     - [The Structure of a Joined Request]
     - [Decoding a Joined Request with a Decodable Record]
@@ -1034,7 +1035,7 @@ let request = Book
     .order(authorAlias[Column("name")], Column("title"))
 ```
 
-The request can also be built in three distinct steps, as below:
+The same request can also be built in three distinct steps, as below:
 
 ```swift
 // 1. include author
@@ -1067,7 +1068,7 @@ extension QueryInterfaceRequest where T == Book {
 }
 ```
 
-And now our complex request looks much more simple:
+And now our complex request looks much simpler:
 
 ```swift
 let request = Book

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1442,26 +1442,6 @@ let request = Book
 
 This code compiles, but you'll get a runtime fatal error "Not implemented: chaining a required association behind an optional association". Future versions of GRDB may allow such requests.
 
-**You can't join two associations with the same [association key](#the-structure-of-a-joined-request) at the same level:**
-
-```swift
-// NOT IMPLEMENTED
-let request = Book
-    .including(required: Book.author) // key "author"
-    .including(required: Book.author) // key "author"
-```
-
-This code compiles, but you'll get a runtime fatal error "The association key `author` is ambiguous. Use the Association.forKey(_:) method is order to disambiguate.". Future versions of GRDB may allow such requests.
-
-To join the same table twice, and make sure GRDB does not modify the fetched results in some future release, make sure no two associations have the same name on a given level:
-
-```swift
-// OK
-let request = Book
-    .including(required: Book.author.forKey("firstAuthor"))
-    .including(required: Book.author.forKey("secondAuthor"))
-```
-
 
 ## Future Directions
 

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -116,6 +116,9 @@
 		5634B10A1CF9B970005360B9 /* TransactionObserverSavepointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5634B1061CF9B970005360B9 /* TransactionObserverSavepointsTests.swift */; };
 		5636E9BC1D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
 		5636E9BF1D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
+		563EF415215F87EB007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF414215F87EB007DAACD /* OrderedDictionary.swift */; };
+		563EF416215F87EB007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF414215F87EB007DAACD /* OrderedDictionary.swift */; };
+		563EF417215F87EB007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF414215F87EB007DAACD /* OrderedDictionary.swift */; };
 		56439B331F4CA1DC0066043F /* FMDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 56BB86191BA988F2001F9168 /* FMDatabase.m */; };
 		56439B341F4CA1DC0066043F /* InsertRecordClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56BB86121BA9886D001F9168 /* InsertRecordClassTests.swift */; };
 		56439B351F4CA1DC0066043F /* FMDatabaseAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 56BB861B1BA988F2001F9168 /* FMDatabaseAdditions.m */; };
@@ -876,6 +879,7 @@
 		563363F81C960711000BE133 /* PerformanceRealmTests.realm */ = {isa = PBXFileReference; lastKnownFileType = file; path = PerformanceRealmTests.realm; sourceTree = "<group>"; };
 		5634B1061CF9B970005360B9 /* TransactionObserverSavepointsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionObserverSavepointsTests.swift; sourceTree = "<group>"; };
 		5636E9BB1D22574100B9B05F /* FetchRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRequest.swift; sourceTree = "<group>"; };
+		563EF414215F87EB007DAACD /* OrderedDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionary.swift; sourceTree = "<group>"; };
 		56439B501F4CA1DC0066043F /* GRDBOSXPerformanceComparisonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBOSXPerformanceComparisonTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAfterNextTransactionCommitTests.swift; sourceTree = "<group>"; };
 		5644DE6C20F8C32E001FFDDE /* DatabaseValueConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversion.swift; sourceTree = "<group>"; };
@@ -1470,10 +1474,11 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				5659F4871EA8D94E004A4992 /* Utils.swift */,
-				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
+				563EF414215F87EB007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
+				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
 				5659F49F1EA8D997004A4992 /* Result.swift */,
+				5659F4871EA8D94E004A4992 /* Utils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2421,6 +2426,7 @@
 				565490DE1D5AE252005622CB /* QueryInterfaceQuery.swift in Sources */,
 				56F5ABDD1D814330001F60CB /* UUID.swift in Sources */,
 				565490CB1D5AE252005622CB /* (null) in Sources */,
+				563EF417215F87EB007DAACD /* OrderedDictionary.swift in Sources */,
 				565490D61D5AE252005622CB /* StandardLibrary.swift in Sources */,
 				5653EB1720944C7C00F46237 /* AssociationQuery.swift in Sources */,
 				565490B81D5AE236005622CB /* DatabaseError.swift in Sources */,
@@ -2483,6 +2489,7 @@
 				5698AC3A1D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
 				5664759D1D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
 				5674048A1CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
+				563EF416215F87EB007DAACD /* OrderedDictionary.swift in Sources */,
 				563363C51C942C37000BE133 /* DatabaseWriter.swift in Sources */,
 				5698AD1B1DAAD17D0056AF8C /* FTS5Tokenizer.swift in Sources */,
 				56F3E7661E67F8C100BF0F01 /* Fixits-0.101.1.swift in Sources */,
@@ -2926,6 +2933,7 @@
 				56A2387B1B9C75030082EB20 /* Configuration.swift in Sources */,
 				566475CC1D981D5E00FF74B8 /* SQLFunctions.swift in Sources */,
 				5698AC371D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
+				563EF415215F87EB007DAACD /* OrderedDictionary.swift in Sources */,
 				564F9C2D1F075DD200877A00 /* DatabaseFunction.swift in Sources */,
 				5659F4981EA8D989004A4992 /* Pool.swift in Sources */,
 				5674A6F41F307F600095F066 /* PersistableRecord+Encodable.swift in Sources */,

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -211,37 +211,28 @@ extension Association {
     }
 }
 
-///// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-///// :nodoc:
-//public struct JoinCondition {
-//    var columnMapping: [(left: Column, right: Column)]
-//
-//    func sqlExpression(leftAlias: TableAlias, rightAlias: TableAlias) -> SQLExpression? {
-//        return columnMapping
-//            .map { $0.right.qualifiedExpression(with: rightAlias) == $0.left.qualifiedExpression(with: leftAlias) }
-//            .joined(operator: .and)
-//    }
-//}
-
-///// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-///// :nodoc:
-//public typealias JoinCondition = (_ leftAlias: TableAlias, _ rightAlias: TableAlias) -> SQLExpression?
-
-/// Turns a ForeignKeyRequest into a JoinCondition
+/// The condition that links two joined tables.
+///
+/// We only support one kind of join condition, today: foreign keys.
+///
+///     SELECT ...
+///     FROM book
+///     JOIN author ON author.id = book.authorId
+///                    <--the join condition--->
+///
+/// When we eventually add support for new ways to join tables, JoinCondition
+/// is the type we'll need to update.
+///
+/// The Equatable conformance is used when we merge associations. Two
+/// associations can be merged if and only if their join conditions
+/// are equal:
+///
+///     let request = Book
+///         .include(required: Book.author)
+///         .include(required: Book.author)
 public struct JoinCondition: Equatable {
     var foreignKeyRequest: ForeignKeyRequest
     var originIsLeft: Bool
-    
-//    func fetch(_ db: Database) throws -> JoinCondition {
-//        let foreignKeyMapping = try foreignKeyRequest.fetch(db).mapping
-//        let columnMapping: [(left: Column, right: Column)]
-//        if originIsLeft {
-//            columnMapping = foreignKeyMapping.map { (left: Column($0.origin), right: Column($0.destination)) }
-//        } else {
-//            columnMapping = foreignKeyMapping.map { (left: Column($0.destination), right: Column($0.origin)) }
-//        }
-//        return JoinCondition(columnMapping: columnMapping)
-//    }
     
     func sqlExpression(_ db: Database, leftAlias: TableAlias, rightAlias: TableAlias) throws -> SQLExpression? {
         let foreignKeyMapping = try foreignKeyRequest.fetch(db).mapping

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -52,7 +52,7 @@ public protocol Association: DerivableRequest {
     var request: AssociationRequest<RowDecoder> { get }
     
     /// :nodoc:
-    func joinCondition(_ db: Database) throws -> JoinCondition
+    var joinCondition: JoinCondition { get }
     
     /// :nodoc:
     func mapRequest(_ transform: (AssociationRequest<RowDecoder>) -> AssociationRequest<RowDecoder>) -> Self
@@ -211,16 +211,39 @@ extension Association {
     }
 }
 
-/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-/// :nodoc:
-public typealias JoinCondition = (_ leftAlias: TableAlias, _ rightAlias: TableAlias) -> SQLExpression?
+///// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+///// :nodoc:
+//public struct JoinCondition {
+//    var columnMapping: [(left: Column, right: Column)]
+//
+//    func sqlExpression(leftAlias: TableAlias, rightAlias: TableAlias) -> SQLExpression? {
+//        return columnMapping
+//            .map { $0.right.qualifiedExpression(with: rightAlias) == $0.left.qualifiedExpression(with: leftAlias) }
+//            .joined(operator: .and)
+//    }
+//}
+
+///// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+///// :nodoc:
+//public typealias JoinCondition = (_ leftAlias: TableAlias, _ rightAlias: TableAlias) -> SQLExpression?
 
 /// Turns a ForeignKeyRequest into a JoinCondition
-struct ForeignKeyJoinConditionRequest {
+public struct JoinCondition: Equatable {
     var foreignKeyRequest: ForeignKeyRequest
     var originIsLeft: Bool
     
-    func fetch(_ db: Database) throws -> JoinCondition {
+//    func fetch(_ db: Database) throws -> JoinCondition {
+//        let foreignKeyMapping = try foreignKeyRequest.fetch(db).mapping
+//        let columnMapping: [(left: Column, right: Column)]
+//        if originIsLeft {
+//            columnMapping = foreignKeyMapping.map { (left: Column($0.origin), right: Column($0.destination)) }
+//        } else {
+//            columnMapping = foreignKeyMapping.map { (left: Column($0.destination), right: Column($0.origin)) }
+//        }
+//        return JoinCondition(columnMapping: columnMapping)
+//    }
+    
+    func sqlExpression(_ db: Database, leftAlias: TableAlias, rightAlias: TableAlias) throws -> SQLExpression? {
         let foreignKeyMapping = try foreignKeyRequest.fetch(db).mapping
         let columnMapping: [(left: Column, right: Column)]
         if originIsLeft {
@@ -228,11 +251,10 @@ struct ForeignKeyJoinConditionRequest {
         } else {
             columnMapping = foreignKeyMapping.map { (left: Column($0.destination), right: Column($0.origin)) }
         }
-        return { (leftAlias, rightAlias) in
-            return columnMapping
-                .map { $0.right.qualifiedExpression(with: rightAlias) == $0.left.qualifiedExpression(with: leftAlias) }
-                .joined(operator: .and)
-        }
+        
+        return columnMapping
+            .map { $0.right.qualifiedExpression(with: rightAlias) == $0.left.qualifiedExpression(with: leftAlias) }
+            .joined(operator: .and)
     }
 }
 
@@ -296,7 +318,7 @@ extension Association where OriginRowDecoder: MutablePersistableRecord {
             .filter { db in
                 // Build a join condition: `association.recordId = record.id`
                 // We still need to replace `record.id` with the actual record id.
-                guard let joinCondition = try self.joinCondition(db)(recordAlias, associationAlias) else {
+                guard let joinExpression = try self.joinCondition.sqlExpression(db, leftAlias: recordAlias, rightAlias: associationAlias) else {
                     fatalError("Can't request from record without join condition")
                 }
                 
@@ -306,7 +328,7 @@ extension Association where OriginRowDecoder: MutablePersistableRecord {
                 let container = PersistenceContainer(record)
                 
                 // Replace `record.id` with 123
-                return joinCondition.resolvedExpression(inContext: [recordAlias: container])
+                return joinExpression.resolvedExpression(inContext: [recordAlias: container])
             }
             
             // We just added a condition qualified with associationAlias. Don't

--- a/GRDB/QueryInterface/Association/AssociationQuery.swift
+++ b/GRDB/QueryInterface/Association/AssociationQuery.swift
@@ -180,11 +180,14 @@ extension AssociationQuery {
         // replace selection unless empty
         let mergedSelection = other.selection.isEmpty ? selection : other.selection
         
+        // replace ordering unless empty
+        let mergedOrdering = other.ordering.isEmpty ? ordering : other.ordering
+        
         return AssociationQuery(
             source: mergedSource,
             selection: mergedSelection,
             filterPromise: mergedFilterPromise,
-            ordering: other.ordering, // replace ordering
+            ordering: mergedOrdering,
             joins: mergedJoins)
     }
 }

--- a/GRDB/QueryInterface/Association/AssociationQuery.swift
+++ b/GRDB/QueryInterface/Association/AssociationQuery.swift
@@ -178,19 +178,14 @@ extension AssociationQuery {
             mergedJoins.append(value: join, forKey: key)
         }
         
-        // There is a possible conflict when both selections are not empty.
-        let mergedSelection: [SQLSelectable]
-        if selection.isEmpty {
-            mergedSelection = other.selection
-        } else {
-            mergedSelection = selection
-        }
+        // replace selection unless empty
+        let mergedSelection = other.selection.isEmpty ? selection : other.selection
         
         return AssociationQuery(
             source: mergedSource,
             selection: mergedSelection,
             filterPromise: mergedFilterPromise,
-            ordering: other.ordering, // reorder
+            ordering: other.ordering, // replace ordering
             joins: mergedJoins)
     }
 }

--- a/GRDB/QueryInterface/Association/AssociationQuery.swift
+++ b/GRDB/QueryInterface/Association/AssociationQuery.swift
@@ -61,12 +61,11 @@ extension AssociationQuery {
     
     func appendingJoin(_ join: AssociationJoin, forKey key: String) -> AssociationQuery {
         var query = self
-        if let existingJoin = query.joins[key] {
+        if let existingJoin = query.joins.removeValue(forKey: key) {
             guard let mergedJoin = existingJoin.merged(with: join) else {
                 // can't merge
                 fatalError("The association key \"\(key)\" is ambiguous. Use the Association.forKey(_:) method is order to disambiguate.")
             }
-            query.joins.removeValue(forKey: key)
             query.joins.append(value: mergedJoin, forKey: key)
         } else {
             query.joins.append(value: join, forKey: key)

--- a/GRDB/QueryInterface/Association/AssociationQuery.swift
+++ b/GRDB/QueryInterface/Association/AssociationQuery.swift
@@ -178,9 +178,17 @@ extension AssociationQuery {
             mergedJoins.append(value: join, forKey: key)
         }
         
+        // There is a possible conflict when both selections are not empty.
+        let mergedSelection: [SQLSelectable]
+        if selection.isEmpty {
+            mergedSelection = other.selection
+        } else {
+            mergedSelection = selection
+        }
+        
         return AssociationQuery(
             source: mergedSource,
-            selection: other.selection, // possible conflict with self.selection here.
+            selection: mergedSelection,
             filterPromise: mergedFilterPromise,
             ordering: other.ordering, // reorder
             joins: mergedJoins)

--- a/GRDB/QueryInterface/Association/AssociationRequest.swift
+++ b/GRDB/QueryInterface/Association/AssociationRequest.swift
@@ -43,8 +43,7 @@ extension AssociationRequest {
         let join = AssociationJoin(
             joinOperator: joinOperator,
             query: association.request.query,
-            key: association.key,
             joinConditionPromise: DatabasePromise(association.joinCondition))
-        return AssociationRequest(query: query.joining(join))
+        return AssociationRequest(query: query.joining(join, forKey: association.key))
     }
 }

--- a/GRDB/QueryInterface/Association/AssociationRequest.swift
+++ b/GRDB/QueryInterface/Association/AssociationRequest.swift
@@ -42,8 +42,8 @@ extension AssociationRequest {
     {
         let join = AssociationJoin(
             joinOperator: joinOperator,
-            query: association.request.query,
-            joinConditionPromise: DatabasePromise(association.joinCondition))
-        return AssociationRequest(query: query.joining(join, forKey: association.key))
+            joinCondition: association.joinCondition,
+            query: association.request.query)
+        return AssociationRequest(query: query.appendingJoin(join, forKey: association.key))
     }
 }

--- a/GRDB/QueryInterface/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Association/BelongsToAssociation.swift
@@ -59,8 +59,6 @@
 ///
 /// See ForeignKey for more information.
 public struct BelongsToAssociation<Origin, Destination>: Association {
-    fileprivate let joinConditionRequest: ForeignKeyJoinConditionRequest
-    
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -70,17 +68,15 @@ public struct BelongsToAssociation<Origin, Destination>: Association {
     public var key: String
     
     /// :nodoc:
+    public let joinCondition: JoinCondition
+    
+    /// :nodoc:
     public var request: AssociationRequest<Destination>
 
     public func forKey(_ key: String) -> BelongsToAssociation<Origin, Destination> {
         var association = self
         association.key = key
         return association
-    }
-    
-    /// :nodoc:
-    public func joinCondition(_ db: Database) throws -> JoinCondition {
-        return try joinConditionRequest.fetch(db)
     }
     
     /// :nodoc:
@@ -166,13 +162,13 @@ extension TableRecord {
             destinationTable: Destination.databaseTableName,
             foreignKey: foreignKey)
         
-        let joinConditionRequest = ForeignKeyJoinConditionRequest(
+        let joinCondition = JoinCondition(
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: true)
 
         return BelongsToAssociation(
-            joinConditionRequest: joinConditionRequest,
             key: key ?? Destination.databaseTableName,
+            joinCondition: joinCondition,
             request: AssociationRequest(Destination.all()))
     }
 }

--- a/GRDB/QueryInterface/Association/ForeignKeyRequest.swift
+++ b/GRDB/QueryInterface/Association/ForeignKeyRequest.swift
@@ -5,7 +5,7 @@
 ///
 /// When the schema does not define any foreign key, we can still infer complete
 /// mappings from partial information and primary keys.
-struct ForeignKeyRequest {
+struct ForeignKeyRequest: Equatable {
     let originTable: String
     let destinationTable: String
     let originColumns: [String]?

--- a/GRDB/QueryInterface/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyAssociation.swift
@@ -59,8 +59,6 @@
 ///
 /// See ForeignKey for more information.
 public struct HasManyAssociation<Origin, Destination>: Association {
-    fileprivate let joinConditionRequest: ForeignKeyJoinConditionRequest
-
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -70,17 +68,15 @@ public struct HasManyAssociation<Origin, Destination>: Association {
     public var key: String
     
     /// :nodoc:
+    public let joinCondition: JoinCondition
+    
+    /// :nodoc:
     public var request: AssociationRequest<Destination>
     
     public func forKey(_ key: String) -> HasManyAssociation<Origin, Destination> {
         var association = self
         association.key = key
         return association
-    }
-    
-    /// :nodoc:
-    public func joinCondition(_ db: Database) throws -> JoinCondition {
-        return try joinConditionRequest.fetch(db)
     }
     
     /// :nodoc:
@@ -166,13 +162,13 @@ extension TableRecord {
             destinationTable: databaseTableName,
             foreignKey: foreignKey)
         
-        let joinConditionRequest = ForeignKeyJoinConditionRequest(
+        let joinCondition = JoinCondition(
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: false)
         
         return HasManyAssociation(
-            joinConditionRequest: joinConditionRequest,
             key: key ?? Destination.databaseTableName,
+            joinCondition: joinCondition,
             request: AssociationRequest(Destination.all()))
     }
 }

--- a/GRDB/QueryInterface/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasOneAssociation.swift
@@ -61,8 +61,6 @@
 ///
 /// See ForeignKey for more information.
 public struct HasOneAssociation<Origin, Destination> : Association {
-    fileprivate let joinConditionRequest: ForeignKeyJoinConditionRequest
-
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -72,17 +70,15 @@ public struct HasOneAssociation<Origin, Destination> : Association {
     public var key: String
     
     /// :nodoc:
+    public let joinCondition: JoinCondition
+    
+    /// :nodoc:
     public var request: AssociationRequest<Destination>
     
     public func forKey(_ key: String) -> HasOneAssociation<Origin, Destination> {
         var association = self
         association.key = key
         return association
-    }
-    
-    /// :nodoc:
-    public func joinCondition(_ db: Database) throws -> JoinCondition {
-        return try joinConditionRequest.fetch(db)
     }
     
     /// :nodoc:
@@ -168,13 +164,13 @@ extension TableRecord {
             destinationTable: databaseTableName,
             foreignKey: foreignKey)
         
-        let joinConditionRequest = ForeignKeyJoinConditionRequest(
+        let joinCondition = JoinCondition(
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: false)
         
         return HasOneAssociation(
-            joinConditionRequest: joinConditionRequest,
             key: key ?? Destination.databaseTableName,
+            joinCondition: joinCondition,
             request: AssociationRequest(Destination.all()))
     }
 }

--- a/GRDB/QueryInterface/QueryInterfaceQuery.swift
+++ b/GRDB/QueryInterface/QueryInterfaceQuery.swift
@@ -132,12 +132,11 @@ extension QueryInterfaceQuery {
     
     func appendingJoin(_ join: AssociationJoin, forKey key: String) -> QueryInterfaceQuery {
         var query = self
-        if let existingJoin = query.joins[key] {
+        if let existingJoin = query.joins.removeValue(forKey: key) {
             guard let mergedJoin = existingJoin.merged(with: join) else {
                 // can't merge
                 fatalError("The association key \"\(key)\" is ambiguous. Use the Association.forKey(_:) method is order to disambiguate.")
             }
-            query.joins.removeValue(forKey: key)
             query.joins.append(value: mergedJoin, forKey: key)
         } else {
             query.joins.append(value: join, forKey: key)

--- a/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
@@ -6,9 +6,8 @@ extension QueryInterfaceRequest where RowDecoder: TableRecord {
         let join = AssociationJoin(
             joinOperator: joinOperator,
             query: association.request.query,
-            key: association.key,
             joinConditionPromise: DatabasePromise(association.joinCondition))
-        return QueryInterfaceRequest(query: query.joining(join))
+        return QueryInterfaceRequest(query: query.joining(join, forKey: association.key))
     }
     
     // MARK: - Associations

--- a/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
@@ -5,9 +5,9 @@ extension QueryInterfaceRequest where RowDecoder: TableRecord {
     {
         let join = AssociationJoin(
             joinOperator: joinOperator,
-            query: association.request.query,
-            joinConditionPromise: DatabasePromise(association.joinCondition))
-        return QueryInterfaceRequest(query: query.joining(join, forKey: association.key))
+            joinCondition: association.joinCondition,
+            query: association.request.query)
+        return QueryInterfaceRequest(query: query.appendingJoin(join, forKey: association.key))
     }
     
     // MARK: - Associations

--- a/GRDB/QueryInterface/QueryOrdering.swift
+++ b/GRDB/QueryInterface/QueryOrdering.swift
@@ -1,9 +1,6 @@
 /// QueryOrdering provides the order clause to QueryInterfaceQuery
 /// and AssociationQuery.
 struct QueryOrdering {
-    private var elements: [Element] = []
-    var isReversed: Bool
-    
     private enum Element {
         case orderingTerms((Database) throws -> [SQLOrderingTerm])
         case queryOrdering(QueryOrdering)
@@ -34,6 +31,13 @@ struct QueryOrdering {
                 return try queryOrdering.resolve(db)
             }
         }
+    }
+    
+    private var elements: [Element] = []
+    var isReversed: Bool
+    
+    var isEmpty: Bool {
+        return elements.isEmpty
     }
     
     private init(elements: [Element], isReversed: Bool) {

--- a/GRDB/Utils/OrderedDictionary.swift
+++ b/GRDB/Utils/OrderedDictionary.swift
@@ -1,0 +1,65 @@
+//
+//  OrderedDictionary.swift
+//  GRDB
+//
+//  Created by Gwendal Roué on 29/09/2018.
+//  Copyright © 2018 Gwendal Roué. All rights reserved.
+//
+
+struct OrderedDictionary<Key: Hashable, Value> {
+    private var keys: [Key]
+    private var values: [Key: Value]
+    
+    init() {
+        self.keys = []
+        self.values = [:]
+    }
+    
+    subscript(_ key: Key) -> Value? {
+        return values[key]
+    }
+    
+    mutating func append(value: Value, forKey key: Key) {
+        guard values.updateValue(value, forKey: key) == nil else {
+            fatalError("key is already defined")
+        }
+        keys.append(key)
+    }
+    
+    func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> OrderedDictionary<Key, T> {
+        var result = OrderedDictionary<Key, T>()
+        for key in keys {
+            let value = values[key]!
+            try result.append(value: transform(value), forKey: key)
+        }
+        return result
+    }
+}
+
+extension OrderedDictionary: Collection {
+    typealias Index = Int
+    
+    var startIndex: Int {
+        return keys.startIndex
+    }
+    
+    var endIndex: Int {
+        return keys.endIndex
+    }
+    
+    func index(after i: Int) -> Int {
+        return i + 1
+    }
+    
+    subscript(position: Int) -> (key: Key, value: Value) {
+        let key = keys[position]
+        return (key: key, value: values[key]!)
+    }
+}
+
+extension OrderedDictionary: ExpressibleByDictionaryLiteral {
+    init(dictionaryLiteral elements: (Key, Value)...) {
+        self.keys = elements.map { $0.0 }
+        self.values = Dictionary(uniqueKeysWithValues: elements)
+    }
+}

--- a/GRDB/Utils/OrderedDictionary.swift
+++ b/GRDB/Utils/OrderedDictionary.swift
@@ -50,11 +50,11 @@ extension OrderedDictionary: Collection {
     typealias Index = Int
     
     var startIndex: Int {
-        return keys.startIndex
+        return 0
     }
     
     var endIndex: Int {
-        return keys.endIndex
+        return keys.count
     }
     
     func index(after i: Int) -> Int {

--- a/GRDB/Utils/OrderedDictionary.swift
+++ b/GRDB/Utils/OrderedDictionary.swift
@@ -26,6 +26,16 @@ struct OrderedDictionary<Key: Hashable, Value> {
         keys.append(key)
     }
     
+    @discardableResult
+    mutating func removeValue(forKey key: Key) -> Value? {
+        guard let value = values.removeValue(forKey: key) else {
+            return nil
+        }
+        let index = keys.index { $0 == key }!
+        keys.remove(at: index)
+        return value
+    }
+    
     func mapValues<T>(_ transform: (Value) throws -> T) rethrows -> OrderedDictionary<Key, T> {
         var result = OrderedDictionary<Key, T>()
         for key in keys {

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -180,6 +180,8 @@
 		5634B10C1CF9B970005360B9 /* TransactionObserverSavepointsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5634B1061CF9B970005360B9 /* TransactionObserverSavepointsTests.swift */; };
 		5636E9BD1D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
 		5636E9C01D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
+		563EF424215F8A88007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF422215F8A88007DAACD /* OrderedDictionary.swift */; };
+		563EF425215F8A88007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF422215F8A88007DAACD /* OrderedDictionary.swift */; };
 		564448841EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */; };
 		564448851EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */; };
 		564448881EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */; };
@@ -974,6 +976,7 @@
 		563363D41C94484E000BE133 /* DatabaseQueueReleaseMemoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueReleaseMemoryTests.swift; sourceTree = "<group>"; };
 		5634B1061CF9B970005360B9 /* TransactionObserverSavepointsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionObserverSavepointsTests.swift; sourceTree = "<group>"; };
 		5636E9BB1D22574100B9B05F /* FetchRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRequest.swift; sourceTree = "<group>"; };
+		563EF422215F8A88007DAACD /* OrderedDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionary.swift; sourceTree = "<group>"; };
 		564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAfterNextTransactionCommitTests.swift; sourceTree = "<group>"; };
 		5644DE7A20F8C903001FFDDE /* DatabaseValueConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversion.swift; sourceTree = "<group>"; };
 		5644DE8120F8D1E4001FFDDE /* DatabaseValueConversionErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversionErrorTests.swift; sourceTree = "<group>"; };
@@ -1538,10 +1541,11 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				5659F4871EA8D94E004A4992 /* Utils.swift */,
-				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
+				563EF422215F8A88007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
+				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
 				5659F49F1EA8D997004A4992 /* Result.swift */,
+				5659F4871EA8D94E004A4992 /* Utils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2178,6 +2182,7 @@
 				5659F4A11EA8D997004A4992 /* Result.swift in Sources */,
 				560FC5201CB003810014AA8E /* Date.swift in Sources */,
 				560FC5221CB003810014AA8E /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
+				563EF424215F8A88007DAACD /* OrderedDictionary.swift in Sources */,
 				560FC5231CB003810014AA8E /* Configuration.swift in Sources */,
 				566475CD1D981D5E00FF74B8 /* SQLFunctions.swift in Sources */,
 				569EF0E9200D387000A9FA45 /* DatabaseRegion.swift in Sources */,
@@ -2620,6 +2625,7 @@
 				5659F4A41EA8D997004A4992 /* Result.swift in Sources */,
 				56AFC9F41CB1A8BB00F48B96 /* CGFloat.swift in Sources */,
 				56AFC9F51CB1A8BB00F48B96 /* Date.swift in Sources */,
+				563EF425215F8A88007DAACD /* OrderedDictionary.swift in Sources */,
 				56AFC9F71CB1A8BB00F48B96 /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
 				566475D01D981D5E00FF74B8 /* SQLFunctions.swift in Sources */,
 				569EF0EA200D387000A9FA45 /* DatabaseRegion.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		562EA8361F17B9EB00FA528C /* CompilationSubClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562EA82E1F17B9EB00FA528C /* CompilationSubClassTests.swift */; };
 		5636E9BE1D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
 		5636E9C11D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
+		563EF420215F8A76007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF41E215F8A76007DAACD /* OrderedDictionary.swift */; };
+		563EF421215F8A76007DAACD /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563EF41E215F8A76007DAACD /* OrderedDictionary.swift */; };
 		564448861EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */; };
 		5644488A1EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */; };
 		5644DE7820F8C8EA001FFDDE /* DatabaseValueConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5644DE7620F8C8E9001FFDDE /* DatabaseValueConversion.swift */; };
@@ -639,6 +641,7 @@
 		563363D41C94484E000BE133 /* DatabaseQueueReleaseMemoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueReleaseMemoryTests.swift; sourceTree = "<group>"; };
 		5634B1061CF9B970005360B9 /* TransactionObserverSavepointsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransactionObserverSavepointsTests.swift; sourceTree = "<group>"; };
 		5636E9BB1D22574100B9B05F /* FetchRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRequest.swift; sourceTree = "<group>"; };
+		563EF41E215F8A76007DAACD /* OrderedDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionary.swift; sourceTree = "<group>"; };
 		564448821EF56B1B00DD2861 /* DatabaseAfterNextTransactionCommitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAfterNextTransactionCommitTests.swift; sourceTree = "<group>"; };
 		5644DE7620F8C8E9001FFDDE /* DatabaseValueConversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversion.swift; sourceTree = "<group>"; };
 		5644DE7E20F8D1D1001FFDDE /* DatabaseValueConversionErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversionErrorTests.swift; sourceTree = "<group>"; };
@@ -1176,10 +1179,11 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				5659F4871EA8D94E004A4992 /* Utils.swift */,
-				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
+				563EF41E215F8A76007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
+				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
 				5659F49F1EA8D997004A4992 /* Result.swift */,
+				5659F4871EA8D94E004A4992 /* Utils.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1845,6 +1849,7 @@
 				F3BA800D1CFB2871003DC1BA /* DatabasePool.swift in Sources */,
 				F3BA800B1CFB286D003DC1BA /* Database.swift in Sources */,
 				F3BA80341CFB28A4003DC1BA /* Record.swift in Sources */,
+				563EF421215F8A76007DAACD /* OrderedDictionary.swift in Sources */,
 				F3BA80161CFB2876003DC1BA /* Row.swift in Sources */,
 				569EF0E7200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */,
 				F3BA80101CFB2876003DC1BA /* DatabaseReader.swift in Sources */,
@@ -2122,6 +2127,7 @@
 				F3BA80691CFB2E55003DC1BA /* DatabasePool.swift in Sources */,
 				F3BA80671CFB2E55003DC1BA /* Database.swift in Sources */,
 				F3BA80901CFB2E7A003DC1BA /* Record.swift in Sources */,
+				563EF420215F8A76007DAACD /* OrderedDictionary.swift in Sources */,
 				F3BA80721CFB2E55003DC1BA /* Row.swift in Sources */,
 				569EF0E6200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */,
 				F3BA806C1CFB2E55003DC1BA /* DatabaseReader.swift in Sources */,

--- a/Tests/GRDBTests/AssociationChainSQLTests.swift
+++ b/Tests/GRDBTests/AssociationChainSQLTests.swift
@@ -67,7 +67,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c)), "TODO")
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
@@ -87,8 +87,156 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d)), "TODO")
             try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+    
+    func testChainOfTwoIncludingIncludingIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).including(required: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).including(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).including(required: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c).including(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c).including(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c).including(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).including(required: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).including(required: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d).including(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d).including(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d).including(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+
+    func testChainOfTwoIncludingIncludingJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).joining(required: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).joining(required: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c).joining(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c).joining(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c).joining(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).joining(required: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).joining(required: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d).joining(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d).joining(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d).joining(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
@@ -113,7 +261,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c)), "")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c)), "")
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
@@ -133,8 +281,156 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d)), "TODO")
             try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d)), """
+                SELECT "b".*, "c".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+    
+    func testChainOfTwoIncludingJoiningIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).including(required: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).including(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).including(required: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c).including(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c).including(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c).including(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).including(required: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).including(required: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d).including(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d).including(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d).including(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "c".*, "d".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+
+    func testChainOfTwoIncludingJoiningJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).joining(required: B.c)), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).joining(required: B.c)), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c).joining(required: B.c)), "")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c).joining(optional: B.c)), "")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c).joining(required: B.c)), "")
+            try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).joining(required: C.d)), """
+                SELECT "b".*, "c".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "c".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).joining(required: C.d)), """
+                SELECT "b".*, "c".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "c".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d).joining(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d).joining(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d).joining(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
@@ -159,7 +455,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c)), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
@@ -179,7 +475,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d)), "TODO")
             try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
@@ -189,6 +485,154 @@ class AssociationChainSQLTests: GRDBTestCase {
         }
     }
     
+    func testChainOfTwoJoiningIncludingIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).including(required: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).including(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).including(required: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c).including(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c).including(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c).including(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).including(required: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).including(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).including(required: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d).including(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d).including(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d).including(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+    
+    func testChainOfTwoJoiningIncludingJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).joining(required: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).joining(required: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c).joining(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c).joining(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c).joining(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).joining(required: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).joining(required: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d).joining(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d).joining(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d).joining(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d).joining(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+
     func testChainOfTwoJoiningJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -205,7 +649,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c)), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
@@ -225,7 +669,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d)), "TODO")
             try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
@@ -235,6 +679,154 @@ class AssociationChainSQLTests: GRDBTestCase {
         }
     }
     
+    func testChainOfTwoJoiningJoiningIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).including(required: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).including(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).including(required: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c).including(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c).including(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c).including(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c).including(optional: B.c)), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).including(required: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).including(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).including(required: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d).including(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d).including(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d).including(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d).including(optional: C.d)), """
+                SELECT "b".*, "d".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+
+    func testChainOfTwoJoiningJoiningJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).joining(required: B.c)), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).joining(optional: B.c)), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).joining(required: B.c)), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c).joining(required: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c).joining(optional: B.c)), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c).joining(required: B.c)), "TODO")
+            try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c).joining(optional: B.c)), """
+                SELECT "a".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).joining(required: C.d)), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).joining(optional: C.d)), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).joining(required: C.d)), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).joining(optional: C.d)), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+            // TODO: chainOptionalRequired
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d).joining(required: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d).joining(optional: C.d)), "TODO")
+            // try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d).joining(required: C.d)), "TODO")
+            try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d).joining(optional: C.d)), """
+                SELECT "b".* \
+                FROM "b" \
+                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
+                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                """)
+        }
+    }
+
     func testChainOfThreeIncludingIncludingIncluding() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -253,7 +845,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".*, "d".* \
                 FROM "a" \
@@ -262,9 +854,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.including(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.including(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.including(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".*, "d".* \
                 FROM "a" \
@@ -293,7 +885,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
@@ -302,9 +894,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.joining(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.joining(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.joining(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
@@ -333,7 +925,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
@@ -342,9 +934,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.including(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.including(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.including(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
@@ -373,7 +965,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
@@ -382,9 +974,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.joining(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.joining(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.joining(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
@@ -413,7 +1005,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "c".*, "d".* \
                 FROM "a" \
@@ -422,9 +1014,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.including(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.including(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.including(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "c".*, "d".* \
                 FROM "a" \
@@ -453,7 +1045,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
@@ -462,9 +1054,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.joining(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.joining(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.joining(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
@@ -493,7 +1085,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
@@ -502,9 +1094,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.including(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.including(optional: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.including(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.including(optional: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
@@ -533,7 +1125,7 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".* \
                 FROM "a" \
@@ -542,9 +1134,9 @@ class AssociationChainSQLTests: GRDBTestCase {
                 LEFT JOIN "d" ON ("d"."id" = "c"."did")
                 """)
             // TODO: chainOptionalRequired
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.joining(required: C.d))), "TODO")
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.joining(optional: C.d))), "TODO)
-//            try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.joining(required: C.d))), "TODO")
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.joining(optional: C.d))), "TODO)
+            // try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".* \
                 FROM "a" \

--- a/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
+++ b/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
@@ -277,6 +277,198 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
         }
     }
     
+    func testDefaultScopeParallelTwoIncludingIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.including(required: A.defaultB).including(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(required: A.defaultB).including(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.defaultB).including(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.defaultB).including(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["b"])
+            XCTAssertEqual(rows[4].scopes["b"]!, ["id":nil, "name":nil])
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertEqual(Set(rows[5].scopes.names), ["b"])
+            XCTAssertEqual(rows[5].scopes["b"]!, ["id":nil, "name":nil])
+        }
+        do {
+            let request = B.including(required: B.defaultA).including(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(required: B.defaultA).including(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.defaultA).including(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.defaultA).including(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["a"])
+            XCTAssertEqual(rows[4].scopes["a"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
+        }
+    }
+    
     func testDefaultScopeParallelTwoIncludingJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         do {
@@ -441,6 +633,198 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
         }
     }
     
+    func testDefaultScopeParallelTwoIncludingJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.including(required: A.defaultB).joining(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(required: A.defaultB).joining(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.defaultB).joining(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.defaultB).joining(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["b"])
+            XCTAssertEqual(rows[4].scopes["b"]!, ["id":nil, "name":nil])
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertEqual(Set(rows[5].scopes.names), ["b"])
+            XCTAssertEqual(rows[5].scopes["b"]!, ["id":nil, "name":nil])
+        }
+        do {
+            let request = B.including(required: B.defaultA).joining(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(required: B.defaultA).joining(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.defaultA).joining(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.defaultA).joining(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["a"])
+            XCTAssertEqual(rows[4].scopes["a"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
+        }
+    }
+
     func testDefaultScopeParallelTwoJoiningIncluding() throws {
         let dbQueue = try makeDatabaseQueue()
         do {
@@ -604,7 +988,199 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
             XCTAssertEqual(rows[4].scopes["c"]!, ["id":nil, "bid":nil, "name":nil])
         }
     }
-    
+
+    func testDefaultScopeParallelTwoJoiningIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.joining(required: A.defaultB).including(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.joining(required: A.defaultB).including(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.joining(optional: A.defaultB).including(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.joining(optional: A.defaultB).including(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["b"])
+            XCTAssertEqual(rows[0].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["b"])
+            XCTAssertEqual(rows[1].scopes["b"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["b"])
+            XCTAssertEqual(rows[2].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["b"])
+            XCTAssertEqual(rows[3].scopes["b"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["b"])
+            XCTAssertEqual(rows[4].scopes["b"]!, ["id":nil, "name":nil])
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertEqual(Set(rows[5].scopes.names), ["b"])
+            XCTAssertEqual(rows[5].scopes["b"]!, ["id":nil, "name":nil])
+        }
+        do {
+            let request = B.joining(required: B.defaultA).including(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.joining(required: B.defaultA).including(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.joining(optional: B.defaultA).including(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.joining(optional: B.defaultA).including(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["a"])
+            XCTAssertEqual(rows[0].scopes["a"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["a"])
+            XCTAssertEqual(rows[1].scopes["a"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["a"])
+            XCTAssertEqual(rows[2].scopes["a"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["a"])
+            XCTAssertEqual(rows[3].scopes["a"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["a"])
+            XCTAssertEqual(rows[4].scopes["a"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
+        }
+    }
+
     func testDefaultScopeParallelTwoJoiningJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         do {
@@ -720,6 +1296,163 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
         }
         do {
             let request = B.joining(optional: B.defaultA).joining(optional: B.defaultC).order(sql: "b.id, a.id, c.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertTrue(rows[4].scopes.names.isEmpty)
+        }
+    }
+
+    func testDefaultScopeParallelTwoJoiningJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.joining(required: A.defaultB).joining(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = A.joining(required: A.defaultB).joining(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = A.joining(optional: A.defaultB).joining(required: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = A.joining(optional: A.defaultB).joining(optional: A.defaultB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertTrue(rows[4].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertTrue(rows[5].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(required: B.defaultA).joining(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(required: B.defaultA).joining(optional: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(optional: B.defaultA).joining(required: B.defaultA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(optional: B.defaultA).joining(optional: B.defaultA).order(sql: "b.id, a.id")
             let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
             
             XCTAssertEqual(rows.count, 5)
@@ -933,6 +1666,198 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
         }
     }
     
+    func testCustomScopeParallelTwoIncludingIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.including(required: A.customB).including(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(required: A.customB).including(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.customB).including(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.customB).including(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["customB"])
+            XCTAssertEqual(rows[4].scopes["customB"]!, ["id":nil, "name":nil])
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertEqual(Set(rows[5].scopes.names), ["customB"])
+            XCTAssertEqual(rows[5].scopes["customB"]!, ["id":nil, "name":nil])
+        }
+        do {
+            let request = B.including(required: B.customA).including(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(required: B.customA).including(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.customA).including(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.customA).including(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["customA"])
+            XCTAssertEqual(rows[4].scopes["customA"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
+        }
+    }
+
     func testCustomScopeParallelTwoIncludingJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         do {

--- a/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
+++ b/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
@@ -2021,7 +2021,199 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
             XCTAssertEqual(rows[4].scopes["customA"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
         }
     }
-    
+
+    func testCustomScopeParallelTwoIncludingJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.including(required: A.customB).joining(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(required: A.customB).joining(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.customB).joining(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.including(optional: A.customB).joining(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["customB"])
+            XCTAssertEqual(rows[4].scopes["customB"]!, ["id":nil, "name":nil])
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertEqual(Set(rows[5].scopes.names), ["customB"])
+            XCTAssertEqual(rows[5].scopes["customB"]!, ["id":nil, "name":nil])
+        }
+        do {
+            let request = B.including(required: B.customA).joining(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(required: B.customA).joining(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.customA).joining(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.including(optional: B.customA).joining(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["customA"])
+            XCTAssertEqual(rows[4].scopes["customA"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
+        }
+    }
+
     func testCustomScopeParallelTwoJoiningIncluding() throws {
         let dbQueue = try makeDatabaseQueue()
         do {
@@ -2185,7 +2377,199 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
             XCTAssertEqual(rows[4].scopes["customC"]!, ["id":nil, "bid":nil, "name":nil])
         }
     }
-    
+
+    func testCustomScopeParallelTwoJoiningIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.joining(required: A.customB).including(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.joining(required: A.customB).including(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.joining(optional: A.customB).including(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+        }
+        do {
+            let request = A.joining(optional: A.customB).including(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customB"])
+            XCTAssertEqual(rows[0].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customB"])
+            XCTAssertEqual(rows[1].scopes["customB"]!, ["id":1, "name":"b1"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customB"])
+            XCTAssertEqual(rows[2].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customB"])
+            XCTAssertEqual(rows[3].scopes["customB"]!, ["id":2, "name":"b2"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["customB"])
+            XCTAssertEqual(rows[4].scopes["customB"]!, ["id":nil, "name":nil])
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertEqual(Set(rows[5].scopes.names), ["customB"])
+            XCTAssertEqual(rows[5].scopes["customB"]!, ["id":nil, "name":nil])
+        }
+        do {
+            let request = B.joining(required: B.customA).including(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.joining(required: B.customA).including(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.joining(optional: B.customA).including(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+        }
+        do {
+            let request = B.joining(optional: B.customA).including(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[0].scopes.names), ["customA"])
+            XCTAssertEqual(rows[0].scopes["customA"]!, ["id":1, "bid":1, "did":1, "name":"a1"])
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertEqual(Set(rows[1].scopes.names), ["customA"])
+            XCTAssertEqual(rows[1].scopes["customA"]!, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[2].scopes.names), ["customA"])
+            XCTAssertEqual(rows[2].scopes["customA"]!, ["id":3, "bid":2, "did":1, "name":"a3"])
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertEqual(Set(rows[3].scopes.names), ["customA"])
+            XCTAssertEqual(rows[3].scopes["customA"]!, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertEqual(Set(rows[4].scopes.names), ["customA"])
+            XCTAssertEqual(rows[4].scopes["customA"]!, ["id":nil, "bid":nil, "did":nil, "name":nil])
+        }
+    }
+
     func testCustomScopeParallelTwoJoiningJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         do {
@@ -2301,6 +2685,163 @@ class AssociationParallelRowScopesTests: GRDBTestCase {
         }
         do {
             let request = B.joining(optional: B.customA).joining(optional: B.customC).order(sql: "b.id, a.id, c.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 5)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":3, "name":"b3"])
+            XCTAssertTrue(rows[4].scopes.names.isEmpty)
+        }
+    }
+
+    func testCustomScopeParallelTwoJoiningJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        do {
+            let request = A.joining(required: A.customB).joining(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = A.joining(required: A.customB).joining(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = A.joining(optional: A.customB).joining(required: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = A.joining(optional: A.customB).joining(optional: A.customB).order(sql: "a.id, b.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 6)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "bid":1, "did":1, "name":"a1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":2, "bid":1, "did":nil, "name":"a2"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":3, "bid":2, "did":1, "name":"a3"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":4, "bid":2, "did":nil, "name":"a4"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[4].unscoped, ["id":5, "bid":nil, "did":1, "name":"a5"])
+            XCTAssertTrue(rows[4].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[5].unscoped, ["id":6, "bid":nil, "did":nil, "name":"a6"])
+            XCTAssertTrue(rows[5].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(required: B.customA).joining(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(required: B.customA).joining(optional: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(optional: B.customA).joining(required: B.customA).order(sql: "b.id, a.id")
+            let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
+            
+            XCTAssertEqual(rows.count, 4)
+            
+            XCTAssertEqual(rows[0].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[0].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[1].unscoped, ["id":1, "name":"b1"])
+            XCTAssertTrue(rows[1].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[2].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[2].scopes.names.isEmpty)
+            
+            XCTAssertEqual(rows[3].unscoped, ["id":2, "name":"b2"])
+            XCTAssertTrue(rows[3].scopes.names.isEmpty)
+        }
+        do {
+            let request = B.joining(optional: B.customA).joining(optional: B.customA).order(sql: "b.id, a.id")
             let rows = try dbQueue.inDatabase { try request.asRequest(of: Row.self).fetchAll($0) }
             
             XCTAssertEqual(rows.count, 5)

--- a/Tests/GRDBTests/AssociationParallelSQLTests.swift
+++ b/Tests/GRDBTests/AssociationParallelSQLTests.swift
@@ -108,6 +108,52 @@ class AssociationParallelSQLTests: GRDBTestCase {
         }
     }
     
+    func testParallelTwoIncludingIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.including(required: A.b).including(required: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b).including(optional: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.including(optional: A.b).including(required: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.including(optional: A.b).including(optional: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, B.including(required: B.a).including(required: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(required: B.a).including(optional: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(optional: B.a).including(required: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(optional: B.a).including(optional: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+        }
+    }
+
     func testParallelTwoIncludingJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/AssociationParallelSQLTests.swift
+++ b/Tests/GRDBTests/AssociationParallelSQLTests.swift
@@ -208,6 +208,52 @@ class AssociationParallelSQLTests: GRDBTestCase {
         }
     }
     
+    func testParallelTwoIncludingJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.including(required: A.b).joining(required: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.including(required: A.b).joining(optional: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.including(optional: A.b).joining(required: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.including(optional: A.b).joining(optional: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, B.including(required: B.a).joining(required: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(required: B.a).joining(optional: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(optional: B.a).joining(required: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.including(optional: B.a).joining(optional: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+        }
+    }
+    
     func testParallelTwoJoiningIncluding() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -262,6 +308,52 @@ class AssociationParallelSQLTests: GRDBTestCase {
         }
     }
     
+    func testParallelTwoJoiningIncludingSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.joining(required: A.b).including(required: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b).including(optional: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.joining(optional: A.b).including(required: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.joining(optional: A.b).including(optional: A.b), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.a).including(required: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.a).including(optional: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(optional: B.a).including(required: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(optional: B.a).including(optional: B.a), """
+                SELECT "b".*, "a".* \
+                FROM "b" \
+                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+        }
+    }
+
     func testParallelTwoJoiningJoining() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -312,6 +404,52 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 FROM "b" \
                 LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
                 LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                """)
+        }
+    }
+
+    func testParallelTwoJoiningJoiningSameAssociation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try assertEqualSQL(db, A.joining(required: A.b).joining(required: A.b), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.joining(required: A.b).joining(optional: A.b), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.joining(optional: A.b).joining(required: A.b), """
+                SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, A.joining(optional: A.b).joining(optional: A.b), """
+                SELECT "a".* \
+                FROM "a" \
+                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.a).joining(required: B.a), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(required: B.a).joining(optional: B.a), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(optional: B.a).joining(required: B.a), """
+                SELECT "b".* \
+                FROM "b" \
+                JOIN "a" ON ("a"."bid" = "b"."id")
+                """)
+            try assertEqualSQL(db, B.joining(optional: B.a).joining(optional: B.a), """
+                SELECT "b".* \
+                FROM "b" \
+                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
                 """)
         }
     }

--- a/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
+++ b/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
@@ -337,4 +337,146 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             }
         }
     }
+    
+    func testAssociationRewrite() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                let request: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias()
+                    let name = Column("name")
+                    return A
+                        .joining(required: A.parent.aliased(parentAlias))
+                        .filter(parentAlias[name] == "foo")
+                }()
+                
+                let request2: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias()
+                    let name = Column("name")
+                    return request
+                        .joining(optional: A.parent.aliased(parentAlias))
+                        .order(parentAlias[name])
+                }()
+                
+                let request3 = request2.including(optional: A.parent)
+                
+                try assertEqualSQL(db, request3, """
+                    SELECT "a1".*, "a2".* \
+                    FROM "a" "a1" \
+                    JOIN "a" "a2" ON ("a2"."id" = "a1"."parentId") \
+                    WHERE ("a2"."name" = 'foo') \
+                    ORDER BY "a2"."name"
+                    """)
+            }
+            do {
+                let request: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias(name: "parent")
+                    let name = Column("name")
+                    return A
+                        .joining(required: A.parent.aliased(parentAlias))
+                        .filter(parentAlias[name] == "foo")
+                }()
+                
+                let request2: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias()
+                    let name = Column("name")
+                    return request
+                        .joining(optional: A.parent.aliased(parentAlias))
+                        .order(parentAlias[name])
+                }()
+                
+                let request3 = request2.including(optional: A.parent)
+                
+                try assertEqualSQL(db, request3, """
+                    SELECT "a".*, "parent".* \
+                    FROM "a" \
+                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
+                    WHERE ("parent"."name" = 'foo') \
+                    ORDER BY "parent"."name"
+                    """)
+            }
+            do {
+                let request: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias()
+                    let name = Column("name")
+                    return A
+                        .joining(required: A.parent.aliased(parentAlias))
+                        .filter(parentAlias[name] == "foo")
+                }()
+                
+                let request2: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias(name: "parent")
+                    let name = Column("name")
+                    return request
+                        .joining(optional: A.parent.aliased(parentAlias))
+                        .order(parentAlias[name])
+                }()
+                
+                let request3 = request2.including(optional: A.parent)
+                
+                try assertEqualSQL(db, request3, """
+                    SELECT "a".*, "parent".* \
+                    FROM "a" \
+                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
+                    WHERE ("parent"."name" = 'foo') \
+                    ORDER BY "parent"."name"
+                    """)
+            }
+            do {
+                let request: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias(name: "parent")
+                    let name = Column("name")
+                    return A
+                        .joining(required: A.parent.aliased(parentAlias))
+                        .filter(parentAlias[name] == "foo")
+                }()
+                
+                let request2: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias(name: "parent")
+                    let name = Column("name")
+                    return request
+                        .joining(optional: A.parent.aliased(parentAlias))
+                        .order(parentAlias[name])
+                }()
+                
+                let request3 = request2.including(optional: A.parent)
+                
+                try assertEqualSQL(db, request3, """
+                    SELECT "a".*, "parent".* \
+                    FROM "a" \
+                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
+                    WHERE ("parent"."name" = 'foo') \
+                    ORDER BY "parent"."name"
+                    """)
+            }
+            do {
+                let request: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias()
+                    let name = Column("name")
+                    return A
+                        .joining(required: A.parent.aliased(parentAlias))
+                        .filter(parentAlias[name] == "foo")
+                }()
+                
+                let request2: QueryInterfaceRequest<A> = {
+                    let parentAlias = TableAlias()
+                    let name = Column("name")
+                    return request
+                        .joining(optional: A.parent.aliased(parentAlias))
+                        .order(parentAlias[name])
+                }()
+                
+                let parentAlias = TableAlias(name: "parent")
+                let request3 = request2.including(optional: A.parent.aliased(parentAlias))
+                
+                try assertEqualSQL(db, request3, """
+                    SELECT "a".*, "parent".* \
+                    FROM "a" \
+                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
+                    WHERE ("parent"."name" = 'foo') \
+                    ORDER BY "parent"."name"
+                    """)
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pull request fixes a known issue with [associations](https://github.com/groue/GRDB.swift/blob/master/Documentation/AssociationsBasics.md).

It is now possible to include or join an association **several times** in the definition of a single request:

```swift
// 1. Start from all books with their author...
var request = Book.including(required: Book.author)

// 2. Then filter on Spanish authors...
request = request.joining(required: Book.author.filter(Column("countryCode") == "ES"))

// 3. Then sort by author name and then book title.
let authorAlias = TableAlias()
request = request
    .joining(optional: Book.author.aliased(authorAlias))
    .order(authorAlias[Column("name")], Column("title"))
```

See the new "Refining Association Requests" chapter in AssociationBasics.md for more information and intended use cases.