### PR TITLE
In place record update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Release Notes
 
 - ValueReducer, the protocol that fuels ValueObservation, is flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). It will remain so until more experience has been acquired.
 
+
+### Documentation Diff
+
+- [Record Comparison](README.md#record-comparison): this chapter has been updated for the new `updateChanges(_:with:)` method.
+
+
 ### API diff
 
 ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,7 @@ Release Notes
 ### New
 
 - [#442](https://github.com/groue/GRDB.swift/pull/442): Reindex
-    
-    ```swift
-    // Deletes and recreates from scratch all indices that use this
-    // locale-dependent collation.
-    try db.reindex(collation: .localizedCompare)
-    ```
-
+- [#443](https://github.com/groue/GRDB.swift/pull/443): In place record update
 - ValueObservation has three new factory methods that accept an array of database regions, and complete the existing variadic methods (addresses [#441](https://github.com/groue/GRDB.swift/issues/441)):
 
     ```swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Release Notes
 +    func reindex(collation: Database.CollationName) throws
 +    func reindex(collation: DatabaseCollation) throws
  }
+ 
+ extension MutablePersistableRecord {
++    mutating func updateChanges(_ db: Database, with change: (inout Self) throws -> Void) throws -> Bool
+ }
+
+ extension PersistableRecord {
++    func updateChanges(_ db: Database, with change: (Self) throws -> Void) throws -> Bool
+ }
 
  struct ValueObservation<Reducer> {
 +    static func tracking(

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -521,22 +521,71 @@ extension MutablePersistableRecord {
         try update(db, columns: Set(columns.map { $0.name }))
     }
     
-    /// If the record has differences from the other record, executes an UPDATE
-    /// statement so that those changes and only those changes are saved in
-    /// the database.
+    /// If the record has any difference from the other record, executes an
+    /// UPDATE statement so that those differences and only those difference are
+    /// saved in the database.
     ///
-    /// This method is guaranteed to have saved the eventual changes in the
+    /// This method is guaranteed to have saved the eventual differences in the
     /// database if it returns without error.
     ///
+    /// For example:
+    ///
+    ///     if let oldPlayer = Player.fetchOne(db, key: 42) {
+    ///         var newPlayer = oldPlayer
+    ///         newPlayer.score += 10
+    ///         newPlayer.hasAward = true
+    ///         try newPlayer.updateChanges(db, from: oldRecord)
+    ///     }
+    ///
     /// - parameter db: A database connection.
-    /// - parameter columns: The columns to update.
+    /// - parameter record: The comparison record.
+    /// - returns: Whether the record had changes.
+    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
+    ///   PersistenceError.recordNotFound is thrown if the primary key does not
+    ///   match any row in the database and record could not be updated.
+    /// - SeeAlso: updateChanges(_:with:)
+    @discardableResult
+    public func updateChanges(_ db: Database, from record: MutablePersistableRecord) throws -> Bool {
+        let oldContainer = PersistenceContainer(record)
+        let changes = databaseChangesIterator(from: oldContainer)
+        let changedColumns: Set<String> = changes.reduce(into: []) { $0.insert($1.0) }
+        if changedColumns.isEmpty {
+            return false
+        } else {
+            try update(db, columns: changedColumns)
+            return true
+        }
+    }
+    
+    /// Mutates the record according to the provided closure, and then, if the
+    /// record has any difference from its previous version, executes an
+    /// UPDATE statement so that those differences and only those difference are
+    /// saved in the database.
+    ///
+    /// This method is guaranteed to have saved the eventual differences in the
+    /// database if it returns without error.
+    ///
+    /// For example:
+    ///
+    ///     if var player = Player.fetchOne(db, key: 42) {
+    ///         try player.updateChanges(db) {
+    ///             $0.score += 10
+    ///             $0.hasAward = true
+    ///         }
+    ///     }
+    ///
+    /// - parameter db: A database connection.
+    /// - parameter change: A closure that modifise the record.
     /// - returns: Whether the record had changes.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     ///   PersistenceError.recordNotFound is thrown if the primary key does not
     ///   match any row in the database and record could not be updated.
     @discardableResult
-    public func updateChanges(_ db: Database, from record: MutablePersistableRecord) throws -> Bool {
-        let changedColumns = Set(databaseChanges(from: record).keys)
+    public mutating func updateChanges(_ db: Database, with change: (inout Self) throws -> Void) throws -> Bool {
+        let oldContainer = PersistenceContainer(self)
+        try change(&self)
+        let changes = databaseChangesIterator(from: oldContainer)
+        let changedColumns: Set<String> = changes.reduce(into: []) { $0.insert($1.0) }
         if changedColumns.isEmpty {
             return false
         } else {
@@ -574,7 +623,7 @@ extension MutablePersistableRecord {
     /// Returns a boolean indicating whether this record and the other record
     /// have the same database representation.
     public func databaseEquals(_ record: Self) -> Bool {
-        return databaseChangesIterator(from: record).next() == nil
+        return databaseChangesIterator(from: PersistenceContainer(record)).next() == nil
     }
 
     /// A dictionary of values changed from the other record.
@@ -586,11 +635,10 @@ extension MutablePersistableRecord {
     /// same set of columns in their `encode(to:)` method, only the columns
     /// defined by the receiver record are considered.
     public func databaseChanges(from record: MutablePersistableRecord) -> [String: DatabaseValue] {
-        return Dictionary(uniqueKeysWithValues: databaseChangesIterator(from: record))
+        return Dictionary(uniqueKeysWithValues: databaseChangesIterator(from: PersistenceContainer(record)))
     }
     
-    fileprivate func databaseChangesIterator(from record: MutablePersistableRecord) -> AnyIterator<(String, DatabaseValue)> {
-        let oldContainer = PersistenceContainer(record)
+    fileprivate func databaseChangesIterator(from oldContainer: PersistenceContainer) -> AnyIterator<(String, DatabaseValue)> {
         var newValueIterator = PersistenceContainer(self).makeIterator()
         return AnyIterator {
             // Loop until we find a change, or exhaust columns:

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -624,7 +624,7 @@ extension MutablePersistableRecord {
         return Dictionary(uniqueKeysWithValues: databaseChangesIterator(from: PersistenceContainer(record)))
     }
     
-    fileprivate func databaseChangesIterator(from oldContainer: PersistenceContainer) -> AnyIterator<(String, DatabaseValue)> {
+    private func databaseChangesIterator(from oldContainer: PersistenceContainer) -> AnyIterator<(String, DatabaseValue)> {
         var newValueIterator = PersistenceContainer(self).makeIterator()
         return AnyIterator {
             // Loop until we find a change, or exhaust columns:
@@ -641,7 +641,7 @@ extension MutablePersistableRecord {
     }
     
     @discardableResult
-    fileprivate func updateChanges(_ db: Database, from container: PersistenceContainer) throws -> Bool {
+    private func updateChanges(_ db: Database, from container: PersistenceContainer) throws -> Bool {
         let changes = databaseChangesIterator(from: container)
         let changedColumns: Set<String> = changes.reduce(into: []) { $0.insert($1.0) }
         if changedColumns.isEmpty {

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -546,8 +546,7 @@ extension MutablePersistableRecord {
     /// - SeeAlso: updateChanges(_:with:)
     @discardableResult
     public func updateChanges(_ db: Database, from record: MutablePersistableRecord) throws -> Bool {
-        let oldContainer = PersistenceContainer(record)
-        return try updateChanges(db, from: oldContainer)
+        return try updateChanges(db, from: PersistenceContainer(record))
     }
     
     /// Mutates the record according to the provided closure, and then, if the
@@ -575,9 +574,9 @@ extension MutablePersistableRecord {
     ///   match any row in the database and record could not be updated.
     @discardableResult
     public mutating func updateChanges(_ db: Database, with change: (inout Self) throws -> Void) throws -> Bool {
-        let oldContainer = PersistenceContainer(self)
+        let container = PersistenceContainer(self)
         try change(&self)
-        return try updateChanges(db, from: oldContainer)
+        return try updateChanges(db, from: container)
     }
 
     /// Executes an INSERT or an UPDATE statement so that `self` is saved in
@@ -624,12 +623,12 @@ extension MutablePersistableRecord {
         return Dictionary(uniqueKeysWithValues: databaseChangesIterator(from: PersistenceContainer(record)))
     }
     
-    private func databaseChangesIterator(from oldContainer: PersistenceContainer) -> AnyIterator<(String, DatabaseValue)> {
+    private func databaseChangesIterator(from container: PersistenceContainer) -> AnyIterator<(String, DatabaseValue)> {
         var newValueIterator = PersistenceContainer(self).makeIterator()
         return AnyIterator {
             // Loop until we find a change, or exhaust columns:
             while let (column, newValue) = newValueIterator.next() {
-                let oldValue = oldContainer[caseInsensitive: column]
+                let oldValue = container[caseInsensitive: column]
                 let oldDbValue = oldValue?.databaseValue ?? .null
                 let newDbValue = newValue?.databaseValue ?? .null
                 if newDbValue != oldDbValue {
@@ -999,9 +998,9 @@ extension PersistableRecord {
     ///   match any row in the database and record could not be updated.
     @discardableResult
     public func updateChanges(_ db: Database, with change: (Self) throws -> Void) throws -> Bool {
-        let oldContainer = PersistenceContainer(self)
+        let container = PersistenceContainer(self)
         try change(self)
-        return try updateChanges(db, from: oldContainer)
+        return try updateChanges(db, from: container)
     }
 
     

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -568,7 +568,7 @@ extension MutablePersistableRecord {
     ///     }
     ///
     /// - parameter db: A database connection.
-    /// - parameter change: A closure that modifise the record.
+    /// - parameter change: A closure that modifies the record.
     /// - returns: Whether the record had changes.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     ///   PersistenceError.recordNotFound is thrown if the primary key does not
@@ -992,7 +992,7 @@ extension PersistableRecord {
     ///     }
     ///
     /// - parameter db: A database connection.
-    /// - parameter change: A closure that modifise the record.
+    /// - parameter change: A closure that modifies the record.
     /// - returns: Whether the record had changes.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     ///   PersistenceError.recordNotFound is thrown if the primary key does not

--- a/README.md
+++ b/README.md
@@ -2982,9 +2982,9 @@ The `updateChanges` methods perform a database update of the changed columns onl
     }
     ```
 
-- `updateChanges(_:)` ([Record](#record-class) class only)
+- `updateChanges(_:)` (Record class only)
     
-    The Record class is able to compare against itself, and knows if it has changes that have not been saved since it was last fetched or persisted:
+    Instances of the [Record](#record-class) class are able to compare against themselves, and know if they have changes that have not been saved since the last fetch or saving:
 
     ```swift
     // Record class only
@@ -3016,7 +3016,7 @@ if newPlayer.databaseEquals(oldPlayer) == false {
 
 ### The `databaseChanges` and `hasDatabaseChanges` Methods
 
-This method lets you iterate the differences between two records:
+`databaseChanges(from:)` returns a dictionary of differences between two records:
 
 ```swift
 let oldPlayer = Player(id: 1, name: "Arthur", score: 100)

--- a/README.md
+++ b/README.md
@@ -2940,9 +2940,9 @@ class Place: Record {
 
 This helps avoiding costly UPDATE statements when a record has not been edited.
 
-- The `updateChanges` Methods
-- The `databaseEquals` Method
-- The `databaseChanges` Methods
+- [The `updateChanges` Methods](#the-updatechanges-methods)
+- [The `databaseEquals` Method](#the-databaseequals-method)
+- [The `databaseChanges` and `hasDatabaseChanges` Methods](#the-databasechanges-and-hasdatabasechanges-methods)
 
 
 ### The `updateChanges` Methods
@@ -3006,7 +3006,7 @@ This method returns whether two records have the same database representation:
 ```swift
 let oldPlayer: Player = ...
 var newPlayer: Player = ...
-if newPlayer.databaseEquals(oldPlayer) {
+if newPlayer.databaseEquals(oldPlayer) == false {
     try newPlayer.save(db)
 }
 ```
@@ -3014,7 +3014,7 @@ if newPlayer.databaseEquals(oldPlayer) {
 > :point_up: **Note**: The comparison is performed on the database representation of records. As long as your record type adopts a PersistableRecord protocol, you don't need to care about Equatable.
 
 
-### The `databaseChanges` Methods
+### The `databaseChanges` and `hasDatabaseChanges` Methods
 
 This method lets you iterate the differences between two records:
 

--- a/Tests/GRDBTests/MutablePersistableRecordChangesTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordChangesTests.swift
@@ -317,7 +317,8 @@ class MutablePersistableRecordChangesTests: GRDBTestCase {
                 t.column("lastName", .text)
             }
             
-            var record = MyRecord(id: nil, firstName: "Arthur", lastName: "Smith")
+            // This `let` is part of the test
+            let record = MyRecord(id: nil, firstName: "Arthur", lastName: "Smith")
             try record.insert(db)
             
             do {
@@ -389,7 +390,8 @@ class MutablePersistableRecordChangesTests: GRDBTestCase {
                 t.column("lastName", .text)
             }
             
-            var record = MyRecord(id: nil, firstName: "Arthur", lastName: "Smith")
+            // This `let` is part of the test
+            let record = MyRecord(id: nil, firstName: "Arthur", lastName: "Smith")
             try record.insert(db)
             
             do {

--- a/Tests/GRDBTests/ValueObservationReducerTests.swift
+++ b/Tests/GRDBTests/ValueObservationReducerTests.swift
@@ -120,6 +120,7 @@ class ValueObservationReducerTests: GRDBTestCase {
             XCTAssertEqual(fetchCount, 4)
             XCTAssertEqual(reduceCount, 4)
             XCTAssertEqual(errors.count, 0)
+            // TODO: Fix flacky test https://travis-ci.org/groue/GRDB.swift/jobs/458101713
             XCTAssertEqual(changes, ["0", "1", "5"])
         }
         


### PR DESCRIPTION
This pull request introduces a new way to perform database updates: `updateChanges(_:with:)`.

```swift
// Mutates the record according to the provided closure, and then, if the
// record has any difference from its previous version, executes an
// UPDATE statement so that those differences and only those difference are
// saved in the database.
if var player = try Player.fetchOne(db, key: 42) {
    try player.updateChanges(db) {
        $0.score += 10
        $0.hasAward = true
    }
}
```

`updateChanges(_:with:)` returns whether the record was changed or not:

```swift
let modified = try player.updateChanges(db) {
    $0.firstName = "Arthur"
    $0.lastName = "Smith"
}
if modified {
    print("Player was modified, and updated in the database")
} else {
    print("Player was not modified")
}
```
