### PR TITLE
Associations: join condition cleanup

### DIFF
--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -246,28 +246,36 @@ extension Association {
     /// associated record are selected. The returned association does not
     /// require that the associated database table contains a matching row.
     public func including<A: Association>(optional association: A) -> Self where A.OriginRowDecoder == RowDecoder {
-        return mapRelation { association.sqlAssociation.relation(from: $0, required: false) }
+        return mapRelation {
+            association.sqlAssociation.relation(from: $0, required: false)
+        }
     }
     
     /// Creates an association that includes another one. The columns of the
     /// associated record are selected. The returned association requires
     /// that the associated database table contains a matching row.
     public func including<A: Association>(required association: A) -> Self where A.OriginRowDecoder == RowDecoder {
-        return mapRelation { association.sqlAssociation.relation(from: $0, required: true) }
+        return mapRelation {
+            association.sqlAssociation.relation(from: $0, required: true)
+        }
     }
     
     /// Creates an association that joins another one. The columns of the
     /// associated record are not selected. The returned association does not
     /// require that the associated database table contains a matching row.
     public func joining<A: Association>(optional association: A) -> Self where A.OriginRowDecoder == RowDecoder {
-        return mapRelation { association.select([]).sqlAssociation.relation(from: $0, required: false) }
+        return mapRelation {
+            association.select([]).sqlAssociation.relation(from: $0, required: false)
+        }
     }
     
     /// Creates an association that joins another one. The columns of the
     /// associated record are not selected. The returned association requires
     /// that the associated database table contains a matching row.
     public func joining<A: Association>(required association: A) -> Self where A.OriginRowDecoder == RowDecoder {
-        return mapRelation { association.select([]).sqlAssociation.relation(from: $0, required: true) }
+        return mapRelation {
+            association.select([]).sqlAssociation.relation(from: $0, required: true)
+        }
     }
 }
 

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -410,7 +410,7 @@ public /* TODO: internal */ struct SQLAssociation {
     // SQLAssociation is a non-empty array of association elements
     private struct Element {
         var key: String
-        var condition: SQLJoin.Condition
+        var condition: SQLJoinCondition
         var relation: SQLRelation
     }
     private var head: Element
@@ -423,7 +423,7 @@ public /* TODO: internal */ struct SQLAssociation {
         self.tail = tail
     }
     
-    init(key: String, condition: SQLJoin.Condition, relation: SQLRelation) {
+    init(key: String, condition: SQLJoinCondition, relation: SQLRelation) {
         head = Element(key: key, condition: condition, relation: relation)
         tail = []
     }

--- a/GRDB/QueryInterface/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Association/BelongsToAssociation.swift
@@ -146,7 +146,7 @@ extension TableRecord {
             destinationTable: Destination.databaseTableName,
             foreignKey: foreignKey)
         
-        let condition = SQLJoin.Condition(
+        let condition = SQLJoinCondition(
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: true)
         

--- a/GRDB/QueryInterface/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyAssociation.swift
@@ -146,7 +146,7 @@ extension TableRecord {
             destinationTable: databaseTableName,
             foreignKey: foreignKey)
         
-        let condition = SQLJoin.Condition(
+        let condition = SQLJoinCondition(
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: false)
         

--- a/GRDB/QueryInterface/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasOneAssociation.swift
@@ -148,7 +148,7 @@ extension TableRecord {
             destinationTable: databaseTableName,
             foreignKey: foreignKey)
         
-        let condition = SQLJoin.Condition(
+        let condition = SQLJoinCondition(
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: false)
         

--- a/GRDB/QueryInterface/Column.swift
+++ b/GRDB/QueryInterface/Column.swift
@@ -36,12 +36,6 @@ extension ColumnExpression {
     public func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return QualifiedColumn(name, alias: alias)
     }
-    
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    /// :nodoc:
-    public func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return self
-    }
 }
 
 /// A column in a database table.
@@ -84,16 +78,6 @@ struct QualifiedColumn: ColumnExpression {
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         // Never requalify
         return self
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        guard
-            let container = context[alias],
-            let value = container.value(forCaseInsensitiveColumn: name) else
-        {
-            return self
-        }
-        return value
     }
 }
 

--- a/GRDB/QueryInterface/SQLExpression+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLExpression+QueryInterface.swift
@@ -89,12 +89,6 @@ public struct SQLExpressionLiteral : SQLExpression {
     public func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return self
     }
-    
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    /// :nodoc:
-    public func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return self
-    }
 }
 
 // MARK: - SQLExpressionUnary
