### PR TITLE
ValueObservation Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,13 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#478](https://github.com/groue/GRDB.swift/pull/478): Swift 5: SQL interpolation
 - [#484](https://github.com/groue/GRDB.swift/pull/484): SE-0193 Cross-module inlining and specialization
 - [#486](https://github.com/groue/GRDB.swift/pull/486): Refactor PersistenceError.recordNotFound
+- [#488](https://github.com/groue/GRDB.swift/pull/488): ValueObservation Cleanup
 
 ### Breaking Changes
 
 - Swift 4.0 and Swift 4.1 are no longer supported
 - iOS 8 is no longer supported. Minimum deployment target is now iOS 9.0
 - Deprecated APIs are no longer available.
-- `SQLRequest.arguments` is no longer optional
 
 ### Documentation Diff
 

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -116,7 +116,7 @@ extension DatabaseSnapshot {
                     }
                 }
             }
-        case let .onQueue(queue, startImmediately: startImmediately):
+        case let .async(onQueue: queue, startImmediately: startImmediately):
             if startImmediately {
                 if let value = try unsafeReentrantRead(observation.initialValue) {
                     queue.async {

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -231,7 +231,7 @@ extension DatabaseWriter {
                 notificationQueue: observation.notificationQueue,
                 onError: onError,
                 onChange: onChange)
-            db.add(transactionObserver: valueObserver, extent: observation.extent)
+            db.add(transactionObserver: valueObserver, extent: .observerLifetime)
             
             return valueObserver
         }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -210,7 +210,7 @@ extension DatabaseWriter {
                         DispatchQueue.main.async { onChange(value) }
                     }
                 }
-            case let .onQueue(queue, startImmediately: startImmediately):
+            case let .async(onQueue: queue, startImmediately: startImmediately):
                 if startImmediately {
                     if let value = try reducer.initialValue(db, requiresWriteAccess: observation.requiresWriteAccess) {
                         queue.async { onChange(value) }

--- a/GRDB/Fixit/GRDB-4.0.swift
+++ b/GRDB/Fixit/GRDB-4.0.swift
@@ -116,3 +116,10 @@ extension DatabaseValue {
     @available(*, unavailable)
     public func losslessConvert<T>(sql: String? = nil, arguments: StatementArguments? = nil) -> T? where T: DatabaseValueConvertible { preconditionFailure() }
 }
+
+extension ValueScheduling {
+    @available(*, unavailable, renamed: "async(onQueue:startImmediately:)")
+    public static func onQueue(_ queue: DispatchQueue, startImmediately: Bool) -> ValueScheduling {
+        return .async(onQueue: queue, startImmediately: startImmediately)
+    }
+}

--- a/GRDB/Fixit/GRDB-4.0.swift
+++ b/GRDB/Fixit/GRDB-4.0.swift
@@ -119,7 +119,13 @@ extension DatabaseValue {
 
 extension ValueScheduling {
     @available(*, unavailable, renamed: "async(onQueue:startImmediately:)")
-    public static func onQueue(_ queue: DispatchQueue, startImmediately: Bool) -> ValueScheduling {
-        return .async(onQueue: queue, startImmediately: startImmediately)
+    public static func onQueue(_ queue: DispatchQueue, startImmediately: Bool) -> ValueScheduling { preconditionFailure() }
+}
+
+extension ValueObservation {
+    @available(*, unavailable, message: "Observation extent is controlled by the lifetime of observers returned by the start() method.")
+    public var extent: Database.TransactionObservationExtent {
+        get { preconditionFailure() }
+        set { preconditionFailure() }
     }
 }

--- a/GRDB/ValueObservation/ValueObservation+MapReducer.swift
+++ b/GRDB/ValueObservation/ValueObservation+MapReducer.swift
@@ -7,7 +7,6 @@ extension ValueObservation {
         var observation = ValueObservation<R>(
             tracking: observedRegion,
             reducer: { db in try transform(db, makeReducer(db)) })
-        observation.extent = extent
         observation.scheduling = scheduling
         observation.requiresWriteAccess = requiresWriteAccess
         return observation

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -89,13 +89,6 @@ public struct ValueObservation<Reducer> {
     /// observation is less efficient than a read-only observation.
     public var requiresWriteAccess: Bool = false
     
-    // TODO: replace ValueObservation.extent
-    /// The extent of the database observation. The default is
-    /// `.observerLifetime`: the observation lasts until the
-    /// observer returned by the `start(in:onError:onChange:)` method
-    /// is deallocated.
-    public var extent = Database.TransactionObservationExtent.observerLifetime
-    
     /// `scheduling` controls how fresh values are notified. Default
     /// is `.mainQueue`.
     ///

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -40,7 +40,7 @@ public enum ValueScheduling {
     ///
     /// An initial value is fetched and notified if `startImmediately`
     /// is true.
-    case onQueue(DispatchQueue, startImmediately: Bool)
+    case async(onQueue: DispatchQueue, startImmediately: Bool)
     
     /// Values are not all notified on the same dispatch queue.
     ///
@@ -158,7 +158,7 @@ public struct ValueObservation<Reducer> {
         switch scheduling {
         case .mainQueue:
             return DispatchQueue.main
-        case .onQueue(let queue, startImmediately: _):
+        case let .async(onQueue: queue, startImmediately: _):
             return queue
         case .unsafe:
             return nil

--- a/Tests/GRDBTests/ValueObservationCombineTests.swift
+++ b/Tests/GRDBTests/ValueObservationCombineTests.swift
@@ -31,43 +31,43 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct T2: TableRecord { }
         let observation1 = ValueObservation.trackingCount(T1.all())
         let observation2 = ValueObservation.trackingCount(T2.all())
-        var observation = ValueObservation.combine(observation1, observation2)
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { value in
+        let observation = ValueObservation.combine(observation1, observation2)
+        let observer = try observation.start(in: dbQueue) { value in
             values.append(value)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+        try withExtendedLifetime(observer) {
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(values.count, 4)
+            XCTAssert(values[0] == (0, 0))
+            XCTAssert(values[1] == (1, 0))
+            XCTAssert(values[2] == (1, 1))
+            XCTAssert(values[3] == (2, 2))
         }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(values.count, 4)
-        XCTAssert(values[0] == (0, 0))
-        XCTAssert(values[1] == (1, 0))
-        XCTAssert(values[2] == (1, 1))
-        XCTAssert(values[3] == (2, 2))
     }
     
     func testCombine3() throws {
@@ -91,54 +91,54 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation1 = ValueObservation.trackingCount(T1.all())
         let observation2 = ValueObservation.trackingCount(T2.all())
         let observation3 = ValueObservation.trackingCount(T3.all())
-        var observation = ValueObservation.combine(observation1, observation2, observation3)
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { value in
+        let observation = ValueObservation.combine(observation1, observation2, observation3)
+        let observer = try observation.start(in: dbQueue) { value in
             values.append(value)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+        try withExtendedLifetime(observer) {
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t3")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "DELETE FROM t3")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(values.count, 5)
+            XCTAssert(values[0] == (0, 0, 0))
+            XCTAssert(values[1] == (1, 0, 0))
+            XCTAssert(values[2] == (1, 1, 0))
+            XCTAssert(values[3] == (1, 1, 1))
+            XCTAssert(values[4] == (2, 2, 2))
         }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t3")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "DELETE FROM t3")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(values.count, 5)
-        XCTAssert(values[0] == (0, 0, 0))
-        XCTAssert(values[1] == (1, 0, 0))
-        XCTAssert(values[2] == (1, 1, 0))
-        XCTAssert(values[3] == (1, 1, 1))
-        XCTAssert(values[4] == (2, 2, 2))
     }
     
     func testCombine4() throws {
@@ -165,65 +165,65 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation2 = ValueObservation.trackingCount(T2.all())
         let observation3 = ValueObservation.trackingCount(T3.all())
         let observation4 = ValueObservation.trackingCount(T4.all())
-        var observation = ValueObservation.combine(observation1, observation2, observation3, observation4)
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { value in
+        let observation = ValueObservation.combine(observation1, observation2, observation3, observation4)
+        let observer = try observation.start(in: dbQueue) { value in
             values.append(value)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+        try withExtendedLifetime(observer) {
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t3")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t4")
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "DELETE FROM t3")
+                try db.execute(sql: "DELETE FROM t4")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+            }
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(values.count, 6)
+            XCTAssert(values[0] == (0, 0, 0, 0))
+            XCTAssert(values[1] == (1, 0, 0, 0))
+            XCTAssert(values[2] == (1, 1, 0, 0))
+            XCTAssert(values[3] == (1, 1, 1, 0))
+            XCTAssert(values[4] == (1, 1, 1, 1))
+            XCTAssert(values[5] == (2, 2, 2, 2))
         }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t3")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t4")
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "DELETE FROM t3")
-            try db.execute(sql: "DELETE FROM t4")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(values.count, 6)
-        XCTAssert(values[0] == (0, 0, 0, 0))
-        XCTAssert(values[1] == (1, 0, 0, 0))
-        XCTAssert(values[2] == (1, 1, 0, 0))
-        XCTAssert(values[3] == (1, 1, 1, 0))
-        XCTAssert(values[4] == (1, 1, 1, 1))
-        XCTAssert(values[5] == (2, 2, 2, 2))
     }
     
     func testCombine5() throws {
@@ -253,76 +253,76 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation3 = ValueObservation.trackingCount(T3.all())
         let observation4 = ValueObservation.trackingCount(T4.all())
         let observation5 = ValueObservation.trackingCount(T5.all())
-        var observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5)
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { value in
+        let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5)
+        let observer = try observation.start(in: dbQueue) { value in
             values.append(value)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+        try withExtendedLifetime(observer) {
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t3")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t4")
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t5")
+                try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM t1")
+                try db.execute(sql: "DELETE FROM t2")
+                try db.execute(sql: "DELETE FROM t3")
+                try db.execute(sql: "DELETE FROM t4")
+                try db.execute(sql: "DELETE FROM t5")
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
+            }
+            try dbQueue.write { db in
+                try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
+                try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
+            }
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(values.count, 7)
+            XCTAssert(values[0] == (0, 0, 0, 0, 0))
+            XCTAssert(values[1] == (1, 0, 0, 0, 0))
+            XCTAssert(values[2] == (1, 1, 0, 0, 0))
+            XCTAssert(values[3] == (1, 1, 1, 0, 0))
+            XCTAssert(values[4] == (1, 1, 1, 1, 0))
+            XCTAssert(values[5] == (1, 1, 1, 1, 1))
+            XCTAssert(values[6] == (2, 2, 2, 2, 2))
         }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t3")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t4")
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t5")
-            try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "DELETE FROM t1")
-            try db.execute(sql: "DELETE FROM t2")
-            try db.execute(sql: "DELETE FROM t3")
-            try db.execute(sql: "DELETE FROM t4")
-            try db.execute(sql: "DELETE FROM t5")
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
-        }
-        try dbQueue.write { db in
-            try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t2 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t3 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t4 DEFAULT VALUES")
-            try db.execute(sql: "INSERT INTO t5 DEFAULT VALUES")
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(values.count, 7)
-        XCTAssert(values[0] == (0, 0, 0, 0, 0))
-        XCTAssert(values[1] == (1, 0, 0, 0, 0))
-        XCTAssert(values[2] == (1, 1, 0, 0, 0))
-        XCTAssert(values[3] == (1, 1, 1, 0, 0))
-        XCTAssert(values[4] == (1, 1, 1, 1, 0))
-        XCTAssert(values[5] == (1, 1, 1, 1, 1))
-        XCTAssert(values[6] == (2, 2, 2, 2, 2))
     }
     
     func testHeterogeneusCombine2() throws {

--- a/Tests/GRDBTests/ValueObservationCompactMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationCompactMapTests.swift
@@ -33,27 +33,27 @@ class ValueObservationCompactMapTests: GRDBTestCase {
             })
             
             // Create an observation
-            var observation = ValueObservation
+            let observation = ValueObservation
                 .tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
                 .compactMap { count -> String? in
                     if count % 2 == 0 { return nil }
                     return "\(count)"
             }
-            observation.extent = .databaseLifetime
             
             // Start observation
-            _ = try observation.start(in: dbWriter) { count in
+            let observer = try observation.start(in: dbWriter) { count in
                 counts.append(count)
                 notificationExpectation.fulfill()
             }
-            
-            try dbWriter.writeWithoutTransaction { db in
-                try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.writeWithoutTransaction { db in
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, ["1", "3"])
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, ["1", "3"])
         }
         
         try test(makeDatabaseQueue())
@@ -62,12 +62,10 @@ class ValueObservationCompactMapTests: GRDBTestCase {
     
     func testCompactMapPreservesConfiguration() {
         var observation = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
-        observation.extent = .nextTransaction
         observation.requiresWriteAccess = true
         observation.scheduling = .unsafe(startImmediately: true)
         
         let mappedObservation = observation.compactMap { _ in }
-        XCTAssertEqual(mappedObservation.extent, observation.extent)
         XCTAssertEqual(mappedObservation.requiresWriteAccess, observation.requiresWriteAccess)
         switch mappedObservation.scheduling {
         case .unsafe:

--- a/Tests/GRDBTests/ValueObservationRecordTests.swift
+++ b/Tests/GRDBTests/ValueObservationRecordTests.swift
@@ -36,31 +36,31 @@ class ValueObservationRecordTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.trackingAll(SQLRequest<Player>(sql: "SELECT * FROM t ORDER BY id"))
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { players in
+        let observation = ValueObservation.trackingAll(SQLRequest<Player>(sql: "SELECT * FROM t ORDER BY id"))
+        let observer = try observation.start(in: dbQueue) { players in
             results.append(players)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.inDatabase { db in
-            try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
-            try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
-            try db.inTransaction {                                       // +1
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
-                try db.execute(sql: "DELETE FROM t WHERE id = 3")
-                return .commit
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
+                try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
+                try db.inTransaction {                                       // +1
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
+                    try db.execute(sql: "DELETE FROM t WHERE id = 3")
+                    return .commit
+                }
+                try db.execute(sql: "DELETE FROM t WHERE id = 1")                 // -1
             }
-            try db.execute(sql: "DELETE FROM t WHERE id = 1")                 // -1
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results.map { $0.map { $0.row }}, [
+                [],
+                [["id":1, "name":"foo"]],
+                [["id":1, "name":"foo"], ["id":2, "name":"bar"]],
+                [["id":2, "name":"bar"]]])
         }
-        
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(results.map { $0.map { $0.row }}, [
-            [],
-            [["id":1, "name":"foo"]],
-            [["id":1, "name":"foo"], ["id":2, "name":"bar"]],
-            [["id":2, "name":"bar"]]])
     }
     
     func testOne() throws {
@@ -72,30 +72,30 @@ class ValueObservationRecordTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.trackingOne(SQLRequest<Player>(sql: "SELECT * FROM t ORDER BY id DESC"))
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { player in
+        let observation = ValueObservation.trackingOne(SQLRequest<Player>(sql: "SELECT * FROM t ORDER BY id DESC"))
+        let observer = try observation.start(in: dbQueue) { player in
             results.append(player)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.inDatabase { db in
-            try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
-            try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
-            try db.inTransaction {                                       // +1
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
-                try db.execute(sql: "DELETE FROM t WHERE id = 3")
-                return .commit
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
+                try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
+                try db.inTransaction {                                       // +1
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
+                    try db.execute(sql: "DELETE FROM t WHERE id = 3")
+                    return .commit
+                }
+                try db.execute(sql: "DELETE FROM t")                              // -1
             }
-            try db.execute(sql: "DELETE FROM t")                              // -1
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results.map { $0.map { $0.row }}, [
+                nil,
+                ["id":1, "name":"foo"],
+                ["id":2, "name":"bar"],
+                nil])
         }
-
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(results.map { $0.map { $0.row }}, [
-            nil,
-            ["id":1, "name":"foo"],
-            ["id":2, "name":"bar"],
-            nil])
     }
 }

--- a/Tests/GRDBTests/ValueObservationRowTests.swift
+++ b/Tests/GRDBTests/ValueObservationRowTests.swift
@@ -22,31 +22,31 @@ class ValueObservationRowTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.trackingAll(SQLRequest<Row>(sql: "SELECT * FROM t ORDER BY id"))
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { rows in
+        let observation = ValueObservation.trackingAll(SQLRequest<Row>(sql: "SELECT * FROM t ORDER BY id"))
+        let observer = try observation.start(in: dbQueue) { rows in
             results.append(rows)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.inDatabase { db in
-            try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
-            try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
-            try db.inTransaction {                                       // +1
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
-                try db.execute(sql: "DELETE FROM t WHERE id = 3")
-                return .commit
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
+                try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
+                try db.inTransaction {                                       // +1
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
+                    try db.execute(sql: "DELETE FROM t WHERE id = 3")
+                    return .commit
+                }
+                try db.execute(sql: "DELETE FROM t WHERE id = 1")                 // -1
             }
-            try db.execute(sql: "DELETE FROM t WHERE id = 1")                 // -1
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results, [
+                [],
+                [["id":1, "name":"foo"]],
+                [["id":1, "name":"foo"], ["id":2, "name":"bar"]],
+                [["id":2, "name":"bar"]]])
         }
-        
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(results, [
-            [],
-            [["id":1, "name":"foo"]],
-            [["id":1, "name":"foo"], ["id":2, "name":"bar"]],
-            [["id":2, "name":"bar"]]])
     }
     
     func testOne() throws {
@@ -58,23 +58,23 @@ class ValueObservationRowTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.trackingOne(SQLRequest<Row>(sql: "SELECT * FROM t ORDER BY id DESC"))
-        observation.extent = .databaseLifetime
-        _ = try observation.start(in: dbQueue) { row in
+        let observation = ValueObservation.trackingOne(SQLRequest<Row>(sql: "SELECT * FROM t ORDER BY id DESC"))
+        let observer = try observation.start(in: dbQueue) { row in
             results.append(row)
             notificationExpectation.fulfill()
         }
-        
-        try dbQueue.inDatabase { db in
-            try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
-            try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
-            try db.inTransaction {                                       // +1
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
-                try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
-                try db.execute(sql: "DELETE FROM t WHERE id = 3")
-                return .commit
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
+                try db.execute(sql: "UPDATE t SET name = 'foo' WHERE id = 1")     // =
+                try db.inTransaction {                                       // +1
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (2, 'bar')")
+                    try db.execute(sql: "INSERT INTO t (id, name) VALUES (3, 'baz')")
+                    try db.execute(sql: "DELETE FROM t WHERE id = 3")
+                    return .commit
+                }
+                try db.execute(sql: "DELETE FROM t")                              // -1
             }
-            try db.execute(sql: "DELETE FROM t")                              // -1
         }
 
         waitForExpectations(timeout: 1, handler: nil)

--- a/Tests/GRDBTests/ValueObservationSchedulingTests.swift
+++ b/Tests/GRDBTests/ValueObservationSchedulingTests.swift
@@ -160,7 +160,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
             observation.extent = .databaseLifetime
-            observation.scheduling = .onQueue(queue, startImmediately: true)
+            observation.scheduling = .async(onQueue: queue, startImmediately: true)
             
             _ = try observation.start(in: dbWriter) { count in
                 XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
@@ -198,7 +198,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
             observation.extent = .databaseLifetime
-            observation.scheduling = .onQueue(queue, startImmediately: false)
+            observation.scheduling = .async(onQueue: queue, startImmediately: false)
             
             _ = try observation.start(in: dbWriter) { count in
                 XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
@@ -238,7 +238,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                 value: { $0 })
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
             observation.extent = .databaseLifetime
-            observation.scheduling = .onQueue(queue, startImmediately: false)
+            observation.scheduling = .async(onQueue: queue, startImmediately: false)
             
             _ = try observation.start(
                 in: dbWriter,

--- a/Tests/GRDBTests/ValueObservationSchedulingTests.swift
+++ b/Tests/GRDBTests/ValueObservationSchedulingTests.swift
@@ -26,12 +26,10 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             DispatchQueue.main.setSpecific(key: key, value: ())
             
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
-            
-            _ = try observation.start(in: dbWriter) { count in
+            let observer = try observation.start(in: dbWriter) { count in
                 XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
                 counts.append(count)
                 notificationExpectation.fulfill()
@@ -40,12 +38,14 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             // dispatched when observation is started from the main queue
             XCTAssertEqual(counts, [0])
             
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1])
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [0, 1])
         }
         
         try test(makeDatabaseQueue())
@@ -66,25 +66,25 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             DispatchQueue.main.setSpecific(key: key, value: ())
             
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
-            
+            var observer: TransactionObserver?
             DispatchQueue.global(qos: .default).async {
-                _ = try! observation.start(in: dbWriter) { count in
+                observer = try! observation.start(in: dbWriter) { count in
                     XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
                     counts.append(count)
                     notificationExpectation.fulfill()
                 }
-                
                 try! dbWriter.write {
                     try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
                 }
             }
             
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [0, 1])
+            withExtendedLifetime(observer) {
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1])
+            }
         }
         
         try test(makeDatabaseQueue())
@@ -113,10 +113,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                     }
             },
                 value: { $0 })
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
-            observation.extent = .databaseLifetime
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
             
-            _ = try observation.start(
+            let observer = try observation.start(
                 in: dbWriter,
                 onError: { error in
                     XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
@@ -127,15 +126,16 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                     XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
                     notificationExpectation.fulfill()
             })
-            
-            struct TestError: Error { }
-            nextError = TestError()
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                struct TestError: Error { }
+                nextError = TestError()
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(errorCount, 1)
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(errorCount, 1)
         }
         
         try test(makeDatabaseQueue())
@@ -159,21 +159,21 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
             observation.scheduling = .async(onQueue: queue, startImmediately: true)
             
-            _ = try observation.start(in: dbWriter) { count in
+            let observer = try observation.start(in: dbWriter) { count in
                 XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
                 counts.append(count)
                 notificationExpectation.fulfill()
             }
-            
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1])
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [0, 1])
         }
         
         try test(makeDatabaseQueue())
@@ -197,21 +197,21 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
             observation.scheduling = .async(onQueue: queue, startImmediately: false)
             
-            _ = try observation.start(in: dbWriter) { count in
+            let observer = try observation.start(in: dbWriter) { count in
                 XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
                 counts.append(count)
                 notificationExpectation.fulfill()
             }
-            
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [1])
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [1])
         }
         
         try test(makeDatabaseQueue())
@@ -237,10 +237,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                 fetch: { _ in throw TestError() },
                 value: { $0 })
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
-            observation.extent = .databaseLifetime
             observation.scheduling = .async(onQueue: queue, startImmediately: false)
             
