### PR TITLE
Quality of service and target dispatch queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Release Notes
 - [#442](https://github.com/groue/GRDB.swift/pull/442): Reindex
 - [#443](https://github.com/groue/GRDB.swift/pull/443): In place record update
 - [#444](https://github.com/groue/GRDB.swift/pull/444): Combine Value Observations
+- [#445](https://github.com/groue/GRDB.swift/pull/445): Quality of service and target dispatch queue
 - ValueObservation has three new factory methods that accept an array of database regions, and complete the existing variadic methods (addresses [#441](https://github.com/groue/GRDB.swift/issues/441)):
 
     ```swift

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Dispatch
 #if SWIFT_PACKAGE
     import CSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
@@ -136,11 +137,28 @@ public struct Configuration {
     /// Default: 5
     public var maximumReaderCount: Int = 5
     
+    /// The quality of service class for the work performed by the database.
+    ///
+    /// The quality of service is ignored if you supply a target queue.
+    ///
+    /// Default: .default (.unspecified on macOS < 10.10)
+    public var qos: DispatchQoS
+    
+    /// The target queue for the work performed by the database.
+    ///
+    /// Default: nil
+    public var targetQueue: DispatchQueue? = nil
     
     // MARK: - Factory Configuration
     
     /// Creates a factory configuration
-    public init() { }
+    public init() {
+        if #available(OSX 10.10, *) {
+            qos = .default
+        } else {
+            qos = .unspecified
+        }
+    }
     
     
     // MARK: - Not Public

--- a/GRDB/Core/SchedulingWatchdog.swift
+++ b/GRDB/Core/SchedulingWatchdog.swift
@@ -30,8 +30,19 @@ final class SchedulingWatchdog {
         allowedDatabases = [database]
     }
     
-    static func makeSerializedQueue(allowingDatabase database: Database, label: String) -> DispatchQueue {
-        let queue = DispatchQueue(label: label)
+    static func makeSerializedQueue(
+        allowingDatabase database: Database,
+        label: String,
+        qos: DispatchQoS,
+        targetQueue: DispatchQueue?)
+        -> DispatchQueue
+    {
+        let queue: DispatchQueue
+        if let targetQueue = targetQueue {
+            queue = DispatchQueue(label: label, target: targetQueue)
+        } else {
+            queue = DispatchQueue(label: label, qos: qos)
+        }
         let watchdog = SchedulingWatchdog(allowedDatabase: database)
         queue.setSpecific(key: specificKey, value: watchdog)
         return queue

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -38,7 +38,11 @@ final class SerializedDatabase {
         config.threadingMode = .multiThread
         
         db = try Database(path: path, configuration: config, schemaCache: schemaCache)
-        queue = SchedulingWatchdog.makeSerializedQueue(allowingDatabase: db, label: label)
+        queue = SchedulingWatchdog.makeSerializedQueue(
+            allowingDatabase: db,
+            label: label,
+            qos: configuration.qos,
+            targetQueue: configuration.targetQueue)
         self.path = path
         try queue.sync {
             try db.setup()

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -1098,7 +1098,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         }
     }
     
-    @available(OSX 10.12, *)
+    @available(OSX 10.12, iOS 10.0, *)
     func testTargetQueue() throws {
         func test(targetQueue: DispatchQueue) throws {
             dbConfiguration.targetQueue = targetQueue

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -1099,67 +1099,71 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         }
     }
     
-    @available(OSX 10.12, iOS 10.0, *)
     func testTargetQueue() throws {
-        func test(targetQueue: DispatchQueue) throws {
-            dbConfiguration.targetQueue = targetQueue
-            let dbPool = try makeDatabasePool()
-            try dbPool.write { _ in
-                dispatchPrecondition(condition: .onQueue(targetQueue))
+        // dispatchPrecondition(condition:) availability
+        if #available(OSX 10.12, iOS 10.0, *) {
+            func test(targetQueue: DispatchQueue) throws {
+                dbConfiguration.targetQueue = targetQueue
+                let dbPool = try makeDatabasePool()
+                try dbPool.write { _ in
+                    dispatchPrecondition(condition: .onQueue(targetQueue))
+                }
+                try dbPool.read { _ in
+                    dispatchPrecondition(condition: .onQueue(targetQueue))
+                }
             }
-            try dbPool.read { _ in
-                dispatchPrecondition(condition: .onQueue(targetQueue))
+            
+            // background queue
+            try test(targetQueue: .global(qos: .background))
+            
+            // main queue
+            let expectation = self.expectation(description: "main")
+            DispatchQueue.global(qos: .default).async {
+                try! test(targetQueue: .main)
+                expectation.fulfill()
             }
+            waitForExpectations(timeout: 1, handler: nil)
         }
-        
-        // background queue
-        try test(targetQueue: .global(qos: .background))
-        
-        // main queue
-        let expectation = self.expectation(description: "main")
-        DispatchQueue.global(qos: .default).async {
-            try! test(targetQueue: .main)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 1, handler: nil)
     }
     
-    @available(OSX 10.12, iOS 10.0, *)
     func testQoS() throws {
-        func test(qos: DispatchQoS) throws {
-            // https://forums.swift.org/t/what-is-the-default-target-queue-for-a-serial-queue/18094/5
-            //
-            // > [...] the default target queue [for a serial queue] is the
-            // > [default] overcommit [global concurrent] queue.
-            //
-            // We want this default target queue in order to test database QoS
-            // with dispatchPrecondition(condition:).
-            //
-            // > [...] You can get a reference to the overcommit queue by
-            // > dropping down to the C function dispatch_get_global_queue
-            // > (available in Swift with a __ prefix) and passing the private
-            // > value of DISPATCH_QUEUE_OVERCOMMIT.
-            // >
-            // > [...] Of course you should not do this in production code,
-            // > because DISPATCH_QUEUE_OVERCOMMIT is not a public API. I don't
-            // > know of a way to get a reference to the overcommit queue using
-            // > only public APIs.
-            let DISPATCH_QUEUE_OVERCOMMIT: UInt = 2
-            let targetQueue = __dispatch_get_global_queue(
-                Int(qos.qosClass.rawValue.rawValue),
-                DISPATCH_QUEUE_OVERCOMMIT)
+        // dispatchPrecondition(condition:) availability
+        if #available(OSX 10.12, iOS 10.0, *) {
+            func test(qos: DispatchQoS) throws {
+                // https://forums.swift.org/t/what-is-the-default-target-queue-for-a-serial-queue/18094/5
+                //
+                // > [...] the default target queue [for a serial queue] is the
+                // > [default] overcommit [global concurrent] queue.
+                //
+                // We want this default target queue in order to test database QoS
+                // with dispatchPrecondition(condition:).
+                //
+                // > [...] You can get a reference to the overcommit queue by
+                // > dropping down to the C function dispatch_get_global_queue
+                // > (available in Swift with a __ prefix) and passing the private
+                // > value of DISPATCH_QUEUE_OVERCOMMIT.
+                // >
+                // > [...] Of course you should not do this in production code,
+                // > because DISPATCH_QUEUE_OVERCOMMIT is not a public API. I don't
+                // > know of a way to get a reference to the overcommit queue using
+                // > only public APIs.
+                let DISPATCH_QUEUE_OVERCOMMIT: UInt = 2
+                let targetQueue = __dispatch_get_global_queue(
+                    Int(qos.qosClass.rawValue.rawValue),
+                    DISPATCH_QUEUE_OVERCOMMIT)
+                
+                dbConfiguration.qos = qos
+                let dbPool = try makeDatabasePool()
+                try dbPool.write { _ in
+                    dispatchPrecondition(condition: .onQueue(targetQueue))
+                }
+                try dbPool.read { _ in
+                    dispatchPrecondition(condition: .onQueue(targetQueue))
+                }
+            }
             
-            dbConfiguration.qos = qos
-            let dbPool = try makeDatabasePool()
-            try dbPool.write { _ in
-                dispatchPrecondition(condition: .onQueue(targetQueue))
-            }
-            try dbPool.read { _ in
-                dispatchPrecondition(condition: .onQueue(targetQueue))
-            }
+            try test(qos: .background)
+            try test(qos: .userInitiated)
         }
-        
-        try test(qos: .background)
-        try test(qos: .userInitiated)
     }
 }

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -133,7 +133,7 @@ class DatabaseQueueTests: GRDBTestCase {
         }
     }
     
-    @available(OSX 10.12, *)
+    @available(OSX 10.12, iOS 10.0, *)
     func testTargetQueue() throws {
         func test(targetQueue: DispatchQueue) throws {
             dbConfiguration.targetQueue = targetQueue

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -8,7 +8,6 @@ import Dispatch
     import GRDB
 #endif
 
-@available(OSX 10.12, *)
 class DatabaseQueueTests: GRDBTestCase {
     
     // Until SPM tests can load resources, disable this test for SPM.

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -157,4 +157,43 @@ class DatabaseQueueTests: GRDBTestCase {
         }
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    @available(OSX 10.12, iOS 10.0, *)
+    func testQoS() throws {
+        func test(qos: DispatchQoS) throws {
+            // https://forums.swift.org/t/what-is-the-default-target-queue-for-a-serial-queue/18094/5
+            //
+            // > [...] the default target queue [for a serial queue] is the
+            // > [default] overcommit [global concurrent] queue.
+            //
+            // We want this default target queue in order to test database QoS
+            // with dispatchPrecondition(condition:).
+            //
+            // > [...] You can get a reference to the overcommit queue by
+            // > dropping down to the C function dispatch_get_global_queue
+            // > (available in Swift with a __ prefix) and passing the private
+            // > value of DISPATCH_QUEUE_OVERCOMMIT.
+            // >
+            // > [...] Of course you should not do this in production code,
+            // > because DISPATCH_QUEUE_OVERCOMMIT is not a public API. I don't
+            // > know of a way to get a reference to the overcommit queue using
+            // > only public APIs.
+            let DISPATCH_QUEUE_OVERCOMMIT: UInt = 2
+            let targetQueue = __dispatch_get_global_queue(
+                Int(qos.qosClass.rawValue.rawValue),
+                DISPATCH_QUEUE_OVERCOMMIT)
+            
+            dbConfiguration.qos = qos
+            let dbQueue = try makeDatabaseQueue()
+            try dbQueue.write { _ in
+                dispatchPrecondition(condition: .onQueue(targetQueue))
+            }
+            dbQueue.read { _ in
+                dispatchPrecondition(condition: .onQueue(targetQueue))
+            }
+        }
+        
+        try test(qos: .background)
+        try test(qos: .userInitiated)
+    }
 }


### PR DESCRIPTION
This PR brings two new configuration options: `qos` and `targetQueue`. They let you control the dispatch of database operations:

```swift
var configuration = Configuration()
configuration.qos = .userInitiated
let dbQueue = DatabaseQueue(path: "...", configuration: configuration)
```
