### PR TITLE
ValueObservation.compactMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 - [#442](https://github.com/groue/GRDB.swift/pull/442): Reindex
 - [#443](https://github.com/groue/GRDB.swift/pull/443): In place record update
 - [#444](https://github.com/groue/GRDB.swift/pull/444): Combine Value Observations
+- [#451](https://github.com/groue/GRDB.swift/pull/451): ValueObservation.compactMap
 - [#445](https://github.com/groue/GRDB.swift/pull/445): Quality of service and target dispatch queue
 - ValueObservation methods which used to accept a variadic list of observed regions now also accept an array.
 - ValueReducer, the protocol that fuels ValueObservation, is flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). It will remain so until more experience has been acquired.
@@ -66,7 +67,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 ### Documentation Diff
 
 - [Record Comparison](README.md#record-comparison): this chapter has been updated for the new `updateChanges(_:with:)` method.
-- [ValueObservation](README.md#valueobservation): this chapter has been updated for the new `ValueObservation.combine(...)` method.
+- [ValueObservation](README.md#valueobservation): this chapter has been updated for the new `ValueObservation.combine(...)` and `ValueObservation.compactMap(...)` methods.
 
 
 ### API diff
@@ -92,7 +93,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 +        -> ValueObservation
  }
  
- extension ValueObservation where Reducer == Void {
++extension ValueObservation where Reducer == Void {
 +    static func tracking<Value>(
 +        _ regions: [DatabaseRegionConvertible],
 +        fetch: @escaping (Database) throws -> Value)
@@ -104,7 +105,13 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 +        where Value: Equatable
 +    static func combine<R1: ValueReducer, ...>(_ o1: ValueObservation<R1>, ...)
 +        -> ValueObservation<...>
- }
++}
+ 
++extension ValueObservation where Reducer: ValueReducer {
++    func compactMap<T>(_ transform: @escaping (Reducer.Value) -> T?)
++        -> ValueObservation<CompactMapValueReducer<Reducer, T>>
++}
+ 
  
  struct Configuration {
 +    var qos: DispatchQoS

--- a/Documentation/GoodPracticesForDesigningRecordTypes.md
+++ b/Documentation/GoodPracticesForDesigningRecordTypes.md
@@ -308,11 +308,13 @@ This synchronization is not automatic with GRDB: records do not "auto-update". T
 
 Instead, have a look at [Database Observation]:
 
-> :bulb: **Tip**: Use [FetchedRecordsController] when a table or collection views should remained synchronized with the database, in an animated way.
+> :bulb: **Tip**: [ValueObservation] performs automated tracking of database changes.
 >
-> :bulb: **Tip**: Use [RxGRDB] when your application needs to react to all changes in the results of a database request.
+> :bulb: **Tip**: [FetchedRecordsController] performs automated tracking of database changes, and can animate the cells of a table or collection view.
 >
-> :bulb: **Tip**: Use [TransactionObserver], the low-level protocol for database observation, for your most advanced needs.
+> :bulb: **Tip**: [RxGRDB] performs automated tracking of database changes, in the [RxSwift](https://github.com/ReactiveX/RxSwift) way.
+>
+> :bulb: **Tip**: [TransactionObserver] provides low-level database observation, for your most advanced needs.
 >
 > :bulb: **Tip**: Don't try to write complex methods that both modify the database and the values in memory at the same time. Instead, modify the database with plain record types, and rely on database observation for automatically refreshing values, even complex ones.
 
@@ -337,6 +339,7 @@ Instead, have a look at [Database Observation]:
 [Concurrency Guide]: ../README.md#concurrency
 [PersistableRecord]: ../README.md#persistablerecord-protocol
 [Database Observation]: ../README.md#database-changes-observation
+[ValueObservation]: ../README.md#valueobservation
 [FetchedRecordsController]: ../README.md#fetchedrecordscontroller
 [RxGRDB]: http://github.com/RxSwiftCommunity/RxGRDB
 [TransactionObserver]: ../README.md#transactionobserver-protocol

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -204,6 +204,13 @@
 		564CE43121AA901800652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43021AA901800652B19 /* ValueObserver.swift */; };
 		564CE43221AA901800652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43021AA901800652B19 /* ValueObserver.swift */; };
 		564CE43321AA901800652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43021AA901800652B19 /* ValueObserver.swift */; };
+		564CE4D621B2DEB600652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4D521B2DEB500652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4D721B2DEB600652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4D521B2DEB500652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4D821B2DEB600652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4D521B2DEB500652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4E621B2E06700652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4E521B2E06700652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4E721B2E06800652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4E521B2E06700652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4E921B2E06F00652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4E821B2E06F00652B19 /* ValueObservationMapTests.swift */; };
+		564CE4EA21B2E06F00652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4E821B2E06F00652B19 /* ValueObservationMapTests.swift */; };
 		564E73DF203D50B9000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73DE203D50B9000C443C /* JoinSupportTests.swift */; };
 		564E73E0203D50B9000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73DE203D50B9000C443C /* JoinSupportTests.swift */; };
 		564F9C1E1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */; };
@@ -964,6 +971,9 @@
 		5644DE6C20F8C32E001FFDDE /* DatabaseValueConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversion.swift; sourceTree = "<group>"; };
 		564A50C61BFF4B7F00B3A3A2 /* DatabaseCollationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseCollationTests.swift; sourceTree = "<group>"; };
 		564CE43021AA901800652B19 /* ValueObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueObserver.swift; sourceTree = "<group>"; };
+		564CE4D521B2DEB500652B19 /* ValueObservation+CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+CompactMap.swift"; sourceTree = "<group>"; };
+		564CE4E521B2E06700652B19 /* ValueObservationCompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationCompactMapTests.swift; sourceTree = "<group>"; };
+		564CE4E821B2E06F00652B19 /* ValueObservationMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationMapTests.swift; sourceTree = "<group>"; };
 		564E73DE203D50B9000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1388,6 +1398,7 @@
 			children = (
 				563B06AA217EF0CC00B38F35 /* ValueObservation.swift */,
 				5613ED3E21A95A8B00DC7A68 /* ValueObservation+Combine.swift */,
+				564CE4D521B2DEB500652B19 /* ValueObservation+CompactMap.swift */,
 				5613ED5321A95DD000DC7A68 /* ValueObservation+Count.swift */,
 				5613ED4F21A95C6D00DC7A68 /* ValueObservation+DatabaseValueConvertible.swift */,
 				5613ED4B21A95C4300DC7A68 /* ValueObservation+FetchableRecord.swift */,
