### PR TITLE
Refactor PersistenceError.recordNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 
 - [#478](https://github.com/groue/GRDB.swift/pull/478): Swift 5: SQL interpolation
 - [#484](https://github.com/groue/GRDB.swift/pull/484): SE-0193 Cross-module inlining and specialization
+- [#486](https://github.com/groue/GRDB.swift/pull/486): Refactor PersistenceError.recordNotFound
 
 ### Breaking Changes
 

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -33,7 +33,7 @@ extension PersistenceError {
         switch self {
         case let .recordNotFound(databaseTableName: databaseTableName, key: key):
             let row = Row(key) // For nice output
-            return "Record not found in table \(databaseTableName): \(row.description)"
+            return "Key not found in table \(databaseTableName): \(row.description)"
         }
     }
 }

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -276,11 +276,11 @@ open class Record : FetchableRecord, TableRecord, PersistableRecord {
         let dao = try DAO(db, self)
         guard let statement = try dao.updateStatement(columns: columns, onConflict: type(of: self).persistenceConflictPolicy.conflictResolutionForUpdate) else {
             // Nil primary key
-            try dao.recordNotFound()
+            throw dao.makeRecordNotFoundError()
         }
         try statement.execute()
         if db.changesCount == 0 {
-            try dao.recordNotFound()
+            throw dao.makeRecordNotFoundError()
         }
         
         // Set hasDatabaseChanges to false

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -276,11 +276,11 @@ open class Record : FetchableRecord, TableRecord, PersistableRecord {
         let dao = try DAO(db, self)
         guard let statement = try dao.updateStatement(columns: columns, onConflict: type(of: self).persistenceConflictPolicy.conflictResolutionForUpdate) else {
             // Nil primary key
-            throw PersistenceError.recordNotFound(self)
+            try dao.recordNotFound()
         }
         try statement.execute()
         if db.changesCount == 0 {
-            throw PersistenceError.recordNotFound(self)
+            try dao.recordNotFound()
         }
         
         // Set hasDatabaseChanges to false

--- a/README.md
+++ b/README.md
@@ -7510,8 +7510,8 @@ do {
 ```swift
 do {
     try player.update(db)
-} catch PersistenceError.recordNotFound {
-    // There was nothing to update
+} catch let PersistenceError.recordNotFound(databaseTableName: table, key: key) {
+    print("Key \(key) was not found in table \(table).")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ let playerId = db.lastInsertedRowID
 Don't miss [Records](#records), that provide classic **persistence methods**:
 
 ```swift
-let player = Player(name: "Arthur", score: 1000)
+var player = Player(name: "Arthur", score: 1000)
 try player.insert(db)
 let playerId = player.id
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,6 @@
 - [ ] Allow joining methods on DerivableRequest
 - [ ] DatabaseWriter.assertWriteAccess()
 - [ ] Configuration.crashOnError = true
-- [ ] Remove associated record from PersistenceError.recordNotFound. It should be possible, in userland, to write a method that throws this error without having a fully constructed record.
 - [ ] Support for "INSERT INTO ... SELECT ...". For example:
     
     ```swift

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -696,4 +696,23 @@ class MutablePersistableRecordTests: GRDBTestCase {
             }
         }
     }
+    
+    func testPersistenceErrorRecordNotFoundDescription() {
+        do {
+            let error = PersistenceError.recordNotFound(
+                databaseTableName: "place",
+                key: ["id": .null])
+            XCTAssertEqual(
+                error.description,
+                "Record not found in table place: [id:NULL]")
+        }
+        do {
+            let error = PersistenceError.recordNotFound(
+                databaseTableName: "user",
+                key: ["uuid": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".databaseValue])
+            XCTAssertEqual(
+                error.description,
+                "Record not found in table user: [uuid:\"E621E1F8-C36C-495A-93FC-0C247A3E6E5F\"]")
+        }
+    }
 }

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -704,7 +704,7 @@ class MutablePersistableRecordTests: GRDBTestCase {
                 key: ["id": .null])
             XCTAssertEqual(
                 error.description,
-                "Record not found in table place: [id:NULL]")
+                "Key not found in table place: [id:NULL]")
         }
         do {
             let error = PersistenceError.recordNotFound(
@@ -712,7 +712,7 @@ class MutablePersistableRecordTests: GRDBTestCase {
                 key: ["uuid": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".databaseValue])
             XCTAssertEqual(
                 error.description,
-                "Record not found in table user: [uuid:\"E621E1F8-C36C-495A-93FC-0C247A3E6E5F\"]")
+                "Key not found in table user: [uuid:\"E621E1F8-C36C-495A-93FC-0C247A3E6E5F\"]")
         }
     }
 }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -115,8 +115,10 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "minimalRowIDs")
+                XCTAssertEqual(key, ["id": record.id.databaseValue])
             }
         }
     }
@@ -142,8 +144,10 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "minimalRowIDs")
+                XCTAssertEqual(key, ["id": record.id.databaseValue])
             }
         }
     }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
@@ -114,8 +114,10 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "minimalSingles")
+                XCTAssertEqual(key, ["UUID": "theUUID".databaseValue])
             }
         }
     }
@@ -143,8 +145,10 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "minimalSingles")
+                XCTAssertEqual(key, ["UUID": "theUUID".databaseValue])
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -169,8 +169,10 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "persons")
+                XCTAssertEqual(key, ["rowid": .null])
             }
         }
     }
@@ -182,8 +184,10 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "persons")
+                XCTAssertEqual(key, ["rowid": record.id.databaseValue])
             }
         }
     }
@@ -210,8 +214,10 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "persons")
+                XCTAssertEqual(key, ["rowid": record.id.databaseValue])
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
@@ -124,8 +124,10 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "citizenships")
+                XCTAssertEqual(key, ["countryName": .null, "personName": .null])
             }
         }
     }
@@ -137,8 +139,10 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "citizenships")
+                XCTAssertEqual(key, ["countryName": "France".databaseValue, "personName": "Arthur".databaseValue])
             }
         }
     }
@@ -165,8 +169,10 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "citizenships")
+                XCTAssertEqual(key, ["countryName": "France".databaseValue, "personName": "Arthur".databaseValue])
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
@@ -166,8 +166,10 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "persons")
+                XCTAssertEqual(key, ["id": .null])
             }
         }
     }
@@ -179,8 +181,10 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "persons")
+                XCTAssertEqual(key, ["id": record.id.databaseValue])
             }
         }
     }
@@ -207,8 +211,10 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "persons")
+                XCTAssertEqual(key, ["id": record.id.databaseValue])
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
@@ -117,8 +117,10 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "pets")
+                XCTAssertEqual(key, ["UUID": .null])
             }
         }
     }
@@ -130,8 +132,10 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "pets")
+                XCTAssertEqual(key, ["UUID": "BobbyUUID".databaseValue])
             }
         }
     }
@@ -158,8 +162,10 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "pets")
+                XCTAssertEqual(key, ["UUID": "BobbyUUID".databaseValue])
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
@@ -121,8 +121,10 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "emails")
+                XCTAssertEqual(key, ["email": record.email.databaseValue])
             }
         }
     }
@@ -150,8 +152,10 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             do {
                 try record.update(db)
                 XCTFail("Expected PersistenceError.recordNotFound")
-            } catch PersistenceError.recordNotFound {
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "emails")
+                XCTAssertEqual(key, ["email": record.email.databaseValue])
             }
         }
     }


### PR DESCRIPTION
In GRDB 3 PersistenceError was defined as below:

```swift
// GRDB 3
public enum PersistenceError: Error {
    /// Thrown by MutablePersistableRecord.update() when no matching row could be
    /// found in the database.
    case recordNotFound(MutablePersistableRecord)
}
```

With such a definition, one can only build PersistenceError.recordNotFound with a fully defined record instance. It is impossible to throw this error with partial information. But some apps need that.

This PR changes the definition of PersistenceError to:

```swift
// GRDB 4
public enum PersistenceError: Error {
    case recordNotFound(databaseTableName: String, key: [String: DatabaseValue])
}
```

When you catch this error, you get the table and the primary key of the unfound record:

```swift
do {
    let place = Place(id: nil, name: "Valencia")
    try place.update(db)
} catch {
    print(error)
    // prints "Key not found in table place: [id:NULL]"
}
```
