### PR TITLE
Reindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Release Notes
 
 ### New
 
+- [#442](https://github.com/groue/GRDB.swift/pull/442): Reindex
+    
+    ```swift
+    // Deletes and recreates from scratch all indices that use this
+    // locale-dependent collation.
+    try db.reindex(collation: .localizedCompare)
+    ```
+
 - ValueObservation has three new factory methods that accept an array of database regions, and complete the existing variadic methods (addresses [#441](https://github.com/groue/GRDB.swift/issues/441)):
 
     ```swift
@@ -15,6 +23,15 @@ Release Notes
     ```
 
 - ValueReducer, the protocol that fuels ValueObservation, is flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). It will remain so until more experience has been acquired.
+
+### API diff
+
+```diff
+ extension Database {
++    func reindex(collation: Database.CollationName) throws
++    func reindex(collation: DatabaseCollation) throws
+ }
+```
 
 
 ## 3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,25 @@ Release Notes
 +    func reindex(collation: Database.CollationName) throws
 +    func reindex(collation: DatabaseCollation) throws
  }
+
+ struct ValueObservation<Reducer> {
++    static func tracking(
++        _ regions: [DatabaseRegionConvertible],
++        reducer: Reducer)
++        -> ValueObservation
+ }
+ 
+ extension ValueObservation where Reducer == Void {
++    static func tracking<Value>(
++        _ regions: [DatabaseRegionConvertible],
++        fetch: @escaping (Database) throws -> Value)
++        -> ValueObservation<ValueReducers.Raw<Value>>
++    static func tracking<Value>(
++        _ regions: [DatabaseRegionConvertible],
++        fetchDistinct fetch: @escaping (Database) throws -> Value)
++        -> ValueObservation<ValueReducers.Distinct<Value>>
++        where Value: Equatable
+ }
 ```
 
 

--- a/GRDB/QueryInterface/TableDefinition.swift
+++ b/GRDB/QueryInterface/TableDefinition.swift
@@ -216,6 +216,30 @@ extension Database {
     public func drop(index name: String) throws {
         try execute("DROP INDEX \(name.quotedDatabaseIdentifier)")
     }
+    
+    /// Delete and recreate from scratch all indices that use this collation.
+    ///
+    /// This method is useful when the definition of a collation sequence
+    /// has changed.
+    ///
+    /// See https://www.sqlite.org/lang_reindex.html
+    ///
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
+    public func reindex(collation: Database.CollationName) throws {
+        try execute("REINDEX \(collation.rawValue)")
+    }
+    
+    /// Delete and recreate from scratch all indices that use this collation.
+    ///
+    /// This method is useful when the definition of a collation sequence
+    /// has changed.
+    ///
+    /// See https://www.sqlite.org/lang_reindex.html
+    ///
+    /// - throws: A DatabaseError whenever an SQLite error occurs.
+    public func reindex(collation: DatabaseCollation) throws {
+        try reindex(collation: Database.CollationName(collation.name))
+    }
 }
 
 /// The TableDefinition class lets you define table columns and constraints.

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -573,4 +573,15 @@ class TableDefinitionTests: GRDBTestCase {
             XCTAssertTrue(try db.indexes(on: "test").isEmpty)
         }
     }
+    
+    func testReindex() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.reindex(collation: .binary)
+            assertEqualSQL(lastSQLQuery, "REINDEX BINARY")
+            
+            try db.reindex(collation: .localizedCompare)
+            assertEqualSQL(lastSQLQuery, "REINDEX swiftLocalizedCompare")
+        }
+    }
 }


### PR DESCRIPTION
`Database.reindex(collation:)` deletes and recreates from scratch all indices that use a collation.

This method is useful when the definition of a collation sequence has changed.

See https://www.sqlite.org/lang_reindex.html
