### PR TITLE
ValueObservation: delayed reducer creation

### DIFF
--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -344,3 +344,21 @@ public struct AnyDatabaseRegionConvertible: DatabaseRegionConvertible {
         return try _region(db)
     }
 }
+
+// MARK: - Utils
+
+extension DatabaseRegion {
+    static func union(_ regions: DatabaseRegion...) -> DatabaseRegion {
+        return regions.reduce(into: DatabaseRegion()) { union, region in
+            union.formUnion(region)
+        }
+    }
+    
+    static func union(_ regions: [DatabaseRegionConvertible]) -> (Database) throws -> DatabaseRegion {
+        return { db in
+            try regions.reduce(into: DatabaseRegion()) { union, region in
+                try union.formUnion(region.databaseRegion(db))
+            }
+        }
+    }
+}

--- a/GRDB/ValueObservation/ValueObservation+Combine.swift
+++ b/GRDB/ValueObservation/ValueObservation+Combine.swift
@@ -8,13 +8,13 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<AnyValueReducer<
             (R1.Fetched, R2.Fetched),
-            (R1.Value, R2.Value)>>.init(
-            tracking: union([
-                o1.observedRegion,
-                o2.observedRegion]),
-            reducer: ValueReducers.combine(
-                o1.reducer,
-                o2.reducer))
+            (R1.Value, R2.Value)>>(
+                tracking: { try DatabaseRegion.union(
+                    o1.observedRegion($0),
+                    o2.observedRegion($0)) },
+                reducer: { try ValueReducers.combine(
+                    o1.makeReducer($0),
+                    o2.makeReducer($0)) })
     }
     
     public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer>(
@@ -27,15 +27,15 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<AnyValueReducer<
             (R1.Fetched, R2.Fetched, R3.Fetched),
-            (R1.Value, R2.Value, R3.Value)>>.init(
-            tracking: union([
-                o1.observedRegion,
-                o2.observedRegion,
-                o3.observedRegion]),
-            reducer: ValueReducers.combine(
-                o1.reducer,
-                o2.reducer,
-                o3.reducer))
+            (R1.Value, R2.Value, R3.Value)>>(
+                tracking: { try DatabaseRegion.union(
+                    o1.observedRegion($0),
+                    o2.observedRegion($0),
+                    o3.observedRegion($0)) },
+                reducer: { try ValueReducers.combine(
+                    o1.makeReducer($0),
+                    o2.makeReducer($0),
+                    o3.makeReducer($0)) })
     }
     
     public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer>(
@@ -49,17 +49,17 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<AnyValueReducer<
             (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched),
-            (R1.Value, R2.Value, R3.Value, R4.Value)>>.init(
-            tracking: union([
-                o1.observedRegion,
-                o2.observedRegion,
-                o3.observedRegion,
-                o4.observedRegion]),
-            reducer: ValueReducers.combine(
-                o1.reducer,
-                o2.reducer,
-                o3.reducer,
-                o4.reducer))
+            (R1.Value, R2.Value, R3.Value, R4.Value)>>(
+                tracking: { try DatabaseRegion.union(
+                    o1.observedRegion($0),
+                    o2.observedRegion($0),
+                    o3.observedRegion($0),
+                    o4.observedRegion($0)) },
+                reducer: { try ValueReducers.combine(
+                    o1.makeReducer($0),
+                    o2.makeReducer($0),
+                    o3.makeReducer($0),
+                    o4.makeReducer($0)) })
     }
     
     public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer, R5: ValueReducer>(
@@ -74,19 +74,19 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<AnyValueReducer<
             (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched),
-            (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)>>.init(
-            tracking: union([
-                o1.observedRegion,
-                o2.observedRegion,
-                o3.observedRegion,
-                o4.observedRegion,
-                o5.observedRegion]),
-            reducer: ValueReducers.combine(
-                o1.reducer,
-                o2.reducer,
-                o3.reducer,
-                o4.reducer,
-                o5.reducer))
+            (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)>>(
+                tracking: { try DatabaseRegion.union(
+                    o1.observedRegion($0),
+                    o2.observedRegion($0),
+                    o3.observedRegion($0),
+                    o4.observedRegion($0),
+                    o5.observedRegion($0)) },
+                reducer: { try ValueReducers.combine(
+                    o1.makeReducer($0),
+                    o2.makeReducer($0),
+                    o3.makeReducer($0),
+                    o4.makeReducer($0),
+                    o5.makeReducer($0)) })
     }
 }
 
