### PR TITLE
DatabaseRegionObservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 - [#451](https://github.com/groue/GRDB.swift/pull/451): ValueObservation.compactMap
 - [#452](https://github.com/groue/GRDB.swift/pull/452): ValueObservation.mapReducer
 - [#454](https://github.com/groue/GRDB.swift/pull/454): ValueObservation.distinctUntilChanged
+- [#455](https://github.com/groue/GRDB.swift/pull/455): DatabaseRegionObservation
 - [#445](https://github.com/groue/GRDB.swift/pull/445): Quality of service and target dispatch queue
 - ValueObservation methods which used to accept a variadic list of observed regions now also accept an array.
 - ValueReducer, the protocol that fuels ValueObservation, is flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). It will remain so until more experience has been acquired.
@@ -66,6 +67,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 
 - [Record Comparison](README.md#record-comparison): this chapter has been updated for the new `updateChanges(_:with:)` method.
 - [ValueObservation](README.md#valueobservation): this chapter has been updated for the new `ValueObservation.combine`, `ValueObservation.compactMap`, and `Value.distinctUntilChanged` methods.
+- [DatabaseRegionObservation](README.md#databaseregionobservation): this chapter describes the new `DatabaseRegionObservation` type.
 
 
 ### API diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,13 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 +    var qos: DispatchQoS
 +    var targetQueue: DispatchQueue?
  }
+ 
++struct DatabaseRegionObservation {
++    var extent: Database.TransactionObservationExtent
++    init(tracking regions: DatabaseRegionConvertible...)
++    init(tracking regions: [DatabaseRegionConvertible])
++    func start(in dbWriter: DatabaseWriter, onChange: @escaping (Database) -> Void) throws -> TransactionObserver
++}
 ```
 
 

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -217,6 +217,9 @@
 		564CE59D21B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE59621B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
 		564CE59E21B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE59621B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
 		564CE59F21B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE59621B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
+		564CE5AC21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5AD21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5AE21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */; };
 		564E73DF203D50B9000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73DE203D50B9000C443C /* JoinSupportTests.swift */; };
 		564E73E0203D50B9000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73DE203D50B9000C443C /* JoinSupportTests.swift */; };
 		564F9C1E1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */; };
@@ -982,6 +985,7 @@
 		564CE4E821B2E06F00652B19 /* ValueObservationMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationMapTests.swift; sourceTree = "<group>"; };
 		564CE51F21B3129900652B19 /* ValueObservation+MapReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+MapReducer.swift"; sourceTree = "<group>"; };
 		564CE59621B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+DistinctUntilChanged.swift"; sourceTree = "<group>"; };
+		564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservation.swift; sourceTree = "<group>"; };
 		564E73DE203D50B9000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1821,6 +1825,7 @@
 				56A238741B9C75030082EB20 /* DatabaseQueue.swift */,
 				563363BF1C942C04000BE133 /* DatabaseReader.swift */,
 				569EF0E1200D2D8400A9FA45 /* DatabaseRegion.swift */,
+				564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */,
 				5695311E1C907A8C00CF1A2B /* DatabaseSchemaCache.swift */,
 				566A84192041146100E50BFD /* DatabaseSnapshot.swift */,
 				56A238751B9C75030082EB20 /* DatabaseValue.swift */,
@@ -2477,6 +2482,7 @@
 				56D51D061EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				565490CE1D5AE252005622CB /* NSNull.swift in Sources */,
 				565490E41D5AE252005622CB /* TableRecord.swift in Sources */,
+				564CE5AE21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
 				565490CF1D5AE252005622CB /* NSNumber.swift in Sources */,
 				566475C01D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				56CEB51F1EAA328900BFAF62 /* FTS5+QueryInterface.swift in Sources */,
@@ -2714,6 +2720,7 @@
 				C96C0F2C2084A459006B2981 /* SQLiteDateParser.swift in Sources */,
 				5605F1681C672E4000235C62 /* NSNumber.swift in Sources */,
 				5613ED5521A95DD000DC7A68 /* ValueObservation+Count.swift in Sources */,
+				564CE5AD21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
 				56CEB5041EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
 				5656BF5020C723E300F98521 /* QueryOrdering.swift in Sources */,
 				5605F1741C672E4000235C62 /* StandardLibrary.swift in Sources */,
@@ -3142,6 +3149,7 @@
 				5698AC371D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
 				563EF415215F87EB007DAACD /* OrderedDictionary.swift in Sources */,
 				564F9C2D1F075DD200877A00 /* DatabaseFunction.swift in Sources */,
+				564CE5AC21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
 				5659F4981EA8D989004A4992 /* Pool.swift in Sources */,
 				5674A6F41F307F600095F066 /* PersistableRecord+Encodable.swift in Sources */,
 				56CEB54C1EAA359A00BFAF62 /* SQLExpressible.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -220,6 +220,8 @@
 		564CE5AC21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */; };
 		564CE5AD21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */; };
 		564CE5AE21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5BE21B8FFA300652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5BD21B8FFA300652B19 /* DatabaseRegionObservationTests.swift */; };
+		564CE5BF21B8FFA300652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5BD21B8FFA300652B19 /* DatabaseRegionObservationTests.swift */; };
 		564E73DF203D50B9000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73DE203D50B9000C443C /* JoinSupportTests.swift */; };
 		564E73E0203D50B9000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73DE203D50B9000C443C /* JoinSupportTests.swift */; };
 		564F9C1E1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */; };
@@ -986,6 +988,7 @@
 		564CE51F21B3129900652B19 /* ValueObservation+MapReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+MapReducer.swift"; sourceTree = "<group>"; };
 		564CE59621B7A8B500652B19 /* ValueObservation+DistinctUntilChanged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+DistinctUntilChanged.swift"; sourceTree = "<group>"; };
 		564CE5AB21B8FAB400652B19 /* DatabaseRegionObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservation.swift; sourceTree = "<group>"; };
+		564CE5BD21B8FFA300652B19 /* DatabaseRegionObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservationTests.swift; sourceTree = "<group>"; };
 		564E73DE203D50B9000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1728,6 +1731,7 @@
 				560A37A91C90084600949E71 /* DatabasePool */,
 				563363BB1C93FD32000BE133 /* DatabaseQueue */,
 				56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */,
+				564CE5BD21B8FFA300652B19 /* DatabaseRegionObservationTests.swift */,
 				56C3F7521CF9F12400F6A361 /* DatabaseSavepointTests.swift */,
 				566A8424204120B700E50BFD /* DatabaseSnapshotTests.swift */,
 				56A238131B9C74A90082EB20 /* DatabaseTests.swift */,
@@ -2879,6 +2883,7 @@
 				56A238401B9C74A90082EB20 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				564F9C221F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				56A8C2481D1918F00096E9D4 /* FoundationUUIDTests.swift in Sources */,
+				564CE5BF21B8FFA300652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				5653EAEF20944B4F00F46237 /* AssociationParallelDecodableRecordTests.swift in Sources */,
 				564CE4E721B2E06800652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56A2383C1B9C74A90082EB20 /* DatabaseErrorTests.swift in Sources */,
@@ -3058,6 +3063,7 @@
 				56D496741D81309E008276D7 /* RecordCopyTests.swift in Sources */,
 				56D496791D81309E008276D7 /* RecordWithColumnNameManglingTests.swift in Sources */,
 				56D4966C1D81309E008276D7 /* RecordMinimalPrimaryKeyRowIDTests.swift in Sources */,
+				564CE5BE21B8FFA300652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				564F9C1E1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				564CE4E621B2E06700652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				5653EAEE20944B4F00F46237 /* AssociationParallelDecodableRecordTests.swift in Sources */,

--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -18,15 +18,15 @@
 ///
 /// - `SelectStatement.databaseRegion`:
 ///
-///     let statement = db.makeSelectStatement("SELECT name, score FROM player")
-///     print(statement.databaseRegion)
-///     // prints "player(name,score)"
+///         let statement = db.makeSelectStatement("SELECT name, score FROM player")
+///         print(statement.databaseRegion)
+///         // prints "player(name,score)"
 ///
 /// - `FetchRequest.databaseRegion(_:)`
 ///
-///     let request = Player.filter(key: 1)
-///     try print(request.databaseRegion(db))
-///     // prints "player(*)[1]"
+///         let request = Player.filter(key: 1)
+///         try print(request.databaseRegion(db))
+///         // prints "player(*)[1]"
 ///
 /// Database regions returned by requests can be more precise than regions
 /// returned by select statements. Especially, regions returned by statements

--- a/GRDB/Core/DatabaseRegionObservation.swift
+++ b/GRDB/Core/DatabaseRegionObservation.swift
@@ -1,0 +1,69 @@
+public final class DatabaseRegionObservation {
+    /// A closure that is evaluated when the observation starts, and returns
+    /// the observed database region.
+    var observedRegion: (Database) throws -> DatabaseRegion
+
+    public init(tracking region: @escaping (Database) throws -> DatabaseRegion) {
+        self.observedRegion = { db in
+            // Remove views from the observed region.
+            //
+            // We can do it because we are only interested in modifications in
+            // actual tables. And we want to do it because we have a fast path
+            // for simple regions that span a single table.
+            let views = try db.schema().names(ofType: .view)
+            return try region(db).ignoring(views)
+        }
+    }
+    
+    public convenience init(tracking regions: DatabaseRegionConvertible...) {
+        self.init(tracking: regions)
+    }
+    
+    public convenience init(tracking regions: [DatabaseRegionConvertible]) {
+        self.init(tracking: DatabaseRegion.union(regions))
+    }
+}
+
+extension DatabaseWriter {
+    public func add(observation: DatabaseRegionObservation, onChange: @escaping (Database) -> Void) throws -> TransactionObserver {
+        return try writeWithoutTransaction { db -> TransactionObserver in
+            let region = try observation.observedRegion(db)
+            let observer = DatabaseRegionObserver(region: region, onChange: onChange)
+            add(transactionObserver: observer)
+            return observer
+        }
+    }
+}
+
+private class DatabaseRegionObserver: TransactionObserver {
+    let region: DatabaseRegion
+    let onChange: (Database) -> Void
+    var isChanged = false
+    
+    init(region: DatabaseRegion, onChange: @escaping (Database) -> Void) {
+        self.region = region
+        self.onChange = onChange
+    }
+    
+    func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool {
+        return region.isModified(byEventsOfKind: eventKind)
+    }
+    
+    func databaseDidChange(with event: DatabaseEvent) {
+        if region.isModified(by: event) {
+            isChanged = true
+            stopObservingDatabaseChangesUntilNextTransaction()
+        }
+    }
+    
+    func databaseDidCommit(_ db: Database) {
+        guard isChanged else { return }
+        isChanged = false
+
+        onChange(db)
+    }
+    
+    func databaseDidRollback(_ db: Database) {
+        isChanged = false
+    }
+}

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -124,7 +124,7 @@ public struct DatabaseValuesReducer<Request: FetchRequest>: ValueReducer
     public mutating func value(_ dbValues: [DatabaseValue]) -> [Request.RowDecoder]? {
         if let previousDbValues = previousDbValues, previousDbValues == dbValues {
             // Don't notify consecutive identical dbValue arrays
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         }
         self.previousDbValues = dbValues
@@ -158,7 +158,7 @@ public struct DatabaseValueReducer<Request: FetchRequest>: ValueReducer
     public mutating func value(_ dbValue: DatabaseValue?) -> Request.RowDecoder?? {
         if let previousDbValue = previousDbValue, previousDbValue == dbValue {
             // Don't notify consecutive identical dbValue
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         }
         self.previousDbValue = dbValue
@@ -169,7 +169,7 @@ public struct DatabaseValueReducer<Request: FetchRequest>: ValueReducer
             return .some(value)
         } else if previousValueWasNil {
             // Don't notify consecutive nil values
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         } else {
             previousValueWasNil = true
@@ -203,7 +203,7 @@ public struct OptionalDatabaseValuesReducer<Request: FetchRequest>: ValueReducer
     public mutating func value(_ dbValues: [DatabaseValue]) -> [Request.RowDecoder._Wrapped?]? {
         if let previousDbValues = previousDbValues, previousDbValues == dbValues {
             // Don't notify consecutive identical dbValue arrays
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         }
         self.previousDbValues = dbValues

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -91,7 +91,7 @@ public struct FetchableRecordsReducer<Request: FetchRequest>: ValueReducer
     public mutating func value(_ rows: [Row]) -> [Request.RowDecoder]? {
         if let previousRows = previousRows, previousRows == rows {
             // Don't notify consecutive identical row arrays
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         }
         self.previousRows = rows
@@ -122,7 +122,7 @@ public struct FetchableRecordReducer<Request: FetchRequest>: ValueReducer
     public mutating func value(_ row: Row?) -> Request.RowDecoder?? {
         if let previousRow = previousRow, previousRow == row {
             // Don't notify consecutive identical rows
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         }
         self.previousRow = row

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -120,7 +120,7 @@ public struct RowReducer<Request: FetchRequest>: ValueReducer
     public mutating func value(_ row: Row?) -> Row?? {
         if let previousRow = previousRow, previousRow == row {
             // Don't notify consecutive identical rows
-            // TODO: Remove this implicit `distinctUntilChanged` in GRDB 4
+            // TODO: Remove this implicit `distinctUntilDatabaseChanged` in GRDB 4
             return nil
         }
         self.previousRow = row

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -164,7 +164,8 @@ public struct ValueObservation<Reducer> {
         }
     }
     
-    // Not public. See ValueObservation.tracking(_:reducer:)
+    // Not public because we foster DatabaseRegionConvertible.
+    // See ValueObservation.tracking(_:reducer:)
     init(
         tracking region: @escaping (Database) throws -> DatabaseRegion,
         reducer: @escaping (Database) throws -> Reducer)

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -278,6 +278,10 @@
 		564CE5A721B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5A421B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
 		564CE5BB21B8FBFD00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */; };
 		564CE5BC21B8FBFD00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5C121B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5C021B8FFD800652B19 /* DatabaseRegionObservationTests.swift */; };
+		564CE5C221B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5C021B8FFD800652B19 /* DatabaseRegionObservationTests.swift */; };
+		564CE5C321B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5C021B8FFD800652B19 /* DatabaseRegionObservationTests.swift */; };
+		564CE5C421B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5C021B8FFD800652B19 /* DatabaseRegionObservationTests.swift */; };
 		564E73EF203DA2A2000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
 		564E73F0203DA2A3000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
 		564E73F1203DA2A3000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
@@ -1096,6 +1100,7 @@
 		564CE51A21B3128400652B19 /* ValueObservation+MapReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+MapReducer.swift"; sourceTree = "<group>"; };
 		564CE5A421B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+DistinctUntilChanged.swift"; sourceTree = "<group>"; };
 		564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservation.swift; sourceTree = "<group>"; };
+		564CE5C021B8FFD800652B19 /* DatabaseRegionObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservationTests.swift; sourceTree = "<group>"; };
 		564E73EB203DA29B000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1793,6 +1798,7 @@
 				560A37A91C90084600949E71 /* DatabasePool */,
 				563363BB1C93FD32000BE133 /* DatabaseQueue */,
 				56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */,
+				564CE5C021B8FFD800652B19 /* DatabaseRegionObservationTests.swift */,
 				56C3F7521CF9F12400F6A361 /* DatabaseSavepointTests.swift */,
 				566A842F20413DCF00E50BFD /* DatabaseSnapshotTests.swift */,
 				56A238131B9C74A90082EB20 /* DatabaseTests.swift */,
@@ -2569,6 +2575,7 @@
 				565EFAEF1D0436CE00A8FA9D /* NumericOverflowTests.swift in Sources */,
 				560FC5961CB00B880014AA8E /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				5653EBC420961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE5C121B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				560FC5971CB00B880014AA8E /* DatabaseErrorTests.swift in Sources */,
 				564CE4EC21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				560FC5991CB00B880014AA8E /* RecordMinimalPrimaryKeySingleTests.swift in Sources */,
@@ -2748,6 +2755,7 @@
 				561667031D08A49900ADD404 /* FoundationNSDecimalNumberTests.swift in Sources */,
 				565EFAF01D0436CE00A8FA9D /* NumericOverflowTests.swift in Sources */,
 				5653EBC520961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE5C221B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				567156551CB16729007DC145 /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				564CE4ED21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				567156561CB16729007DC145 /* DatabaseErrorTests.swift in Sources */,
@@ -3055,6 +3063,7 @@
 				56AFCA631CB1AA9900F48B96 /* RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
 				5698AC8E1DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,
 				5653EBC620961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE5C321B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				56AFCA641CB1AA9900F48B96 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				564CE4EE21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56A8C24A1D1918F10096E9D4 /* FoundationUUIDTests.swift in Sources */,
@@ -3234,6 +3243,7 @@
 				56AFCAB81CB1ABC800F48B96 /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				5698AC8F1DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,
 				5653EBC720961FE800F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE5C421B8FFD800652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				56AFCAB91CB1ABC800F48B96 /* RecordPrimaryKeyRowIDTests.swift in Sources */,
 				564CE4EF21B2E08300652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56AFCABA1CB1ABC800F48B96 /* RecordEditedTests.swift in Sources */,

--- a/GRDBCipher.xcodeproj/project.pbxproj
+++ b/GRDBCipher.xcodeproj/project.pbxproj
@@ -276,6 +276,8 @@
 		564CE52721B312B700652B19 /* ValueObservation+MapReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE51A21B3128400652B19 /* ValueObservation+MapReducer.swift */; };
 		564CE5A621B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5A421B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
 		564CE5A721B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5A421B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
+		564CE5BB21B8FBFD00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5BC21B8FBFD00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */; };
 		564E73EF203DA2A2000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
 		564E73F0203DA2A3000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
 		564E73F1203DA2A3000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73EB203DA29B000C443C /* JoinSupportTests.swift */; };
@@ -1093,6 +1095,7 @@
 		564CE4F021B2E08A00652B19 /* ValueObservationMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationMapTests.swift; sourceTree = "<group>"; };
 		564CE51A21B3128400652B19 /* ValueObservation+MapReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+MapReducer.swift"; sourceTree = "<group>"; };
 		564CE5A421B7A9D600652B19 /* ValueObservation+DistinctUntilChanged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+DistinctUntilChanged.swift"; sourceTree = "<group>"; };
+		564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservation.swift; sourceTree = "<group>"; };
 		564E73EB203DA29B000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1887,6 +1890,7 @@
 				56A238741B9C75030082EB20 /* DatabaseQueue.swift */,
 				563363BF1C942C04000BE133 /* DatabaseReader.swift */,
 				569EF0E8200D387000A9FA45 /* DatabaseRegion.swift */,
+				564CE5B921B8FBFD00652B19 /* DatabaseRegionObservation.swift */,
 				5695311E1C907A8C00CF1A2B /* DatabaseSchemaCache.swift */,
 				566A842720413D6E00E50BFD /* DatabaseSnapshot.swift */,
 				56A238751B9C75030082EB20 /* DatabaseValue.swift */,
@@ -2409,6 +2413,7 @@
 				566AD8B31D5318F4002EC1A8 /* TableDefinition.swift in Sources */,
 				5613ED7F21A95E8400DC7A68 /* ValueObservation+Map.swift in Sources */,
 				5698AD221DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift in Sources */,
+				564CE5BB21B8FBFD00652B19 /* DatabaseRegionObservation.swift in Sources */,
 				560FC53C1CB003810014AA8E /* DatabaseQueue.swift in Sources */,
 				5653EB9720961FC000F46237 /* ForeignKey.swift in Sources */,
 				569A98FC2039B72D008D7DBF /* Fixits-3.0.swift in Sources */,
@@ -2894,6 +2899,7 @@
 				566AD8B61D5318F4002EC1A8 /* TableDefinition.swift in Sources */,
 				5613ED8021A95E8400DC7A68 /* ValueObservation+Map.swift in Sources */,
 				5698AD251DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift in Sources */,
+				564CE5BC21B8FBFD00652B19 /* DatabaseRegionObservation.swift in Sources */,
 				56AFCA121CB1A8BB00F48B96 /* NSNumber.swift in Sources */,
 				5653EB9820961FC000F46237 /* ForeignKey.swift in Sources */,
 				569A98FD2039B72D008D7DBF /* Fixits-3.0.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -109,6 +109,8 @@
 		564CE5A321B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5A021B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
 		564CE5B721B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */; };
 		564CE5B821B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5C621B8FFE600652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5C521B8FFE500652B19 /* DatabaseRegionObservationTests.swift */; };
+		564CE5C721B8FFE600652B19 /* DatabaseRegionObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5C521B8FFE500652B19 /* DatabaseRegionObservationTests.swift */; };
 		564E73F3203DA2AC000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73E7203DA278000C443C /* JoinSupportTests.swift */; };
 		564E73F4203DA2AD000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73E7203DA278000C443C /* JoinSupportTests.swift */; };
 		564F9C211F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */; };
@@ -733,6 +735,7 @@
 		564CE52321B312AC00652B19 /* ValueObservation+MapReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+MapReducer.swift"; sourceTree = "<group>"; };
 		564CE5A021B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+DistinctUntilChanged.swift"; sourceTree = "<group>"; };
 		564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservation.swift; sourceTree = "<group>"; };
+		564CE5C521B8FFE500652B19 /* DatabaseRegionObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservationTests.swift; sourceTree = "<group>"; };
 		564E73E7203DA278000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1403,6 +1406,7 @@
 				560A37A91C90084600949E71 /* DatabasePool */,
 				563363BB1C93FD32000BE133 /* DatabaseQueue */,
 				56EA86931C91DFE7002BB4DF /* DatabaseReaderTests.swift */,
+				564CE5C521B8FFE500652B19 /* DatabaseRegionObservationTests.swift */,
 				56C3F7521CF9F12400F6A361 /* DatabaseSavepointTests.swift */,
 				566A843420413DE400E50BFD /* DatabaseSnapshotTests.swift */,
 				56A238131B9C74A90082EB20 /* DatabaseTests.swift */,
@@ -2208,6 +2212,7 @@
 				F3BA812B1CFB3063003DC1BA /* RecordWithColumnNameManglingTests.swift in Sources */,
 				5698ACA51DA4B0430056AF8C /* FTS4TableBuilderTests.swift in Sources */,
 				5653EB6F20961FB200F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE5C721B8FFE600652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				F3BA80B11CFB2FC4003DC1BA /* DatabaseTests.swift in Sources */,
 				564CE4E121B2E04500652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				56A8C24E1D1918F30096E9D4 /* FoundationUUIDTests.swift in Sources */,
@@ -2515,6 +2520,7 @@
 				F3BA81311CFB3064003DC1BA /* RecordPrimaryKeySingleTests.swift in Sources */,
 				5698AC431DA2BED90056AF8C /* FTS3PatternTests.swift in Sources */,
 				5653EB6E20961FB200F46237 /* AssociationBelongsToSQLDerivationTests.swift in Sources */,
+				564CE5C621B8FFE600652B19 /* DatabaseRegionObservationTests.swift in Sources */,
 				F3BA80E11CFB300F003DC1BA /* DatabaseValueConversionTests.swift in Sources */,
 				564CE4E021B2E04500652B19 /* ValueObservationCompactMapTests.swift in Sources */,
 				5623931B1DECC02000A6B01F /* RowFetchTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -107,6 +107,8 @@
 		564CE52521B312AD00652B19 /* ValueObservation+MapReducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE52321B312AC00652B19 /* ValueObservation+MapReducer.swift */; };
 		564CE5A221B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5A021B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
 		564CE5A321B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5A021B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift */; };
+		564CE5B721B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */; };
+		564CE5B821B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */; };
 		564E73F3203DA2AC000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73E7203DA278000C443C /* JoinSupportTests.swift */; };
 		564E73F4203DA2AD000C443C /* JoinSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E73E7203DA278000C443C /* JoinSupportTests.swift */; };
 		564F9C211F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */; };
@@ -730,6 +732,7 @@
 		564CE4E221B2E05400652B19 /* ValueObservationMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationMapTests.swift; sourceTree = "<group>"; };
 		564CE52321B312AC00652B19 /* ValueObservation+MapReducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+MapReducer.swift"; sourceTree = "<group>"; };
 		564CE5A021B7A9C700652B19 /* ValueObservation+DistinctUntilChanged.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ValueObservation+DistinctUntilChanged.swift"; sourceTree = "<group>"; };
+		564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegionObservation.swift; sourceTree = "<group>"; };
 		564E73E7203DA278000C443C /* JoinSupportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JoinSupportTests.swift; sourceTree = "<group>"; };
 		564F9C1D1F069B4E00877A00 /* DatabaseAggregateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAggregateTests.swift; sourceTree = "<group>"; };
 		564F9C2C1F075DD200877A00 /* DatabaseFunction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseFunction.swift; sourceTree = "<group>"; };
@@ -1497,6 +1500,7 @@
 				56A238741B9C75030082EB20 /* DatabaseQueue.swift */,
 				563363BF1C942C04000BE133 /* DatabaseReader.swift */,
 				569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */,
+				564CE5B521B8FBEA00652B19 /* DatabaseRegionObservation.swift */,
 				5695311E1C907A8C00CF1A2B /* DatabaseSchemaCache.swift */,
 				566A842B20413D9A00E50BFD /* DatabaseSnapshot.swift */,
 				56A238751B9C75030082EB20 /* DatabaseValue.swift */,
@@ -2048,6 +2052,7 @@
 				566AD8B71D5318F4002EC1A8 /* TableDefinition.swift in Sources */,
 				5613ED6621A95E6100DC7A68 /* ValueObservation+Map.swift in Sources */,
 				5698AD261DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift in Sources */,
+				564CE5B821B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */,
 				F3BA802C1CFB289B003DC1BA /* SQLCollatedExpression.swift in Sources */,
 				5653EB4A20961F6100F46237 /* ForeignKey.swift in Sources */,
 				569A98F92039B716008D7DBF /* Fixits-3.0.swift in Sources */,
@@ -2354,6 +2359,7 @@
 				566AD8B41D5318F4002EC1A8 /* TableDefinition.swift in Sources */,
 				5613ED6521A95E6100DC7A68 /* ValueObservation+Map.swift in Sources */,
 				5698AD231DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift in Sources */,
+				564CE5B721B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */,
 				F3BA80881CFB2E70003DC1BA /* SQLCollatedExpression.swift in Sources */,
 				5653EB4920961F6100F46237 /* ForeignKey.swift in Sources */,
 				569A98F82039B716008D7DBF /* Fixits-3.0.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -4571,7 +4571,7 @@ The `prepare` method returns a prepared statement and an optional row adapter. T
 
 The `fetchCount` method has a default implementation that builds a correct but naive SQL query from the statement returned by `prepare`: `SELECT COUNT(*) FROM (...)`. Adopting types can refine the counting SQL by customizing their `fetchCount` implementation.
 
-The base `DatabaseRegionConvertible` protocol is involved in [database observation](#database-changes-observation). For more information, see [DatabaseRegion](#databaseregion), [DatabaseRegionObservation], and [ValueObservation].
+The base `DatabaseRegionConvertible` protocol is involved in [database observation](#database-changes-observation). For more information, see [DatabaseRegion], [DatabaseRegionObservation], and [ValueObservation].
 
 The FetchRequest protocol is adopted, for example, by [query interface requests](#requests):
 
@@ -6955,7 +6955,7 @@ protocol TransactionObserver : class {
 - [Database Changes And Transactions](#database-changes-and-transactions)
 - [Filtering Database Events](#filtering-database-events)
 - [Observation Extent](#observation-extent)
-- [DatabaseRegion](#databaseregion)
+- [DatabaseRegion]
 - [Support for SQLite Pre-Update Hooks](#support-for-sqlite-pre-update-hooks)
 
 
@@ -7103,7 +7103,7 @@ class PureTransactionObserver: TransactionObserver {
 }
 ```
 
-For more information about event filtering, see [DatabaseRegion](#databaseregion).
+For more information about event filtering, see [DatabaseRegion].
 
 
 ### Observation Extent
@@ -8600,3 +8600,4 @@ This chapter has been renamed [Beyond FetchableRecord].
 [RxGRDB]: http://github.com/RxSwiftCommunity/RxGRDB
 [DatabaseRegionConvertible]: #the-databaseregionconvertible-protocol
 [ValueObservation and DatabaseRegionObservation]: #valueobservation-and-databaseregionobservation
+[DatabaseRegion]: #databaseregion

--- a/README.md
+++ b/README.md
@@ -5848,8 +5848,6 @@ GRDB puts this SQLite feature to some good use, and lets you observe the databas
 
 - [After Commit Hook](#after-commit-hook): Handle successful transactions one by one.
 - [ValueObservation and DatabaseRegionObservation](#valueobservation-and-databaseregionobservation): Automated tracking of database requests.
-    - [DatabaseRegionObservation]
-    - [ValueObservation]
 - [FetchedRecordsController]: Animate table views according to database changes.
 - [TransactionObserver Protocol](#transactionobserver-protocol): Low-level database observation.
 - [RxGRDB]: Automated tracking of database changes, with [RxSwift](https://github.com/ReactiveX/RxSwift).

--- a/README.md
+++ b/README.md
@@ -5925,7 +5925,7 @@ let valueObservation = ValueObservation.trackingAll(request)
 let regionObservation = DatabaseRegionObservation(tracking: request)
 ```
 
-[ValueObservation] notifies your application with **fresh values**. This is what most applications need:
+[ValueObservation] notifies your application with **fresh values** (this is what most applications need :+1:):
 
 ```swift
 let observer = valueObservation.start(in: dbQueue) { players: [Player] in
@@ -5939,7 +5939,7 @@ try dbQueue.write { db in
 
 ```
 
-[DatabaseRegionObservation] notifies your application with **database connections**, right after an impactful database transaction has been committed:
+[DatabaseRegionObservation] notifies your application with **database connections**, right after an impactful database transaction has been committed (reserved for advanced use cases :nerd_face:):
 
 ```swift
 let observer = regionObservation.start(in: dbQueue) { db: Database in
@@ -5951,8 +5951,6 @@ try dbQueue.write { db in
 }
 // Prints "Players have changed."
 ```
-
-Both observations are based on the low-level [TransactionObserver Protocol](#transactionobserver-protocol).
 
 
 ## DatabaseRegionObservation
@@ -6044,11 +6042,7 @@ Changes are only notified after they have been committed in the database. No ins
 - **[ValueObservation Usage](#valueobservation-usage)**
 - [ValueObservation.trackingCount, trackingOne, trackingAll](#valueobservationtrackingcount-trackingone-trackingall)
 - [ValueObservation.tracking(_:fetch:)](#valueobservationtracking_fetch)
-- [ValueObservation Transformations](#valueobservation-transformations)
-    - [ValueObservation.map](#valueobservationmap)
-    - [ValueObservation.compactMap](#valueobservationcompactmap)
-    - [ValueObservation.distinctUntilChanged](#valueobservationdistinctuntilchanged)
-    - [ValueObservation.combine(...)](#valueobservationcombine)
+- [ValueObservation Transformations](#valueobservation-transformations): ([map](#valueobservationmap), [compactMap](#valueobservationcompactmap), ...)
 - [ValueObservation Error Handling](#valueobservation-error-handling)
 - [ValueObservation Options](#valueobservation-options)
 - [Advanced: ValueObservation.tracking(_:reducer:)](#advanced-valueobservationtracking_reducer)

--- a/README.md
+++ b/README.md
@@ -6052,7 +6052,7 @@ Changes are only notified after they have been committed in the database. No ins
 - **[ValueObservation Usage](#valueobservation-usage)**
 - [ValueObservation.trackingCount, trackingOne, trackingAll](#valueobservationtrackingcount-trackingone-trackingall)
 - [ValueObservation.tracking(_:fetch:)](#valueobservationtracking_fetch)
-- [ValueObservation Transformations](#valueobservation-transformations): ([map](#valueobservationmap), [compactMap](#valueobservationcompactmap), ...)
+- [ValueObservation Transformations](#valueobservation-transformations): [map](#valueobservationmap), [compactMap](#valueobservationcompactmap), ...
 - [ValueObservation Error Handling](#valueobservation-error-handling)
 - [ValueObservation Options](#valueobservation-options)
 - [Advanced: ValueObservation.tracking(_:reducer:)](#advanced-valueobservationtracking_reducer)

--- a/Tests/GRDBTests/DatabaseRegionObservationTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionObservationTests.swift
@@ -13,47 +13,6 @@ import XCTest
 #endif
 
 class DatabaseRegionObservationTests: GRDBTestCase {
-    func testDatabaseRegionObservation() throws {
-        let dbQueue = try makeDatabaseQueue()
-        try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)") }
-        
-        var results: [[Row]] = []
-        let notificationExpectation = expectation(description: "notification")
-        notificationExpectation.assertForOverFulfill = true
-        notificationExpectation.expectedFulfillmentCount = 4
-        
-        let request = SQLRequest<Row>("SELECT * FROM t ORDER BY id")
-        let observation = DatabaseRegionObservation(tracking: { db in
-            try request.databaseRegion(db)
-        })
-        let observer = try observation.start(in: dbQueue) { db in
-            let rows = try! request.fetchAll(db)
-            results.append(rows)
-            notificationExpectation.fulfill()
-        }
-        try withExtendedLifetime(observer) {
-            try dbQueue.inDatabase { db in
-                try db.execute("INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
-                try db.execute("UPDATE t SET name = 'foo' WHERE id = 1")     // =
-                try db.inTransaction {                                       // +1
-                    try db.execute("INSERT INTO t (id, name) VALUES (2, 'bar')")
-                    try db.execute("INSERT INTO t (id, name) VALUES (3, 'baz')")
-                    try db.execute("DELETE FROM t WHERE id = 3")
-                    return .commit
-                }
-                try db.execute("DELETE FROM t WHERE id = 1")                 // -1
-            }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-        }
-        
-        XCTAssertEqual(results, [
-            [["id":1, "name":"foo"]],
-            [["id":1, "name":"foo"]],
-            [["id":1, "name":"foo"], ["id":2, "name":"bar"]],
-            [["id":2, "name":"bar"]]])
-    }
-    
     func testDatabaseRegionObservationVariadic() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {

--- a/Tests/GRDBTests/DatabaseRegionObservationTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionObservationTests.swift
@@ -185,6 +185,7 @@ class DatabaseRegionObservationTests: GRDBTestCase {
         try dbQueue.write { db in
             try db.execute("INSERT INTO t (id, name) VALUES (1, 'foo')")
         }
+        // not notified
         try dbQueue.write { db in
             try db.execute("INSERT INTO t (id, name) VALUES (2, 'bar')")
         }

--- a/Tests/GRDBTests/DatabaseRegionObservationTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionObservationTests.swift
@@ -1,0 +1,195 @@
+import XCTest
+#if GRDBCIPHER
+    import GRDBCipher
+#elseif GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    #if SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
+    import GRDB
+#endif
+
+class DatabaseRegionObservationTests: GRDBTestCase {
+    func testDatabaseRegionObservation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)") }
+        
+        var results: [[Row]] = []
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 4
+        
+        let request = SQLRequest<Row>("SELECT * FROM t ORDER BY id")
+        let observation = DatabaseRegionObservation(tracking: { db in
+            try request.databaseRegion(db)
+        })
+        let observer = try observation.start(in: dbQueue) { db in
+            let rows = try! request.fetchAll(db)
+            results.append(rows)
+            notificationExpectation.fulfill()
+        }
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute("INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
+                try db.execute("UPDATE t SET name = 'foo' WHERE id = 1")     // =
+                try db.inTransaction {                                       // +1
+                    try db.execute("INSERT INTO t (id, name) VALUES (2, 'bar')")
+                    try db.execute("INSERT INTO t (id, name) VALUES (3, 'baz')")
+                    try db.execute("DELETE FROM t WHERE id = 3")
+                    return .commit
+                }
+                try db.execute("DELETE FROM t WHERE id = 1")                 // -1
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+        }
+        
+        XCTAssertEqual(results, [
+            [["id":1, "name":"foo"]],
+            [["id":1, "name":"foo"]],
+            [["id":1, "name":"foo"], ["id":2, "name":"bar"]],
+            [["id":2, "name":"bar"]]])
+    }
+    
+    func testDatabaseRegionObservationVariadic() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute("CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+            try $0.execute("CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+        }
+
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 3
+        
+        let request1 = SQLRequest<Row>("SELECT * FROM t1 ORDER BY id")
+        let request2 = SQLRequest<Row>("SELECT * FROM t2 ORDER BY id")
+        
+        var observation = DatabaseRegionObservation(tracking: request1, request2)
+        observation.extent = .databaseLifetime
+
+        var count = 0
+        _ = try observation.start(in: dbQueue) { db in
+            count += 1
+            notificationExpectation.fulfill()
+        }
+        
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t1 (id, name) VALUES (1, 'foo')")
+        }
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t2 (id, name) VALUES (1, 'foo')")
+        }
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t1 (id, name) VALUES (2, 'foo')")
+            try db.execute("INSERT INTO t2 (id, name) VALUES (2, 'foo')")
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+        
+        XCTAssertEqual(count, 3)
+    }
+    
+    func testDatabaseRegionObservationArray() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute("CREATE TABLE t1(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+            try $0.execute("CREATE TABLE t2(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+        }
+        
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 3
+        
+        let request1 = SQLRequest<Row>("SELECT * FROM t1 ORDER BY id")
+        let request2 = SQLRequest<Row>("SELECT * FROM t2 ORDER BY id")
+        
+        var observation = DatabaseRegionObservation(tracking: [request1, request2])
+        observation.extent = .databaseLifetime
+        
+        var count = 0
+        _ = try observation.start(in: dbQueue) { db in
+            count += 1
+            notificationExpectation.fulfill()
+        }
+        
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t1 (id, name) VALUES (1, 'foo')")
+        }
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t2 (id, name) VALUES (1, 'foo')")
+        }
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t1 (id, name) VALUES (2, 'foo')")
+            try db.execute("INSERT INTO t2 (id, name) VALUES (2, 'foo')")
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+        
+        XCTAssertEqual(count, 3)
+    }
+    
+    func testDatabaseRegionDefaultExtent() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)") }
+        
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 2
+        
+        let observation = DatabaseRegionObservation(tracking: SQLRequest<Row>("SELECT * FROM t ORDER BY id"))
+        
+        var count = 0
+        do {
+            let observer = try observation.start(in: dbQueue) { db in
+                count += 1
+                notificationExpectation.fulfill()
+            }
+            
+            try withExtendedLifetime(observer) {
+                try dbQueue.write { db in
+                    try db.execute("INSERT INTO t (id, name) VALUES (1, 'foo')")
+                }
+                try dbQueue.write { db in
+                    try db.execute("INSERT INTO t (id, name) VALUES (2, 'bar')")
+                }
+            }
+        }
+        // not notified
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t (id, name) VALUES (3, 'baz')")
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+        
+        XCTAssertEqual(count, 2)
+    }
+    
+    func testDatabaseRegionExtentNextTransaction() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { try $0.execute("CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)") }
+        
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 1
+        
+        var observation = DatabaseRegionObservation(tracking: SQLRequest<Row>("SELECT * FROM t ORDER BY id"))
+        observation.extent = .nextTransaction
+        
+        var count = 0
+        _ = try observation.start(in: dbQueue) { db in
+            count += 1
+            notificationExpectation.fulfill()
+        }
+        
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t (id, name) VALUES (1, 'foo')")
+        }
+        try dbQueue.write { db in
+            try db.execute("INSERT INTO t (id, name) VALUES (2, 'bar')")
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+        
+        XCTAssertEqual(count, 1)
+    }
+}


### PR DESCRIPTION
This PR continues the job of moving some [RxGRDB](https://github.com/RxSwiftCommunity/RxGRDB) features back to GRDB, so that we can share code between reactive engines (and even not use any reactive engine at all).

`DatabaseRegionObservation` is like [ValueObservation](https://github.com/groue/GRDB.swift/blob/master/README.md#valueobservation), except that it does not notify fresh values on every change. Instead, it notifies all impactful transactions right after they have been committed, and before any other thread had any opportunity to perform further changes:

```swift
let observation = DatabaseRegionObservation(tracking: Player.all())
let observer = observation.start(in: dbQueue) { db: Database in
    print("Players were changed")
}

try dbQueue.write { db in
    try Player(name: "Arthur").insert(db)
}
// Prints "Players were changed"
```

DatabaseRegionObservation is not a tool that should be used frequently. The intended use cases are all pretty advanced:

- One needs to write in the database after an impactful transaction.

- One needs to synchronize the content of the database file with some external resources, like other files, or system sensors like CLRegion monitoring.

- On iOS, one needs to process a database transaction before the operating system had any opportunity to put the application in the suspended state.

- One want to build a [database snapshot](https://github.com/groue/GRDB.swift/blob/master/README.md#database-snapshots) with a guaranteed snapshot content.
