### PR TITLE
Remove SR-6067 workaround

### DIFF
--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -159,43 +159,34 @@ extension Database {
         // It adds support for arguments, and the tricky part is to consume
         // arguments as statements are executed.
         //
-        // Here we build two functions:
-        // - consumeArguments returns arguments for a statement
-        // - validateRemainingArguments validates the remaining arguments, after
-        //   all statements have been executed, in the same way
-        //   as Statement.validate(arguments:)
+        // This job is performed by StatementArguments.extractBindings(forStatement:allowingRemainingValues:)
+        //
+        // And before we return, we'll check that all arguments were consumed.
         
-        let sql = sqlLiteral.sql
         var arguments = sqlLiteral.arguments
-        
         let initialValuesCount = arguments.values.count
-        let consumeArguments = { (statement: UpdateStatement) throws -> StatementArguments in
-            let bindings = try arguments.consume(statement, allowingRemainingValues: true)
-            return StatementArguments(bindings)
-        }
-        let validateRemainingArguments = {
-            if !arguments.values.isEmpty {
-                throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)")
-            }
-        }
         
-        // Iterate SQL statements
-        let sqlCodeUnits = sql.utf8CString
-        try sqlCodeUnits.withUnsafeBufferPointer { codeUnits in
-            let sqlStart = UnsafePointer<Int8>(codeUnits.baseAddress)!
-            let sqlEnd = sqlStart + sqlCodeUnits.count
-            var statementStart = sqlStart
-            while statementStart < sqlEnd - 1 {
-                var statementEnd: UnsafePointer<Int8>? = nil
-                do {
-                    let statement: UpdateStatement
+        // Build a C string (SQLite wants that), and execute SQL statements one
+        // after the other.
+        try sqlLiteral.sql.utf8CString.withUnsafeBufferPointer { (buffer: UnsafeBufferPointer<CChar>) in
+            // CChar will be the same as either CSignedChar (in the common
+            // case) or CUnsignedChar, depending on the platform. SQLite always
+            // wants signed Int8.
+            try buffer.withMemoryRebound(to: Int8.self) { buffer in
+                guard let sqlStart = buffer.baseAddress else { return }
+                let sqlEnd = sqlStart + buffer.count // past \0
+                var statementStart = sqlStart
+                while statementStart < sqlEnd {
+                    var statementEnd: UnsafePointer<Int8>? = nil
+                    let nextStatement: UpdateStatement?
+                    
                     // Compile
                     do {
                         let statementCompilationAuthorizer = StatementCompilationAuthorizer()
                         authorizer = statementCompilationAuthorizer
                         defer { authorizer = nil }
                         
-                        statement = try UpdateStatement(
+                        nextStatement = try UpdateStatement(
                             database: self,
                             statementStart: statementStart,
                             statementEnd: &statementEnd,
@@ -203,23 +194,30 @@ extension Database {
                             authorizer: statementCompilationAuthorizer)
                     }
                     
+                    guard let statement = nextStatement else {
+                        // End of SQL string
+                        break
+                    }
+                    
+                    // Extract statement arguments
+                    let bindings = try arguments.extractBindings(forStatement: statement, allowingRemainingValues: true)
+                    // unsafe is OK because we just extracted the correct number of arguments
+                    statement.unsafeSetArguments(StatementArguments(bindings))
+                    
                     // Execute
-                    let arguments = try consumeArguments(statement)
-                    statement.unsafeSetArguments(arguments)
                     try statement.execute()
                     
                     // Next
                     statementStart = statementEnd!
-                } catch is EmptyStatementError {
-                    // End
-                    break
                 }
             }
         }
         
-        // Force arguments validity: it is a programmer error to provide
-        // arguments that do not match the statement.
-        try! validateRemainingArguments()   // throws if there are remaining arguments.
+        // Check that all arguments were consumed: it is a programmer error to
+        // provide arguments that do not match the statement.
+        if arguments.values.isEmpty == false {
+            throw DatabaseError(resultCode: .SQLITE_MISUSE, message: "wrong number of statement arguments: \(initialValuesCount)")
+        }
     }
 }
 

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -11,10 +11,6 @@ public typealias SQLiteStatement = OpaquePointer
 /// Statements are separated by semicolons and white spaces
 let statementSeparatorCharacterSet = CharacterSet(charactersIn: ";").union(.whitespacesAndNewlines)
 
-/// An error emitted when one tries to compile an empty statement.
-struct EmptyStatementError : Error {
-}
-
 /// A statement represents an SQL query.
 ///
 /// It is the base class of UpdateStatement that executes *update statements*,
@@ -33,7 +29,8 @@ public class Statement {
     
     unowned let database: Database
     
-    /// Creates a prepared statement.
+    /// Creates a prepared statement. Returns nil if the compiled string is
+    /// blank or empty.
     ///
     /// - parameter database: A database connection.
     /// - parameter statementStart: A pointer to a UTF-8 encoded C string
@@ -42,9 +39,8 @@ public class Statement {
     ///   statement in the C string.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
     ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
-    /// - throws: DatabaseError in case of compilation error, and
-    ///   EmptyStatementError if the compiled string is blank or empty.
-    required init(
+    /// - throws: DatabaseError in case of compilation error.
+    required init?(
         database: Database,
         statementStart: UnsafePointer<Int8>,
         statementEnd: UnsafeMutablePointer<UnsafePointer<Int8>?>,
@@ -71,14 +67,7 @@ public class Statement {
         }
         
         guard let statement = sqliteStatement else {
-            // I wish we could simply return nil, and make this initializer failable.
-            //
-            // Unfortunately, there is a Swift bug with failable+throwing initializers:
-            // https://bugs.swift.org/browse/SR-6067
-            //
-            // We thus use sentinel error for empty statements.
-            // TODO: is it fixed in Xcode 10.0
-            throw EmptyStatementError()
+            return nil
         }
         
         self.database = database
@@ -131,7 +120,7 @@ public class Statement {
     /// statement arguments.
     public func validate(arguments: StatementArguments) throws {
         var arguments = arguments
-        _ = try arguments.consume(self, allowingRemainingValues: false)
+        _ = try arguments.extractBindings(forStatement: self, allowingRemainingValues: false)
     }
     
     /// Set arguments without any validation. Trades safety for performance.
@@ -158,7 +147,7 @@ public class Statement {
         // Validate
         _arguments = arguments
         var arguments = arguments
-        let bindings = try arguments.consume(self, allowingRemainingValues: false)
+        let bindings = try arguments.extractBindings(forStatement: self, allowingRemainingValues: false)
         argumentsNeedValidation = false
         
         // Apply
@@ -240,15 +229,13 @@ extension StatementProtocol where Self: Statement {
         return try sqlCodeUnits.withUnsafeBufferPointer { codeUnits in
             let statementStart = UnsafePointer<Int8>(codeUnits.baseAddress)!
             var statementEnd: UnsafePointer<Int8>? = nil
-            let statement: Self
-            do {
-                statement = try self.init(
-                    database: database,
-                    statementStart: statementStart,
-                    statementEnd: &statementEnd,
-                    prepFlags: prepFlags,
-                    authorizer: authorizer)
-            } catch is EmptyStatementError {
+            guard let statement = try self.init(
+                database: database,
+                statementStart: statementStart,
+                statementEnd: &statementEnd,
+                prepFlags: prepFlags,
+                authorizer: authorizer) else
+            {
                 throw DatabaseError(
                     resultCode: .SQLITE_ERROR,
                     message: "empty statement",
@@ -292,7 +279,8 @@ public final class SelectStatement : Statement {
     /// The database region that the statement looks into.
     public private(set) var databaseRegion = DatabaseRegion()
     
-    /// Creates a prepared statement.
+    /// Creates a prepared statement. Returns nil if the compiled string is
+    /// blank or empty.
     ///
     /// - parameter database: A database connection.
     /// - parameter statementStart: A pointer to a UTF-8 encoded C string
@@ -302,9 +290,8 @@ public final class SelectStatement : Statement {
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
     ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
     /// - authorizer: A StatementCompilationAuthorizer
-    /// - throws: DatabaseError in case of compilation error, and
-    ///   EmptyStatementError if the compiled string is blank or empty.
-    required init(
+    /// - throws: DatabaseError in case of compilation error.
+    required init?(
         database: Database,
         statementStart: UnsafePointer<Int8>,
         statementEnd: UnsafeMutablePointer<UnsafePointer<Int8>?>,
@@ -454,7 +441,8 @@ public final class UpdateStatement : Statement {
     private(set) var transactionEffect: TransactionEffect?
     private(set) var databaseEventKinds: [DatabaseEventKind] = []
     
-    /// Creates a prepared statement.
+    /// Creates a prepared statement. Returns nil if the compiled string is
+    /// blank or empty.
     ///
     /// - parameter database: A database connection.
     /// - parameter statementStart: A pointer to a UTF-8 encoded C string
@@ -464,9 +452,8 @@ public final class UpdateStatement : Statement {
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
     ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
     /// - authorizer: A StatementCompilationAuthorizer
-    /// - throws: DatabaseError in case of compilation error, and
-    ///   EmptyStatementError if the compiled string is blank or empty.
-    required init(
+    /// - throws: DatabaseError in case of compilation error.
+    required init?(
         database: Database,
         statementStart: UnsafePointer<Int8>,
         statementEnd: UnsafeMutablePointer<UnsafePointer<Int8>?>,
@@ -868,7 +855,7 @@ public struct StatementArguments: CustomStringConvertible, Equatable, Expressibl
     
     // MARK: Not Public
     
-    mutating func consume(_ statement: Statement, allowingRemainingValues: Bool) throws -> [DatabaseValue] {
+    mutating func extractBindings(forStatement statement: Statement, allowingRemainingValues: Bool) throws -> [DatabaseValue] {
         let initialValuesCount = values.count
         let bindings = try statement.sqliteArgumentNames.map { argumentName -> DatabaseValue in
             if let argumentName = argumentName {


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-6067 has long been fixed.

Also, test that an error is thrown when user provides too many statement arguments (it used to be untestable because of fatalError, long ago).