@@ -271,13 +271,5 @@ extension ValueReducers {
             }
         }
         return AnyValueReducer(fetch: fetch, value: value)
-    }
-}
-
-private func union(_ regions: [(Database) throws -> DatabaseRegion]) -> (Database) throws -> DatabaseRegion {
-    return { db in
-        try regions.reduce(into: DatabaseRegion()) { union, region in
-            try union.formUnion(region(db))
-        }
     }
 }

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -32,7 +32,7 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<ValueReducers.Values<Request.RowDecoder>>.tracking(
             request,
-            reducer: ValueReducers.Values { try DatabaseValue.fetchAll($0, request) })
+            reducer: { _ in ValueReducers.Values { try DatabaseValue.fetchAll($0, request) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -64,7 +64,7 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<ValueReducers.Value<Request.RowDecoder>>.tracking(
             request,
-            reducer: ValueReducers.Value { try DatabaseValue.fetchOne($0, request) })
+            reducer: { _ in ValueReducers.Value { try DatabaseValue.fetchOne($0, request) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies
@@ -98,7 +98,7 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<ValueReducers.OptionalValues<Request.RowDecoder._Wrapped>>.tracking(
             request,
-            reducer: ValueReducers.OptionalValues { try DatabaseValue.fetchAll($0, request) })
+            reducer: { _ in ValueReducers.OptionalValues { try DatabaseValue.fetchAll($0, request) } })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -32,7 +32,7 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<ValueReducers.Records<Request.RowDecoder>>.tracking(
             request,
-            reducer: ValueReducers.Records { try Row.fetchAll($0, request) })
+            reducer: { _ in ValueReducers.Records { try Row.fetchAll($0, request) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -64,7 +64,7 @@ extension ValueObservation where Reducer == Void {
     {
         return ValueObservation<ValueReducers.Record<Request.RowDecoder>>.tracking(
             request,
-            reducer: ValueReducers.Record { try Row.fetchOne($0, request) })
+            reducer: { _ in ValueReducers.Record { try Row.fetchOne($0, request) } })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+Map.swift
+++ b/GRDB/ValueObservation/ValueObservation+Map.swift
@@ -4,9 +4,10 @@ extension ValueObservation where Reducer: ValueReducer {
     public func map<T>(_ transform: @escaping (Reducer.Value) -> T)
         -> ValueObservation<MapValueReducer<Reducer, T>>
     {
+        let makeReducer = self.makeReducer
         return ValueObservation<MapValueReducer<Reducer, T>>(
             tracking: observedRegion,
-            reducer: reducer.map(transform))
+            reducer: { db in try makeReducer(db).map(transform) })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -243,7 +243,7 @@ extension ValueObservation {
     /// the ValueReducer protocol are supported.
     public static func tracking(
         _ regions: DatabaseRegionConvertible...,
-        reducer: Reducer)
+        reducer: @escaping (Database) -> Reducer)
         -> ValueObservation
     {
         return ValueObservation.tracking(regions, reducer: reducer)
@@ -285,12 +285,12 @@ extension ValueObservation {
     /// the ValueReducer protocol are supported.
     public static func tracking(
         _ regions: [DatabaseRegionConvertible],
-        reducer: Reducer)
+        reducer: @escaping (Database) -> Reducer)
         -> ValueObservation
     {
         return ValueObservation(
             tracking: DatabaseRegion.union(regions),
-            reducer: { _ in reducer })
+            reducer: reducer)
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -217,13 +217,13 @@ extension ValueObservation {
     /// table is modified:
     ///
     ///     var count = 0
-    ///     let reducer = AnyValueReducer(
-    ///         fetch: { _ in },
-    ///         value: { _ -> Int? in
-    ///             count += 1
-    ///             return count
+    ///     let observation = ValueObservation.tracking(Player.all(), reducer: ( db in
+    ///         AnyValueReducer(
+    ///             fetch: { _ in },
+    ///             value: { _ -> Int? in
+    ///                 count += 1
+    ///                 return count })
     ///     })
-    ///     let observation = ValueObservation.tracking(Player.all(), reducer: reducer)
     ///     let observer = observation.start(in: dbQueue) { count: Int in
     ///         print("Players have been modified \(count) times.")
     ///     }
@@ -259,13 +259,13 @@ extension ValueObservation {
     /// table is modified:
     ///
     ///     var count = 0
-    ///     let reducer = AnyValueReducer(
-    ///         fetch: { _ in },
-    ///         value: { _ -> Int? in
-    ///             count += 1
-    ///             return count
+    ///     let observation = ValueObservation.tracking([Player.all()], reducer: ( db in
+    ///         AnyValueReducer(
+    ///             fetch: { _ in },
+    ///             value: { _ -> Int? in
+    ///                 count += 1
+    ///                 return count })
     ///     })
-    ///     let observation = ValueObservation.tracking([Player.all()], reducer: reducer)
     ///     let observer = observation.start(in: dbQueue) { count: Int in
     ///         print("Players have been modified \(count) times.")
     ///     }

--- a/README.md
+++ b/README.md
@@ -6566,17 +6566,22 @@ The sample code below counts the number of times the player table is modified:
 
 ```swift
 var count = 0
-let reducer = AnyValueReducer(
-    fetch: { _ in },
-    value: { _ -> Int? in
-        count += 1
-        return count
-    })
-let observer = ValueObservation
-    .tracking(Player.all(), reducer: reducer)
-    .start(in: dbQueue) { count: Int in
-        print("Players have been modified \(count) times.")
-    }
+let observation = ValueObservation.tracking(Player.all(), reducer: { _ in
+    AnyValueReducer(
+        fetch: { _ in /* don't fetch anything */ },
+        value: { _ -> Int? in
+            defer { count += 1 }
+            return count })
+})
+let observer = observation.start(in: dbQueue) { count: Int in
+    print("\(count) transaction(s) have modified the players.")
+}
+// Prints "0 transaction(s) have modified the players."
+
+try dbQueue.write { db in
+    try Player(...).insert(db)
+}
+// Prints "1 transaction(s) have modified the players."
 ```
 
 

--- a/Tests/GRDBTests/ValueObservationExtentTests.swift
+++ b/Tests/GRDBTests/ValueObservationExtentTests.swift
@@ -34,7 +34,7 @@ class ValueObservationExtentTests: GRDBTestCase {
             value: { $0 })
         
         // Create an observation
-        var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: reducer)
+        var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
         observation.extent = .databaseLifetime
         
         // Start observation
@@ -72,7 +72,7 @@ class ValueObservationExtentTests: GRDBTestCase {
             value: { $0 })
         
         // Create an observation
-        var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: reducer)
+        var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
         observation.extent = .observerLifetime
         
         // Start observation and deallocate observer after second change
@@ -118,7 +118,7 @@ class ValueObservationExtentTests: GRDBTestCase {
             value: { $0 })
         
         // Create an observation
-        var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: reducer)
+        var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
         observation.extent = .nextTransaction
         
         // Start observation

--- a/Tests/GRDBTests/ValueObservationSchedulingTests.swift
+++ b/Tests/GRDBTests/ValueObservationSchedulingTests.swift
@@ -113,7 +113,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                     }
             },
                 value: { $0 })
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: reducer)
+            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
             observation.extent = .databaseLifetime
             
             _ = try observation.start(
@@ -236,7 +236,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let reducer = AnyValueReducer(
                 fetch: { _ in throw TestError() },
                 value: { $0 })
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: reducer)
+            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
             observation.extent = .databaseLifetime
             observation.scheduling = .onQueue(queue, startImmediately: false)
             
@@ -391,7 +391,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let reducer = AnyValueReducer(
                 fetch: { _ in throw TestError() },
                 value: { $0 })
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: reducer)
+            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
             observation.extent = .databaseLifetime
             observation.scheduling = .unsafe(startImmediately: false)
             


### PR DESCRIPTION
This PR fixes an issue with ValueObservation.

The most low-level ValueObservation creation method used to be:

```swift
ValueObservation.tracking(...: reducer: Reducer)
```

It is now:

```swift
ValueObservation.tracking(...: reducer: @escaping (Database) -> Reducer)
```

This fixes two problems:

- It used to be painful to perform initial configuration of the reducer with a database connection.
- The reducing process starts when the observation is started: starting an observation several times should thus create as many reducers.

This PR replaces the old method with the new one, without deprecation: this is a breaking change. This should be OK since value reducers are an advanced and low-level feature, and ValueObservation is still very young.