-            _ = try observation.start(
+            let observer = try observation.start(
                 in: dbWriter,
                 onError: { error in
                     XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
@@ -248,13 +247,14 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                     notificationExpectation.fulfill()
             },
                 onChange: { _ in fatalError() })
-            
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(errorCount, 1)
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(errorCount, 1)
         }
         
         try test(makeDatabaseQueue())
@@ -277,10 +277,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
             observation.scheduling = .unsafe(startImmediately: true)
             
-            _ = try observation.start(in: dbWriter) { count in
+            let observer = try observation.start(in: dbWriter) { count in
                 if counts.isEmpty {
                     // require main queue on first element
                     XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
@@ -288,13 +287,14 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                 counts.append(count)
                 notificationExpectation.fulfill()
             }
-            
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1])
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [0, 1])
         }
         
         try test(makeDatabaseQueue())
@@ -318,11 +318,10 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
             observation.scheduling = .unsafe(startImmediately: true)
-            
+            var observer: TransactionObserver?
             queue.async {
-                _ = try! observation.start(in: dbWriter) { count in
+                observer = try! observation.start(in: dbWriter) { count in
                     if counts.isEmpty {
                         // require custom queue on first notification
                         XCTAssertNotNil(DispatchQueue.getSpecific(key: key))
@@ -330,14 +329,15 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                     counts.append(count)
                     notificationExpectation.fulfill()
                 }
-                
                 try! dbWriter.write {
                     try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
                 }
             }
             
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [0, 1])
+            withExtendedLifetime(observer) {
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1])
+            }
         }
         
         try test(makeDatabaseQueue())
