### PR TITLE
Fix "destination database is in use " error during database backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Release Notes
 
 ## Next Version
 
+### Fixed
+
+- [#425](https://github.com/groue/GRDB.swift/pull/425): Fix "destination database is in use " error during database backup
+
+
 ### New
 
 - [#422](https://github.com/groue/GRDB.swift/pull/422): Refining Association Requests

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -778,6 +778,16 @@ extension Database {
     // MARK: - Backup
     
     static func backup(from dbFrom: Database, to dbDest: Database, afterBackupInit: (() -> ())? = nil, afterBackupStep: (() -> ())? = nil) throws {
+        // The schema of the destination database will change: we need to clear
+        // the schema and statements cache.
+        //
+        // We especially need to clear the statements cache before calling
+        // sqlite3_backup_init, so that we avoid an SQLite error
+        // "destination database is in use" (SQLITE_ERROR).
+        //
+        // See https://github.com/groue/GRDB.swift/issues/424
+        dbDest.clearSchemaCache()
+        
         guard let backup = sqlite3_backup_init(dbDest.sqliteConnection, "main", dbFrom.sqliteConnection, "main") else {
             throw DatabaseError(resultCode: dbDest.lastErrorCode, message: dbDest.lastErrorMessage)
         }
@@ -810,8 +820,6 @@ extension Database {
         case let code:
             throw DatabaseError(resultCode: code, message: dbDest.lastErrorMessage)
         }
-        
-        dbDest.clearSchemaCache()
     }
 }
 

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -153,6 +153,10 @@ extension DatabaseWriter {
         // SQLCipher does not support the backup API: https://discuss.zetetic.net/t/using-the-sqlite-online-backup-api/2631
         // So we'll drop all database objects one after the other.
         try writeWithoutTransaction { db in
+            // Clear schema and statement cache so that no prepared statement
+            // can prevent schema change.
+            db.clearSchemaCache()
+            
             // Prevent foreign keys from messing with drop table statements
             let foreignKeysEnabled = try Bool.fetchOne(db, "PRAGMA foreign_keys")!
             if foreignKeysEnabled {

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -105,4 +105,18 @@ class DatabaseWriterTests : GRDBTestCase {
         }
         try dbQueue.erase()
     }
+    
+    // See https://github.com/groue/GRDB.swift/issues/424
+    func testIssue424Minimal() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute("""
+                CREATE TABLE t(a);
+                INSERT INTO t VALUES (1);
+                PRAGMA query_only = 1;
+                """)
+            _ = try Row.fetchCursor(db.cachedSelectStatement("SELECT * FROM t")).next()
+        }
+        try DatabaseQueue().backup(to: dbQueue)
+    }
 }

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -90,4 +90,19 @@ class DatabaseWriterTests : GRDBTestCase {
             try XCTAssertNil(Row.fetchOne(db, "SELECT * FROM sqlite_master"))
         }
     }
+    
+    // See https://github.com/groue/GRDB.swift/issues/424
+    func testIssue424() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.execute("""
+                CREATE TABLE t(a);
+                INSERT INTO t VALUES (1)
+                """)
+        }
+        try dbQueue.read { db in
+            _ = try Row.fetchCursor(db.cachedSelectStatement("SELECT * FROM t")).next()
+        }
+        try dbQueue.erase()
+    }
 }


### PR DESCRIPTION
This PR addresses #424.

The `DatabaseWriter.erase()` method internally uses the SQLite [Online Backup API](https://www.sqlite.org/c3ref/backup_finish.html):

```swift
extension DatabaseWriter {
    func erase() throws {
        // In order to erase the content, we backup
        // an empty in-memory database into self:
        DatabaseQueue().backup(to: self)
    }
}
```

This technique used to fail with an error of code 1 (SQLITE_ERROR), message "destination database is in use" when live SQLite prepared statement would prevent the backup from starting (see the regression tests for the precise failure setup).

It happens that Record methods keep prepared statements in a cache, in order to optimize insertions, updates, deletions, and tests for record existence.

This PR thus clears the statement cache *before* starting a backup, when we used to do it after a successful backup.

The error "destination database is in use" can still happen during a backup, if the client application keeps its own prepared statements alive. To fix this error, the client application must release all prepared statements before starting the backup.