@@ -165,12 +159,6 @@ public struct SQLExpressionUnary : SQLExpression {
     /// :nodoc:
     public func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionUnary(op, expression.qualifiedExpression(with: alias))
-    }
-    
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    /// :nodoc:
-    public func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionUnary(op, expression.resolvedExpression(inContext: context))
     }
 }
 
@@ -275,12 +263,6 @@ public struct SQLExpressionBinary : SQLExpression {
     public func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionBinary(op, lhs.qualifiedExpression(with: alias), rhs.qualifiedExpression(with: alias))
     }
-    
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    /// :nodoc:
-    public func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionBinary(op, lhs.resolvedExpression(inContext: context), rhs.resolvedExpression(inContext: context))
-    }
 }
 
 // MARK: - SQLExpressionAnd
@@ -306,10 +288,6 @@ struct SQLExpressionAnd : SQLExpression {
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionAnd(expressions.map { $0.qualifiedExpression(with: alias) })
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionAnd(expressions.map { $0.resolvedExpression(inContext: context) })
     }
     
     func matchedRowIds(rowIdName: String?) -> Set<Int64>? {
@@ -346,10 +324,6 @@ struct SQLExpressionOr : SQLExpression {
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionOr(expressions.map { $0.qualifiedExpression(with: alias) })
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionOr(expressions.map { $0.resolvedExpression(inContext: context) })
     }
     
     func matchedRowIds(rowIdName: String?) -> Set<Int64>? {
@@ -412,10 +386,6 @@ struct SQLExpressionEqual: SQLExpression {
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionEqual(op, lhs.qualifiedExpression(with: alias), rhs.qualifiedExpression(with: alias))
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionEqual(op, lhs.resolvedExpression(inContext: context), rhs.resolvedExpression(inContext: context))
     }
     
     func matchedRowIds(rowIdName: String?) -> Set<Int64>? {
@@ -486,10 +456,6 @@ struct SQLExpressionContains : SQLExpression {
         return SQLExpressionContains(expression.qualifiedExpression(with: alias), collection, negated: isNegated)
     }
     
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionContains(expression.resolvedExpression(inContext: context), collection, negated: isNegated)
-    }
-    
     func matchedRowIds(rowIdName: String?) -> Set<Int64>? {
         // FIXME: this implementation ignores column aliases
         // Look for `id IN (1, 2, 3)`
@@ -558,14 +524,6 @@ struct SQLExpressionBetween : SQLExpression {
             expression.qualifiedExpression(with: alias),
             lowerBound.qualifiedExpression(with: alias),
             upperBound.qualifiedExpression(with: alias),
-            negated: isNegated)
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionBetween(
-            expression.resolvedExpression(inContext: context),
-            lowerBound.resolvedExpression(inContext: context),
-            upperBound.resolvedExpression(inContext: context),
             negated: isNegated)
     }
 }
@@ -646,12 +604,6 @@ public struct SQLExpressionFunction : SQLExpression {
     public func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionFunction(functionName, arguments: arguments.map { $0.qualifiedExpression(with: alias) })
     }
-    
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    /// :nodoc:
-    public func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionFunction(functionName, arguments: arguments.map { $0.resolvedExpression(inContext: context) })
-    }
 }
 
 // MARK: - SQLExpressionCount
@@ -675,10 +627,6 @@ struct SQLExpressionCount : SQLExpression {
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionCount(counted.qualifiedSelectable(with: alias))
     }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return self
-    }
 }
 
 // MARK: - SQLExpressionCountDistinct
@@ -700,10 +648,6 @@ struct SQLExpressionCountDistinct : SQLExpression {
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionCountDistinct(counted.qualifiedExpression(with: alias))
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return self
     }
 }
 
@@ -737,10 +681,6 @@ struct SQLExpressionIsEmpty : SQLExpression {
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionIsEmpty(countExpression.qualifiedExpression(with: alias), isEmpty: isEmpty)
     }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionIsEmpty(countExpression.resolvedExpression(inContext: context), isEmpty: isEmpty)
-    }
 }
 
 // MARK: - TableMatchExpression
@@ -757,12 +697,6 @@ struct TableMatchExpression: SQLExpression {
         return TableMatchExpression(
             alias: self.alias,
             pattern: pattern.qualifiedExpression(with: alias))
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return TableMatchExpression(
-            alias: alias,
-            pattern: pattern.resolvedExpression(inContext: context))
     }
 }
 