@@ -357,20 +357,20 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            observation.extent = .databaseLifetime
             observation.scheduling = .unsafe(startImmediately: false)
             
-            _ = try observation.start(in: dbWriter) { count in
+            let observer = try observation.start(in: dbWriter) { count in
                 counts.append(count)
                 notificationExpectation.fulfill()
             }
-            
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [1])
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(counts, [1])
         }
         
         try test(makeDatabaseQueue())
@@ -392,23 +392,23 @@ class ValueObservationSchedulingTests: GRDBTestCase {
                 fetch: { _ in throw TestError() },
                 value: { $0 })
             var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
-            observation.extent = .databaseLifetime
             observation.scheduling = .unsafe(startImmediately: false)
             
-            _ = try observation.start(
+            let observer = try observation.start(
                 in: dbWriter,
                 onError: { error in
                     errorCount += 1
                     notificationExpectation.fulfill()
             },
                 onChange: { _ in fatalError() })
-            
-            try dbWriter.write {
-                try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            try withExtendedLifetime(observer) {
+                try dbWriter.write {
+                    try $0.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(errorCount, 1)
             }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(errorCount, 1)
         }
         
         try test(makeDatabaseQueue())


### PR DESCRIPTION
This pull request fixes some issues with ValueObservation in GRDB3:

- To guarantee asynchronous notifications (and never ever block your main thread), use the `.async(onQueue:startImmediately:)` scheduling:

    ```swift
    // On main queue
    var observation = ValueObservation.trackingAll(Player.all())
    observation.scheduling = .async(onQueue: .main, startImmediately: true)
    let observer = try observation.start(in: dbQueue) { (players: [Player]) in
        // On main queue
        print("fresh players: \(players)")s
    }
    // <- here "fresh players" is not printed yet.
    ```

    This scheduling used to be named `.queue(_: startImmediately:)` (a poor name which did not express the intent).
- `ValueObservation.extent` has been removed. Now all observations last until the observer returned by the `start` method is deallocated.