### PR TITLE
Rename Future to DatabaseFuture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#490](https://github.com/groue/GRDB.swift/pull/490): Indirect Associations
 - [#493](https://github.com/groue/GRDB.swift/pull/493): Bump SQLite to [3.27.2](https://www.sqlite.org/releaselog/3_27_2.html)
 - [#499](https://github.com/groue/GRDB.swift/pull/499): Extract EncodableRecord from MutablePersistableRecord
+- [#502](https://github.com/groue/GRDB.swift/pull/502): Rename Future to DatabaseFuture
 
 ### Breaking Changes
 

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -357,7 +357,7 @@ extension DatabasePool : DatabaseReader {
         }
     }
     
-    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
+    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> DatabaseFuture<T> {
         // Check that we're on the writer queue...
         writer.execute { db in
             // ... and that no transaction is opened.
@@ -404,13 +404,13 @@ extension DatabasePool : DatabaseReader {
                 futureSemaphore.signal()
             }
         } catch {
-            return Future { throw error }
+            return DatabaseFuture { throw error }
         }
         
         // Block the writer queue until snapshot isolation success or error
         _ = isolationSemaphore.wait(timeout: .distantFuture)
         
-        return Future {
+        return DatabaseFuture {
             // Block the future until results are fetched
             _ = futureSemaphore.wait(timeout: .distantFuture)
             return try futureResult!.get()

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -201,10 +201,10 @@ extension DatabaseQueue {
         return try writer.reentrantSync(block)
     }
     
-    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> Future<T> {
+    public func concurrentRead<T>(_ block: @escaping (Database) throws -> T) -> DatabaseFuture<T> {
         // DatabaseQueue can't perform parallel reads.
         // Perform a blocking read instead.
-        return Future(Result {
+        return DatabaseFuture(Result {
             // Check that we're on the writer queue...
             try writer.execute { db in
                 // ... and that no transaction is opened.

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -5,7 +5,7 @@ import Foundation
 class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
     /* private */ let region: DatabaseRegion // Internal for testability
     private var reducer: Reducer
-    private let fetch: (Database, Reducer) -> Future<Reducer.Fetched>
+    private let fetch: (Database, Reducer) -> DatabaseFuture<Reducer.Fetched>
     private let notificationQueue: DispatchQueue?
     private let onError: ((Error) -> Void)?
     private let onChange: (Reducer.Value) -> Void
@@ -16,7 +16,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
         region: DatabaseRegion,
         reducer: Reducer,
         configuration: Configuration,
-        fetch: @escaping (Database, Reducer) -> Future<Reducer.Fetched>,
+        fetch: @escaping (Database, Reducer) -> DatabaseFuture<Reducer.Fetched>,
         notificationQueue: DispatchQueue?,
         onError: ((Error) -> Void)?,
         onChange: @escaping (Reducer.Value) -> Void)

--- a/README.md
+++ b/README.md
@@ -8049,7 +8049,7 @@ The correct solution is the `concurrentRead` method, which must be called from w
 
 ```swift
 // CORRECT
-let futureCount: Future<Int> = try dbPool.writeWithoutTransaction { db in
+let futureCount: DatabaseFuture<Int> = try dbPool.writeWithoutTransaction { db in
     // increment the number of players
     try Player(...).insert(db)
     

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -855,8 +855,8 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         //                              <
         //                              }
         
-        let future: Future<Int> = try dbPool.writeWithoutTransaction { db in
-            let future: Future<Int> = dbPool.concurrentRead { db in
+        let future: DatabaseFuture<Int> = try dbPool.writeWithoutTransaction { db in
+            let future: DatabaseFuture<Int> = dbPool.concurrentRead { db in
                 _ = s1.wait(timeout: .distantFuture)
                 return try! Int.fetchOne(db, sql: "SELECT COUNT(*) FROM persons")!
             }


### PR DESCRIPTION
This PR renames the Future type to DatabaseFuture.

Futures are returned by the advanced [DatabasePool.concurrentRead](https://github.com/groue/GRDB.swift/blob/master/README.md#advanced-databasepool) method. Concurrent reads are a useful [optimization technique](https://forums.swift.org/t/concurrentread-question/20308/2), but remains a niche use case. GRDB is not a promise/future library.

The name Future can clash with other libraries (as reported by @pakko972). Renaming it to `DatabaseFuture` avoids this clash.