@@ -1537,10 +1548,12 @@
 			isa = PBXGroup;
 			children = (
 				5613EDA521A96A9200DC7A68 /* ValueObservationCombineTests.swift */,
+				564CE4E521B2E06700652B19 /* ValueObservationCompactMapTests.swift */,
 				563B06F621861D8300B38F35 /* ValueObservationCountTests.swift */,
 				563B071721862F4C00B38F35 /* ValueObservationDatabaseValueConvertibleTests.swift */,
 				563B06C02185D29F00B38F35 /* ValueObservationExtentTests.swift */,
 				563B06C92185D2E500B38F35 /* ValueObservationFetchTests.swift */,
+				564CE4E821B2E06F00652B19 /* ValueObservationMapTests.swift */,
 				563B06C22185D29F00B38F35 /* ValueObservationReadonlyTests.swift */,
 				563B071421862C4600B38F35 /* ValueObservationRecordTests.swift */,
 				563B06BC2185CCD300B38F35 /* ValueObservationReducerTests.swift */,
@@ -2559,6 +2572,7 @@
 				565490D61D5AE252005622CB /* StandardLibrary.swift in Sources */,
 				5653EB1720944C7C00F46237 /* AssociationQuery.swift in Sources */,
 				565490B81D5AE236005622CB /* DatabaseError.swift in Sources */,
+				564CE4D821B2DEB600652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				56BF6D3C1DEF47DA006039A3 /* Fixits-0-90-1.swift in Sources */,
 				56DAA2E11DE9C827006E10C8 /* Cursor.swift in Sources */,
 				5653EB0520944C7C00F46237 /* BelongsToAssociation.swift in Sources */,
@@ -2663,6 +2677,7 @@
 				56FC987B1D969DEF00E3C842 /* SQLExpression+QueryInterface.swift in Sources */,
 				56A238881B9C75030082EB20 /* Row.swift in Sources */,
 				5613ED4D21A95C4300DC7A68 /* ValueObservation+FetchableRecord.swift in Sources */,
+				564CE4D721B2DEB600652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				563EF44B2161F179007DAACD /* Inflections.swift in Sources */,
 				56CEB4F41EAA2EFA00BFAF62 /* FetchableRecord.swift in Sources */,
 				569531201C907A8C00CF1A2B /* DatabaseSchemaCache.swift in Sources */,
@@ -2844,6 +2859,7 @@
 				564F9C221F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				56A8C2481D1918F00096E9D4 /* FoundationUUIDTests.swift in Sources */,
 				5653EAEF20944B4F00F46237 /* AssociationParallelDecodableRecordTests.swift in Sources */,
+				564CE4E721B2E06800652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56A2383C1B9C74A90082EB20 /* DatabaseErrorTests.swift in Sources */,
 				5690C32A1D23E6D800E59934 /* FoundationDateComponentsTests.swift in Sources */,
 				5657AB3A1D108BA9006283EF /* FoundationDataTests.swift in Sources */,
@@ -2869,6 +2885,7 @@
 				56F0B9921B6001C600A2F135 /* FoundationNSDateTests.swift in Sources */,
 				56A238381B9C74A90082EB20 /* DatabaseTests.swift in Sources */,
 				5653EAED20944B4F00F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE4EA21B2E06F00652B19 /* ValueObservationMapTests.swift in Sources */,
 				56300B5F1C53C38F005A543B /* QueryInterfaceRequestTests.swift in Sources */,
 				5634B10A1CF9B970005360B9 /* TransactionObserverSavepointsTests.swift in Sources */,
 				560C97C81BFD0B8400BF8471 /* DatabaseFunctionTests.swift in Sources */,
@@ -3021,6 +3038,7 @@
 				56D496791D81309E008276D7 /* RecordWithColumnNameManglingTests.swift in Sources */,
 				56D4966C1D81309E008276D7 /* RecordMinimalPrimaryKeyRowIDTests.swift in Sources */,
 				564F9C1E1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
+				564CE4E621B2E06700652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				5653EAEE20944B4F00F46237 /* AssociationParallelDecodableRecordTests.swift in Sources */,
 				56D496861D813147008276D7 /* UpdateStatementTests.swift in Sources */,
 				56D4965D1D81304E008276D7 /* FoundationNSNumberTests.swift in Sources */,
@@ -3046,6 +3064,7 @@
 				5674A7201F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
 				56D496551D812F83008276D7 /* FoundationDataTests.swift in Sources */,
 				56D4966A1D813086008276D7 /* TableRecord+QueryInterfaceRequestTests.swift in Sources */,
+				564CE4E921B2E06F00652B19 /* ValueObservationMapTests.swift in Sources */,
 				5653EAEC20944B4F00F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				562206071E420EA4005860AC /* DatabasePoolConcurrencyTests.swift in Sources */,
 				5698ACB61DA6285E0056AF8C /* FTS3TokenizerTests.swift in Sources */,
@@ -3122,6 +3141,7 @@
 				5653EB252094A14400F46237 /* QueryInterfaceRequest+Association.swift in Sources */,
 				5605F1691C672E4000235C62 /* NSString.swift in Sources */,
 				560D92401C672C3E00F4F92B /* DatabaseValueConvertible.swift in Sources */,
+				564CE4D621B2DEB600652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				56A8C2301D1914540096E9D4 /* UUID.swift in Sources */,
 				56CEB5011EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
 				56CEB55A1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -171,6 +171,15 @@ public struct Configuration {
         let readWriteFlags = readonly ? SQLITE_OPEN_READONLY : (SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE)
         return threadingMode.SQLiteOpenFlags | readWriteFlags
     }
+    
+    func makeDispatchQueue(defaultLabel: String, purpose: String? = nil) -> DispatchQueue {
+        let label = (self.label ?? defaultLabel) + (purpose.map { "." + $0 } ?? "")
+        if let targetQueue = targetQueue {
+            return DispatchQueue(label: label, target: targetQueue)
+        } else {
+            return DispatchQueue(label: label, qos: qos)
+        }
+    }
 }
 
 /// A tracing function that takes an SQL string.

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -52,7 +52,8 @@ public final class DatabasePool: DatabaseWriter {
             path: path,
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: (configuration.label ?? "GRDB.DatabasePool") + ".writer")
+            defaultLabel: "GRDB.DatabasePool",
+            purpose: "writer")
         
         // Activate WAL Mode unless readonly
         if !configuration.readonly {
@@ -89,7 +90,8 @@ public final class DatabasePool: DatabaseWriter {
                 path: path,
                 configuration: self.readerConfig,
                 schemaCache: SimpleDatabaseSchemaCache(),
-                label: (self.readerConfig.label ?? "GRDB.DatabasePool") + ".reader.\(readerCount)")
+                defaultLabel: "GRDB.DatabasePool",
+                purpose: "reader.\(readerCount)")
             reader.sync { self.setupDatabase($0) }
             return reader
         })
