### PR TITLE
Fix notification name.

### DIFF
--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -185,7 +185,7 @@ extension DatabasePool {
         center.addObserver(
             self,
             selector: #selector(DatabasePool.applicationDidEnterBackground(_:)),
-            name: UIApplication.didReceiveMemoryWarningNotification,
+            name: UIApplication.didEnterBackgroundNotification,
             object: nil)
     }
     


### PR DESCRIPTION
Due to a typo, `DatabasePool` erroneously observes the same notification type.  I've fixed the typo.

- [x] This pull request is submitted against the `development` branch.

Per your comment on #510, I've opened this against GRDB-4.0.

- [x] Inline documentation has been updated.

Just fixing a typo; no docs need to be changed.

- [x] README.md or another dedicated guide has been updated.

Just fixing a typo; no docs need to be changed.

- [x] Changes are tested, for all flavors of GRDB, GRDBCipher, and GRDBCustomSQLite.

I haven't tested - the fix seems trivial?