@@ -792,9 +726,5 @@ struct SQLExpressionCollate : SQLExpression {
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionCollate(expression.qualifiedExpression(with: alias), collationName: collationName)
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionCollate(expression.resolvedExpression(inContext: context), collationName: collationName)
     }
 }

--- a/GRDB/QueryInterface/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQLExpression.swift
@@ -48,9 +48,6 @@ public protocol SQLExpression : SQLSpecificExpressible, SQLSelectable, SQLOrderi
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression
-    
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression
 }
 
 extension SQLExpression {
@@ -146,9 +143,5 @@ struct SQLExpressionNot : SQLExpression {
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
         return SQLExpressionNot(expression.qualifiedExpression(with: alias))
-    }
-    
-    func resolvedExpression(inContext context: [TableAlias: PersistenceContainer]) -> SQLExpression {
-        return SQLExpressionNot(expression.resolvedExpression(inContext: context))
     }
 }

--- a/GRDB/QueryInterface/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQLRelation.swift
@@ -198,89 +198,91 @@ extension SQLRelation {
     }
 }
 
+// MARK: - SQLJoinCondition
+
+/// The condition that links two joined tables.
+///
+/// Currently, we only support one kind of join condition: foreign keys.
+///
+///     SELECT ... FROM book JOIN author ON author.id = book.authorId
+///                                         <- the join condition -->
+///
+/// When we eventually add support for new ways to join tables, Condition
+/// is the type we'll need to update.
+///
+/// Condition equality allows merging of associations:
+///
+///     // request1 and request2 are equivalent
+///     let request1 = Book
+///         .including(required: Book.author)
+///     let request2 = Book
+///         .including(required: Book.author)
+///         .including(required: Book.author)
+///
+///     // request3 and request4 are equivalent
+///     let request3 = Book
+///         .including(required: Book.author.filter(condition1 && condition2))
+///     let request4 = Book
+///         .joining(required: Book.author.filter(condition1))
+///         .including(optional: Book.author.filter(condition2))
+struct SQLJoinCondition: Equatable {
+    /// Definition of a foreign key
+    var foreignKeyRequest: ForeignKeyRequest
+    
+    /// True if the table at the origin of the foreign key is on the left of
+    /// the sql JOIN operator.
+    ///
+    /// Let's consider the `book.authorId -> author.id` foreign key.
+    /// Its origin table is `book`.
+    ///
+    /// The origin table `book` is on the left of the JOIN operator for
+    /// the BelongsTo association:
+    ///
+    ///     -- Book.including(required: Book.author)
+    ///     SELECT ... FROM book JOIN author ON author.id = book.authorId
+    ///
+    /// The origin table `book`is on the right of the JOIN operator for
+    /// the HasMany and HasOne associations:
+    ///
+    ///     -- Author.including(required: Author.books)
+    ///     SELECT ... FROM author JOIN book ON author.id = book.authorId
+    var originIsLeft: Bool
+    
+    var reversed: SQLJoinCondition {
+        return SQLJoinCondition(foreignKeyRequest: foreignKeyRequest, originIsLeft: !originIsLeft)
+    }
+    
+    /// Returns an SQL expression for the join condition.
+    ///
+    ///     SELECT ... FROM book JOIN author ON author.id = book.authorId
+    ///                                         <- the SQL expression -->
+    ///
+    /// - parameter db: A database connection.
+    /// - parameter leftAlias: A TableAlias for the table on the left of the
+    ///   JOIN operator.
+    /// - parameter rightAlias: A TableAlias for the table on the right of the
+    ///   JOIN operator.
+    /// - Returns: An SQL expression.
+    func sqlExpression(_ db: Database, leftAlias: TableAlias, rightAlias: TableAlias) throws -> SQLExpression {
+        let foreignKeyMapping = try foreignKeyRequest.fetchMapping(db)
+        let columnMapping: [(left: Column, right: Column)]
+        if originIsLeft {
+            columnMapping = foreignKeyMapping.map { (left: Column($0.origin), right: Column($0.destination)) }
+        } else {
+            columnMapping = foreignKeyMapping.map { (left: Column($0.destination), right: Column($0.origin)) }
+        }
+        
+        return columnMapping
+            .map { $0.right.qualifiedExpression(with: rightAlias) == $0.left.qualifiedExpression(with: leftAlias) }
+            .joined(operator: .and)
+    }
+}
+
 // MARK: - SQLJoin
 
 struct SQLJoin {
-    /// The condition that links two joined tables.
-    ///
-    /// Currently, we only support one kind of join condition: foreign keys.
-    ///
-    ///     SELECT ... FROM book JOIN author ON author.id = book.authorId
-    ///                                         <- the join condition -->
-    ///
-    /// When we eventually add support for new ways to join tables, Condition
-    /// is the type we'll need to update.
-    ///
-    /// Condition equality allows merging of associations:
-    ///
-    ///     // request1 and request2 are equivalent
-    ///     let request1 = Book
-    ///         .including(required: Book.author)
-    ///     let request2 = Book
-    ///         .including(required: Book.author)
-    ///         .including(required: Book.author)
-    ///
-    ///     // request3 and request4 are equivalent
-    ///     let request3 = Book
-    ///         .including(required: Book.author.filter(condition1 && condition2))
-    ///     let request4 = Book
-    ///         .joining(required: Book.author.filter(condition1))
-    ///         .including(optional: Book.author.filter(condition2))
-    struct Condition: Equatable {
-        /// Definition of a foreign key
-        var foreignKeyRequest: ForeignKeyRequest
-        
-        /// True if the table at the origin of the foreign key is on the left of
-        /// the sql JOIN operator.
-        ///
-        /// Let's consider the `book.authorId -> author.id` foreign key.
-        /// Its origin table is `book`.
-        ///
-        /// The origin table `book` is on the left of the JOIN operator for
-        /// the BelongsTo association:
-        ///
-        ///     -- Book.including(required: Book.author)
-        ///     SELECT ... FROM book JOIN author ON author.id = book.authorId
-        ///
-        /// The origin table `book`is on the right of the JOIN operator for
-        /// the HasMany and HasOne associations:
-        ///
-        ///     -- Author.including(required: Author.books)
-        ///     SELECT ... FROM author JOIN book ON author.id = book.authorId
-        var originIsLeft: Bool
-        
-        var reversed: Condition {
-            return Condition(foreignKeyRequest: foreignKeyRequest, originIsLeft: !originIsLeft)
-        }
-        
-        /// Returns an SQL expression for the join condition.
-        ///
-        ///     SELECT ... FROM book JOIN author ON author.id = book.authorId
-        ///                                         <- the SQL expression -->
-        ///
-        /// - parameter db: A database connection.
-        /// - parameter leftAlias: A TableAlias for the table on the left of the
-        ///   JOIN operator.
-        /// - parameter rightAlias: A TableAlias for the table on the right of the
-        ///   JOIN operator.
-        /// - Returns: An SQL expression.
-        func sqlExpression(_ db: Database, leftAlias: TableAlias, rightAlias: TableAlias) throws -> SQLExpression {
-            let foreignKeyMapping = try foreignKeyRequest.fetchMapping(db)
-            let columnMapping: [(left: Column, right: Column)]
-            if originIsLeft {
-                columnMapping = foreignKeyMapping.map { (left: Column($0.origin), right: Column($0.destination)) }
-            } else {
-                columnMapping = foreignKeyMapping.map { (left: Column($0.destination), right: Column($0.origin)) }
-            }
-            
-            return columnMapping
-                .map { $0.right.qualifiedExpression(with: rightAlias) == $0.left.qualifiedExpression(with: leftAlias) }
-                .joined(operator: .and)
-        }
-    }
-    
     var isRequired: Bool
-    var condition: Condition
+    var condition: SQLJoinCondition
     var relation: SQLRelation
 }
 

--- a/GRDB/QueryInterface/SQLSelectQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLSelectQueryGenerator.swift
@@ -405,7 +405,7 @@ private enum SQLQualifiedSource {
 /// A "qualified" join, where all tables are identified with a table alias.
 private struct SQLQualifiedJoin {
     private let isRequired: Bool
-    private let condition: SQLJoin.Condition
+    private let condition: SQLJoinCondition
     let relation: SQLQualifiedRelation
     
     init(_ join: SQLJoin) {


### PR DESCRIPTION
This PR brings no new feature, but refactors associations in a way that will help implementing eager loading of to-many associations.

Basically we need to inject raw values into join conditions such as `book.authorId = author.id`.

For example `author.books.fetchAll(db)` needs `book.authorId = 1`. And this was already possible.

Soon `Author.including(all: Author.books)` will need `book.authorId IN (1, 2, 3)`. And this is what this PR brings.