@@ -757,7 +759,8 @@ extension DatabasePool {
         let snapshot = try DatabaseSnapshot(
             path: path,
             configuration: writer.configuration,
-            labelSuffix: ".snapshot.\(snapshotCount.increment())")
+            defaultLabel: "GRDB.DatabasePool",
+            purpose: "snapshot.\(snapshotCount.increment())")
         snapshot.read { setupDatabase($0) }
         return snapshot
     }

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -40,7 +40,7 @@ public final class DatabaseQueue: DatabaseWriter {
             path: path,
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: configuration.label ?? "GRDB.DatabaseQueue")
+            defaultLabel: "GRDB.DatabaseQueue")
     }
     
     /// Opens an in-memory SQLite database.
@@ -56,7 +56,7 @@ public final class DatabaseQueue: DatabaseWriter {
             path: ":memory:",
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: configuration.label ?? "GRDB.DatabaseQueue")
+            defaultLabel: "GRDB.DatabaseQueue")
     }
     
     #if os(iOS)

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -14,7 +14,7 @@ public class DatabaseSnapshot : DatabaseReader {
         return serializedDatabase.configuration
     }
     
-    init(path: String, configuration: Configuration = Configuration(), labelSuffix: String) throws {
+    init(path: String, configuration: Configuration = Configuration(), defaultLabel: String, purpose: String) throws {
         var configuration = configuration
         configuration.readonly = true
         configuration.allowsUnsafeTransactions = true // Snaphost keeps a long-lived transaction
@@ -23,7 +23,8 @@ public class DatabaseSnapshot : DatabaseReader {
             path: path,
             configuration: configuration,
             schemaCache: SimpleDatabaseSchemaCache(),
-            label: (configuration.label ?? "GRDB.DatabasePool") + labelSuffix)
+            defaultLabel: defaultLabel,
+            purpose: purpose)
         
         try serializedDatabase.sync { db in
             // Assert WAL mode

--- a/GRDB/Core/SchedulingWatchdog.swift
+++ b/GRDB/Core/SchedulingWatchdog.swift
@@ -22,7 +22,7 @@ import Dispatch
 /// - preconditionValidQueue() crashes whenever a database is used in an invalid
 ///   dispatch queue.
 final class SchedulingWatchdog {
-    private static let specificKey = DispatchSpecificKey<SchedulingWatchdog>()
+    private static let watchDogKey = DispatchSpecificKey<SchedulingWatchdog>()
     private(set) var allowedDatabases: [Database]
     var databaseObservationBroker: DatabaseObservationBroker?
     
@@ -30,22 +30,10 @@ final class SchedulingWatchdog {
         allowedDatabases = [database]
     }
     
-    static func makeSerializedQueue(
-        allowingDatabase database: Database,
-        label: String,
-        qos: DispatchQoS,
-        targetQueue: DispatchQueue?)
-        -> DispatchQueue
-    {
-        let queue: DispatchQueue
-        if let targetQueue = targetQueue {
-            queue = DispatchQueue(label: label, target: targetQueue)
-        } else {
-            queue = DispatchQueue(label: label, qos: qos)
-        }
+    static func allowDatabase(_ database: Database, onQueue queue: DispatchQueue) {
+        precondition(queue.getSpecific(key: watchDogKey) == nil)
         let watchdog = SchedulingWatchdog(allowedDatabase: database)
-        queue.setSpecific(key: specificKey, value: watchdog)
-        return queue
+        queue.setSpecific(key: watchDogKey, value: watchdog)
     }
     
     func inheritingAllowedDatabases<T>(from other: SchedulingWatchdog, execute body: () throws -> T) rethrows -> T {
@@ -60,7 +48,7 @@ final class SchedulingWatchdog {
     }
     
     static var current: SchedulingWatchdog? {
-        return DispatchQueue.getSpecific(key: specificKey)
+        return DispatchQueue.getSpecific(key: watchDogKey)
     }
     
     func allows(_ db: Database) -> Bool {

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -16,7 +16,7 @@ final class SerializedDatabase {
     /// The dispatch queue
     private let queue: DispatchQueue
     
-    init(path: String, configuration: Configuration = Configuration(), schemaCache: DatabaseSchemaCache, label: String) throws {
+    init(path: String, configuration: Configuration = Configuration(), schemaCache: DatabaseSchemaCache, defaultLabel: String, purpose: String? = nil) throws {
         // According to https://www.sqlite.org/threadsafe.html
         //
         // > SQLite support three different threading modes:
@@ -37,13 +37,10 @@ final class SerializedDatabase {
         var config = configuration
         config.threadingMode = .multiThread
         
-        db = try Database(path: path, configuration: config, schemaCache: schemaCache)
-        queue = SchedulingWatchdog.makeSerializedQueue(
-            allowingDatabase: db,
-            label: label,
-            qos: configuration.qos,
-            targetQueue: configuration.targetQueue)
         self.path = path
+        self.db = try Database(path: path, configuration: config, schemaCache: schemaCache)
+        self.queue = configuration.makeDispatchQueue(defaultLabel: defaultLabel, purpose: purpose)
+        SchedulingWatchdog.allowDatabase(db, onQueue: queue)
         try queue.sync {
             try db.setup()
         }

--- a/GRDB/ValueObservation/ValueObservation+CompactMap.swift
+++ b/GRDB/ValueObservation/ValueObservation+CompactMap.swift
@@ -1,0 +1,43 @@
+extension ValueObservation where Reducer: ValueReducer {
+    /// Returns a ValueObservation which notifies the non-nil results of calling
+    /// the given transformation which each element notified by this
+    /// value observation.
+    public func compactMap<T>(_ transform: @escaping (Reducer.Value) -> T?)
+        -> ValueObservation<CompactMapValueReducer<Reducer, T>>
+    {
+        let makeReducer = self.makeReducer
+        return ValueObservation<CompactMapValueReducer<Reducer, T>>(
+            tracking: observedRegion,
+            reducer: { db in try makeReducer(db).compactMap(transform) })
+    }
+}
+
+extension ValueReducer {
+    /// Returns a reducer which outputs the non-nil results of calling the given
+    /// transformation which each element emitted by this reducer.
+    public func compactMap<T>(_ transform: @escaping (Value) -> T?) -> CompactMapValueReducer<Self, T> {
+        return CompactMapValueReducer(self, transform)
+    }
+}
+
+/// See ValueReducer.compactMap(_:)
+///
+/// :nodoc:
+public struct CompactMapValueReducer<Base: ValueReducer, T>: ValueReducer {
+    private var base: Base
+    private let transform: (Base.Value) -> T?
+    
+    init(_ base: Base, _ transform: @escaping (Base.Value) -> T?) {
+        self.base = base
+        self.transform = transform
+    }
+    
+    public func fetch(_ db: Database) throws -> Base.Fetched {
+        return try base.fetch(db)
+    }
+    
+    public mutating func value(_ fetched: Base.Fetched) -> T? {
+        guard let value = base.value(fetched) else { return nil }
+        return transform(value)
+    }
+}

--- a/GRDB/ValueObservation/ValueObservation+CompactMap.swift
+++ b/GRDB/ValueObservation/ValueObservation+CompactMap.swift
@@ -6,9 +6,13 @@ extension ValueObservation where Reducer: ValueReducer {
         -> ValueObservation<CompactMapValueReducer<Reducer, T>>
     {
         let makeReducer = self.makeReducer
-        return ValueObservation<CompactMapValueReducer<Reducer, T>>(
+        var observation = ValueObservation<CompactMapValueReducer<Reducer, T>>(
             tracking: observedRegion,
             reducer: { db in try makeReducer(db).compactMap(transform) })
+        observation.extent = extent
+        observation.scheduling = scheduling
+        observation.requiresWriteAccess = requiresWriteAccess
+        return observation
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+Map.swift
+++ b/GRDB/ValueObservation/ValueObservation+Map.swift
@@ -6,9 +6,13 @@ extension ValueObservation where Reducer: ValueReducer {
         -> ValueObservation<MapValueReducer<Reducer, T>>
     {
         let makeReducer = self.makeReducer
-        return ValueObservation<MapValueReducer<Reducer, T>>(
+        var observation = ValueObservation<MapValueReducer<Reducer, T>>(
             tracking: observedRegion,
             reducer: { db in try makeReducer(db).map(transform) })
+        observation.extent = extent
+        observation.scheduling = scheduling
+        observation.requiresWriteAccess = requiresWriteAccess
+        return observation
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+Map.swift
+++ b/GRDB/ValueObservation/ValueObservation+Map.swift
@@ -1,6 +1,7 @@
 extension ValueObservation where Reducer: ValueReducer {
-    /// Returns a ValueObservation which transforms the values returned by
-    /// this ValueObservation.
+    /// Returns a ValueObservation which notifies the results of calling the
+    /// given transformation which each element notified by this
+    /// value observation.
     public func map<T>(_ transform: @escaping (Reducer.Value) -> T)
         -> ValueObservation<MapValueReducer<Reducer, T>>
     {
@@ -12,8 +13,9 @@ extension ValueObservation where Reducer: ValueReducer {
 }
 
 extension ValueReducer {
-    /// Returns a reducer which transforms the values returned by this reducer.
-    public func map<T>(_ transform: @escaping (Value) -> T?) -> MapValueReducer<Self, T> {
+    /// Returns a reducer which outputs the results of calling the given
+    /// transformation which each element emitted by this reducer.
+    public func map<T>(_ transform: @escaping (Value) -> T) -> MapValueReducer<Self, T> {
         return MapValueReducer(self, transform)
     }
 }
@@ -26,9 +28,9 @@ extension ValueReducer {
 /// :nodoc:
 public struct MapValueReducer<Base: ValueReducer, T>: ValueReducer {
     private var base: Base
-    private let transform: (Base.Value) -> T?
+    private let transform: (Base.Value) -> T
     
-    init(_ base: Base, _ transform: @escaping (Base.Value) -> T?) {
+    init(_ base: Base, _ transform: @escaping (Base.Value) -> T) {
         self.base = base
         self.transform = transform
     }

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -27,12 +27,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
         self.notificationQueue = notificationQueue
         self.onChange = onChange
         self.onError = onError
-        let reduceQueueLabel = (configuration.label ?? "GRDB") + ".ValueObservation.reducer"
-        if let targetQueue = configuration.targetQueue {
-            self.reduceQueue = DispatchQueue(label: reduceQueueLabel, target: targetQueue)
-        } else {
-            self.reduceQueue = DispatchQueue(label: reduceQueueLabel, qos: configuration.qos)
-        }
+        self.reduceQueue = configuration.makeDispatchQueue(defaultLabel: "GRDB", purpose: "ValueObservation.reducer")
     }
     
     func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool {

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -262,6 +262,16 @@
 		5644DE8520F8D1E4001FFDDE /* DatabaseValueConversionErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5644DE8120F8D1E4001FFDDE /* DatabaseValueConversionErrorTests.swift */; };
 		564CE44021AA957000652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43F21AA957000652B19 /* ValueObserver.swift */; };
 		564CE44121AA957000652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43F21AA957000652B19 /* ValueObserver.swift */; };
+		564CE4DD21B2DEF700652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4DC21B2DEF700652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4DE21B2DEF700652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4DC21B2DEF700652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4EC21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4EB21B2E08200652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4ED21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4EB21B2E08200652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4EE21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4EB21B2E08200652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4EF21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4EB21B2E08200652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4F121B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */; };
+		564CE4F221B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */; };
+		564CE4F321B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */; };
+		564CE4F421B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */; };
 		564E73EF203DA2A2000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
 		564E73F0203DA2A3000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
 		564E73F1203DA2A3000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
@@ -1074,6 +1084,9 @@
 		5644DE8120F8D1E4001FFDDE /* DatabaseValueConversionErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversionErrorTests.swift; sourceTree = "<group>"; };
 		564A50C61BFF4B7F00B3A3A2 /* DatabaseCollationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseCollationTests.swift; sourceTree = "<group>"; };
 		564CE43F21AA957000652B19 /* ValueObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObserver.swift; sourceTree = "<group>"; };
+		564CE4DC21B2DEF700652B19 /* ValueObservation+CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+CompactMap.swift"; sourceTree = "<group>"; };
+		564CE4EB21B2E08200652B19 /* ValueObservationCompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationCompactMapTests.swift; sourceTree = "<group>"; };
+		564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationMapTests.swift; sourceTree = "<group>"; };
 		564E73EB203DA29B000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1468,6 +1481,7 @@
 			children = (
 				5613ED7321A95E8400DC7A68 /* ValueObservation.swift */,
 				5613ED7421A95E8400DC7A68 /* ValueObservation+Combine.swift */,
+				564CE4DC21B2DEF700652B19 /* ValueObservation+CompactMap.swift */,
 				5613ED7A21A95E8400DC7A68 /* ValueObservation+Count.swift */,
 				5613ED7821A95E8400DC7A68 /* ValueObservation+DatabaseValueConvertible.swift */,
 				5613ED7721A95E8400DC7A68 /* ValueObservation+FetchableRecord.swift */,
@@ -1617,10 +1631,12 @@
 			isa = PBXGroup;
 			children = (
 				5613ED9D21A96A6F00DC7A68 /* ValueObservationCombineTests.swift */,
+				564CE4EB21B2E08200652B19 /* ValueObservationCompactMapTests.swift */,
 				563B06F921861D8B00B38F35 /* ValueObservationCountTests.swift */,
 				563B071D21862F5D00B38F35 /* ValueObservationDatabaseValueConvertibleTests.swift */,
 				563B06DC2185E07100B38F35 /* ValueObservationExtentTests.swift */,
 				563B06DE2185E07200B38F35 /* ValueObservationFetchTests.swift */,
+				564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */,
 				563B06DD2185E07200B38F35 /* ValueObservationReadonlyTests.swift */,
 				563B070C21862C3500B38F35 /* ValueObservationRecordTests.swift */,
 				563B06DF2185E07200B38F35 /* ValueObservationReducerTests.swift */,
@@ -2338,6 +2354,7 @@
 				56B964B21DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				560FC5261CB003810014AA8E /* SerializedDatabase.swift in Sources */,
 				560FC5271CB003810014AA8E /* NSString.swift in Sources */,
+				564CE4DD21B2DEF700652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				560FC5291CB003810014AA8E /* DatabaseValueConvertible.swift in Sources */,
 				56A8C2311D1914540096E9D4 /* UUID.swift in Sources */,
 				56CEB5021EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
@@ -2538,6 +2555,7 @@
 				560FC5961CB00B880014AA8E /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				5653EBC420961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				560FC5971CB00B880014AA8E /* DatabaseErrorTests.swift in Sources */,
+				564CE4EC21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				560FC5991CB00B880014AA8E /* RecordMinimalPrimaryKeySingleTests.swift in Sources */,
 				564F9C1F1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				562393731DEE104400A6B01F /* MapCursorTests.swift in Sources */,
@@ -2563,6 +2581,7 @@
 				560FC5A21CB00B880014AA8E /* DatabaseFunctionTests.swift in Sources */,
 				560FC5A41CB00B880014AA8E /* RecordWithColumnNameManglingTests.swift in Sources */,
 				5674A7221F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
+				564CE4F121B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */,
 				5690C3271D23E6D800E59934 /* FoundationDateComponentsTests.swift in Sources */,
 				560FC5A51CB00B880014AA8E /* CGFloatTests.swift in Sources */,
 				56FF45571D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift in Sources */,
@@ -2715,6 +2734,7 @@
 				565EFAF01D0436CE00A8FA9D /* NumericOverflowTests.swift in Sources */,
 				5653EBC520961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				567156551CB16729007DC145 /* DatabaseValueConvertibleFetchTests.swift in Sources */,
+				564CE4ED21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				567156561CB16729007DC145 /* DatabaseErrorTests.swift in Sources */,
 				564F9C201F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				562393741DEE104400A6B01F /* MapCursorTests.swift in Sources */,
@@ -2740,6 +2760,7 @@
 				5698ACD01DA8C2620056AF8C /* RecordPrimaryKeyHiddenRowIDTests.swift in Sources */,
 				569178481CED9B6000E179EA /* DatabaseQueueTests.swift in Sources */,
 				5674A7241F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
+				564CE4F221B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */,
 				5634B1091CF9B970005360B9 /* TransactionObserverSavepointsTests.swift in Sources */,
 				567156601CB16729007DC145 /* DatabaseFunctionTests.swift in Sources */,
 				567156611CB16729007DC145 /* RecordWithColumnNameManglingTests.swift in Sources */,
@@ -2816,6 +2837,7 @@
 				56B964B51DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				56AFC9FB1CB1A8BB00F48B96 /* SerializedDatabase.swift in Sources */,
 				56AFC9FC1CB1A8BB00F48B96 /* DatabaseMigrator.swift in Sources */,
+				564CE4DE21B2DEF700652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				56AFC9FD1CB1A8BB00F48B96 /* NSString.swift in Sources */,
 				56A8C2341D1914540096E9D4 /* UUID.swift in Sources */,
 				56CEB5051EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
@@ -3016,6 +3038,7 @@
 				5698AC8E1DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,
 				5653EBC620961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				56AFCA641CB1AA9900F48B96 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
+				564CE4EE21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56A8C24A1D1918F10096E9D4 /* FoundationUUIDTests.swift in Sources */,
 				56AFCA651CB1AA9900F48B96 /* DatabaseErrorTests.swift in Sources */,
 				564F9C231F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
@@ -3041,6 +3064,7 @@
 				56AFCA6D1CB1AA9900F48B96 /* TableRecord+QueryInterfaceRequestTests.swift in Sources */,
 				56AFCA6E1CB1AA9900F48B96 /* FoundationNSDateTests.swift in Sources */,
 				5674A7211F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
+				564CE4F321B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */,
 				56AFCA6F1CB1AA9900F48B96 /* DatabaseTests.swift in Sources */,
 				56AFCA701CB1AA9900F48B96 /* QueryInterfaceRequestTests.swift in Sources */,
 				5634B10B1CF9B970005360B9 /* TransactionObserverSavepointsTests.swift in Sources */,
@@ -3193,6 +3217,7 @@
 				5698AC8F1DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,
 				5653EBC720961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				56AFCAB91CB1ABC800F48B96 /* RecordPrimaryKeyRowIDTests.swift in Sources */,
+				564CE4EF21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56AFCABA1CB1ABC800F48B96 /* RecordEditedTests.swift in Sources */,
 				56AFCABB1CB1ABC800F48B96 /* DatabasePoolSchemaCacheTests.swift in Sources */,
 				564F9C241F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
@@ -3218,6 +3243,7 @@
 				56AFCAC71CB1ABC800F48B96 /* FoundationNSDateTests.swift in Sources */,
 				56AFCAC81CB1ABC800F48B96 /* DatabaseTests.swift in Sources */,
 				5674A71E1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
+				564CE4F421B2E08A00652B19 /* ValueObservationMapTests.swift in Sources */,
 				56AFCAC91CB1ABC800F48B96 /* QueryInterfaceRequestTests.swift in Sources */,
 				5691784B1CED9B6000E179EA /* DatabaseQueueTests.swift in Sources */,
 				56AFCACB1CB1ABC800F48B96 /* DatabaseFunctionTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -97,6 +97,12 @@
 		5644DE8020F8D1D1001FFDDE /* DatabaseValueConversionErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5644DE7E20F8D1D1001FFDDE /* DatabaseValueConversionErrorTests.swift */; };
 		564CE43C21AA955B00652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43B21AA955B00652B19 /* ValueObserver.swift */; };
 		564CE43D21AA955B00652B19 /* ValueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE43B21AA955B00652B19 /* ValueObserver.swift */; };
+		564CE4DA21B2DEEB00652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4D921B2DEEB00652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4DB21B2DEEB00652B19 /* ValueObservation+CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4D921B2DEEB00652B19 /* ValueObservation+CompactMap.swift */; };
+		564CE4E021B2E04500652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4DF21B2E04500652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4E121B2E04500652B19 /* ValueObservationCompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4DF21B2E04500652B19 /* ValueObservationCompactMapTests.swift */; };
+		564CE4E321B2E05400652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4E221B2E05400652B19 /* ValueObservationMapTests.swift */; };
+		564CE4E421B2E05400652B19 /* ValueObservationMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE4E221B2E05400652B19 /* ValueObservationMapTests.swift */; };
 		564E73F3203DA2AC000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73E7203DA278000C443C /* JoinSupportTests.swift */; };
 		564E73F4203DA2AD000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73E7203DA278000C443C /* JoinSupportTests.swift */; };
 		564F9C211F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */; };
@@ -715,6 +721,9 @@
 		5644DE7E20F8D1D1001FFDDE /* DatabaseValueConversionErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConversionErrorTests.swift; sourceTree = "<group>"; };
 		564A50C61BFF4B7F00B3A3A2 /* DatabaseCollationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseCollationTests.swift; sourceTree = "<group>"; };
 		564CE43B21AA955B00652B19 /* ValueObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObserver.swift; sourceTree = "<group>"; };
+		564CE4D921B2DEEB00652B19 /* ValueObservation+CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+CompactMap.swift"; sourceTree = "<group>"; };
+		564CE4DF21B2E04500652B19 /* ValueObservationCompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationCompactMapTests.swift; sourceTree = "<group>"; };
+		564CE4E221B2E05400652B19 /* ValueObservationMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationMapTests.swift; sourceTree = "<group>"; };
 		564E73E7203DA278000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1075,6 +1084,7 @@
 			children = (
 				5613ED5921A95E6100DC7A68 /* ValueObservation.swift */,
 				5613ED5A21A95E6100DC7A68 /* ValueObservation+Combine.swift */,
+				564CE4D921B2DEEB00652B19 /* ValueObservation+CompactMap.swift */,
 				5613ED6021A95E6100DC7A68 /* ValueObservation+Count.swift */,
 				5613ED5E21A95E6100DC7A68 /* ValueObservation+DatabaseValueConvertible.swift */,
 				5613ED5D21A95E6100DC7A68 /* ValueObservation+FetchableRecord.swift */,
@@ -1231,10 +1241,12 @@
 			isa = PBXGroup;
 			children = (
 				5613EDA221A96A8000DC7A68 /* ValueObservationCombineTests.swift */,
+				564CE4DF21B2E04500652B19 /* ValueObservationCompactMapTests.swift */,
 				563B06FE21861D9D00B38F35 /* ValueObservationCountTests.swift */,
 				563B071A21862F5600B38F35 /* ValueObservationDatabaseValueConvertibleTests.swift */,
 				563B06CC2185E04500B38F35 /* ValueObservationExtentTests.swift */,
 				563B06CE2185E04600B38F35 /* ValueObservationFetchTests.swift */,
+				564CE4E221B2E05400652B19 /* ValueObservationMapTests.swift */,
 				563B06CD2185E04600B38F35 /* ValueObservationReadonlyTests.swift */,
 				563B071121862C3E00B38F35 /* ValueObservationRecordTests.swift */,
 				563B06CF2185E04600B38F35 /* ValueObservationReducerTests.swift */,
@@ -1981,6 +1993,7 @@
 				F3BA80131CFB2876003DC1BA /* DatabaseValue.swift in Sources */,
 				56B964B61DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				F3BA80171CFB2876003DC1BA /* RowAdapter.swift in Sources */,
+				564CE4DB21B2DEEB00652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				F3BA802F1CFB289B003DC1BA /* QueryInterfaceQuery.swift in Sources */,
 				56CEB5061EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
 				56CEB55F1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
@@ -2181,6 +2194,7 @@
 				5698ACA51DA4B0430056AF8C /* FTS4TableBuilderTests.swift in Sources */,
 				5653EB6F20961FB200F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				F3BA80B11CFB2FC4003DC1BA /* DatabaseTests.swift in Sources */,
+				564CE4E121B2E04500652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56A8C24E1D1918F30096E9D4 /* FoundationUUIDTests.swift in Sources */,
 				564F9C251F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				5657AB3D1D108BA9006283EF /* FoundationDataTests.swift in Sources */,
@@ -2206,6 +2220,7 @@
 				5657AB5D1D108BA9006283EF /* FoundationNSStringTests.swift in Sources */,
 				F3BA81241CFB3063003DC1BA /* RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
 				5674A71F1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
+				564CE4E421B2E05400652B19 /* ValueObservationMapTests.swift in Sources */,
 				F3BA80E81CFB3016003DC1BA /* RowFromDictionaryTests.swift in Sources */,
 				562393671DEE06D300A6B01F /* CursorTests.swift in Sources */,
 				F3BA80B41CFB2FC9003DC1BA /* DatabaseQueueReadOnlyTests.swift in Sources */,
@@ -2282,6 +2297,7 @@
 				F3BA806F1CFB2E55003DC1BA /* DatabaseValue.swift in Sources */,
 				56B964B31DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				F3BA80731CFB2E55003DC1BA /* RowAdapter.swift in Sources */,
+				564CE4DA21B2DEEB00652B19 /* ValueObservation+CompactMap.swift in Sources */,
 				F3BA808B1CFB2E70003DC1BA /* QueryInterfaceQuery.swift in Sources */,
 				56CEB5031EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
 				56CEB55C1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
@@ -2482,6 +2498,7 @@
 				5698AC431DA2BED90056AF8C /* FTS3PatternTests.swift in Sources */,
 				5653EB6E20961FB200F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
 				F3BA80E11CFB300F003DC1BA /* DatabaseValueConversionTests.swift in Sources */,
+				564CE4E021B2E04500652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				5623931B1DECC02000A6B01F /* RowFetchTests.swift in Sources */,
 				564F9C211F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				F3BA80ED1CFB3017003DC1BA /* RowFromDictionaryTests.swift in Sources */,
@@ -2507,6 +2524,7 @@
 				56741EAB1E66A8B3003E422D /* FetchRequestTests.swift in Sources */,
 				56B964D61DA521450002DA19 /* FTS5TableBuilderTests.swift in Sources */,
 				5674A71D1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */,
+				564CE4E321B2E05400652B19 /* ValueObservationMapTests.swift in Sources */,
 				562393511DEDFEFB00A6B01F /* EnumeratedCursorTests.swift in Sources */,
 				F3BA812D1CFB3064003DC1BA /* RecordMinimalPrimaryKeySingleTests.swift in Sources */,
 				5698AC831DA380A20056AF8C /* VirtualTableModuleTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -6549,7 +6549,7 @@ The transformation closure does not run on the main queue, and is suitable for h
 
 #### ValueObservation.compactMap
 
-The `compactMap` method lets you transform the and filter values notified by a ValueObservation. Only non-nil transformed values are notified.
+The `compactMap` method lets you transform and filter the values notified by a ValueObservation. Only non-nil transformed values are notified.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -6306,6 +6306,7 @@ The observer returned by the `start` method is stored in a property of the view 
     - [ValueObservation.map](#valueobservationmap)
     - [ValueObservation.compactMap](#valueobservationcompactmap)
     - [ValueObservation.combine(...)](#valueobservationcombine)
+- [ValueObservation Error Handling](#valueobservation-error-handling)
 - [ValueObservation Options](#valueobservation-options)
 - [Advanced: ValueObservation.tracking(_:reducer:)](#advanced-valueobservationtracking_reducer)
 
@@ -6592,6 +6593,22 @@ Combining observations provides the guarantee that notified values are [**consis
 > :point_up: **Note**: readers who are familiar with Reactive Programming will recognize the [CombineLatest](http://reactivex.io/documentation/operators/combinelatest.html) operator in the `ValueObservation.combine` method. The reactive operator does not care about data consistency, though: if you use a Reactive layer such as [RxGRDB], compose observations with `ValueObservation.combine`, not with the CombineLatest operator.
 
 
+### ValueObservation Error Handling
+
+When you start an observation, you can provide an `onError` callback. This callback is called whenever an error happens when a fresh value is fetched after a database change. It is scheduled just like values (see [ValueObservation.scheduling](#valueobservationscheduling)):
+
+```swift
+let observer = try observation.start(
+    in: dbQueue,
+    onError: { error in
+        print("fresh value could not be fetched")
+    },
+    onChange: { value in
+        print("fresh value: \(value)")
+    })
+```
+
+
 ### ValueObservation Options
 
 Some behaviors of value observations can be configured:
@@ -6599,7 +6616,6 @@ Some behaviors of value observations can be configured:
 - [ValueObservation.extent](#valueobservationextent): Precise control of the observation duration.
 - [ValueObservation.scheduling](#valueobservationscheduling): Control the dispatching of notified values.
 - [ValueObservation.requiresWriteAccess](#valueobservationrequireswriteaccess): Allow observations to write in the database.
-- [ValueObservation Error Handling](#valueobservation-error-handling)
 
 
 #### ValueObservation.extent
@@ -6711,22 +6727,6 @@ observation.requiresWriteAccess = true
 ```
 
 When you use a [database pool](#database-pools), don't use this flag unless you really need it. Observations with write access are less efficient because they block all writes for the whole duration of a fetch.
-
-
-#### ValueObservation Error Handling
-
-When you start an observation, you can provide an `onError` callback. This callback is called whenever an error happens when a fresh value is fetched after a database change. It is scheduled just like values (see [ValueObservation.scheduling](#valueobservationscheduling)):
-
-```swift
-let observer = try observation.start(
-    in: dbQueue,
-    onError: { error in
-        print("fresh value could not be fetched")
-    },
-    onChange: { value in
-        print("fresh value: \(value)")
-    })
-```
 
 
 ### Advanced: ValueObservation.tracking(_:reducer:)

--- a/README.md
+++ b/README.md
@@ -6303,8 +6303,8 @@ The observer returned by the `start` method is stored in a property of the view 
 - [ValueObservation.trackingCount, trackingOne, trackingAll](#valueobservationtrackingcount-trackingone-trackingall)
 - [ValueObservation.tracking(_:fetch:)](#valueobservationtracking_fetch)
 - [ValueObservation Transformations](#valueobservation-transformations)
-    - [ValueObservation.map](#valueobservationmap): Transform notified values.
-    - [ValueObservation.compactMap](#valueobservationcompactmap): Transform and filter notified values.
+    - [ValueObservation.map](#valueobservationmap)
+    - [ValueObservation.compactMap](#valueobservationcompactmap)
     - [ValueObservation.combine(...)](#valueobservationcombine)
 - [ValueObservation Options](#valueobservation-options)
 - [Advanced: ValueObservation.tracking(_:reducer:)](#advanced-valueobservationtracking_reducer)
@@ -6516,8 +6516,8 @@ let observer = ValueObservation
 
 ### ValueObservation Transformations
 
-- [ValueObservation.map](#valueobservationmap): Transform notified values.
-- [ValueObservation.compactMap](#valueobservationcompactmap): Transform and filter notified values.
+- [ValueObservation.map](#valueobservationmap)
+- [ValueObservation.compactMap](#valueobservationcompactmap)
 - [ValueObservation.combine(...)](#valueobservationcombine)
 
 

--- a/README.md
+++ b/README.md
@@ -6260,6 +6260,21 @@ protocol TransactionObserverType : class {
 
 Changes are only notified after they have been committed in the database. No insertion, update, or deletion in tracked tables is missed. This includes indirect changes triggered by [foreign keys](https://www.sqlite.org/foreignkeys.html#fk_actions) or [SQL triggers](https://www.sqlite.org/lang_createtrigger.html).
 
+
+- **[ValueObservation Usage](#valueobservation-usage)**
+- [ValueObservation.trackingCount, trackingOne, trackingAll](#valueobservationtrackingcount-trackingone-trackingall)
+- [ValueObservation.tracking(_:fetch:)](#valueobservationtracking_fetch)
+- [ValueObservation Transformations](#valueobservation-transformations)
+    - [ValueObservation.map](#valueobservationmap)
+    - [ValueObservation.compactMap](#valueobservationcompactmap)
+    - [ValueObservation.combine(...)](#valueobservationcombine)
+- [ValueObservation Error Handling](#valueobservation-error-handling)
+- [ValueObservation Options](#valueobservation-options)
+- [Advanced: ValueObservation.tracking(_:reducer:)](#advanced-valueobservationtracking_reducer)
+
+
+### ValueObservation Usage
+
 Here is a typical UIViewController which observes the database in order to keep its view up-to-date:
 
 ```swift
@@ -6299,16 +6314,6 @@ An initial fetch is performed as soon as the observation starts: the view is set
 The observer returned by the `start` method is stored in a property of the view controller. This allows the view controller to control the duration of the observation. When the observer is deallocated, the observation stops. Meanwhile, all transactions that modify the observed player are notified, and the `nameLabel` is kept up-to-date.
 
 > :bulb: **Tip**: see the [Demo Application](DemoApps/GRDBDemoiOS/README.md) for a sample app that uses ValueObservation.
-
-- [ValueObservation.trackingCount, trackingOne, trackingAll](#valueobservationtrackingcount-trackingone-trackingall)
-- [ValueObservation.tracking(_:fetch:)](#valueobservationtracking_fetch)
-- [ValueObservation Transformations](#valueobservation-transformations)
-    - [ValueObservation.map](#valueobservationmap)
-    - [ValueObservation.compactMap](#valueobservationcompactmap)
-    - [ValueObservation.combine(...)](#valueobservationcombine)
-- [ValueObservation Error Handling](#valueobservation-error-handling)
-- [ValueObservation Options](#valueobservation-options)
-- [Advanced: ValueObservation.tracking(_:reducer:)](#advanced-valueobservationtracking_reducer)
 
 
 ### ValueObservation.trackingCount, trackingOne, trackingAll

--- a/Tests/GRDBTests/ValueObservationCompactMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationCompactMapTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+#if GRDBCIPHER
+    import GRDBCipher
+#elseif GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    #if SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
+    import GRDB
+#endif
+
+class ValueObservationCompactMapTests: GRDBTestCase {
+    func testCompactMap() throws {
+        func test(_ dbWriter: DatabaseWriter) throws {
+            // We need something to change
+            try dbWriter.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
+            
+            var counts: [String] = []
+            let notificationExpectation = expectation(description: "notification")
+            notificationExpectation.assertForOverFulfill = true
+            notificationExpectation.expectedFulfillmentCount = 2
+            
+            // The base reducer
+            var count = 0
+            let reducer = AnyValueReducer(
+                fetch: { _ in /* don't fetch anything */ },
+                value: { _ -> Int? in
+                    count += 1
+                    return count
+            })
+            
+            // Create an observation
+            var observation = ValueObservation
+                .tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+                .compactMap { count -> String? in
+                    if count % 2 == 0 { return nil }
+                    return "\(count)"
+            }
+            observation.extent = .databaseLifetime
+            
+            // Start observation
+            _ = try observation.start(in: dbWriter) { count in
+                counts.append(count)
+                notificationExpectation.fulfill()
+            }
+            
+            try dbWriter.writeWithoutTransaction { db in
+                try db.execute("INSERT INTO t DEFAULT VALUES")
+                try db.execute("INSERT INTO t DEFAULT VALUES")
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(counts, ["1", "3"])
+        }
+        
+        try test(makeDatabaseQueue())
+        try test(makeDatabasePool())
+    }
+}

--- a/Tests/GRDBTests/ValueObservationCompactMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationCompactMapTests.swift
@@ -59,4 +59,21 @@ class ValueObservationCompactMapTests: GRDBTestCase {
         try test(makeDatabaseQueue())
         try test(makeDatabasePool())
     }
+    
+    func testCompactMapPreservesConfiguration() {
+        var observation = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
+        observation.extent = .nextTransaction
+        observation.requiresWriteAccess = true
+        observation.scheduling = .unsafe(startImmediately: true)
+        
+        let mappedObservation = observation.compactMap { _ in }
+        XCTAssertEqual(mappedObservation.extent, observation.extent)
+        XCTAssertEqual(mappedObservation.requiresWriteAccess, observation.requiresWriteAccess)
+        switch mappedObservation.scheduling {
+        case .unsafe:
+            break
+        default:
+            XCTFail()
+        }
+    }
 }

--- a/Tests/GRDBTests/ValueObservationExtentTests.swift
+++ b/Tests/GRDBTests/ValueObservationExtentTests.swift
@@ -23,7 +23,7 @@ class ValueObservationExtentTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
         
-        // Track reducer proceess
+        // Track reducer process
         let notificationExpectation = expectation(description: "notification")
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 3
@@ -60,7 +60,7 @@ class ValueObservationExtentTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
         
-        // Track reducer proceess
+        // Track reducer process
         var changesCount = 0
         let notificationExpectation = expectation(description: "notification")
         notificationExpectation.assertForOverFulfill = true
@@ -107,7 +107,7 @@ class ValueObservationExtentTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
         
-        // Track reducer proceess
+        // Track reducer process
         let notificationExpectation = expectation(description: "notification")
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 2

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+#if GRDBCIPHER
+    import GRDBCipher
+#elseif GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    #if SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
+    import GRDB
+#endif
+
+class ValueObservationMapTests: GRDBTestCase {
+    func testMap() throws {
+        func test(_ dbWriter: DatabaseWriter) throws {
+            // We need something to change
+            try dbWriter.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
+            
+            var counts: [String] = []
+            let notificationExpectation = expectation(description: "notification")
+            notificationExpectation.assertForOverFulfill = true
+            notificationExpectation.expectedFulfillmentCount = 3
+            
+            // The base reducer
+            var count = 0
+            let reducer = AnyValueReducer(
+                fetch: { _ in /* don't fetch anything */ },
+                value: { _ -> Int? in
+                    count += 1
+                    return count
+            })
+            
+            // Create an observation
+            var observation = ValueObservation
+                .tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+                .map { count -> String in return "\(count)" }
+            observation.extent = .databaseLifetime
+            
+            // Start observation
+            _ = try observation.start(in: dbWriter) { count in
+                counts.append(count)
+                notificationExpectation.fulfill()
+            }
+            
+            try dbWriter.writeWithoutTransaction { db in
+                try db.execute("INSERT INTO t DEFAULT VALUES")
+                try db.execute("INSERT INTO t DEFAULT VALUES")
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(counts, ["1", "2", "3"])
+        }
+        
+        try test(makeDatabaseQueue())
+        try test(makeDatabasePool())
+    }
+}

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -56,4 +56,21 @@ class ValueObservationMapTests: GRDBTestCase {
         try test(makeDatabaseQueue())
         try test(makeDatabasePool())
     }
+    
+    func testMapPreservesConfiguration() {
+        var observation = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
+        observation.extent = .nextTransaction
+        observation.requiresWriteAccess = true
+        observation.scheduling = .unsafe(startImmediately: true)
+        
+        let mappedObservation = observation.map { _ in }
+        XCTAssertEqual(mappedObservation.extent, observation.extent)
+        XCTAssertEqual(mappedObservation.requiresWriteAccess, observation.requiresWriteAccess)
+        switch mappedObservation.scheduling {
+        case .unsafe:
+            break
+        default:
+            XCTFail()
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces `ValueObservation.compactMap`, which notifies the non-nil results of a transformation applied to the notified elements of a base ValueObservation:

```swift
extension ValueObservation where Reducer: ValueReducer {
    func compactMap<T>(_ transform: @escaping (Reducer.Value) -> T?)
        -> ValueObservation<CompactMapValueReducer<Reducer, T>>
}
```
