### PR TITLE
Make updateChanges(_:with:) available to PersistableRecord structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ GRDB adheres to [Semantic Versioning](https://semver.org/).
 - [0.110.0](#01100), ...
 
 
+## Next Release
+
+
+### Fixed
+
+- [#464](https://github.com/groue/GRDB.swift/pull/464): Make updateChanges(_:with:) available to PersistableRecord structs
+
+
 ## 3.6.1
 
 Released December 9, 2018 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v3.6.0...v3.6.1)


### PR DESCRIPTION
GRDB 3.6.0 has introduced the [updateChanges(_:with:)](https://github.com/groue/GRDB.swift/pull/443) method.

Structs that adopt the PersistableRecord protocol could not use it, due to a wrong definition of mutating/non-mutating variants of the method. This PR fixes this.