### PR TITLE
Eager Loading of HasMany associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#510](https://github.com/groue/GRDB.swift/pull/510) by [@charlesmchen-signal](https://github.com/charlesmchen-signal): Expose DatabaseRegion(table:) initializer
 - [#515](https://github.com/groue/GRDB.swift/pull/515) by [@alextrob](https://github.com/alextrob): Add "LIMIT 1" to `fetchOne` requests
 - [#517](https://github.com/groue/GRDB.swift/pull/517): Support for SQLCipher 4
+- [#525](https://github.com/groue/GRDB.swift/pull/525): Eager Loading of HasMany associations
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ The ideas, in alphabetical order:
 
 :bowtie: Public API Challenge :muscle: Hard :fire: Experimental
 
-Associations can be enhanced in several ways. See the "Known Issues" and "Future Directions" chapter of the [Associations Guide](Documentation/AssociationsBasics.md)
+Associations can be enhanced in several ways. See the "Known Issues" chapter of the [Associations Guide](Documentation/AssociationsBasics.md)
 
 
 ### CloudKit

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1514,17 +1514,17 @@ let request = Book
 
 This requests for all books, with their cover images, and their authors and translators. Those people are themselves decorated with their respective nationalities.
 
-We plan to decode this request into is the following record:
+We plan to decode this request into is the following nested record:
 
 ```swift
 struct BookInfo: FetchableRecord, Decodable {
-    struct AuthorInfo: Decodable {
-        var author: Author
+    struct PersonInfo: Decodable {
+        var person: Person
         var country: Country?
     }
     var book: Book
-    var authorInfo: AuthorInfo
-    var translatorInfo: AuthorInfo?
+    var authorInfo: PersonInfo
+    var translatorInfo: PersonInfo?
     var coverImage: CoverImage?
 }
 ```

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -12,7 +12,6 @@ GRDB Associations
     - [Choosing Between BelongsTo and HasOne]
     - [Self Joins]
 - [Associations and the Database Schema]
-    - [Convention for Database Table Names]
     - [Convention for the BelongsTo Association]
     - [Convention for the HasOne Association]
     - [Convention for the HasMany Association]
@@ -434,63 +433,11 @@ GRDB also comes with several *conventions* for defining your database schema.
 
 Those conventions help associations be convenient and, generally, "just work". When you can't, or don't want to follow conventions, you will have to override the expected defaults in your Swift code.
 
-- [Convention for Database Table Names]
 - [Convention for the BelongsTo Association]
 - [Convention for the HasMany Association]
 - [Convention for the HasOne Association]
 - [Foreign Keys]
 
-
-## Convention for Database Table Names
-
-**Database table names should be singular and camel-cased.**
-
-Make them look like Swift identifiers: `book`, `author`, `postalAddress`.
-
-This convention helps fetching values from associations. It is used, for example, in the sample code below, where we load all pairs of books along with their authors:
-
-```swift
-// The Author record
-struct Author: FetchableRecord, TableRecord {
-}
-
-// The Book record
-struct Book: FetchableRecord, TableRecord {
-    static let author = belongsTo(Author.self)
-}
-
-// A pair made of a book and its author
-struct BookInfo: FetchableRecord, Decodable {
-    let book: Book
-    let author: Author?
-}
-
-let request = Book.including(optional: Book.author)
-let bookInfos = BookInfo.fetchAll(db, request)
-```
-
-This sample code only works if the database table for authors is called "author". The name "author" is the key that helps BookInfo initialize its `author` property. For your convenience, "author" is also the default value of the `Author.databaseTableName` property (see the [TableRecord] protocol).
-
-If the database schema does not follow this convention, and has, for example, database tables named with plural names (`authors` and `books`), you can still use associations. But you need to help row consumption by providing the required key:
-
-```swift
-// Setup for customized table names
-
-struct Author: FetchableRecord, TableRecord {
-    // Customized table name
-    static let databaseTableName = "authors"
-}
-
-struct Book: FetchableRecord, TableRecord {
-    // Customized table name
-    static let databaseTableName = "books"
-    
-    // Explicit association key
-    static let author = belongsTo(Author.self, key: "author")
-}
-```
-
-See [The Structure of a Joined Request] for more information.
 
 
 ## Convention for the BelongsTo Association
@@ -2202,7 +2149,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [Record]: ../README.md#records
 [Foreign Key Actions]: https://sqlite.org/foreignkeys.html#fk_actions
 [Associations and the Database Schema]: #associations-and-the-database-schema
-[Convention for Database Table Names]: #convention-for-database-table-names
 [Convention for the BelongsTo Association]: #convention-for-the-belongsto-association
 [Convention for the HasOne Association]: #convention-for-the-hasone-association
 [Convention for the HasMany Association]: #convention-for-the-hasmany-association

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -2271,6 +2271,25 @@ let request = Author
 
 Come [discuss](http://twitter.com/groue) for more information, or if you wish to help turning those features into reality.
 
+**You can't use the `including(all:)` method with a [HasMany] and a [HasManyThrough] associations that shares the same base association in the same request:
+
+```swift
+// NOT IMPLEMENTED
+let request = Country
+    .including(all: Country.passports)
+    .including(all: Country.citizens)
+```
+
+This code compiles, but you'll get a runtime fatal error "Not implemented: merging a direct association and an indirect one with including(all:)". Future versions of GRDB may allow such requests.
+
+The workaround is to nest the most remote association:
+
+```swift
+// Workaround
+let request = Country
+    .including(all: Country.passports
+        .including(required: Passport.citizen))
+```
 
 ---
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -149,7 +149,7 @@ Generally speaking, associations use the [TableRecord], [FetchableRecord], and [
     // Who's prolific?
     let authors = try dbQueue.read { db in
         try Author
-            .having(Author.book.count >= 20)
+            .having(Author.books.count >= 20)
             .fetchAll(db) // [Author]
     }
     ```

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -839,10 +839,11 @@ The pattern is always the same: you start from a base request, that you extend w
         .including(required: Book.author)
     
     // This request can feed the following record:
-    struct BookInfo {
+    struct BookInfo: FetchableRecord, Decodable {
         var book: Book
         var author: Author
     }
+    let bookInfos: [BookInfo] = try BookInfo.fetchAll(db, request)
     ```
     
     And to load authors with their respective books (a to-many association), you use `including` as well:
@@ -853,10 +854,11 @@ The pattern is always the same: you start from a base request, that you extend w
         .including(all: Author.books)
     
     // This request can feed the following record:
-    struct AuthorInfo {
+    struct AuthorInfo: FetchableRecord, Decodable {
         var author: Author
         var books: [Book]
     }
+    let authorInfos: [AuthorInfo] = try AuthorInfo.fetchAll(db, request)
     ```
     
     On the other side, to load all books written by a French author, you sure need to filter authors, but you don't need them to be present in the fetched results. You prefer `joining`:
@@ -866,7 +868,8 @@ The pattern is always the same: you start from a base request, that you extend w
     let request = Book
         .joining(required: Book.author.filter(Column("countryCode") == "FR"))
     
-    // This request can feed the Book record.
+    // This request can feed the Book record:
+    let books: [Book] = try request.fetchAll(db)
     ```
 
 2. For to-one associations, should the request allow missing associated records?
@@ -881,10 +884,11 @@ The pattern is always the same: you start from a base request, that you extend w
         .including(optional: Book.author)
     
     // This request can feed the following record:
-    struct BookInfo {
+    struct BookInfo: FetchableRecord, Decodable {
         var book: Book
         var author: Author?
     }
+    let bookInfos: [BookInfo] = try BookInfo.fetchAll(db, request)
     ```
     
     You can remember to use `optional` when the fetched associated records should feed optional Swift values, of type `Author?`. Conversely, when the fetched results feed non-optional values of type `Author`, prefer `required`.

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -485,9 +485,9 @@ extension Author {
 
 GRDB will automatically **pluralize** or **singularize** names in order to help you easily associate records.
 
-For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without any explicit configuration, if the names of the backing database tables are "book" and "author".
+For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount` in your decoded records, without any explicit configuration, as long as the names of the backing database tables are "book" and "author".
 
-The GRDB pluralization mechanisms are very powerful, being capable of pluralizing (and singularizing) both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
+The GRDB pluralization mechanisms are very powerful, being capable of pluralizing and singularizing both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
 
 When using class names composed of two or more words, the table name should use the camelCase singular form:
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -712,8 +712,6 @@ Building Requests from Associations
 
 **Once you have defined associations, you can define fetch request that involve several record types.**
 
-> :point_up: **Note**: Those requests are executed by SQLite as *SQL joined queries*. In all examples below, we'll show the SQL queries executed by our association-based requests. You can ignore them if you are not familiar with SQL.
-
 Fetch requests do not visit the database until you fetch values from them. This will be covered in [Fetching Values from Associations]. But before you can fetch anything, you have to describe what you want to fetch. This is the topic of this chapter.
 
 - [Requesting Associated Records]

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1378,7 +1378,7 @@ Each association included in the request can feed a property of the decoded reco
     
     struct EmployeeInfo: FetchableRecord, Decodable {
         var employee: Employee
-        var manager: Employee?
+        var manager: Employee? // the optional manager
         var subordinates: Set<Employee>
     }
     let employeeInfos: [EmployeeInfo] = try EmployeeInfo.fetchAll(db, request)
@@ -1395,7 +1395,7 @@ Each association included in the request can feed a property of the decoded reco
     
     struct BookInfo: FetchableRecord, Decodable {
         var book: Book
-        var author: Author
+        var author: Author // the required author
         var country: Country?
         var coverImage: CoverImage?
     }

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -2269,8 +2269,6 @@ let request = Book.joining(required: Book.author
             .filter(Column("publishDate") >= authorAlias[Column("deathDate")]))    
     ```
 
-    Come [discuss](http://twitter.com/groue) for more information, or if you wish to help turning those features into reality.
-
 - **You can't use the `including(all:)` method with a [HasMany] and a [HasManyThrough] associations that share the same base association in the same request**:
 
     ```swift
@@ -2290,6 +2288,8 @@ let request = Book.joining(required: Book.author
         .including(all: Country.passports
             .including(required: Passport.citizen))
     ```
+    
+Come [discuss](http://twitter.com/groue) for more information, or if you wish to help turning those missing features into reality.
 
 ---
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1402,12 +1402,12 @@ By default, **association keys** are the names of the database tables of associa
 extension Author {
     static let books = hasMany(Book.self)
 }
-Author.including(all: Author.books)            // key "books"
+Author.including(all: Author.books)            // association key "books"
 
 extension Book {
     static let author = belongsTo(Author.self)
 }
-Book.including(required: Book.author)          // key "author"
+Book.including(required: Book.author)          // association key "author"
 ```
 
 Keys can be customized when the association is defined:
@@ -1416,7 +1416,7 @@ Keys can be customized when the association is defined:
 extension Employee {
     static let manager = belongsTo(Employee.self, key: "manager")
 }
-Employee.including(optional: Employee.manager) // key "manager"
+Employee.including(optional: Employee.manager) // association key "manager"
 ```
 
 Keys can also be customized with the `forKey` method:
@@ -1427,7 +1427,7 @@ extension Author {
         .filter(Column("kind") == "novel")
         .forKey("novels")
 }
-Author.including(all: Author.novels)           // key "novels"
+Author.including(all: Author.novels)           // association key "novels"
 ```
 
 
@@ -1718,12 +1718,12 @@ As seen in the above example, some aggregated values are given a **default name*
 
 | Method | Key | Column | Default name |
 | --------- | --- | ------ | ------------- |
-| `Author.books.isEmpty  `                | `book` | -        | -                  |
-| `Author.books.count  `                  | `book` | -        | `bookCount`        |
-| `Author.books.min(Column("year"))`      | `book` | `year`   | `minBookYear`      |
-| `Author.books.max(Column("year"))`      | `book` | `year`   | `maxBookYear`      |
-| `Author.books.average(Column("price"))` | `book` | `price`  | `averageBookPrice` |
-| `Author.books.sum(Column("awards"))   ` | `book` | `awards` | `bookAwardsSum`    |
+| `Author.books.isEmpty  `                | `books` | -        | -                  |
+| `Author.books.count  `                  | `books` | -        | `bookCount`        |
+| `Author.books.min(Column("year"))`      | `books` | `year`   | `minBookYear`      |
+| `Author.books.max(Column("year"))`      | `books` | `year`   | `maxBookYear`      |
+| `Author.books.average(Column("price"))` | `books` | `price`  | `averageBookPrice` |
+| `Author.books.sum(Column("awards"))   ` | `books` | `awards` | `bookAwardsSum`    |
 
 You give a custom name to an aggregated value with the `aliased` method:
 
@@ -2025,7 +2025,7 @@ In the example below, we use compute two aggregates from the same association `A
     
     ```swift
     struct Author: TableRecord {
-        static let books = hasMany(Book.self) // association key "book"
+        static let books = hasMany(Book.self) // association key "books"
     }
     
     struct AuthorInfo: Decodable, FetchableRecord {
@@ -2035,8 +2035,8 @@ In the example below, we use compute two aggregates from the same association `A
     }
     
     let request = Author.annotated(with:
-        Author.books.min(Column("year")), // association key "book"
-        Author.books.max(Column("year"))) // association key "book"
+        Author.books.min(Column("year")), // association key "books"
+        Author.books.max(Column("year"))) // association key "books"
     let authorInfos: [AuthorInfo] = try AuthorInfo.fetchAll(db, request)
     ```
 
@@ -2060,8 +2060,8 @@ In this other example, the `Author.books` and `Author.paintings` have the distin
     
     ```swift
     struct Author: TableRecord {
-        static let books = hasMany(Book.self)         // association key "book"
-        static let paintings = hasMany(Painting.self) // association key "painting"
+        static let books = hasMany(Book.self)         // association key "books"
+        static let paintings = hasMany(Painting.self) // association key "paintings"
     }
     
     struct AuthorInfo: Decodable, FetchableRecord {
@@ -2069,8 +2069,8 @@ In this other example, the `Author.books` and `Author.paintings` have the distin
         var workCount: Int
     }
     
-    let aggregate = Author.books.count +   // association key "book"
-                    Author.paintings.count // association key "painting"
+    let aggregate = Author.books.count +   // association key "books"
+                    Author.paintings.count // association key "paintings"
     let request = Author.annotated(with: aggregate.aliased("workCount"))
     let authorInfos: [AuthorInfo] = try AuthorInfo.fetchAll(db, request)
     ```
@@ -2096,7 +2096,7 @@ But in the following example, we use the same association `Author.books` twice, 
     
     ```swift
     struct Author: TableRecord {
-        static let books = hasMany(Book.self) // association key "book"
+        static let books = hasMany(Book.self) // association key "books"
     }
     
     struct AuthorInfo: Decodable, FetchableRecord {
@@ -2107,11 +2107,11 @@ But in the following example, we use the same association `Author.books` twice, 
     
     let novelCount = Author.books
         .filter(Column("kind") == "novel")
-        .forKey("novel")                         // association key "novel"
+        .forKey("novels")                        // association key "novels"
         .count
     let theatrePlayCount = Author.books
         .filter(Column("kind") == "theatrePlay")
-        .forKey("theatrePlay")                   // association key "theatrePlay"
+        .forKey("theatrePlays")                  // association key "theatrePlays"
         .count
     let request = Author.annotated(with: novelCount, theatrePlayCount)
     let authorInfos: [AuthorInfo] = try AuthorInfo.fetchAll(db, request)
@@ -2136,11 +2136,11 @@ But in the following example, we use the same association `Author.books` twice, 
     
     ```swift
     // WRONG: not counting distinct sets of associated books
-    let novelCount = Author.books                // association key "book"
+    let novelCount = Author.books                // association key "books"
         .filter(Column("kind") == "novel")
         .count
         .aliased("novelCount")
-    let theatrePlayCount = Author.books          // association key "book"
+    let theatrePlayCount = Author.books          // association key "books"
         .filter(Column("kind") == "theatrePlay")
         .count
         .aliased("theatrePlayCount")

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1559,7 +1559,7 @@ let bookInfos = try BookInfo.all().fetchAll(db, request) // [BookInfo]
 
 When [Dedocable](#decoding-a-joined-request-with-a-decodable-record) records provides convenient decoding of joined rows, you may want a little more control over row decoding.
 
-The `init(row:)` initializer of the FetchableRecord protocol is what you look after:
+The `init(row:)` initializer of the [FetchableRecord] protocol is what you look after:
 
 ```swift
 let request = Book

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -12,6 +12,7 @@ GRDB Associations
     - [Choosing Between BelongsTo and HasOne]
     - [Self Joins]
 - [Associations and the Database Schema]
+    - [Convention for Database Table Names]
     - [Convention for the BelongsTo Association]
     - [Convention for the HasOne Association]
     - [Convention for the HasMany Association]
@@ -270,7 +271,7 @@ The **HasOne** association between a country and its demographics needs that the
 
 ![HasOneSchema](https://cdn.rawgit.com/groue/GRDB.swift/master/Documentation/Images/Associations2/HasOneSchema.svg)
 
-Note that this demographics example of HasOne association uses an explicit `"demographics"` key, unlike the BelongsTo and HasMany associations above. This key is necessary when you use a plural name for a one-to-one association. See [TODO] for more information.
+Note that this demographics example of HasOne association uses an explicit `"demographics"` key, unlike the BelongsTo and HasMany associations above. This key is necessary when you use a plural name for a one-to-one association. See [Convention for Database Table Names] for more information.
 
 See [Convention for the HasOne Association] for some sample code that defines the database schema for such an association, and [Building Requests from Associations] in order to learn how to use it.
 
@@ -450,11 +451,51 @@ GRDB also comes with several *conventions* for defining your database schema.
 
 Those conventions help associations be convenient and, generally, "just work". When you can't, or don't want to follow conventions, you will have to override the expected defaults in your Swift code.
 
+- [Convention for Database Table Names]
 - [Convention for the BelongsTo Association]
 - [Convention for the HasMany Association]
 - [Convention for the HasOne Association]
 - [Foreign Keys]
 
+
+## Convention for Database Table Names
+
+**Database table names should be singular and camelCased.**
+
+Make them look like Swift identifiers: `book`, `author`, `postalAddress`.
+
+If the database schema does not follow this convention, and has, for example, database tables which are named with underscores (`postal_address`), you can still use associations. But you need to help row consumption by providing the required key:
+
+```swift
+// Setup for customized table names
+
+struct PostalAddress: TableRecord {
+    // Customized table name
+    static let databaseTableName = "postal_address"
+}
+
+extension Author {
+    // Explicit association key
+    static let postalAddress = belongsTo(PostalAddress.self, key: "postalAddress")
+}
+```
+
+GRDB will automatically *pluralize** or *singularize** names in order to help you easily associate records.
+
+For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without explicit configuration, if the names of the backing database tables are "book" and "author".
+
+The GRDB pluralization mechanisms are very powerful, being capable of pluralizing (and singularizing) both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
+
+When using class names composed of two or more words, the table name should use the camelCase singular form:
+
+| RecordType | Table Name | Derived identifiers |
+| ---------- | ---------- | ------------------- |
+| Book       | book       | `book`, `books`, `bookCount` |
+| LineItem   | lineItem   | `lineItem`, `lineItems`, `lineItemPriceSum` |
+| Mouse      | mouse      | `mouse`, `mice`, `mouseCount` |
+| Person     | person     | `person`, `people`, `personCount` |
+
+See [The Structure of a Joined Request] for more information.
 
 
 ## Convention for the BelongsTo Association
@@ -2264,6 +2305,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [Record]: ../README.md#records
 [Foreign Key Actions]: https://sqlite.org/foreignkeys.html#fk_actions
 [Associations and the Database Schema]: #associations-and-the-database-schema
+[Convention for Database Table Names]: #convention-for-database-table-names
 [Convention for the BelongsTo Association]: #convention-for-the-belongsto-association
 [Convention for the HasOne Association]: #convention-for-the-hasone-association
 [Convention for the HasMany Association]: #convention-for-the-hasmany-association

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -492,7 +492,7 @@ migrator.registerMigration("Books and Authors") { db in
 4. Create an index on the `book.authorId` column in order to ease the selection of an author's books.
 5. Create a foreign key from `book.authorId` column to `authors.id`, so that SQLite guarantees that no book refers to a missing author. The `onDelete: .cascade` option has SQLite automatically delete all of an author's books when that author is deleted. See [Foreign Key Actions] for more information.
 
-The example above uses auto-incremented primary keys. But generally speaking, all primary keys are supported.
+The example above uses auto-incremented primary keys. But generally speaking, all primary keys are supported, including composite primary keys that span several columns.
 
 Following this convention lets you write, for example:
 
@@ -551,7 +551,7 @@ migrator.registerMigration("Books and Authors") { db in
 4. Create an index on the `book.authorId` column in order to ease the selection of an author's books.
 5. Create a foreign key from `book.authorId` column to `authors.id`, so that SQLite guarantees that no book refers to a missing author. The `onDelete: .cascade` option has SQLite automatically delete all of an author's books when that author is deleted. See [Foreign Key Actions] for more information.
 
-The example above uses auto-incremented primary keys. But generally speaking, all primary keys are supported.
+The example above uses auto-incremented primary keys. But generally speaking, all primary keys are supported, including composite primary keys that span several columns.
 
 Following this convention lets you write, for example:
 
@@ -611,7 +611,7 @@ migrator.registerMigration("Countries") { db in
 4. Create a unique index on the `demographics.countryCode` column in order to guarantee the unicity of any country's profile.
 5. Create a foreign key from `demographics.countryCode` column to `country.code`, so that SQLite guarantees that no profile refers to a missing country. The `onDelete: .cascade` option has SQLite automatically delete a profile when its country is deleted. See [Foreign Key Actions] for more information.
 
-The example above uses a string primary key for the "country" table. But generally speaking, all primary keys are supported.
+The example above uses a string primary key for the "country" table. But generally speaking, all primary keys are supported, including composite primary keys that span several columns.
 
 Following this convention lets you write, for example:
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -2247,49 +2247,49 @@ let request = Book.joining(required: Book.author
 
 ## Known Issues
 
-**You can't chain a required association on an optional association:**
+- **You can't chain a required association on an optional association:**
 
-```swift
-// NOT IMPLEMENTED
-let request = Book
-    .joining(optional: Book.author
-        .including(required: Person.country))
-```
+    ```swift
+    // NOT IMPLEMENTED
+    let request = Book
+        .joining(optional: Book.author
+            .including(required: Person.country))
+    ```
 
-This code compiles, but you'll get a runtime fatal error "Not implemented: chaining a required association behind an optional association". Future versions of GRDB may allow such requests.
+    This code compiles, but you'll get a runtime fatal error "Not implemented: chaining a required association behind an optional association". Future versions of GRDB may allow such requests.
 
-**You can't use the `including(all:)` method and use table aliases to filter the associated records on other records:**
+- **You can't use the `including(all:)` method and use table aliases to filter the associated records on other records:**
 
-```swift
-// NOT IMPLEMENTED: loading all authors along with their posthumous books
-let authorAlias = TableAlias()
-let request = Author
-    .aliased(authorAlias)
-    .including(all: Author.books
-        .filter(Column("publishDate") >= authorAlias[Column("deathDate")]))    
-```
+    ```swift
+    // NOT IMPLEMENTED: loading all authors along with their posthumous books
+    let authorAlias = TableAlias()
+    let request = Author
+        .aliased(authorAlias)
+        .including(all: Author.books
+            .filter(Column("publishDate") >= authorAlias[Column("deathDate")]))    
+    ```
 
-Come [discuss](http://twitter.com/groue) for more information, or if you wish to help turning those features into reality.
+    Come [discuss](http://twitter.com/groue) for more information, or if you wish to help turning those features into reality.
 
-**You can't use the `including(all:)` method with a [HasMany] and a [HasManyThrough] associations that shares the same base association in the same request:
+- **You can't use the `including(all:)` method with a [HasMany] and a [HasManyThrough] associations that share the same base association in the same request**:
 
-```swift
-// NOT IMPLEMENTED
-let request = Country
-    .including(all: Country.passports)
-    .including(all: Country.citizens)
-```
+    ```swift
+    // NOT IMPLEMENTED
+    let request = Country
+        .including(all: Country.passports)
+        .including(all: Country.citizens)
+    ```
 
-This code compiles, but you'll get a runtime fatal error "Not implemented: merging a direct association and an indirect one with including(all:)". Future versions of GRDB may allow such requests.
+    This code compiles, but you'll get a runtime fatal error "Not implemented: merging a direct association and an indirect one with including(all:)". Future versions of GRDB may allow such requests.
 
-The workaround is to nest the most remote association:
+    The workaround is to nest the most remote association:
 
-```swift
-// Workaround
-let request = Country
-    .including(all: Country.passports
-        .including(required: Passport.citizen))
-```
+    ```swift
+    // Workaround
+    let request = Country
+        .including(all: Country.passports
+            .including(required: Passport.citizen))
+    ```
 
 ---
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -128,7 +128,7 @@ Before we dive in, please remember that associations can not generate all possib
 
 When your record type is a subclass of the [Record class], all necessary protocols are already setup and ready: you can skip this chapter.
 
-Otherwise:
+Generally speaking, associations use the [TableRecord], [FetchableRecord], and [EncodableRecord] protocols:
 
 - **[TableRecord]** is the protocol that lets you declare associations between record types:
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1438,7 +1438,7 @@ struct BookInfo: FetchableRecord, Decodable {
 let bookInfos: [BookInfo] = try BookInfo.fetchAll(db, request)
 ```
 
-By default, **association keys** are the names of the database tables of associated records. Keys are automatically singularized, or pluralized, depending of the cardinality of the included association:
+By default, **association keys** are the names of the database tables of associated records. Keys are automatically [singularized or pluralized](#convention-for-database-table-names), depending of the cardinality of the included association:
 
 ```swift
 extension Author {

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -37,7 +37,6 @@ GRDB Associations
     - [Isolation of Multiple Aggregates]
 - [DerivableRequest Protocol]
 - [Known Issues]
-- [Future Directions]
 
 
 ## Associations Benefits
@@ -2208,15 +2207,6 @@ let request = Author
         .filter(Column("publishDate") >= authorAlias[Column("deathDate")]))    
 ```
 
-
-## Future Directions
-
-The APIs that have been described above do not cover the whole topic of joined requests. Among the biggest omissions, there is:
-
-- One can not yet join two tables without a foreign key. One can not build the plain `SELECT * FROM a JOIN b`, for example.
-
-- One can not yet express requests such as "all authors with all their books".
-
 Come [discuss](http://twitter.com/groue) for more information, or if you wish to help turning those features into reality.
 
 
@@ -2304,7 +2294,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 [Isolation of Multiple Aggregates]: #isolation-of-multiple-aggregates
 [DerivableRequest Protocol]: #derivablerequest-protocol
 [Known Issues]: #known-issues
-[Future Directions]: #future-directions
 [Row Adapters]: ../README.md#row-adapters
 [query interface requests]: ../README.md#requests
 [TableRecord]: ../README.md#tablerecord-protocol

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -463,7 +463,7 @@ Those conventions help associations be convenient and, generally, "just work". W
 
 ## Convention for Database Table Names
 
-**Database table names should be singular and camelCased.**
+**Database table names should be written in English, singular, and camelCased.**
 
 Make them look like Swift identifiers: `book`, `author`, `postalAddress`.
 
@@ -495,8 +495,10 @@ When using class names composed of two or more words, the table name should use 
 | ---------- | ---------- | ------------------- |
 | Book       | book       | `book`, `books`, `bookCount` |
 | LineItem   | lineItem   | `lineItem`, `lineItems`, `lineItemPriceSum` |
-| Mouse      | mouse      | `mouse`, `mice`, `mouseCount` |
+| Mouse      | mouse      | `mouse`, `mice`, `maxMouseSize` |
 | Person     | person     | `person`, `people`, `personCount` |
+
+If your application relies on non-English names, GRDB may generate unexpected identifiers. If this happens, please [open an issue](http://github.com/groue/GRDB.swift/issues).
 
 See [The Structure of a Joined Request] for more information.
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -467,10 +467,10 @@ Those conventions help associations be convenient and, generally, "just work". W
 
 Make them look like Swift identifiers: `book`, `author`, `postalAddress`.
 
-If the database schema does not follow this convention, and has, for example, database tables which are named with underscores (`postal_address`), you can still use associations. But you need to help row consumption by providing the required key:
+If the database schema does not follow this convention, and has, for example, database tables which are named with underscores (`postal_address`), you can still use associations. But you need to help row consumption by naming your associations with a customized key:
 
 ```swift
-// Setup for customized table names
+// Setup for table names that does not follow the expected convention
 
 struct PostalAddress: TableRecord {
     // Customized table name
@@ -478,7 +478,7 @@ struct PostalAddress: TableRecord {
 }
 
 extension Author {
-    // Explicit association key
+    // Customized association key
     static let postalAddress = belongsTo(PostalAddress.self, key: "postalAddress")
 }
 ```

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -482,7 +482,7 @@ extension Author {
 }
 ```
 
-GRDB will automatically *pluralize** or *singularize** names in order to help you easily associate records.
+GRDB will automatically **pluralize** or **singularize** names in order to help you easily associate records.
 
 For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without explicit configuration, if the names of the backing database tables are "book" and "author".
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -485,7 +485,7 @@ extension Author {
 
 GRDB will automatically **pluralize** or **singularize** names in order to help you easily associate records.
 
-For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without explicit configuration, if the names of the backing database tables are "book" and "author".
+For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without any explicit configuration, if the names of the backing database tables are "book" and "author".
 
 The GRDB pluralization mechanisms are very powerful, being capable of pluralizing (and singularizing) both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -423,7 +423,7 @@ migrator.registerMigration("Employees") { db in
 }
 ```
 
-Note that both sides of the self-join use a customized [association key]. This helps consuming this association. For example:
+Note that both sides of the self-join use a customized **[association key](#the-structure-of-a-joined-request)**. This helps consuming this association. For example:
 
 ```swift
 struct EmployeeInfo: FetchableRecord, Decodable {
@@ -438,6 +438,8 @@ let request = Employee
 
 let employeeInfos: [EmployeeInfo] = try EmployeeInfo.fetchAll(db, request)
 ```
+
+See [Fetching Values from Associations] for more information.
 
 
 Associations and the Database Schema

--- a/Documentation/GRDB3MigrationGuide.md
+++ b/Documentation/GRDB3MigrationGuide.md
@@ -75,7 +75,7 @@ GRDB4 brought a few new [associations] features:
     
     let country: Country = ...
     let citizens: [Citizen] = try dbQueue.read { db in
-        country.citizens.fetchAll(db)
+        try country.citizens.fetchAll(db)
     }
     ```
     
@@ -101,7 +101,7 @@ GRDB4 brought a few new [associations] features:
     
     GRDB will automatically **pluralize** or **singularize** names in order to help you easily associate records.
 
-    For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without explicit configuration, as long as the names of the backing database tables are "book" and "author".
+    For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without any explicit configuration, as long as the names of the backing database tables are "book" and "author".
 
     The GRDB pluralization mechanisms are very powerful, being capable of pluralizing (and singularizing) both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
     

--- a/Documentation/GRDB3MigrationGuide.md
+++ b/Documentation/GRDB3MigrationGuide.md
@@ -101,9 +101,9 @@ GRDB4 brought a few new [associations] features:
     
     GRDB will automatically **pluralize** or **singularize** names in order to help you easily associate records.
 
-    For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without any explicit configuration, as long as the names of the backing database tables are "book" and "author".
+    For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount` in your decoded records, without any explicit configuration, as long as the names of the backing database tables are "book" and "author".
 
-    The GRDB pluralization mechanisms are very powerful, being capable of pluralizing (and singularizing) both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
+    The GRDB pluralization mechanisms are very powerful, being capable of pluralizing and singularizing both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
     
     However, this change may have introduced some incompatibilities with GRDB 3 associations. Check [The Structure of a Joined Request] for more information.
 

--- a/Documentation/GRDB3MigrationGuide.md
+++ b/Documentation/GRDB3MigrationGuide.md
@@ -50,6 +50,64 @@ In GRDB 3, this scheduling used to be named `.queue(_: startImmediately:)`.
 The second breaking change is `ValueObservation.extent`, which was removed in GRDB 4. Now all observations last until the observer returned by the `start` method is deallocated.
 
 
+### Associations
+
+GRDB4 brought a few new [associations] features:
+
+- **Indirect associations** [HasOneThrough] and [HasManyThrough] let you define associations from a record to another through a third one. For example, they let you easily express many-to-many relations such as "a country has many citizens through its passports":
+
+    ```swift
+    struct Country: TableRecord, EncodableRecord {
+        static let passports = hasMany(Passport.self)
+        // New!
+        static let citizens = hasMany(Citizen.self, through: passports, using: Passport.citizen)
+        var citizens: QueryInterfaceRequest<Citizen> {
+            return request(for: Country.citizens)
+        }
+    }
+
+    struct Passport: TableRecord {
+        static let citizen = belongsTo(Citizen.self)
+    }
+ 
+    struct Citizen: TableRecord {
+    }
+    
+    let country: Country = ...
+    let citizens: [Citizen] = try dbQueue.read { db in
+        country.citizens.fetchAll(db)
+    }
+    ```
+    
+    ![HasManyThroughSchema](https://cdn.rawgit.com/groue/GRDB.swift/master/Documentation/Images/Associations2/HasManyThroughSchema.svg)
+
+- **Eager loading of HasMany associations**: The new `including(all:)` method lets you load arrays or sets of associated records in a single request:
+
+    ```swift
+    // All authors with their respective books
+    let request = Author.including(all: Author.books)
+    
+    // This request can feed the following record:
+    struct AuthorInfo: FetchableRecord, Decodable {
+        var author: Author
+        var books: [Book] // all associated books
+    }
+    let authorInfos: [AuthorInfo] = try AuthorInfo.fetchAll(db, request)
+    ```
+    
+    See [Joining And Prefetching Associated Records] for more information.
+
+- **Automatic pluralization and singularization** of association identifiers.
+    
+    GRDB will automatically **pluralize** or **singularize** names in order to help you easily associate records.
+
+    For example, the Book and Author records will automatically feed properties named `books`, `author`, or `bookCount`, without explicit configuration, as long as the names of the backing database tables are "book" and "author".
+
+    The GRDB pluralization mechanisms are very powerful, being capable of pluralizing (and singularizing) both regular and irregular words (it's directly inspired from the battle-tested [Ruby on Rails inflections](https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-pluralize)).
+    
+    However, this change may have introduced some incompatibilities with GRDB 3 associations. Check [The Structure of a Joined Request] for more information.
+
+
 ### SQLCipher
 
 The integration of GRDB with SQLCipher has changed.
@@ -70,9 +128,9 @@ The integration of GRDB with SQLCipher has changed.
     +import GRDB
     ```
 
-2. The default SQLCipher version which comes with GRDB 4 is now SQLCipher 4, which is incompatible with SQLCipher 3. See [Encryption] for more details.
+2. The default SQLCipher version which comes with GRDB 4 is now SQLCipher 4, which is incompatible with SQLCipher 3. SQLCipher 3 is still supported, though. See [Encryption] for more details.
 
-3. The `cipherPageSize` and `kdfIterations` configuration properties are discontinued. With GRDB 4, run sql pragmas in `prepareDatabase`:
+3. The `cipherPageSize` and `kdfIterations` configuration properties are discontinued. With GRDB 4, run sql pragmas in the `prepareDatabase` property of the configuration:
     
     ```swift
     var configuration = Configuration()
@@ -109,3 +167,10 @@ do {
 [SQL Interpolation]: SQLInterpolation.md
 [ValueObservation]: ../README.md#valueobservation
 [Encryption]: ../README.md#encryption
+[HasOneThrough]: AssociationBasics.md#hasonethrough
+[HasManyThrough]: AssociationBasics.md#hasmanythrough
+[PersistableRecord]: ../README.md#persistablerecord-protocol
+[associations]: AssociationBasics.md
+[EncodableRecord]: ../README.md#persistablerecord-protocol
+[The Structure of a Joined Request]: AssociationBasics.md#the-structure-of-a-joined-request
+[Joining And Prefetching Associated Records]: AssociationBasics.md#joining-and-prefetching-associated-records

--- a/Documentation/GRDB3MigrationGuide.md
+++ b/Documentation/GRDB3MigrationGuide.md
@@ -167,10 +167,10 @@ do {
 [SQL Interpolation]: SQLInterpolation.md
 [ValueObservation]: ../README.md#valueobservation
 [Encryption]: ../README.md#encryption
-[HasOneThrough]: AssociationBasics.md#hasonethrough
-[HasManyThrough]: AssociationBasics.md#hasmanythrough
+[HasOneThrough]: AssociationsBasics.md#hasonethrough
+[HasManyThrough]: AssociationsBasics.md#hasmanythrough
 [PersistableRecord]: ../README.md#persistablerecord-protocol
-[associations]: AssociationBasics.md
+[associations]: AssociationsBasics.md
 [EncodableRecord]: ../README.md#persistablerecord-protocol
-[The Structure of a Joined Request]: AssociationBasics.md#the-structure-of-a-joined-request
-[Joining And Prefetching Associated Records]: AssociationBasics.md#joining-and-prefetching-associated-records
+[The Structure of a Joined Request]: AssociationsBasics.md#the-structure-of-a-joined-request
+[Joining And Prefetching Associated Records]: AssociationsBasics.md#joining-and-prefetching-associated-records

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		31A778841C6A4E0600F507F6 /* FetchedRecordsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */; };
 		560432A0228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
 		560432A1228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
+		560432A3228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		560432A4228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		5605F1591C672E4000235C62 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F1491C672E4000235C62 /* CGFloat.swift */; };
 		5605F15A1C672E4000235C62 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F1491C672E4000235C62 /* CGFloat.swift */; };
 		5605F15D1C672E4000235C62 /* DatabaseDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */; };
@@ -931,6 +933,7 @@
 /* Begin PBXFileReference section */
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
+		560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		5605F1491C672E4000235C62 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDateComponents.swift; sourceTree = "<group>"; };
 		5605F14F1C672E4000235C62 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1654,6 +1657,7 @@
 				5653EAD520944B4F00F46237 /* AssociationParallelSQLTests.swift */,
 				56DF001A228DDBA300D611F3 /* AssociationPrefetchingCodableRecordTests.swift */,
 				569BBA20228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift */,
+				560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */,
 				56DF0019228DDBA200D611F3 /* AssociationPrefetchingRowTests.swift */,
 				560714E2227DD0810091BB10 /* AssociationPrefetchingSQLTests.swift */,
 				5653EAC820944B4D00F46237 /* AssociationRowScopeSearchTests.swift */,
@@ -2922,6 +2926,7 @@
 				5623935B1DEE013C00A6B01F /* FilterCursorTests.swift in Sources */,
 				5613EDA721A96A9300DC7A68 /* ValueObservationCombineTests.swift in Sources */,
 				5674A72D1F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,
+				560432A4228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				566A84412041914000E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,
 				56176C701EACCCC9000F3F2B /* FTS5WrapperTokenizerTests.swift in Sources */,
 				56FEE7FF1F47253700D930EA /* TableRecordTests.swift in Sources */,
@@ -3116,6 +3121,7 @@
 				56D496541D812F5B008276D7 /* SQLExpressionLiteralTests.swift in Sources */,
 				5613EDA621A96A9300DC7A68 /* ValueObservationCombineTests.swift in Sources */,
 				56D496961D81317B008276D7 /* PersistableRecordTests.swift in Sources */,
+				560432A3228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				5698AC9E1DA4B0430056AF8C /* FTS4TableBuilderTests.swift in Sources */,
 				5674A72A1F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,
 				566A84402041914000E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -544,6 +544,9 @@
 		569BBA3722905FFA00478429 /* InflectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA3522905FFA00478429 /* InflectionsTests.swift */; };
 		569BBA4622906A8200478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA4522906A8200478429 /* InflectionsTests.json */; };
 		569BBA4722906A8200478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA4522906A8200478429 /* InflectionsTests.json */; };
+		569BBA4E229170F800478429 /* Inflections+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA482291707D00478429 /* Inflections+English.swift */; };
+		569BBA4F229170F900478429 /* Inflections+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA482291707D00478429 /* Inflections+English.swift */; };
+		569BBA50229170FA00478429 /* Inflections+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA482291707D00478429 /* Inflections+English.swift */; };
 		569C1EB51CF07DDD0042627B /* SchedulingWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */; };
 		569D6DDE220EF9E100A058A9 /* SQLInterpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */; };
 		569D6DDF220EF9E100A058A9 /* SQLInterpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */; };
@@ -1164,6 +1167,7 @@
 		569BBA20228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		569BBA3522905FFA00478429 /* InflectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InflectionsTests.swift; sourceTree = "<group>"; };
 		569BBA4522906A8200478429 /* InflectionsTests.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = InflectionsTests.json; sourceTree = "<group>"; };
+		569BBA482291707D00478429 /* Inflections+English.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inflections+English.swift"; sourceTree = "<group>"; };
 		569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulingWatchdogTests.swift; sourceTree = "<group>"; };
 		569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLInterpolation.swift; sourceTree = "<group>"; };
 		569EF0E1200D2D8400A9FA45 /* DatabaseRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegion.swift; sourceTree = "<group>"; };
@@ -1692,6 +1696,7 @@
 			isa = PBXGroup;
 			children = (
 				563EF4492161F179007DAACD /* Inflections.swift */,
+				569BBA482291707D00478429 /* Inflections+English.swift */,
 				563EF414215F87EB007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
 				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
@@ -2657,6 +2662,7 @@
 				565490B61D5AE236005622CB /* Configuration.swift in Sources */,
 				565490E11D5AE252005622CB /* PersistableRecord.swift in Sources */,
 				56FC987E1D969DEF00E3C842 /* SQLExpression+QueryInterface.swift in Sources */,
+				569BBA50229170FA00478429 /* Inflections+English.swift in Sources */,
 				565490E01D5AE252005622CB /* FetchedRecordsController.swift in Sources */,
 				566B91391FA4D3810012D5B0 /* TransactionObserver.swift in Sources */,
 				565490C81D5AE252005622CB /* CGFloat.swift in Sources */,
@@ -2751,6 +2757,7 @@
 				5671FC231DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56D51D031EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				560D924C1C672C4B00F4F92B /* TableRecord.swift in Sources */,
+				569BBA4F229170F900478429 /* Inflections+English.swift in Sources */,
 				5617294F223533F40006E219 /* EncodableRecord.swift in Sources */,
 				564CE52121B3129A00652B19 /* ValueObservation+MapReducer.swift in Sources */,
 				5653EC132098738B00F46237 /* SQLGenerationContext.swift in Sources */,
@@ -3273,6 +3280,7 @@
 				567404881CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
 				5653EB0320944C7C00F46237 /* BelongsToAssociation.swift in Sources */,
 				563363C41C942C37000BE133 /* DatabaseWriter.swift in Sources */,
+				569BBA4E229170F800478429 /* Inflections+English.swift in Sources */,
 				5617294E223533F40006E219 /* EncodableRecord.swift in Sources */,
 				5698AD181DAAD17A0056AF8C /* FTS5Tokenizer.swift in Sources */,
 				56B964B11DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		560432A1228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
 		560432A3228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		560432A4228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		56057C552291B16A00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C562291B16A00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		5605F1591C672E4000235C62 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F1491C672E4000235C62 /* CGFloat.swift */; };
 		5605F15A1C672E4000235C62 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F1491C672E4000235C62 /* CGFloat.swift */; };
 		5605F15D1C672E4000235C62 /* DatabaseDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */; };
@@ -941,6 +943,7 @@
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
+		56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
 		5605F1491C672E4000235C62 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDateComponents.swift; sourceTree = "<group>"; };
 		5605F14F1C672E4000235C62 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1653,6 +1656,7 @@
 				5653EAC920944B4D00F46237 /* AssociationBelongsToSQLTests.swift */,
 				5653EAC620944B4C00F46237 /* AssociationChainRowScopesTests.swift */,
 				5653EACF20944B4E00F46237 /* AssociationChainSQLTests.swift */,
+				56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				56959632222D056D002CB7C9 /* AssociationHasManySQLTests.swift */,
 				56959615222C456C002CB7C9 /* AssociationHasManyThroughSQLTests.swift */,
 				5653EACA20944B4D00F46237 /* AssociationHasOneSQLDerivationTests.swift */,
@@ -2948,6 +2952,7 @@
 				566A84412041914000E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,
 				56176C701EACCCC9000F3F2B /* FTS5WrapperTokenizerTests.swift in Sources */,
 				56FEE7FF1F47253700D930EA /* TableRecordTests.swift in Sources */,
+				56057C562291B16A00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				56A2386A1B9C74A90082EB20 /* RecordSubClassTests.swift in Sources */,
 				56A2383E1B9C74A90082EB20 /* DatabaseValueTests.swift in Sources */,
 				567156181CB142AA007DC145 /* DatabaseQueueReadOnlyTests.swift in Sources */,
@@ -3144,6 +3149,7 @@
 				5698AC9E1DA4B0430056AF8C /* FTS4TableBuilderTests.swift in Sources */,
 				5674A72A1F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,
 				566A84402041914000E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,
+				56057C552291B16A00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				56176C5E1EACCCC7000F3F2B /* FTS5WrapperTokenizerTests.swift in Sources */,
 				56FEE7FB1F47253700D930EA /* TableRecordTests.swift in Sources */,
 				56D496641D81304E008276D7 /* FoundationUUIDTests.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -540,6 +540,10 @@
 		5698AD3B1DABAF4A0056AF8C /* FTS5CustomTokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5698AD341DABAF4A0056AF8C /* FTS5CustomTokenizer.swift */; };
 		569BBA27228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA20228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA28228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA20228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
+		569BBA3622905FFA00478429 /* InflectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA3522905FFA00478429 /* InflectionsTests.swift */; };
+		569BBA3722905FFA00478429 /* InflectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA3522905FFA00478429 /* InflectionsTests.swift */; };
+		569BBA4622906A8200478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA4522906A8200478429 /* InflectionsTests.json */; };
+		569BBA4722906A8200478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA4522906A8200478429 /* InflectionsTests.json */; };
 		569C1EB51CF07DDD0042627B /* SchedulingWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */; };
 		569D6DDE220EF9E100A058A9 /* SQLInterpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */; };
 		569D6DDF220EF9E100A058A9 /* SQLInterpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */; };
@@ -1158,6 +1162,8 @@
 		5698AD201DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5WrapperTokenizer.swift; sourceTree = "<group>"; };
 		5698AD341DABAF4A0056AF8C /* FTS5CustomTokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5CustomTokenizer.swift; sourceTree = "<group>"; };
 		569BBA20228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
+		569BBA3522905FFA00478429 /* InflectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InflectionsTests.swift; sourceTree = "<group>"; };
+		569BBA4522906A8200478429 /* InflectionsTests.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = InflectionsTests.json; sourceTree = "<group>"; };
 		569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulingWatchdogTests.swift; sourceTree = "<group>"; };
 		569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLInterpolation.swift; sourceTree = "<group>"; };
 		569EF0E1200D2D8400A9FA45 /* DatabaseRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseRegion.swift; sourceTree = "<group>"; };
@@ -1775,6 +1781,8 @@
 				5605F1861C69111300235C62 /* DatabaseRegionTests.swift */,
 				56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */,
 				56EB0AB11BCD787300A3DC55 /* DataMemoryTests.swift */,
+				569BBA4522906A8200478429 /* InflectionsTests.json */,
+				569BBA3522905FFA00478429 /* InflectionsTests.swift */,
 				56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */,
 				56FF45551D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift */,
 				56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */,
@@ -2475,6 +2483,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				569BBA4722906A8200478429 /* InflectionsTests.json in Resources */,
 				568735A21CEDE16C009B9116 /* Betty.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2483,6 +2492,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				569BBA4622906A8200478429 /* InflectionsTests.json in Resources */,
 				56D496C21D81374C008276D7 /* Betty.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2873,6 +2883,7 @@
 				56FDECE31BB32DFD009AD709 /* RowFromStatementTests.swift in Sources */,
 				56DE7B121C3D93ED00861EB8 /* StatementArgumentsTests.swift in Sources */,
 				56AF746F1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
+				569BBA3722905FFA00478429 /* InflectionsTests.swift in Sources */,
 				5672DE6A1CDB751D0022BA81 /* DatabasePoolBackupTests.swift in Sources */,
 				5698AC4D1DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
 				56B15D0B1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */,
@@ -3068,6 +3079,7 @@
 				56DAA2D21DE99DAB006E10C8 /* DatabaseCursorTests.swift in Sources */,
 				56D496AE1D813345008276D7 /* DatabasePoolCollationTests.swift in Sources */,
 				5698AC491DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
+				569BBA3622905FFA00478429 /* InflectionsTests.swift in Sources */,
 				56D496931D81316E008276D7 /* FetchableRecordTests.swift in Sources */,
 				56D496881D81316E008276D7 /* DatabaseValueConversionTests.swift in Sources */,
 				56D496BA1D813482008276D7 /* DatabaseQueueSchemaCacheTests.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		560432A4228F1668009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		56057C552291B16A00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		56057C562291B16A00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C622291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C612291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
+		56057C632291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C612291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
 		5605F1591C672E4000235C62 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F1491C672E4000235C62 /* CGFloat.swift */; };
 		5605F15A1C672E4000235C62 /* CGFloat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F1491C672E4000235C62 /* CGFloat.swift */; };
 		5605F15D1C672E4000235C62 /* DatabaseDateComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */; };
@@ -944,6 +946,7 @@
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
+		56057C612291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyThroughRowScopeTests.swift; sourceTree = "<group>"; };
 		5605F1491C672E4000235C62 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDateComponents.swift; sourceTree = "<group>"; };
 		5605F14F1C672E4000235C62 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1658,6 +1661,7 @@
 				5653EACF20944B4E00F46237 /* AssociationChainSQLTests.swift */,
 				56057C4E2291B16900A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				56959632222D056D002CB7C9 /* AssociationHasManySQLTests.swift */,
+				56057C612291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */,
 				56959615222C456C002CB7C9 /* AssociationHasManyThroughSQLTests.swift */,
 				5653EACA20944B4D00F46237 /* AssociationHasOneSQLDerivationTests.swift */,
 				5653EACC20944B4D00F46237 /* AssociationHasOneSQLTests.swift */,
@@ -2897,6 +2901,7 @@
 				569BBA3722905FFA00478429 /* InflectionsTests.swift in Sources */,
 				5672DE6A1CDB751D0022BA81 /* DatabasePoolBackupTests.swift in Sources */,
 				5698AC4D1DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
+				56057C632291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				56B15D0B1CD4C35100A24C8B /* FetchedRecordsControllerTests.swift in Sources */,
 				56A238681B9C74A90082EB20 /* RecordInitializersTests.swift in Sources */,
 				5615B261222AE1B400061C1C /* AssociationHasOneThroughSQLDerivationTests.swift in Sources */,
@@ -3094,6 +3099,7 @@
 				569BBA3622905FFA00478429 /* InflectionsTests.swift in Sources */,
 				56D496931D81316E008276D7 /* FetchableRecordTests.swift in Sources */,
 				56D496881D81316E008276D7 /* DatabaseValueConversionTests.swift in Sources */,
+				56057C622291C7C600A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				56D496BA1D813482008276D7 /* DatabaseQueueSchemaCacheTests.swift in Sources */,
 				56D496781D81309E008276D7 /* RecordSubClassTests.swift in Sources */,
 				5615B262222AE1B400061C1C /* AssociationHasOneThroughSQLDerivationTests.swift in Sources */,

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -361,7 +361,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     
     /// A cursor over fetched values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches String
+    ///     let request: ... // Some FetchRequest that fetches String
     ///     let strings = try request.fetchCursor(db) // Cursor of String
     ///     while let string = try strings.next() {   // String
     ///         ...
@@ -382,7 +382,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     
     /// An array of fetched values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches String
+    ///     let request: ... // Some FetchRequest that fetches String
     ///     let strings = try request.fetchAll(db) // [String]
     ///
     /// - parameter db: A database connection.
@@ -398,7 +398,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     /// The result is nil if the request returns no row, or if no value can be
     /// extracted from the first row.
     ///
-    ///     let request: ... // Some TypedRequest that fetches String
+    ///     let request: ... // Some FetchRequest that fetches String
     ///     let string = try request.fetchOne(db) // String?
     ///
     /// - parameter db: A database connection.
@@ -562,7 +562,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     
     /// A cursor over fetched optional values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Optional<String>
+    ///     let request: ... // Some FetchRequest that fetches Optional<String>
     ///     let strings = try request.fetchCursor(db) // Cursor of String?
     ///     while let string = try strings.next() {   // String?
     ///         ...
@@ -583,7 +583,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     
     /// An array of fetched optional values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Optional<String>
+    ///     let request: ... // Some FetchRequest that fetches Optional<String>
     ///     let strings = try request.fetchAll(db) // [String?]
     ///
     /// - parameter db: A database connection.

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -719,9 +719,9 @@ extension Row {
         // Remove prefetchedRows
         if row.prefetchedRows.isEmpty == false {
             // Make sure we build another Row instance
-            row = Row.init(impl: row.copy().impl)
+            row = Row(impl: row.copy().impl)
             assert(row !== self)
-            row.prefetchedRows = PrefetchedRowsView()
+            assert(row.prefetchedRows.isEmpty)
         }
         return row
     }

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1282,7 +1282,7 @@ extension Row {
         private let row: Row
         private let scopes: [String: LayoutedRowAdapter]
         private let prefetchedRows: Row.PrefetchedRowsView
-
+        
         /// The scopes defined on this row.
         public var names: Dictionary<String, LayoutedRowAdapter>.Keys {
             return scopes.keys
@@ -1323,7 +1323,8 @@ extension Row {
                 //
                 //      let request = A.including(required: A.b.including(all: B.c))
                 //      let row = try Row.fetchOne(db, request)!
-                //      row.scopes["b"]!.prefetchedRows["cs"]
+                //      row.prefetchedRows["cs"]              // Some array
+                //      row.scopes["b"]!.prefetchedRows["cs"] // The same array
                 adaptedRow.prefetchedRows = Row.PrefetchedRowsView(prefetches: prefetch.prefetches)
             }
             return (name: name, row: adaptedRow)
@@ -1432,7 +1433,15 @@ extension Row {
             return prefetches.isEmpty
         }
 
-        /// The prefetch keys defined on this row
+        /// The keys for available prefetched rows
+        ///
+        /// For example:
+        ///
+        ///     let request = Author.including(all: Author.books)
+        ///     let row = try Row.fetchOne(db, request)!
+        ///
+        ///     print(row.prefetchedRows.keys)
+        ///     // Prints ["books"]
         public var keys: Set<String> {
             var result: Set<String> = []
             var fifo = Array(prefetches)
@@ -1448,6 +1457,18 @@ extension Row {
 
         /// Returns the rows associated with the given key, by performing a
         /// breadth-first search in this row's prefetch tree.
+        ///
+        /// For example:
+        ///
+        ///     let request = Author.including(all: Author.books)
+        ///     let row = try Row.fetchOne(db, request)!
+        ///
+        ///     print(row)
+        ///     // Prints [id:1 name:"Herman Melville"]
+        ///
+        ///     let bookRows = row.prefetchedRows["books"]
+        ///     print(bookRows[0])
+        ///     // Prints [id:42 title:"Moby-Dick"]
         public subscript(_ key: String) -> [Row]? {
             var fifo = Array(prefetches)
             while !fifo.isEmpty {

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -545,7 +545,8 @@ extension Row {
     ///     print(country.name)
     ///     // Prints "United States"
     ///
-    /// A fatal error is raised if the scope is not available.
+    /// A fatal error is raised if the scope is not available, or contains only
+    /// null values.
     ///
     /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
     /// for more information.
@@ -553,6 +554,10 @@ extension Row {
         guard let scopedRow = scopesTree[scope] else {
             // Programmer error
             fatalError("missing scope `\(scope)` (row: \(self))")
+        }
+        guard scopedRow.containsNonNullValue else {
+            // Programmer error
+            fatalError("scope `\(scope)` only contains null values (row: \(self))")
         }
         return Record(row: scopedRow)
     }
@@ -637,7 +642,7 @@ extension Row {
     ///     // Prints "Herman Melville"
     ///
     ///     let books: Set<Book> = row["books"]
-    ///     print(books[0].title)
+    ///     print(books.first!.title)
     ///     // Prints "Moby-Dick"
     public subscript<Record: FetchableRecord & Hashable>(_ key: String) -> Set<Record> {
         guard let rows = prefetchedRows[key] else {
@@ -1399,6 +1404,8 @@ extension Row {
         ///     let countryRow = row.scopesTree["country"]
         ///     print(countryRow)
         ///     // Prints [code:"US" name:"United States"]
+        ///
+        /// Nil is returned if the scope is not available.
         public subscript(_ name: String) -> Row? {
             var fifo = Array(scopes)
             while !fifo.isEmpty {
@@ -1485,6 +1492,8 @@ extension Row {
         ///
         /// Prefetched rows stored in nested "to-one" associations are
         /// available, too.
+        ///
+        /// Nil is returned if the key is not available.
         public subscript(_ key: String) -> [Row]? {
             var fifo = Array(prefetches)
             while !fifo.isEmpty {

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1012,7 +1012,7 @@ extension FetchRequest where RowDecoder == Row {
     
     /// A cursor over fetched rows.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Row
+    ///     let request: ... // Some FetchRequest that fetches Row
     ///     let rows = try request.fetchCursor(db) // RowCursor
     ///     while let row = try rows.next() {  // Row
     ///         let id: Int64 = row[0]
@@ -1042,7 +1042,7 @@ extension FetchRequest where RowDecoder == Row {
     
     /// An array of fetched rows.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Row
+    ///     let request: ... // Some FetchRequest that fetches Row
     ///     let rows = try request.fetchAll(db)
     ///
     /// - parameter db: A database connection.
@@ -1055,7 +1055,7 @@ extension FetchRequest where RowDecoder == Row {
     
     /// The first fetched row.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Row
+    ///     let request: ... // Some FetchRequest that fetches Row
     ///     let row = try request.fetchOne(db)
     ///
     /// - parameter db: A database connection.

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -357,7 +357,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & StatementCol
     
     /// A cursor over fetched values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches String
+    ///     let request: ... // Some FetchRequest that fetches String
     ///     let strings = try request.fetchCursor(db) // Cursor of String
     ///     while let string = try strings.next() {   // String
     ///         ...
@@ -378,7 +378,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & StatementCol
     
     /// An array of fetched values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches String
+    ///     let request: ... // Some FetchRequest that fetches String
     ///     let strings = try request.fetchAll(db) // [String]
     ///
     /// - parameter db: A database connection.
@@ -394,7 +394,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & StatementCol
     /// The result is nil if the request returns no row, or if no value can be
     /// extracted from the first row.
     ///
-    ///     let request: ... // Some TypedRequest that fetches String
+    ///     let request: ... // Some FetchRequest that fetches String
     ///     let string = try request.fetchOne(db) // String?
     ///
     /// - parameter db: A database connection.
@@ -558,7 +558,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     
     /// A cursor over fetched optional values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Optional<String>
+    ///     let request: ... // Some FetchRequest that fetches Optional<String>
     ///     let strings = try request.fetchCursor(db) // Cursor of String?
     ///     while let string = try strings.next() {   // String?
     ///         ...
@@ -579,7 +579,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     
     /// An array of fetched optional values.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Optional<String>
+    ///     let request: ... // Some FetchRequest that fetches Optional<String>
     ///     let strings = try request.fetchAll(db) // [String?]
     ///
     /// - parameter db: A database connection.

--- a/GRDB/Fixit/GRDB-4.0.swift
+++ b/GRDB/Fixit/GRDB-4.0.swift
@@ -155,32 +155,3 @@ extension Configuration {
         set { preconditionFailure() }
     }
 }
-
-extension TableRecord {
-    @available(*, unavailable, renamed: "belongsTo(_:name:using:)")
-    public static func belongsTo<Destination>(
-        _ destination: Destination.Type,
-        key: String?,
-        using foreignKey: ForeignKey? = nil)
-        -> BelongsToAssociation<Self, Destination>
-        where Destination: TableRecord
-    { preconditionFailure() }
-
-    @available(*, unavailable, renamed: "hasMany(_:name:using:)")
-    public static func hasMany<Destination>(
-        _ destination: Destination.Type,
-        key: String?,
-        using foreignKey: ForeignKey? = nil)
-        -> HasManyAssociation<Self, Destination>
-        where Destination: TableRecord
-    { preconditionFailure() }
-    
-    @available(*, unavailable, renamed: "hasOne(_:name:using:)")
-    public static func hasOne<Destination>(
-        _ destination: Destination.Type,
-        key: String?,
-        using foreignKey: ForeignKey? = nil)
-        -> HasOneAssociation<Self, Destination>
-        where Destination: TableRecord
-    { preconditionFailure() }
-}

--- a/GRDB/Fixit/GRDB-4.0.swift
+++ b/GRDB/Fixit/GRDB-4.0.swift
@@ -155,3 +155,32 @@ extension Configuration {
         set { preconditionFailure() }
     }
 }
+
+extension TableRecord {
+    @available(*, unavailable, renamed: "belongsTo(_:name:using:)")
+    public static func belongsTo<Destination>(
+        _ destination: Destination.Type,
+        key: String?,
+        using foreignKey: ForeignKey? = nil)
+        -> BelongsToAssociation<Self, Destination>
+        where Destination: TableRecord
+    { preconditionFailure() }
+
+    @available(*, unavailable, renamed: "hasMany(_:name:using:)")
+    public static func hasMany<Destination>(
+        _ destination: Destination.Type,
+        key: String?,
+        using foreignKey: ForeignKey? = nil)
+        -> HasManyAssociation<Self, Destination>
+        where Destination: TableRecord
+    { preconditionFailure() }
+    
+    @available(*, unavailable, renamed: "hasOne(_:name:using:)")
+    public static func hasOne<Destination>(
+        _ destination: Destination.Type,
+        key: String?,
+        using foreignKey: ForeignKey? = nil)
+        -> HasOneAssociation<Self, Destination>
+        where Destination: TableRecord
+    { preconditionFailure() }
+}

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -673,13 +673,6 @@ public /* TODO: internal */ struct SQLAssociation {
         return result
     }
     
-    /// Changes the pivot key
-    func forPivotKey(_ key: SQLAssociationKey) -> SQLAssociation {
-        var result = self
-        result.pivot.key = key
-        return result
-    }
-    
     /// Transforms the destination relation
     func mapDestinationRelation(_ transform: (SQLRelation) -> SQLRelation) -> SQLAssociation {
         var result = self
@@ -792,52 +785,7 @@ public /* TODO: internal */ struct SQLAssociation {
             //          static let citizens = hasMany(Citizens.self, through: passports, using: Passport.citizen)
             //      }
             //      let request = Country.including(all: Country.citizens)
-            //
-            // Also, pick a unique pivot key.
-            //
-            // Why? Consider this request:
-            //
-            //      let request = Country
-            //          .including(all: Country.passports.filter(Column("isExpired") == true))
-            //          .including(all: Country.citizens)
-            //
-            // A unique key makes the citizens' passports distinct from the
-            // expired passports. This has two desirable consequences:
-            //
-            // 1. As expected (since Country.citizens is included from Country),
-            //    it attaches prefetched citizens to countries, not
-            //    to passports.
-            // 2. It loads all citizens, not only citizens who have an expired
-            //    passport. This is debatable actually, because unlike
-            //    prefetches, joins are merged by keys. Joins require user to
-            //    provide explicit disambiguation keys in order to prevent
-            //    merging. But this inconsistency really helps our
-            //    implementation here. And it's not sure it is very wrong, from
-            //    the user's point of view.
-            //
-            // On the other side, if we would NOT pick a unique pivot key, then
-            // our current implementation makes the above request equivalent to
-            // the one below, which attaches citizens to passports, not
-            // to countries:
-            //
-            //      let request = Country
-            //          .including(all: Country.passports
-            //              .filter(Column("isExpired") == true)
-            //              .including(all: Passport.citizens))
-            //
-            // 1. It attaches citizens to passports, not to countries (BUG).
-            // 2. When we fetch citizens, we generate an SQL query which does
-            //    not contain country columns: we can not dispatch citizens
-            //    in countries when we have to (BUG).
-            // 3. It fetches citizens who have an expired passport (we have
-            //    decided it's a BUG).
-            //
-            // Conclusion: for better or for worse, let's pick a unique pivot
-            // key, and prevent merging of intermediate steps of
-            // indirect associations:
-            return reducedAssociation
-                .forPivotKey(SQLAssociationKey.fixed("grdb_\(UUID().uuidString)"))
-                .extendedRelation(origin, kind: .allNotPrefetched)
+            return reducedAssociation.extendedRelation(origin, kind: .allNotPrefetched)
         }
     }
     

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -494,7 +494,7 @@ enum SQLAssociationKey {
     case fixedSingular(String)
     
     /// Fixed plural (stricly honors user-provided name in plural contexts).
-    /// See .singular for some context.
+    /// See .inflected and .fixedSingular for some context.
     case fixedPlural(String)
     
     /// Not inflected in singular or plural context.

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -463,9 +463,37 @@ public protocol AssociationToOne: Association { }
 
 // MARK: - SQLAssociationKey
 
+/// Associations are meant to be consumed, most often into Decodable records.
+/// Those have singular or plural property names, depending on the way
+/// associations are used:
+///
+///     struct Author: TableRecord {
+///         static let books = hasMany(Book.self)
+///     }
+///     struct Book: TableRecord {
+///         static let author = belongsTo(Author.self)
+///     }
+///
+///     struct AuthorInfo: FetchableRecord, Decodable {
+///         var author: Author
+///         var books: [Book]   // plural
+///     }
+///     let request = Author.including(all: Author.books)
+///     let authorInfos = try AuthorInfo.fetchAll(db, request)
+///
+///     struct BookInfo: FetchableRecord, Decodable {
+///         var book: Book
+///         var author: Author  // singular
+///     }
+///     let request = Book.including(required: Book.author)
+///     let bookInfos = try BookInfo.fetchAll(db, request)
+///
+/// SQLAssociationKey aims at helping GRDB providing support for automatic
+/// inflections of association and database table names, so that the user does
+/// not have to explicitly provide any singular or plural form.
 enum SQLAssociationKey {
-    /// Inflected in singular and plural contexts.
-    //
+    /// A key that is inflected in singular and plural contexts.
+    ///
     /// For example:
     ///
     ///     struct Author: TableRecord {
@@ -480,8 +508,9 @@ enum SQLAssociationKey {
     ///     row.scopes["author"]  // singularized "authors" table name
     case inflected(String)
     
-    /// Fixed singular (stricly honors user-provided name in singular contexts).
-    //
+    /// A key that is inflected in plural contexts, but stricly honors
+    /// user-provided name in singular contexts.
+    ///
     /// For example:
     ///
     ///     struct Country: TableRecord {
@@ -493,11 +522,12 @@ enum SQLAssociationKey {
     ///     row.scopes["demographics"]  // not singularized
     case fixedSingular(String)
     
-    /// Fixed plural (stricly honors user-provided name in plural contexts).
+    /// A key that is inflected in singular contexts, but stricly honors
+    /// user-provided name in plural contexts.
     /// See .inflected and .fixedSingular for some context.
     case fixedPlural(String)
     
-    /// Not inflected in singular or plural context.
+    /// A key that is never inflected.
     case fixed(String)
     
     var pluralizedName: String {

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -259,37 +259,41 @@ extension Association {
 }
 
 extension SQLRelation {
-    /// Creates an relation that prefetches another one.
+    /// Creates a relation that prefetches another one.
     func including(all sqlAssociation: SQLAssociation) -> SQLRelation {
         return sqlAssociation.extendedRelation(self, kind: .allPrefetched)
     }
     
-    /// Creates an relation that includes another one. The columns of the
+    /// Creates a relation that includes another one. The columns of the
     /// associated record are selected. The returned relation does not
     /// require that the associated database table contains a matching row.
     func including(optional sqlAssociation: SQLAssociation) -> SQLRelation {
         return sqlAssociation.extendedRelation(self, kind: .oneOptional)
     }
     
-    /// Creates an relation that includes another one. The columns of the
+    /// Creates a relation that includes another one. The columns of the
     /// associated record are selected. The returned relation requires
     /// that the associated database table contains a matching row.
     func including(required sqlAssociation: SQLAssociation) -> SQLRelation {
         return sqlAssociation.extendedRelation(self, kind: .oneRequired)
     }
     
-    /// Creates an relation that joins another one. The columns of the
+    /// Creates a relation that joins another one. The columns of the
     /// associated record are not selected. The returned relation does not
     /// require that the associated database table contains a matching row.
     func joining(optional sqlAssociation: SQLAssociation) -> SQLRelation {
-        return sqlAssociation.mapDestinationRelation { $0.select([]) }.extendedRelation(self, kind: .oneOptional)
+        return sqlAssociation
+            .mapDestinationRelation { $0.select([]) }
+            .extendedRelation(self, kind: .oneOptional)
     }
     
-    /// Creates an relation that joins another one. The columns of the
+    /// Creates a relation that joins another one. The columns of the
     /// associated record are not selected. The returned relation requires
     /// that the associated database table contains a matching row.
     func joining(required sqlAssociation: SQLAssociation) -> SQLRelation {
-        return sqlAssociation.mapDestinationRelation { $0.select([]) }.extendedRelation(self, kind: .oneRequired)
+        return sqlAssociation
+            .mapDestinationRelation { $0.select([]) }
+            .extendedRelation(self, kind: .oneRequired)
     }
 }
 

--- a/GRDB/QueryInterface/Association/Association.swift
+++ b/GRDB/QueryInterface/Association/Association.swift
@@ -559,8 +559,8 @@ enum SQLAssociationKey {
 
 // MARK: - SQLAssociation
 
-/// An SQL association is a non-empty chain on steps which starts from the
-/// "pivot" and ends to the "destination":
+/// An SQL association is a non-empty chain of steps which starts at the
+/// "pivot" and ends on the "destination":
 ///
 ///     // SELECT origin.*, destination.*
 ///     // FROM origin

--- a/GRDB/QueryInterface/Association/AssociationAggregate.swift
+++ b/GRDB/QueryInterface/Association/AssociationAggregate.swift
@@ -129,7 +129,7 @@ public func && <RowDecoder>(lhs: AssociationAggregate<RowDecoder>, rhs: Associat
     }
 }
 
-// TODO: test & document
+// TODO: test
 /// :nodoc:
 public func && <RowDecoder>(lhs: AssociationAggregate<RowDecoder>, rhs: SQLExpressible) -> AssociationAggregate<RowDecoder> {
     return AssociationAggregate { request in
@@ -138,7 +138,7 @@ public func && <RowDecoder>(lhs: AssociationAggregate<RowDecoder>, rhs: SQLExpre
     }
 }
 
-// TODO: test & document
+// TODO: test
 /// :nodoc:
 public func && <RowDecoder>(lhs: SQLExpressible, rhs: AssociationAggregate<RowDecoder>) -> AssociationAggregate<RowDecoder> {
     return AssociationAggregate { request in
@@ -161,7 +161,7 @@ public func || <RowDecoder>(lhs: AssociationAggregate<RowDecoder>, rhs: Associat
     }
 }
 
-// TODO: test & document
+// TODO: test
 /// :nodoc:
 public func || <RowDecoder>(lhs: AssociationAggregate<RowDecoder>, rhs: SQLExpressible) -> AssociationAggregate<RowDecoder> {
     return AssociationAggregate { request in
@@ -170,7 +170,7 @@ public func || <RowDecoder>(lhs: AssociationAggregate<RowDecoder>, rhs: SQLExpre
     }
 }
 
-// TODO: test & document
+// TODO: test
 /// :nodoc:
 public func || <RowDecoder>(lhs: SQLExpressible, rhs: AssociationAggregate<RowDecoder>) -> AssociationAggregate<RowDecoder> {
     return AssociationAggregate { request in

--- a/GRDB/QueryInterface/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Association/BelongsToAssociation.swift
@@ -152,10 +152,9 @@ extension TableRecord {
         
         let associationKey: SQLAssociationKey
         if let key = key {
-            assert(key.singularized == key)
-            associationKey = .inflectableSingular(key)
+            associationKey = .fixedSingular(key)
         } else {
-            associationKey = .inflectable(Destination.databaseTableName)
+            associationKey = .inflected(Destination.databaseTableName)
         }
         
         return BelongsToAssociation(sqlAssociation: SQLAssociation(

--- a/GRDB/QueryInterface/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Association/BelongsToAssociation.swift
@@ -136,7 +136,7 @@ extension TableRecord {
     ///       foreign keys to the destination table.
     public static func belongsTo<Destination>(
         _ destination: Destination.Type,
-        name: String? = nil,    // TODD: fixit because `name` has replaced `key`
+        key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> BelongsToAssociation<Self, Destination>
         where Destination: TableRecord
@@ -150,8 +150,16 @@ extension TableRecord {
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: true)
         
+        let associationKey: SQLAssociationKey
+        if let key = key {
+            assert(key.singularized == key)
+            associationKey = .inflectableSingular(key)
+        } else {
+            associationKey = .inflectable(Destination.databaseTableName)
+        }
+        
         return BelongsToAssociation(sqlAssociation: SQLAssociation(
-            key: SQLAssociationKey(name: name ?? Destination.databaseTableName, isInflectable: true),
+            key: associationKey,
             condition: condition,
             relation: Destination.all().relation,
             isSingular: true))

--- a/GRDB/QueryInterface/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Association/BelongsToAssociation.swift
@@ -136,7 +136,7 @@ extension TableRecord {
     ///       foreign keys to the destination table.
     public static func belongsTo<Destination>(
         _ destination: Destination.Type,
-        key: String? = nil,
+        name: String? = nil,    // TODD: fixit because `name` has replaced `key`
         using foreignKey: ForeignKey? = nil)
         -> BelongsToAssociation<Self, Destination>
         where Destination: TableRecord
@@ -151,8 +151,9 @@ extension TableRecord {
             originIsLeft: true)
         
         return BelongsToAssociation(sqlAssociation: SQLAssociation(
-            key: key ?? Destination.databaseTableName,
+            key: SQLAssociationKey(name: name ?? Destination.databaseTableName, isInflectable: true),
             condition: condition,
-            relation: Destination.all().relation))
+            relation: Destination.all().relation,
+            isSingular: true))
     }
 }

--- a/GRDB/QueryInterface/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyAssociation.swift
@@ -152,10 +152,9 @@ extension TableRecord {
         
         let associationKey: SQLAssociationKey
         if let key = key {
-            assert(key.pluralized == key)
-            associationKey = .inflectablePlural(key)
+            associationKey = .fixedPlural(key)
         } else {
-            associationKey = .inflectable(Destination.databaseTableName)
+            associationKey = .inflected(Destination.databaseTableName)
         }
         
         return HasManyAssociation(sqlAssociation: SQLAssociation(

--- a/GRDB/QueryInterface/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyAssociation.swift
@@ -136,7 +136,7 @@ extension TableRecord {
     ///       foreign keys from the destination table.
     public static func hasMany<Destination>(
         _ destination: Destination.Type,
-        name: String? = nil,    // TODD: fixit because `name` has replaced `key`
+        key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> HasManyAssociation<Self, Destination>
         where Destination: TableRecord
@@ -150,8 +150,16 @@ extension TableRecord {
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: false)
         
+        let associationKey: SQLAssociationKey
+        if let key = key {
+            assert(key.pluralized == key)
+            associationKey = .inflectablePlural(key)
+        } else {
+            associationKey = .inflectable(Destination.databaseTableName)
+        }
+        
         return HasManyAssociation(sqlAssociation: SQLAssociation(
-            key: SQLAssociationKey(name: name ?? Destination.databaseTableName, isInflectable: true),
+            key: associationKey,
             condition: condition,
             relation: Destination.all().relation,
             isSingular: false))

--- a/GRDB/QueryInterface/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyAssociation.swift
@@ -136,7 +136,7 @@ extension TableRecord {
     ///       foreign keys from the destination table.
     public static func hasMany<Destination>(
         _ destination: Destination.Type,
-        key: String? = nil,
+        name: String? = nil,    // TODD: fixit because `name` has replaced `key`
         using foreignKey: ForeignKey? = nil)
         -> HasManyAssociation<Self, Destination>
         where Destination: TableRecord
@@ -151,8 +151,9 @@ extension TableRecord {
             originIsLeft: false)
         
         return HasManyAssociation(sqlAssociation: SQLAssociation(
-            key: key ?? Destination.databaseTableName,
+            key: SQLAssociationKey(name: name ?? Destination.databaseTableName, isInflectable: true),
             condition: condition,
-            relation: Destination.all().relation))
+            relation: Destination.all().relation,
+            isSingular: false))
     }
 }

--- a/GRDB/QueryInterface/Association/HasManyThroughAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyThroughAssociation.swift
@@ -61,8 +61,6 @@ public struct HasManyThroughAssociation<Origin, Destination>: AssociationToMany 
 extension HasManyThroughAssociation: TableRequest where Destination: TableRecord { }
 
 extension TableRecord {
-    // TODO: version without using: which figures out the foreign key to use.
-    
     /// Creates a "Has Many Through" association between Self and the
     /// destination type.
     ///

--- a/GRDB/QueryInterface/Association/HasManyThroughAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasManyThroughAssociation.swift
@@ -119,19 +119,29 @@ extension TableRecord {
     ///
     /// - parameters:
     ///     - destination: The record type at the other side of the association.
-    ///     - through: An association from Self to the intermediate type.
-    ///     - using: An association from the intermediate type to the
+    ///     - pivot: An association from Self to the intermediate type.
+    ///     - target: A target association from the intermediate type to the
     ///       destination type.
+    ///     - key: An eventual decoding key for the association. By default, it
+    ///       is the same key as the target.
     public static func hasMany<Pivot, Target>(
         _ destination: Target.RowDecoder.Type,
         through pivot: Pivot,
-        using target: Target)
+        using target: Target,
+        key: String? = nil)
         -> HasManyThroughAssociation<Self, Target.RowDecoder>
         where Pivot: Association,
         Target: Association,
         Pivot.OriginRowDecoder == Self,
         Pivot.RowDecoder == Target.OriginRowDecoder
     {
-        return HasManyThroughAssociation(sqlAssociation: target.sqlAssociation.through(pivot.sqlAssociation))
+        let association = HasManyThroughAssociation<Self, Target.RowDecoder>(
+            sqlAssociation: target.sqlAssociation.through(pivot.sqlAssociation))
+        
+        if let key = key {
+            return association.forKey(key)
+        } else {
+            return association
+        }
     }
 }

--- a/GRDB/QueryInterface/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasOneAssociation.swift
@@ -138,7 +138,7 @@ extension TableRecord {
     ///       foreign keys from the destination table.
     public static func hasOne<Destination>(
         _ destination: Destination.Type,
-        key: String? = nil,
+        name: String? = nil,    // TODD: fixit because `name` has replaced `key`
         using foreignKey: ForeignKey? = nil)
         -> HasOneAssociation<Self, Destination>
         where Destination: TableRecord
@@ -153,8 +153,9 @@ extension TableRecord {
             originIsLeft: false)
         
         return HasOneAssociation(sqlAssociation: SQLAssociation(
-            key: key ?? Destination.databaseTableName,
+            key: SQLAssociationKey(name: name ?? Destination.databaseTableName, isInflectable: true),
             condition: condition,
-            relation: Destination.all().relation))
+            relation: Destination.all().relation,
+            isSingular: true))
     }
 }

--- a/GRDB/QueryInterface/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasOneAssociation.swift
@@ -154,10 +154,9 @@ extension TableRecord {
         
         let associationKey: SQLAssociationKey
         if let key = key {
-            assert(key.singularized == key)
-            associationKey = .inflectableSingular(key)
+            associationKey = .fixedSingular(key)
         } else {
-            associationKey = .inflectable(Destination.databaseTableName)
+            associationKey = .inflected(Destination.databaseTableName)
         }
         
         return HasOneAssociation(sqlAssociation: SQLAssociation(

--- a/GRDB/QueryInterface/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasOneAssociation.swift
@@ -138,7 +138,7 @@ extension TableRecord {
     ///       foreign keys from the destination table.
     public static func hasOne<Destination>(
         _ destination: Destination.Type,
-        name: String? = nil,    // TODD: fixit because `name` has replaced `key`
+        key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> HasOneAssociation<Self, Destination>
         where Destination: TableRecord
@@ -152,8 +152,16 @@ extension TableRecord {
             foreignKeyRequest: foreignKeyRequest,
             originIsLeft: false)
         
+        let associationKey: SQLAssociationKey
+        if let key = key {
+            assert(key.singularized == key)
+            associationKey = .inflectableSingular(key)
+        } else {
+            associationKey = .inflectable(Destination.databaseTableName)
+        }
+        
         return HasOneAssociation(sqlAssociation: SQLAssociation(
-            key: SQLAssociationKey(name: name ?? Destination.databaseTableName, isInflectable: true),
+            key: associationKey,
             condition: condition,
             relation: Destination.all().relation,
             isSingular: true))

--- a/GRDB/QueryInterface/Association/HasOneThroughAssociation.swift
+++ b/GRDB/QueryInterface/Association/HasOneThroughAssociation.swift
@@ -97,19 +97,29 @@ extension TableRecord {
     ///
     /// - parameters:
     ///     - destination: The record type at the other side of the association.
-    ///     - through: An association from Self to the intermediate type.
-    ///     - using: An association from the intermediate type to the
+    ///     - pivot: An association from Self to the intermediate type.
+    ///     - target: A target association from the intermediate type to the
     ///       destination type.
+    ///     - key: An eventual decoding key for the association. By default, it
+    ///       is the same key as the target.
     public static func hasOne<Pivot, Target>(
         _ destination: Target.RowDecoder.Type,
         through pivot: Pivot,
-        using target: Target)
+        using target: Target,
+        key: String? = nil)
         -> HasOneThroughAssociation<Self, Target.RowDecoder>
         where Pivot: AssociationToOne,
         Target: AssociationToOne,
         Pivot.OriginRowDecoder == Self,
         Pivot.RowDecoder == Target.OriginRowDecoder
     {
-        return HasOneThroughAssociation(sqlAssociation: target.sqlAssociation.through(pivot.sqlAssociation))
+        let association = HasOneThroughAssociation<Self, Target.RowDecoder>(
+            sqlAssociation: target.sqlAssociation.through(pivot.sqlAssociation))
+        
+        if let key = key {
+            return association.forKey(key)
+        } else {
+            return association
+        }
     }
 }

--- a/GRDB/QueryInterface/FetchableRecord+QueryInterface.swift
+++ b/GRDB/QueryInterface/FetchableRecord+QueryInterface.swift
@@ -1,7 +1,7 @@
 extension QueryInterfaceRequest where RowDecoder: FetchableRecord {
     /// A cursor over fetched records.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Player
+    ///     let request: QueryInterfaceRequest<Player> = ...
     ///     let players = try request.fetchCursor(db) // Cursor of Player
     ///     while let player = try players.next() {   // Player
     ///         ...

--- a/GRDB/QueryInterface/FetchableRecord+QueryInterface.swift
+++ b/GRDB/QueryInterface/FetchableRecord+QueryInterface.swift
@@ -15,7 +15,6 @@ extension QueryInterfaceRequest where RowDecoder: FetchableRecord {
     /// - parameter db: A database connection.
     /// - returns: A cursor over fetched records.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    @inlinable // TODO: should not be inlinable
     public func fetchCursor(_ db: Database) throws -> RecordCursor<RowDecoder> {
         return try RowDecoder.fetchCursor(db, self)
     }
@@ -28,7 +27,6 @@ extension QueryInterfaceRequest where RowDecoder: FetchableRecord {
     /// - parameter db: A database connection.
     /// - returns: An array of records.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    @inlinable // TODO: should not be inlinable
     public func fetchAll(_ db: Database) throws -> [RowDecoder] {
         return try RowDecoder.fetchAll(db, self)
     }
@@ -41,7 +39,6 @@ extension QueryInterfaceRequest where RowDecoder: FetchableRecord {
     /// - parameter db: A database connection.
     /// - returns: An optional record.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    @inlinable // TODO: should not be inlinable
     public func fetchOne(_ db: Database) throws -> RowDecoder? {
         return try RowDecoder.fetchOne(db, self)
     }
@@ -69,9 +66,8 @@ extension FetchableRecord {
     ///     - sql: a FetchRequest.
     /// - returns: A cursor over fetched records.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    @inlinable // TODO: should not be inlinable
     public static func fetchCursor<T>(_ db: Database, _ request: QueryInterfaceRequest<T>) throws -> RecordCursor<Self> {
-        precondition(request.prefetchedAssociations.isEmpty, "Not implemented: fetching cursor with prefetched associations")
+        precondition(request.prefetchedAssociations.isEmpty, "Not implemented: fetchCursor with prefetched associations")
         let (statement, adapter) = try request.prepare(db, forSingleResult: false)
         return try fetchCursor(statement, adapter: adapter)
     }
@@ -86,7 +82,6 @@ extension FetchableRecord {
     ///     - sql: a FetchRequest.
     /// - returns: An array of records.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    @inlinable // TODO: should not be inlinable
     public static func fetchAll<T>(_ db: Database, _ request: QueryInterfaceRequest<T>) throws -> [Self] {
         let (statement, adapter) = try request.prepare(db, forSingleResult: false)
         let associations = request.prefetchedAssociations
@@ -109,7 +104,6 @@ extension FetchableRecord {
     ///     - sql: a FetchRequest.
     /// - returns: An optional record.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    @inlinable // TODO: should not be inlinable
     public static func fetchOne<T>(_ db: Database, _ request: QueryInterfaceRequest<T>) throws -> Self? {
         let (statement, adapter) = try request.prepare(db, forSingleResult: true)
         let associations = request.prefetchedAssociations

--- a/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
@@ -21,7 +21,7 @@ extension QueryInterfaceRequest where RowDecoder: TableRecord {
         }
     }
     
-    /// Creates a request that joins an association. The columns of the
+    /// Creates a request that includes an association. The columns of the
     /// associated record are selected. The returned request requires
     /// that the associated database table contains a matching row.
     public func including<A: Association>(required association: A) -> QueryInterfaceRequest where A.OriginRowDecoder == RowDecoder {
@@ -43,7 +43,7 @@ extension QueryInterfaceRequest where RowDecoder: TableRecord {
         }
     }
     
-    /// Creates a request that includes an association. The columns of the
+    /// Creates a request that joins an association. The columns of the
     /// associated record are not selected. The returned request requires
     /// that the associated database table contains a matching row.
     public func joining<A: Association>(required association: A) -> QueryInterfaceRequest where A.OriginRowDecoder == RowDecoder {

--- a/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest+Association.swift
@@ -119,7 +119,7 @@ extension TableRecord where Self: EncodableRecord {
         let destinationRelation = association.sqlAssociation.destinationRelation(fromOriginRows: { db in
             try [Row(PersistenceContainer(db, self))]
         })
-        return QueryInterfaceRequest<A.RowDecoder>(relation: destinationRelation)
+        return QueryInterfaceRequest(relation: destinationRelation)
     }
 }
 

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -39,7 +39,6 @@ public struct QueryInterfaceRequest<T> {
         self.init(query: SQLSelectQuery(relation: relation))
     }
     
-    @usableFromInline // TODO: should not be @usableFromInline
     var prefetchedAssociations: [SQLAssociation] {
         return query.relation.prefetchedAssociations
     }

--- a/GRDB/QueryInterface/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/QueryInterfaceRequest.swift
@@ -39,7 +39,7 @@ public struct QueryInterfaceRequest<T> {
         self.init(query: SQLSelectQuery(relation: relation))
     }
     
-    @usableFromInline
+    @usableFromInline // TODO: should not be @usableFromInline
     var prefetchedAssociations: [SQLAssociation] {
         return query.relation.prefetchedAssociations
     }

--- a/GRDB/QueryInterface/Row+QueryInterface.swift
+++ b/GRDB/QueryInterface/Row+QueryInterface.swift
@@ -149,6 +149,7 @@ extension Row {
             return
         }
         
+        // CAUTION: Keep this code in sync with QueryInterfaceRequest.databaseRegion(_:)
         for association in associations {
             let pivotMapping = try association.pivotCondition.columnMapping(db)
             

--- a/GRDB/QueryInterface/Row+QueryInterface.swift
+++ b/GRDB/QueryInterface/Row+QueryInterface.swift
@@ -4,7 +4,7 @@ extension QueryInterfaceRequest where RowDecoder == Row {
     
     /// A cursor over fetched rows.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Row
+    ///     let request: QueryInterfaceRequest<Row> = ...
     ///     let rows = try request.fetchCursor(db) // RowCursor
     ///     while let row = try rows.next() {  // Row
     ///         let id: Int64 = row[0]

--- a/GRDB/QueryInterface/SQLGenerationContext.swift
+++ b/GRDB/QueryInterface/SQLGenerationContext.swift
@@ -321,7 +321,7 @@ extension Array where Element == TableAlias {
             var index = 1
             for alias in group {
                 if alias.hasUserName { continue }
-                let radical = alias.identityName.databaseQualifierRadical
+                let radical = alias.identityName.digitlessRadical
                 var resolvedName: String
                 repeat {
                     resolvedName = "\(radical)\(index)"
@@ -332,19 +332,5 @@ extension Array where Element == TableAlias {
             }
         }
         return resolvedNames
-    }
-}
-
-extension String {
-    /// "bar" => "bar"
-    /// "foo12" => "foo"
-    fileprivate var databaseQualifierRadical: String {
-        let digits: ClosedRange<Character> = "0"..."9"
-        let radicalEndIndex = self                  // "foo12"
-            .reversed()                             // "21oof"
-            .prefix(while: { digits.contains($0) }) // "21"
-            .endIndex                               // reversed(foo^12)
-            .base                                   // foo^12
-        return String(prefix(upTo: radicalEndIndex))
     }
 }

--- a/GRDB/QueryInterface/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQLRelation.swift
@@ -446,7 +446,7 @@ struct SQLAssociationCondition: Equatable {
     /// `right.a IN (1, 2, 3)`.
     func filteringExpression(_ db: Database, leftRows: [Row], rightAlias: TableAlias) throws -> SQLExpression {
         if leftRows.isEmpty {
-            // Degenerate case: therre is no row to attach
+            // Degenerate case: there is no row to attach
             return false.sqlExpression
         }
         

--- a/GRDB/QueryInterface/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQLRelation.swift
@@ -128,7 +128,7 @@ struct SQLRelation {
             }
         }
         
-        fileprivate func associationForKey(_ key: String) -> SQLAssociation {
+        fileprivate func makeAssociationForKey(_ key: String) -> SQLAssociation {
             return SQLAssociation(key: key, condition: condition, relation: relation)
         }
         
@@ -147,10 +147,10 @@ struct SQLRelation {
         return children.flatMap { key, child -> [SQLAssociation] in
             switch child.kind {
             case .allPrefetched:
-                return [child.associationForKey(key)]
+                return [child.makeAssociationForKey(key)]
             case .oneOptional, .oneRequired, .allNotPrefetched:
                 return child.relation.prefetchedAssociations.map {
-                    $0.through(child.associationForKey(key))
+                    $0.through(child.makeAssociationForKey(key))
                 }
             }
         }

--- a/GRDB/QueryInterface/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQLRelation.swift
@@ -138,7 +138,7 @@ struct SQLRelation {
         }
         
         fileprivate func makeAssociationForKey(_ key: String) -> SQLAssociation {
-            let key = SQLAssociationKey(name: key, isInflectable: false)
+            let key = SQLAssociationKey.fixed(key)
             return SQLAssociation(key: key, condition: condition, relation: relation, isSingular: kind.isSingular)
         }
         

--- a/GRDB/QueryInterface/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQLRelation.swift
@@ -109,6 +109,15 @@ struct SQLRelation {
             case allPrefetched
             // Record.including(all: associationThroughPivot)
             case allNotPrefetched
+            
+            var isSingular: Bool {
+                switch self {
+                case .oneOptional, .oneRequired:
+                    return true
+                case .allPrefetched, .allNotPrefetched:
+                    return false
+                }
+            }
         }
         
         var kind: Kind
@@ -129,7 +138,8 @@ struct SQLRelation {
         }
         
         fileprivate func makeAssociationForKey(_ key: String) -> SQLAssociation {
-            return SQLAssociation(key: key, condition: condition, relation: relation)
+            let key = SQLAssociationKey(name: key, isInflectable: false)
+            return SQLAssociation(key: key, condition: condition, relation: relation, isSingular: kind.isSingular)
         }
         
         func mapRelation(_ transform: (SQLRelation) -> SQLRelation) -> Child {

--- a/GRDB/QueryInterface/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQLRelation.swift
@@ -644,16 +644,21 @@ extension SQLRelation.Child.Kind {
             //   .including(optional: association)
             return .oneOptional
             
-        case (.allPrefetched, .allPrefetched),
-             (.allPrefetched, .allNotPrefetched),
-             (.allNotPrefetched, .allPrefetched):
-            // Prefetches both Pivot and Destination:
+        case (.allPrefetched, .allPrefetched):
+            // Equivalent to Record.including(all: association):
             //
+            // Record
+            //   .including(all: association)
+            //   .including(all: association)
+            return .allPrefetched
+            
+        case (.allPrefetched, .allNotPrefetched),
+             (.allNotPrefetched, .allPrefetched):
             // Record
             //   .including(all: associationToDestinationThroughPivot)
             //   .including(all: associationToPivot)
-            return .allPrefetched
-            
+            fatalError("Not implemented: merging a direct association and an indirect one with including(all:)")
+
         case (.allNotPrefetched, .allNotPrefetched):
             // Equivalent to Record.including(all: association)
             //

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -249,13 +249,13 @@ private struct RowDecoder<R: FetchableRecord>: Decoder {
 private struct PrefetchedRowsDecoder<R: FetchableRecord>: Decoder {
     var rows: [Row]
     var codingPath: [CodingKey]
-    var index: Int
+    var currentIndex: Int
     var userInfo: [CodingUserInfoKey: Any] { return R.databaseDecodingUserInfo }
     
     init(rows: [Row], codingPath: [CodingKey]) {
         self.rows = rows
         self.codingPath = codingPath
-        self.index = 0
+        self.currentIndex = 0
     }
     
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key : CodingKey {
@@ -273,99 +273,32 @@ private struct PrefetchedRowsDecoder<R: FetchableRecord>: Decoder {
 
 extension PrefetchedRowsDecoder: UnkeyedDecodingContainer {
     var count: Int? {
-        // TODO
-        fatalError("not implemented")
+        return rows.count
     }
     
     var isAtEnd: Bool {
-        return index >= rows.endIndex
-    }
-    
-    var currentIndex: Int {
-        // TODO
-        fatalError("not implemented")
+        return currentIndex >= rows.count
     }
     
     mutating func decodeNil() throws -> Bool {
-        // TODO
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Bool.Type) throws -> Bool {
-        // TODO
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: String.Type) throws -> String {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Double.Type) throws -> Double {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Float.Type) throws -> Float {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Int.Type) throws -> Int {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Int8.Type) throws -> Int8 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Int16.Type) throws -> Int16 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Int32.Type) throws -> Int32 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: Int64.Type) throws -> Int64 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: UInt.Type) throws -> UInt {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
-        fatalError("not implemented")
-    }
-    
-    mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
-        fatalError("not implemented")
+        return false
     }
     
     mutating func decode<T>(_ type: T.Type) throws -> T where T : Decodable {
-        defer { index += 1 }
-        let decoder = RowDecoder<R>(row: rows[index], codingPath: codingPath)
+        defer { currentIndex += 1 }
+        let decoder = RowDecoder<R>(row: rows[currentIndex], codingPath: codingPath)
         return try T(from: decoder)
     }
     
     mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {
-        // TODO
         fatalError("not implemented")
     }
     
     mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
-        // TODO
         fatalError("not implemented")
     }
     
     mutating func superDecoder() throws -> Decoder {
-        // TODO
         fatalError("not implemented")
     }
 }

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -328,7 +328,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     
     /// A cursor over fetched records.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Player
+    ///     let request: ... // Some FetchRequest that fetches Player
     ///     let players = try request.fetchCursor(db) // Cursor of Player
     ///     while let player = try players.next() {   // Player
     ///         ...
@@ -349,7 +349,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     
     /// An array of fetched records.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Player
+    ///     let request: ... // Some FetchRequest that fetches Player
     ///     let players = try request.fetchAll(db) // [Player]
     ///
     /// - parameter db: A database connection.
@@ -362,7 +362,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     
     /// The first fetched record.
     ///
-    ///     let request: ... // Some TypedRequest that fetches Player
+    ///     let request: ... // Some FetchRequest that fetches Player
     ///     let player = try request.fetchOne(db) // Player?
     ///
     /// - parameter db: A database connection.

--- a/GRDB/Utils/Inflections+English.swift
+++ b/GRDB/Utils/Inflections+English.swift
@@ -61,7 +61,7 @@ extension Inflections {
         inflections.plural("(octop|vir)i$", "$1i")
         inflections.plural("(alias|status)$", "$1es")
         inflections.plural("(bu)s$", "$1ses")
-        inflections.plural("(buffal|tomat)o$", "$1oes")
+        inflections.plural("(buffal|tomat|her)o$", "$1oes")
         inflections.plural("([ti])um$", "$1a")
         inflections.plural("([ti])a$", "$1a")
         inflections.plural("sis$", "ses")
@@ -124,6 +124,8 @@ extension Inflections {
             ])
         
         inflections.irregular("child", "children")
+        inflections.irregular("foot", "feet")
+        inflections.irregular("leaf", "leaves")
         inflections.irregular("man", "men")
         inflections.irregular("move", "moves")
         inflections.irregular("person", "people")

--- a/GRDB/Utils/Inflections+English.swift
+++ b/GRDB/Utils/Inflections+English.swift
@@ -1,0 +1,136 @@
+// Copyright (C) 2019 Gwendal Roué
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// =============================================================================
+//
+// Copyright (c) 2005-2019 David Heinemeier Hansson
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+extension Inflections {
+    /// The default inflections
+    public static var `default`: Inflections = {
+        // Defines the standard inflection rules. These are the starting point
+        // for new projects and are not considered complete. The current set of
+        // inflection rules is frozen. This means, we do not change them to
+        // become more complete. This is a safety measure to keep existing
+        // applications from breaking.
+        //
+        // https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/inflections.rb
+        var inflections = Inflections()
+        
+        inflections.plural("$", "s")
+        inflections.plural("s$", "s")
+        inflections.plural("^(ax|test)is$", "$1es")
+        inflections.plural("(octop|vir)us$", "$1i")
+        inflections.plural("(octop|vir)i$", "$1i")
+        inflections.plural("(alias|status)$", "$1es")
+        inflections.plural("(bu)s$", "$1ses")
+        inflections.plural("(buffal|tomat)o$", "$1oes")
+        inflections.plural("([ti])um$", "$1a")
+        inflections.plural("([ti])a$", "$1a")
+        inflections.plural("sis$", "ses")
+        inflections.plural("(?:([^f])fe|([lr])f)$", "$1$2ves")
+        inflections.plural("(hive)$", "$1s")
+        inflections.plural("([^aeiouy]|qu)y$", "$1ies")
+        inflections.plural("(x|ch|ss|sh)$", "$1es")
+        inflections.plural("(matr|vert|ind)(?:ix|ex)$", "$1ices")
+        inflections.plural("^(m|l)ouse$", "$1ice")
+        inflections.plural("^(m|l)ice$", "$1ice")
+        inflections.plural("^(ox)$", "$1en")
+        inflections.plural("^(oxen)$", "$1")
+        inflections.plural("(quiz)$", "$1zes")
+        inflections.plural("(canva)s$", "$1ses")
+        
+        inflections.singular("s$", "")
+        inflections.singular("(ss)$", "$1")
+        inflections.singular("(n)ews$", "$1ews")
+        inflections.singular("([ti])a$", "$1um")
+        inflections.singular("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", "$1sis")
+        inflections.singular("(^analy)(sis|ses)$", "$1sis")
+        inflections.singular("([^f])ves$", "$1fe")
+        inflections.singular("(hive)s$", "$1")
+        inflections.singular("(tive)s$", "$1")
+        inflections.singular("([lr])ves$", "$1f")
+        inflections.singular("([^aeiouy]|qu)ies$", "$1y")
+        inflections.singular("(s)eries$", "$1eries")
+        inflections.singular("(m)ovies$", "$1ovie")
+        inflections.singular("(x|ch|ss|sh)es$", "$1")
+        inflections.singular("^(m|l)ice$", "$1ouse")
+        inflections.singular("(bus)(es)?$", "$1")
+        inflections.singular("(o)es$", "$1")
+        inflections.singular("(shoe)s$", "$1")
+        inflections.singular("(cris|test)(is|es)$", "$1is")
+        inflections.singular("^(a)x[ie]s$", "$1xis")
+        inflections.singular("(octop|vir)(us|i)$", "$1us")
+        inflections.singular("(alias|status)(es)?$", "$1")
+        inflections.singular("^(ox)en$", "$1")
+        inflections.singular("(vert|ind)ices$", "$1ex")
+        inflections.singular("(matr)ices$", "$1ix")
+        inflections.singular("(quiz)zes$", "$1")
+        inflections.singular("(database)s$", "$1")
+        inflections.singular("(canvas)(es)?$", "$1")
+        
+        inflections.uncountable([
+            "advice",
+            "corps",
+            "dice",
+            "equipment",
+            "fish",
+            "information",
+            "jeans",
+            "kudos",
+            "money",
+            "offspring",
+            "police",
+            "rice",
+            "sheep",
+            "species",
+            ])
+        
+        inflections.irregular("child", "children")
+        inflections.irregular("man", "men")
+        inflections.irregular("move", "moves")
+        inflections.irregular("person", "people")
+        inflections.irregular("sex", "sexes")
+        inflections.irregular("specimen", "specimens")
+        inflections.irregular("zombie", "zombies")
+        
+        return inflections
+    }()
+}

--- a/GRDB/Utils/Inflections.swift
+++ b/GRDB/Utils/Inflections.swift
@@ -1,3 +1,47 @@
+// Copyright (C) 2019 Gwendal Roué
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// =============================================================================
+//
+// Copyright (c) 2005-2019 David Heinemeier Hansson
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 import Foundation
 
 extension String {
@@ -148,6 +192,8 @@ extension Inflections {
         // inflection rules is frozen. This means, we do not change them to
         // become more complete. This is a safety measure to keep existing
         // applications from breaking.
+        //
+        // https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/inflections.rb
         
         var inflections = Inflections()
         

--- a/GRDB/Utils/Inflections.swift
+++ b/GRDB/Utils/Inflections.swift
@@ -17,7 +17,8 @@ extension String {
     }
 }
 
-struct Inflections {
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+public struct Inflections {
     private var pluralizeRules: [(NSRegularExpression, String)] = []
     private var singularizeRules: [(NSRegularExpression, String)] = []
     private var uncountablesRegularExpressions: [String: NSRegularExpression] = [:]
@@ -28,16 +29,35 @@ struct Inflections {
     public init() {
     }
     
+    /// Appends a pluralization rule.
+    ///
+    ///     var inflections = Inflections()
+    ///     inflections.plural("$", "s")
+    ///     inflections.pluralize("foo") // "foos"
+    ///     inflections.pluralize("bar") // "bars"
     public mutating func plural(_ pattern: String, options: NSRegularExpression.Options = [.caseInsensitive], _ template: String) {
         let reg = try! NSRegularExpression(pattern: pattern, options: options)
         pluralizeRules.append((reg, template))
     }
     
+    /// Appends a singularization rule.
+    ///
+    ///     var inflections = Inflections()
+    ///     inflections.singular("s$", "")
+    ///     inflections.singularize("foos") // "foo"
+    ///     inflections.singularize("bars") // "bar"
     public mutating func singular(_ pattern: String, options: NSRegularExpression.Options = [.caseInsensitive], _ template: String) {
         let reg = try! NSRegularExpression(pattern: pattern, options: options)
         singularizeRules.append((reg, template))
     }
     
+    /// Appends uncountable words.
+    ///
+    ///     var inflections = Inflections()
+    ///     inflections.plural("$", "s")
+    ///     inflections.uncountable("foo")
+    ///     inflections.pluralize("foo") // "foo"
+    ///     inflections.pluralize("bar") // "bars"
     public mutating func uncountable(_ words: String...) {
         for word in words {
             let escWord = NSRegularExpression.escapedPattern(for: word)
@@ -45,6 +65,13 @@ struct Inflections {
         }
     }
     
+    /// Appends an irregular singular/plural pair.
+    ///
+    ///     var inflections = Inflections()
+    ///     inflections.plural("$", "s")
+    ///     inflections.irregular("man", "men")
+    ///     inflections.pluralize("man")      // "men"
+    ///     inflections.singularizes("women") // "woman"
     public mutating func irregular(_ singular: String, _ plural: String) {
         let s0 = singular.first!
         let srest = singular.dropFirst()
@@ -71,16 +98,7 @@ struct Inflections {
         }
     }
     
-    func isUncountable(_ string: String) -> Bool {
-        let range = NSRange(location: 0, length: string.utf16.count)
-        for (_, reg) in uncountablesRegularExpressions {
-            if reg.firstMatch(in: string, options: [], range: range) != nil {
-                return true
-            }
-        }
-        return false
-    }
-    
+    /// Returns a pluralized string.
     public func pluralize(_ string: String) -> String {
         if isUncountable(string) {
             return string
@@ -88,11 +106,22 @@ struct Inflections {
         return inflect(string, with: pluralizeRules)
     }
     
+    /// Returns a singularized string.
     public func singularize(_ string: String) -> String {
         if isUncountable(string) {
             return string
         }
         return inflect(string, with: singularizeRules)
+    }
+    
+    private func isUncountable(_ string: String) -> Bool {
+        let range = NSRange(location: 0, length: string.utf16.count)
+        for (_, reg) in uncountablesRegularExpressions {
+            if reg.firstMatch(in: string, options: [], range: range) != nil {
+                return true
+            }
+        }
+        return false
     }
     
     private func inflect(_ string: String, with rules: [(NSRegularExpression, String)]) -> String {
@@ -112,6 +141,7 @@ struct Inflections {
 }
 
 extension Inflections {
+    /// The default inflections
     static var `default`: Inflections = {
         // Defines the standard inflection rules. These are the starting point
         // for new projects and are not considered complete. The current set of
@@ -165,7 +195,7 @@ extension Inflections {
         inflections.singular("^(a)x[ie]s$", "$1xis")
         inflections.singular("(octop|vir)(us|i)$", "$1us")
         inflections.singular("(alias|status)(es)?$", "$1")
-        inflections.singular("^(ox)en", "$1")
+        inflections.singular("^(ox)en$", "$1")
         inflections.singular("(vert|ind)ices$", "$1ex")
         inflections.singular("(matr)ices$", "$1ix")
         inflections.singular("(quiz)zes$", "$1")

--- a/GRDB/Utils/Inflections.swift
+++ b/GRDB/Utils/Inflections.swift
@@ -218,6 +218,7 @@ extension Inflections {
         inflections.plural("^(ox)$", "$1en")
         inflections.plural("^(oxen)$", "$1")
         inflections.plural("(quiz)$", "$1zes")
+        inflections.plural("(canva)s$", "$1ses")
 
         inflections.singular("s$", "")
         inflections.singular("(ss)$", "$1")
@@ -246,6 +247,7 @@ extension Inflections {
         inflections.singular("(matr)ices$", "$1ix")
         inflections.singular("(quiz)zes$", "$1")
         inflections.singular("(database)s$", "$1")
+        inflections.singular("(canvas)(es)?$", "$1")
         
         inflections.uncountable(
             "equipment",

--- a/GRDB/Utils/Inflections.swift
+++ b/GRDB/Utils/Inflections.swift
@@ -189,6 +189,7 @@ extension Inflections {
         inflections.irregular("sex", "sexes")
         inflections.irregular("move", "moves")
         inflections.irregular("zombie", "zombies")
+        inflections.irregular("specimen", "specimens")
         
         return inflections
     }()

--- a/GRDB/Utils/Inflections.swift
+++ b/GRDB/Utils/Inflections.swift
@@ -7,4 +7,189 @@ extension String {
         }
         return String(first).uppercased() + dropFirst()
     }
+    
+    var pluralized: String {
+        return Inflections.default.pluralize(self)
+    }
+    
+    var singularized: String {
+        return Inflections.default.singularize(self)
+    }
+}
+
+struct Inflections {
+    private var pluralizeRules: [(NSRegularExpression, String)] = []
+    private var singularizeRules: [(NSRegularExpression, String)] = []
+    private var uncountablesRegularExpressions: [String: NSRegularExpression] = [:]
+    var uncountables: Set<String> {
+        return Set(uncountablesRegularExpressions.keys)
+    }
+    
+    public init() {
+    }
+    
+    public mutating func plural(_ pattern: String, options: NSRegularExpression.Options = [.caseInsensitive], _ template: String) {
+        let reg = try! NSRegularExpression(pattern: pattern, options: options)
+        pluralizeRules.append((reg, template))
+    }
+    
+    public mutating func singular(_ pattern: String, options: NSRegularExpression.Options = [.caseInsensitive], _ template: String) {
+        let reg = try! NSRegularExpression(pattern: pattern, options: options)
+        singularizeRules.append((reg, template))
+    }
+    
+    public mutating func uncountable(_ words: String...) {
+        for word in words {
+            let escWord = NSRegularExpression.escapedPattern(for: word)
+            uncountablesRegularExpressions[word] = try! NSRegularExpression(pattern: "\\b\(escWord)\\Z", options: [.caseInsensitive])
+        }
+    }
+    
+    public mutating func irregular(_ singular: String, _ plural: String) {
+        let s0 = singular.first!
+        let srest = singular.dropFirst()
+        
+        let p0 = plural.first!
+        let prest = plural.dropFirst()
+        
+        if s0.uppercased() == p0.uppercased() {
+            self.plural("(\(s0))\(srest)$", options: [.caseInsensitive], "$1\(prest)")
+            self.plural("(\(p0))\(prest)$", options: [.caseInsensitive], "$1\(prest)")
+            
+            self.singular("(\(s0))\(srest)$", options: [.caseInsensitive], "$1\(srest)")
+            self.singular("(\(p0))\(prest)$", options: [.caseInsensitive], "$1\(srest)")
+        } else {
+            self.plural("\(s0.uppercased())(?i)\(srest)$", options: [], p0.uppercased() + prest)
+            self.plural("\(s0.lowercased())(?i)\(srest)$", options: [], p0.lowercased() + prest)
+            self.plural("\(p0.uppercased())(?i)\(prest)$", options: [], p0.uppercased() + prest)
+            self.plural("\(p0.lowercased())(?i)\(prest)$", options: [], p0.lowercased() + prest)
+            
+            self.singular("\(s0.uppercased())(?i)\(srest)$", options: [], s0.uppercased() + srest)
+            self.singular("\(s0.lowercased())(?i)\(srest)$", options: [], s0.lowercased() + srest)
+            self.singular("\(p0.uppercased())(?i)\(prest)$", options: [], s0.uppercased() + srest)
+            self.singular("\(p0.lowercased())(?i)\(prest)$", options: [], s0.lowercased() + srest)
+        }
+    }
+    
+    func isUncountable(_ string: String) -> Bool {
+        let range = NSRange(location: 0, length: string.utf16.count)
+        for (_, reg) in uncountablesRegularExpressions {
+            if reg.firstMatch(in: string, options: [], range: range) != nil {
+                return true
+            }
+        }
+        return false
+    }
+    
+    public func pluralize(_ string: String) -> String {
+        if isUncountable(string) {
+            return string
+        }
+        return inflect(string, with: pluralizeRules)
+    }
+    
+    public func singularize(_ string: String) -> String {
+        if isUncountable(string) {
+            return string
+        }
+        return inflect(string, with: singularizeRules)
+    }
+    
+    private func inflect(_ string: String, with rules: [(NSRegularExpression, String)]) -> String {
+        if string.isEmpty {
+            return string
+        }
+        let range = NSRange(location: 0, length: string.utf16.count)
+        for (reg, template) in rules.reversed() {
+            let result = NSMutableString(string: string)
+            let count = reg.replaceMatches(in: result, options: [], range: range, withTemplate: template)
+            if count > 0 {
+                return String(result)
+            }
+        }
+        return string
+    }
+}
+
+extension Inflections {
+    static var `default`: Inflections = {
+        // Defines the standard inflection rules. These are the starting point
+        // for new projects and are not considered complete. The current set of
+        // inflection rules is frozen. This means, we do not change them to
+        // become more complete. This is a safety measure to keep existing
+        // applications from breaking.
+        
+        var inflections = Inflections()
+        
+        inflections.plural("$", "s")
+        inflections.plural("s$", "s")
+        inflections.plural("^(ax|test)is$", "$1es")
+        inflections.plural("(octop|vir)us$", "$1i")
+        inflections.plural("(octop|vir)i$", "$1i")
+        inflections.plural("(alias|status)$", "$1es")
+        inflections.plural("(bu)s$", "$1ses")
+        inflections.plural("(buffal|tomat)o$", "$1oes")
+        inflections.plural("([ti])um$", "$1a")
+        inflections.plural("([ti])a$", "$1a")
+        inflections.plural("sis$", "ses")
+        inflections.plural("(?:([^f])fe|([lr])f)$", "$1$2ves")
+        inflections.plural("(hive)$", "$1s")
+        inflections.plural("([^aeiouy]|qu)y$", "$1ies")
+        inflections.plural("(x|ch|ss|sh)$", "$1es")
+        inflections.plural("(matr|vert|ind)(?:ix|ex)$", "$1ices")
+        inflections.plural("^(m|l)ouse$", "$1ice")
+        inflections.plural("^(m|l)ice$", "$1ice")
+        inflections.plural("^(ox)$", "$1en")
+        inflections.plural("^(oxen)$", "$1")
+        inflections.plural("(quiz)$", "$1zes")
+
+        inflections.singular("s$", "")
+        inflections.singular("(ss)$", "$1")
+        inflections.singular("(n)ews$", "$1ews")
+        inflections.singular("([ti])a$", "$1um")
+        inflections.singular("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", "$1sis")
+        inflections.singular("(^analy)(sis|ses)$", "$1sis")
+        inflections.singular("([^f])ves$", "$1fe")
+        inflections.singular("(hive)s$", "$1")
+        inflections.singular("(tive)s$", "$1")
+        inflections.singular("([lr])ves$", "$1f")
+        inflections.singular("([^aeiouy]|qu)ies$", "$1y")
+        inflections.singular("(s)eries$", "$1eries")
+        inflections.singular("(m)ovies$", "$1ovie")
+        inflections.singular("(x|ch|ss|sh)es$", "$1")
+        inflections.singular("^(m|l)ice$", "$1ouse")
+        inflections.singular("(bus)(es)?$", "$1")
+        inflections.singular("(o)es$", "$1")
+        inflections.singular("(shoe)s$", "$1")
+        inflections.singular("(cris|test)(is|es)$", "$1is")
+        inflections.singular("^(a)x[ie]s$", "$1xis")
+        inflections.singular("(octop|vir)(us|i)$", "$1us")
+        inflections.singular("(alias|status)(es)?$", "$1")
+        inflections.singular("^(ox)en", "$1")
+        inflections.singular("(vert|ind)ices$", "$1ex")
+        inflections.singular("(matr)ices$", "$1ix")
+        inflections.singular("(quiz)zes$", "$1")
+        inflections.singular("(database)s$", "$1")
+        
+        inflections.uncountable(
+            "equipment",
+            "information",
+            "rice",
+            "money",
+            "species",
+            "series",
+            "fish",
+            "sheep",
+            "jeans",
+            "police")
+        
+        inflections.irregular("person", "people")
+        inflections.irregular("man", "men")
+        inflections.irregular("child", "children")
+        inflections.irregular("sex", "sexes")
+        inflections.irregular("move", "moves")
+        inflections.irregular("zombie", "zombies")
+        
+        return inflections
+    }()
 }

--- a/GRDB/Utils/Inflections.swift
+++ b/GRDB/Utils/Inflections.swift
@@ -1,47 +1,3 @@
-// Copyright (C) 2019 Gwendal Roué
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-//
-// =============================================================================
-//
-// Copyright (c) 2005-2019 David Heinemeier Hansson
-//
-// Permission is hereby granted, free of charge, to any person obtaining
-// a copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so, subject to
-// the following conditions:
-//
-// The above copyright notice and this permission notice shall be
-// included in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 import Foundation
 
 extension String {
@@ -186,7 +142,7 @@ public struct Inflections {
     ///
     ///     Inflections.default.pluralize("player") // "players"
     public func pluralize(_ string: String) -> String {
-        let indexOfLastWord = Inflections.indexOfLastWord(string)
+        let indexOfLastWord = Inflections.startIndexOfLastWord(string)
         let lastWord = String(string.suffix(from: indexOfLastWord))
         if isUncountable(lastWord) {
             return string
@@ -196,7 +152,7 @@ public struct Inflections {
     
     /// Returns a singularized string.
     public func singularize(_ string: String) -> String {
-        let indexOfLastWord = Inflections.indexOfLastWord(string)
+        let indexOfLastWord = Inflections.startIndexOfLastWord(string)
         let lastWord = String(string.suffix(from: indexOfLastWord))
         if isUncountable(lastWord) {
             return string
@@ -231,11 +187,11 @@ public struct Inflections {
         return string
     }
     
-    /// indexOfLastWord("foo")     -> "foo"
-    /// indexOfLastWord("foo bar") -> "bar"
-    /// indexOfLastWord("foo_bar") -> "bar"
-    /// indexOfLastWord("fooBar")  -> "Bar"
-    static func indexOfLastWord(_ string: String) -> String.Index {
+    /// startIndexOfLastWord("foo")     -> "foo"
+    /// startIndexOfLastWord("foo bar") -> "bar"
+    /// startIndexOfLastWord("foo_bar") -> "bar"
+    /// startIndexOfLastWord("fooBar")  -> "Bar"
+    static func startIndexOfLastWord(_ string: String) -> String.Index {
         let range = NSRange(string.startIndex..<string.endIndex, in: string)
 
         let index1: String.Index? = wordBoundaryReg.firstMatch(in: string, options: [], range: range).flatMap {
@@ -259,96 +215,3 @@ public struct Inflections {
     private static let caseBoundaryReg = try! NSRegularExpression(pattern: "[^A-Z][A-Z]+[a-z1-9]+$", options: [])
 }
 
-extension Inflections {
-    /// The default inflections
-    public static var `default`: Inflections = {
-        // Defines the standard inflection rules. These are the starting point
-        // for new projects and are not considered complete. The current set of
-        // inflection rules is frozen. This means, we do not change them to
-        // become more complete. This is a safety measure to keep existing
-        // applications from breaking.
-        //
-        // https://github.com/rails/rails/blob/b2eb1d1c55a59fee1e6c4cba7030d8ceb524267c/activesupport/lib/active_support/inflections.rb
-        
-        var inflections = Inflections()
-        
-        inflections.plural("$", "s")
-        inflections.plural("s$", "s")
-        inflections.plural("^(ax|test)is$", "$1es")
-        inflections.plural("(octop|vir)us$", "$1i")
-        inflections.plural("(octop|vir)i$", "$1i")
-        inflections.plural("(alias|status)$", "$1es")
-        inflections.plural("(bu)s$", "$1ses")
-        inflections.plural("(buffal|tomat)o$", "$1oes")
-        inflections.plural("([ti])um$", "$1a")
-        inflections.plural("([ti])a$", "$1a")
-        inflections.plural("sis$", "ses")
-        inflections.plural("(?:([^f])fe|([lr])f)$", "$1$2ves")
-        inflections.plural("(hive)$", "$1s")
-        inflections.plural("([^aeiouy]|qu)y$", "$1ies")
-        inflections.plural("(x|ch|ss|sh)$", "$1es")
-        inflections.plural("(matr|vert|ind)(?:ix|ex)$", "$1ices")
-        inflections.plural("^(m|l)ouse$", "$1ice")
-        inflections.plural("^(m|l)ice$", "$1ice")
-        inflections.plural("^(ox)$", "$1en")
-        inflections.plural("^(oxen)$", "$1")
-        inflections.plural("(quiz)$", "$1zes")
-        inflections.plural("(canva)s$", "$1ses")
-
-        inflections.singular("s$", "")
-        inflections.singular("(ss)$", "$1")
-        inflections.singular("(n)ews$", "$1ews")
-        inflections.singular("([ti])a$", "$1um")
-        inflections.singular("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", "$1sis")
-        inflections.singular("(^analy)(sis|ses)$", "$1sis")
-        inflections.singular("([^f])ves$", "$1fe")
-        inflections.singular("(hive)s$", "$1")
-        inflections.singular("(tive)s$", "$1")
-        inflections.singular("([lr])ves$", "$1f")
-        inflections.singular("([^aeiouy]|qu)ies$", "$1y")
-        inflections.singular("(s)eries$", "$1eries")
-        inflections.singular("(m)ovies$", "$1ovie")
-        inflections.singular("(x|ch|ss|sh)es$", "$1")
-        inflections.singular("^(m|l)ice$", "$1ouse")
-        inflections.singular("(bus)(es)?$", "$1")
-        inflections.singular("(o)es$", "$1")
-        inflections.singular("(shoe)s$", "$1")
-        inflections.singular("(cris|test)(is|es)$", "$1is")
-        inflections.singular("^(a)x[ie]s$", "$1xis")
-        inflections.singular("(octop|vir)(us|i)$", "$1us")
-        inflections.singular("(alias|status)(es)?$", "$1")
-        inflections.singular("^(ox)en$", "$1")
-        inflections.singular("(vert|ind)ices$", "$1ex")
-        inflections.singular("(matr)ices$", "$1ix")
-        inflections.singular("(quiz)zes$", "$1")
-        inflections.singular("(database)s$", "$1")
-        inflections.singular("(canvas)(es)?$", "$1")
-        
-        inflections.uncountable([
-            "advice",
-            "corps",
-            "dice",
-            "equipment",
-            "fish",
-            "information",
-            "jeans",
-            "kudos",
-            "money",
-            "offspring",
-            "police",
-            "rice",
-            "sheep",
-            "species",
-            ])
-        
-        inflections.irregular("child", "children")
-        inflections.irregular("man", "men")
-        inflections.irregular("move", "moves")
-        inflections.irregular("person", "people")
-        inflections.irregular("sex", "sexes")
-        inflections.irregular("specimen", "specimens")
-        inflections.irregular("zombie", "zombies")
-
-        return inflections
-    }()
-}

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -106,3 +106,15 @@ extension Sequence {
     }
 }
 // #endif
+
+#if !compiler(>=5.0)
+extension Character {
+    func uppercased() -> String {
+        return String(self).uppercased()
+    }
+    
+    func lowercased() -> String {
+        return String(self).lowercased()
+    }
+}
+#endif

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -335,6 +335,10 @@
 		5698AD3A1DABAF4A0056AF8C /* FTS5CustomTokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5698AD341DABAF4A0056AF8C /* FTS5CustomTokenizer.swift */; };
 		569BBA2B228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA29228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA2C228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA29228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
+		569BBA40229065CF00478429 /* InflectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA3E229065CF00478429 /* InflectionsTests.swift */; };
+		569BBA41229065CF00478429 /* InflectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA3E229065CF00478429 /* InflectionsTests.swift */; };
+		569BBA43229066CB00478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA42229066CB00478429 /* InflectionsTests.json */; };
+		569BBA44229066CB00478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA42229066CB00478429 /* InflectionsTests.json */; };
 		569EF0E6200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */; };
 		569EF0E7200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */; };
 		56A4CDB31D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */; };
@@ -898,6 +902,8 @@
 		5698AD201DABAEFA0056AF8C /* FTS5WrapperTokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5WrapperTokenizer.swift; sourceTree = "<group>"; };
 		5698AD341DABAF4A0056AF8C /* FTS5CustomTokenizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5CustomTokenizer.swift; sourceTree = "<group>"; };
 		569BBA29228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
+		569BBA3E229065CF00478429 /* InflectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InflectionsTests.swift; sourceTree = "<group>"; };
+		569BBA42229066CB00478429 /* InflectionsTests.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = InflectionsTests.json; sourceTree = "<group>"; };
 		569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulingWatchdogTests.swift; sourceTree = "<group>"; };
 		569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegion.swift; sourceTree = "<group>"; };
 		56A238131B9C74A90082EB20 /* DatabaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
@@ -1462,6 +1468,8 @@
 				5605F1861C69111300235C62 /* DatabaseRegionTests.swift */,
 				56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */,
 				56EB0AB11BCD787300A3DC55 /* DataMemoryTests.swift */,
+				569BBA42229066CB00478429 /* InflectionsTests.json */,
+				569BBA3E229065CF00478429 /* InflectionsTests.swift */,
 				56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */,
 				56FF45551D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift */,
 				56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */,
@@ -1961,6 +1969,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				569BBA44229066CB00478429 /* InflectionsTests.json in Resources */,
 				F3BA80CE1CFB2FDE003DC1BA /* Betty.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1976,6 +1985,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				569BBA43229066CB00478429 /* InflectionsTests.json in Resources */,
 				F3BA80CD1CFB2FDD003DC1BA /* Betty.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2203,6 +2213,7 @@
 				F3BA80CF1CFB2FEA003DC1BA /* SchedulingWatchdogTests.swift in Sources */,
 				F3BA80E71CFB3016003DC1BA /* RowCopiedFromStatementTests.swift in Sources */,
 				F3BA812A1CFB3063003DC1BA /* RecordSubClassTests.swift in Sources */,
+				569BBA40229065CF00478429 /* InflectionsTests.swift in Sources */,
 				5653EB7F20961FB200F46237 /* AssociationChainSQLTests.swift in Sources */,
 				6340BF871E5E3F7900832805 /* RecordPersistenceConflictPolicy.swift in Sources */,
 				56AF74721D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
@@ -2528,6 +2539,7 @@
 				F3BA80D31CFB2FF4003DC1BA /* MutablePersistableRecordTests.swift in Sources */,
 				562393751DEE104400A6B01F /* MapCursorTests.swift in Sources */,
 				F3BA80D01CFB2FEC003DC1BA /* SchedulingWatchdogTests.swift in Sources */,
+				569BBA41229065CF00478429 /* InflectionsTests.swift in Sources */,
 				5653EB7E20961FB200F46237 /* AssociationChainSQLTests.swift in Sources */,
 				F3BA80EC1CFB3017003DC1BA /* RowCopiedFromStatementTests.swift in Sources */,
 				F3BA80D41CFB2FF4003DC1BA /* PersistableRecordTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		560432A7228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		56057C592291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		56057C5A2291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C652291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C642291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
+		56057C662291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C642291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
 		5607149B227618660091BB10 /* Row+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56071499227618660091BB10 /* Row+QueryInterface.swift */; };
 		5607149C227618660091BB10 /* Row+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56071499227618660091BB10 /* Row+QueryInterface.swift */; };
 		5607149E227618800091BB10 /* FetchableRecord+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5607149D227618800091BB10 /* FetchableRecord+QueryInterface.swift */; };
@@ -698,6 +700,7 @@
 		56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
+		56057C642291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyThroughRowScopeTests.swift; sourceTree = "<group>"; };
 		5605F1491C672E4000235C62 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDateComponents.swift; sourceTree = "<group>"; };
 		5605F14F1C672E4000235C62 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1375,6 +1378,7 @@
 				5653EB6320961FB200F46237 /* AssociationChainSQLTests.swift */,
 				56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				56959635222D058B002CB7C9 /* AssociationHasManySQLTests.swift */,
+				56057C642291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */,
 				5695961E222C4589002CB7C9 /* AssociationHasManyThroughSQLTests.swift */,
 				5653EB5F20961FB100F46237 /* AssociationHasOneSQLDerivationTests.swift */,
 				5653EB5D20961FB100F46237 /* AssociationHasOneSQLTests.swift */,
@@ -2225,6 +2229,7 @@
 				569BBA40229065CF00478429 /* InflectionsTests.swift in Sources */,
 				5653EB7F20961FB200F46237 /* AssociationChainSQLTests.swift in Sources */,
 				6340BF871E5E3F7900832805 /* RecordPersistenceConflictPolicy.swift in Sources */,
+				56057C662291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				56AF74721D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */,
 				F3BA80D21CFB2FF3003DC1BA /* PersistableRecordTests.swift in Sources */,
 				5615B259222AE19100061C1C /* AssociationHasOneThroughSQLDerivationTests.swift in Sources */,
@@ -2553,6 +2558,7 @@
 				569BBA41229065CF00478429 /* InflectionsTests.swift in Sources */,
 				5653EB7E20961FB200F46237 /* AssociationChainSQLTests.swift in Sources */,
 				F3BA80EC1CFB3017003DC1BA /* RowCopiedFromStatementTests.swift in Sources */,
+				56057C652291C7E500A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				F3BA80D41CFB2FF4003DC1BA /* PersistableRecordTests.swift in Sources */,
 				6340BF831E5E3F7900832805 /* RecordPersistenceConflictPolicy.swift in Sources */,
 				5615B258222AE19100061C1C /* AssociationHasOneThroughSQLDerivationTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -339,6 +339,8 @@
 		569BBA41229065CF00478429 /* InflectionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA3E229065CF00478429 /* InflectionsTests.swift */; };
 		569BBA43229066CB00478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA42229066CB00478429 /* InflectionsTests.json */; };
 		569BBA44229066CB00478429 /* InflectionsTests.json in Resources */ = {isa = PBXBuildFile; fileRef = 569BBA42229066CB00478429 /* InflectionsTests.json */; };
+		569BBA4C229170B300478429 /* Inflections+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA4B229170B300478429 /* Inflections+English.swift */; };
+		569BBA4D229170B300478429 /* Inflections+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA4B229170B300478429 /* Inflections+English.swift */; };
 		569EF0E6200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */; };
 		569EF0E7200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */; };
 		56A4CDB31D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */; };
@@ -904,6 +906,7 @@
 		569BBA29228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		569BBA3E229065CF00478429 /* InflectionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InflectionsTests.swift; sourceTree = "<group>"; };
 		569BBA42229066CB00478429 /* InflectionsTests.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = InflectionsTests.json; sourceTree = "<group>"; };
+		569BBA4B229170B300478429 /* Inflections+English.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Inflections+English.swift"; sourceTree = "<group>"; };
 		569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulingWatchdogTests.swift; sourceTree = "<group>"; };
 		569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseRegion.swift; sourceTree = "<group>"; };
 		56A238131B9C74A90082EB20 /* DatabaseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseTests.swift; sourceTree = "<group>"; };
@@ -1394,6 +1397,7 @@
 			isa = PBXGroup;
 			children = (
 				563EF44C2161F196007DAACD /* Inflections.swift */,
+				569BBA4B229170B300478429 /* Inflections+English.swift */,
 				563EF41E215F8A76007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
 				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
@@ -2081,6 +2085,7 @@
 				5653EB5520961F7D00F46237 /* QueryInterfaceRequest+Association.swift in Sources */,
 				F3BA802B1CFB289B003DC1BA /* QueryInterfaceRequest.swift in Sources */,
 				5698AD171DAAD16F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				569BBA4C229170B300478429 /* Inflections+English.swift in Sources */,
 				561729552235340E0006E219 /* EncodableRecord.swift in Sources */,
 				F3BA80131CFB2876003DC1BA /* DatabaseValue.swift in Sources */,
 				56B964B61DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
@@ -2407,6 +2412,7 @@
 				5653EB5420961F7D00F46237 /* QueryInterfaceRequest+Association.swift in Sources */,
 				F3BA80871CFB2E70003DC1BA /* QueryInterfaceRequest.swift in Sources */,
 				5698AD161DAAD16F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				569BBA4D229170B300478429 /* Inflections+English.swift in Sources */,
 				561729562235340E0006E219 /* EncodableRecord.swift in Sources */,
 				F3BA806F1CFB2E55003DC1BA /* DatabaseValue.swift in Sources */,
 				56B964B31DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		56043297228F00A9009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */; };
 		560432A6228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		560432A7228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		56057C592291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C5A2291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		5607149B227618660091BB10 /* Row+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56071499227618660091BB10 /* Row+QueryInterface.swift */; };
 		5607149C227618660091BB10 /* Row+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56071499227618660091BB10 /* Row+QueryInterface.swift */; };
 		5607149E227618800091BB10 /* FetchableRecord+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5607149D227618800091BB10 /* FetchableRecord+QueryInterface.swift */; };
@@ -695,6 +697,7 @@
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
+		56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
 		5605F1491C672E4000235C62 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDateComponents.swift; sourceTree = "<group>"; };
 		5605F14F1C672E4000235C62 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1370,6 +1373,7 @@
 				5653EB6220961FB200F46237 /* AssociationBelongsToSQLTests.swift */,
 				5653EB6020961FB100F46237 /* AssociationChainRowScopesTests.swift */,
 				5653EB6320961FB200F46237 /* AssociationChainSQLTests.swift */,
+				56057C572291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				56959635222D058B002CB7C9 /* AssociationHasManySQLTests.swift */,
 				5695961E222C4589002CB7C9 /* AssociationHasManyThroughSQLTests.swift */,
 				5653EB5F20961FB100F46237 /* AssociationHasOneSQLDerivationTests.swift */,
@@ -2276,6 +2280,7 @@
 				5690C33E1D23E7D200E59934 /* FoundationDateTests.swift in Sources */,
 				567A805A1D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				5674A7291F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,
+				56057C5A2291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				56FEE8021F47253700D930EA /* TableRecordTests.swift in Sources */,
 				F3BA81211CFB3063003DC1BA /* RecordPrimaryKeyNoneTests.swift in Sources */,
 				F3BA80F71CFB3021003DC1BA /* SelectStatementTests.swift in Sources */,
@@ -2603,6 +2608,7 @@
 				5698AC061D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift in Sources */,
 				F3BA80FA1CFB3021003DC1BA /* SelectStatementTests.swift in Sources */,
 				5674A7271F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,
+				56057C592291B18E00A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				56FEE7FE1F47253700D930EA /* TableRecordTests.swift in Sources */,
 				F3BA81191CFB305F003DC1BA /* QueryInterfaceRequestTests.swift in Sources */,
 				F3BA812F1CFB3064003DC1BA /* RecordPrimaryKeyNoneTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		56043296228F00A9009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */; };
 		56043297228F00A9009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */; };
+		560432A6228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		560432A7228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		5607149B227618660091BB10 /* Row+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56071499227618660091BB10 /* Row+QueryInterface.swift */; };
 		5607149C227618660091BB10 /* Row+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56071499227618660091BB10 /* Row+QueryInterface.swift */; };
 		5607149E227618800091BB10 /* FetchableRecord+QueryInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5607149D227618800091BB10 /* FetchableRecord+QueryInterface.swift */; };
@@ -686,6 +688,7 @@
 /* Begin PBXFileReference section */
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
+		560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		5605F1491C672E4000235C62 /* CGFloat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloat.swift; sourceTree = "<group>"; };
 		5605F14C1C672E4000235C62 /* DatabaseDateComponents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDateComponents.swift; sourceTree = "<group>"; };
 		5605F14F1C672E4000235C62 /* Date.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
@@ -1372,6 +1375,7 @@
 				5653EB5820961FB000F46237 /* AssociationParallelSQLTests.swift */,
 				56DF0013228DDB8200D611F3 /* AssociationPrefetchingCodableRecordTests.swift */,
 				569BBA29228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift */,
+				560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */,
 				56DF0014228DDB8200D611F3 /* AssociationPrefetchingRowTests.swift */,
 				560714EB227DD10F0091BB10 /* AssociationPrefetchingSQLTests.swift */,
 				5653EB5E20961FB100F46237 /* AssociationRowScopeSearchTests.swift */,
@@ -2252,6 +2256,7 @@
 				5698ACCC1DA62A2D0056AF8C /* FTS5TokenizerTests.swift in Sources */,
 				5613EDA421A96A8100DC7A68 /* ValueObservationCombineTests.swift in Sources */,
 				5653EB6B20961FB200F46237 /* AssociationBelongsToFetchableRecordTests.swift in Sources */,
+				560432A7228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				5690C33E1D23E7D200E59934 /* FoundationDateTests.swift in Sources */,
 				567A805A1D41350C00C7DCEC /* IndexInfoTests.swift in Sources */,
 				5674A7291F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,
@@ -2576,6 +2581,7 @@
 				F3BA80B81CFB2FCD003DC1BA /* DatabaseErrorTests.swift in Sources */,
 				5613EDA321A96A8100DC7A68 /* ValueObservationCombineTests.swift in Sources */,
 				5653EB6A20961FB200F46237 /* AssociationBelongsToFetchableRecordTests.swift in Sources */,
+				560432A6228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				5698AC061D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift in Sources */,
 				F3BA80FA1CFB3021003DC1BA /* SelectStatementTests.swift in Sources */,
 				5674A7271F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */,

--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,6 @@ GRDB 4.0
 
 - [ ] FTS: prefix queries
 - [ ] Test NOT TESTED methods
-- [ ] Remove references to obsolete `TypedRequest`
 
 Swift 4.2
 

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		560432A9228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		560432AA228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		56057C5F2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C602291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		560714F0227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		560714F1227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		564A1FDE226B89E1001F64F1 /* MutablePersistableRecordDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A1F27226B89CE001F64F1 /* MutablePersistableRecordDeleteTests.swift */; };
@@ -392,6 +394,7 @@
 		04298D834C818285823558AB /* Pods-GRDBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTests.release.xcconfig"; path = "Target Support Files/Pods-GRDBTests/Pods-GRDBTests.release.xcconfig"; sourceTree = "<group>"; };
 		47C5D1B9AFFE795AA1D6EA5D /* Pods-GRDBTestsEncrypted.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTestsEncrypted.release.xcconfig"; path = "Target Support Files/Pods-GRDBTestsEncrypted/Pods-GRDBTestsEncrypted.release.xcconfig"; sourceTree = "<group>"; };
 		560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
+		56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
 		560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingSQLTests.swift; sourceTree = "<group>"; };
 		564A1F1D226B876D001F64F1 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A1F22226B876D001F64F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -642,6 +645,7 @@
 				564A1F95226B89DA001F64F1 /* AssociationBelongsToSQLTests.swift */,
 				564A1F33226B89CF001F64F1 /* AssociationChainRowScopesTests.swift */,
 				564A1F4D226B89D2001F64F1 /* AssociationChainSQLTests.swift */,
+				56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				564A1F7C226B89D7001F64F1 /* AssociationHasManySQLTests.swift */,
 				564A1FB4226B89DD001F64F1 /* AssociationHasManyThroughSQLTests.swift */,
 				564A1FAE226B89DC001F64F1 /* AssociationHasOneSQLDerivationTests.swift */,
@@ -1115,6 +1119,7 @@
 				564A1FF1226B89E1001F64F1 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				564A2015226B89E1001F64F1 /* EncryptionTests.swift in Sources */,
 				564A2032226B89E1001F64F1 /* AssociationBelongsToFetchableRecordTests.swift in Sources */,
+				56057C5F2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				564A1FE7226B89E1001F64F1 /* FoundationURLTests.swift in Sources */,
 				564A1FFD226B89E1001F64F1 /* PrefixWhileCursorTests.swift in Sources */,
 				564A2079226B89E1001F64F1 /* FoundationNSDecimalNumberTests.swift in Sources */,
@@ -1309,6 +1314,7 @@
 				564A20DE226B8E18001F64F1 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				564A20DF226B8E18001F64F1 /* EncryptionTests.swift in Sources */,
 				564A20E0226B8E18001F64F1 /* AssociationBelongsToFetchableRecordTests.swift in Sources */,
+				56057C602291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				564A20E1226B8E18001F64F1 /* FoundationURLTests.swift in Sources */,
 				564A20E2226B8E18001F64F1 /* PrefixWhileCursorTests.swift in Sources */,
 				564A20E3226B8E18001F64F1 /* FoundationNSDecimalNumberTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		560432A9228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		560432AA228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		560714F0227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		560714F1227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		564A1FDE226B89E1001F64F1 /* MutablePersistableRecordDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A1F27226B89CE001F64F1 /* MutablePersistableRecordDeleteTests.swift */; };
@@ -389,6 +391,7 @@
 /* Begin PBXFileReference section */
 		04298D834C818285823558AB /* Pods-GRDBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTests.release.xcconfig"; path = "Target Support Files/Pods-GRDBTests/Pods-GRDBTests.release.xcconfig"; sourceTree = "<group>"; };
 		47C5D1B9AFFE795AA1D6EA5D /* Pods-GRDBTestsEncrypted.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTestsEncrypted.release.xcconfig"; path = "Target Support Files/Pods-GRDBTestsEncrypted/Pods-GRDBTestsEncrypted.release.xcconfig"; sourceTree = "<group>"; };
+		560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingSQLTests.swift; sourceTree = "<group>"; };
 		564A1F1D226B876D001F64F1 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A1F22226B876D001F64F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -653,6 +656,7 @@
 				564A1FDC226B89E1001F64F1 /* AssociationParallelSQLTests.swift */,
 				56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */,
 				569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */,
+				560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */,
 				56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */,
 				560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */,
 				564A1F3E226B89D0001F64F1 /* AssociationRowScopeSearchTests.swift */,
@@ -1207,6 +1211,7 @@
 				564A206D226B89E1001F64F1 /* ValueObservationCombineTests.swift in Sources */,
 				564A2022226B89E1001F64F1 /* CursorTests.swift in Sources */,
 				564A203A226B89E1001F64F1 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
+				560432A9228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				564A2036226B89E1001F64F1 /* SchedulingWatchdogTests.swift in Sources */,
 				564A2052226B89E1001F64F1 /* RowTestCase.swift in Sources */,
 				564A1FF3226B89E1001F64F1 /* TruncateOptimizationTests.swift in Sources */,
@@ -1400,6 +1405,7 @@
 				564A213C226B8E18001F64F1 /* ValueObservationCombineTests.swift in Sources */,
 				564A213D226B8E18001F64F1 /* CursorTests.swift in Sources */,
 				564A213E226B8E18001F64F1 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
+				560432AA228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				564A213F226B8E18001F64F1 /* SchedulingWatchdogTests.swift in Sources */,
 				564A2140226B8E18001F64F1 /* RowTestCase.swift in Sources */,
 				564A2141226B8E18001F64F1 /* TruncateOptimizationTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		560432AA228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		56057C5F2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		56057C602291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C682291D0AC00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C672291D0AB00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
+		56057C692291D0AC00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C672291D0AB00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
 		560714F0227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		560714F1227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		564A1FDE226B89E1001F64F1 /* MutablePersistableRecordDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A1F27226B89CE001F64F1 /* MutablePersistableRecordDeleteTests.swift */; };
@@ -395,6 +397,7 @@
 		47C5D1B9AFFE795AA1D6EA5D /* Pods-GRDBTestsEncrypted.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTestsEncrypted.release.xcconfig"; path = "Target Support Files/Pods-GRDBTestsEncrypted/Pods-GRDBTestsEncrypted.release.xcconfig"; sourceTree = "<group>"; };
 		560432A8228F1752009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
+		56057C672291D0AB00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyThroughRowScopeTests.swift; sourceTree = "<group>"; };
 		560714EF227DD1810091BB10 /* AssociationPrefetchingSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingSQLTests.swift; sourceTree = "<group>"; };
 		564A1F1D226B876D001F64F1 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A1F22226B876D001F64F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -647,6 +650,7 @@
 				564A1F4D226B89D2001F64F1 /* AssociationChainSQLTests.swift */,
 				56057C5E2291B8E400A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				564A1F7C226B89D7001F64F1 /* AssociationHasManySQLTests.swift */,
+				56057C672291D0AB00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */,
 				564A1FB4226B89DD001F64F1 /* AssociationHasManyThroughSQLTests.swift */,
 				564A1FAE226B89DC001F64F1 /* AssociationHasOneSQLDerivationTests.swift */,
 				564A1F9D226B89DA001F64F1 /* AssociationHasOneSQLTests.swift */,
@@ -1188,6 +1192,7 @@
 				564A205F226B89E1001F64F1 /* SQLLiteralTests.swift in Sources */,
 				564A206C226B89E1001F64F1 /* FTS5CustomTokenizerTests.swift in Sources */,
 				564A2002226B89E1001F64F1 /* DerivableRequestTests.swift in Sources */,
+				56057C682291D0AC00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				564A1FEB226B89E1001F64F1 /* FoundationNSUUIDTests.swift in Sources */,
 				564A1FFE226B89E1001F64F1 /* FilterCursorTests.swift in Sources */,
 				564A208A226B89E1001F64F1 /* MutablePersistableRecordChangesTests.swift in Sources */,
@@ -1383,6 +1388,7 @@
 				564A2122226B8E18001F64F1 /* SQLLiteralTests.swift in Sources */,
 				564A2123226B8E18001F64F1 /* FTS5CustomTokenizerTests.swift in Sources */,
 				564A2124226B8E18001F64F1 /* DerivableRequestTests.swift in Sources */,
+				56057C692291D0AC00A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				564A2125226B8E18001F64F1 /* FoundationNSUUIDTests.swift in Sources */,
 				564A2126226B8E18001F64F1 /* FilterCursorTests.swift in Sources */,
 				564A2127226B8E18001F64F1 /* MutablePersistableRecordChangesTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		560432AD228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		56057C5C2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		56057C5D2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C6B2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C6A2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
+		56057C6C2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C6A2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */; };
 		560714F3227DD1AE0091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		560714F4227DD1AE0091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		564A1FDE226B89E1001F64F1 /* MutablePersistableRecordDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A1F27226B89CE001F64F1 /* MutablePersistableRecordDeleteTests.swift */; };
@@ -397,6 +399,7 @@
 		47C5D1B9AFFE795AA1D6EA5D /* Pods-GRDBTestsEncrypted.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTestsEncrypted.release.xcconfig"; path = "Target Support Files/Pods-GRDBTestsEncrypted/Pods-GRDBTestsEncrypted.release.xcconfig"; sourceTree = "<group>"; };
 		560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
+		56057C6A2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyThroughRowScopeTests.swift; sourceTree = "<group>"; };
 		560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingSQLTests.swift; sourceTree = "<group>"; };
 		564A1F1D226B876D001F64F1 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A1F22226B876D001F64F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -650,6 +653,7 @@
 				564A1F4D226B89D2001F64F1 /* AssociationChainSQLTests.swift */,
 				56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				564A1F7C226B89D7001F64F1 /* AssociationHasManySQLTests.swift */,
+				56057C6A2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift */,
 				564A1FB4226B89DD001F64F1 /* AssociationHasManyThroughSQLTests.swift */,
 				564A1FAE226B89DC001F64F1 /* AssociationHasOneSQLDerivationTests.swift */,
 				564A1F9D226B89DA001F64F1 /* AssociationHasOneSQLTests.swift */,
@@ -1194,6 +1198,7 @@
 				564A205F226B89E1001F64F1 /* SQLLiteralTests.swift in Sources */,
 				564A206C226B89E1001F64F1 /* FTS5CustomTokenizerTests.swift in Sources */,
 				564A2002226B89E1001F64F1 /* DerivableRequestTests.swift in Sources */,
+				56057C6B2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				564A1FEB226B89E1001F64F1 /* FoundationNSUUIDTests.swift in Sources */,
 				564A1FFE226B89E1001F64F1 /* FilterCursorTests.swift in Sources */,
 				564A208A226B89E1001F64F1 /* MutablePersistableRecordChangesTests.swift in Sources */,
@@ -1389,6 +1394,7 @@
 				564A2122226B8E18001F64F1 /* SQLLiteralTests.swift in Sources */,
 				564A2123226B8E18001F64F1 /* FTS5CustomTokenizerTests.swift in Sources */,
 				564A2124226B8E18001F64F1 /* DerivableRequestTests.swift in Sources */,
+				56057C6C2291D0C000A7CB10 /* AssociationHasManyThroughRowScopeTests.swift in Sources */,
 				564A2125226B8E18001F64F1 /* FoundationNSUUIDTests.swift in Sources */,
 				564A2126226B8E18001F64F1 /* FilterCursorTests.swift in Sources */,
 				564A2127226B8E18001F64F1 /* MutablePersistableRecordChangesTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		560432AC228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		560432AD228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		56057C5C2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
+		56057C5D2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */; };
 		560714F3227DD1AE0091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		560714F4227DD1AE0091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		564A1FDE226B89E1001F64F1 /* MutablePersistableRecordDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A1F27226B89CE001F64F1 /* MutablePersistableRecordDeleteTests.swift */; };
@@ -394,6 +396,7 @@
 		04298D834C818285823558AB /* Pods-GRDBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTests.release.xcconfig"; path = "Target Support Files/Pods-GRDBTests/Pods-GRDBTests.release.xcconfig"; sourceTree = "<group>"; };
 		47C5D1B9AFFE795AA1D6EA5D /* Pods-GRDBTestsEncrypted.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTestsEncrypted.release.xcconfig"; path = "Target Support Files/Pods-GRDBTestsEncrypted/Pods-GRDBTestsEncrypted.release.xcconfig"; sourceTree = "<group>"; };
 		560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
+		56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasManyRowScopeTests.swift; sourceTree = "<group>"; };
 		560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingSQLTests.swift; sourceTree = "<group>"; };
 		564A1F1D226B876D001F64F1 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A1F22226B876D001F64F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -645,6 +648,7 @@
 				564A1F95226B89DA001F64F1 /* AssociationBelongsToSQLTests.swift */,
 				564A1F33226B89CF001F64F1 /* AssociationChainRowScopesTests.swift */,
 				564A1F4D226B89D2001F64F1 /* AssociationChainSQLTests.swift */,
+				56057C5B2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift */,
 				564A1F7C226B89D7001F64F1 /* AssociationHasManySQLTests.swift */,
 				564A1FB4226B89DD001F64F1 /* AssociationHasManyThroughSQLTests.swift */,
 				564A1FAE226B89DC001F64F1 /* AssociationHasOneSQLDerivationTests.swift */,
@@ -1121,6 +1125,7 @@
 				564A1FF1226B89E1001F64F1 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				564A2015226B89E1001F64F1 /* EncryptionTests.swift in Sources */,
 				564A2032226B89E1001F64F1 /* AssociationBelongsToFetchableRecordTests.swift in Sources */,
+				56057C5C2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				564A1FE7226B89E1001F64F1 /* FoundationURLTests.swift in Sources */,
 				564A1FFD226B89E1001F64F1 /* PrefixWhileCursorTests.swift in Sources */,
 				564A2079226B89E1001F64F1 /* FoundationNSDecimalNumberTests.swift in Sources */,
@@ -1315,6 +1320,7 @@
 				564A20DE226B8E18001F64F1 /* DatabaseValueConvertibleSubclassTests.swift in Sources */,
 				564A20DF226B8E18001F64F1 /* EncryptionTests.swift in Sources */,
 				564A20E0226B8E18001F64F1 /* AssociationBelongsToFetchableRecordTests.swift in Sources */,
+				56057C5D2291B8D600A7CB10 /* AssociationHasManyRowScopeTests.swift in Sources */,
 				564A20E1226B8E18001F64F1 /* FoundationURLTests.swift in Sources */,
 				564A20E2226B8E18001F64F1 /* PrefixWhileCursorTests.swift in Sources */,
 				564A20E3226B8E18001F64F1 /* FoundationNSDecimalNumberTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		560432AC228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
+		560432AD228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
 		560714F3227DD1AE0091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		560714F4227DD1AE0091BB10 /* AssociationPrefetchingSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */; };
 		564A1FDE226B89E1001F64F1 /* MutablePersistableRecordDeleteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564A1F27226B89CE001F64F1 /* MutablePersistableRecordDeleteTests.swift */; };
@@ -391,6 +393,7 @@
 /* Begin PBXFileReference section */
 		04298D834C818285823558AB /* Pods-GRDBTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTests.release.xcconfig"; path = "Target Support Files/Pods-GRDBTests/Pods-GRDBTests.release.xcconfig"; sourceTree = "<group>"; };
 		47C5D1B9AFFE795AA1D6EA5D /* Pods-GRDBTestsEncrypted.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GRDBTestsEncrypted.release.xcconfig"; path = "Target Support Files/Pods-GRDBTestsEncrypted/Pods-GRDBTestsEncrypted.release.xcconfig"; sourceTree = "<group>"; };
+		560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
 		560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingSQLTests.swift; sourceTree = "<group>"; };
 		564A1F1D226B876D001F64F1 /* GRDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A1F22226B876D001F64F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -656,6 +659,7 @@
 				564A1FDC226B89E1001F64F1 /* AssociationParallelSQLTests.swift */,
 				56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */,
 				569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */,
+				560432AB228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift */,
 				56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */,
 				560714F2227DD1AD0091BB10 /* AssociationPrefetchingSQLTests.swift */,
 				564A1F3E226B89D0001F64F1 /* AssociationRowScopeSearchTests.swift */,
@@ -1213,6 +1217,7 @@
 				564A2022226B89E1001F64F1 /* CursorTests.swift in Sources */,
 				564A203A226B89E1001F64F1 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
 				564A2036226B89E1001F64F1 /* SchedulingWatchdogTests.swift in Sources */,
+				560432AC228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				564A2052226B89E1001F64F1 /* RowTestCase.swift in Sources */,
 				564A1FF3226B89E1001F64F1 /* TruncateOptimizationTests.swift in Sources */,
 				56DF0023228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */,
@@ -1406,6 +1411,7 @@
 				564A213D226B8E18001F64F1 /* CursorTests.swift in Sources */,
 				564A213E226B8E18001F64F1 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
 				564A213F226B8E18001F64F1 /* SchedulingWatchdogTests.swift in Sources */,
+				560432AD228F1761009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */,
 				564A2140226B8E18001F64F1 /* RowTestCase.swift in Sources */,
 				564A2141226B8E18001F64F1 /* TruncateOptimizationTests.swift in Sources */,
 				56DF0024228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */,

--- a/Tests/GRDBTests/AssociationAggregateTests.swift
+++ b/Tests/GRDBTests/AssociationAggregateTests.swift
@@ -8,7 +8,7 @@ import XCTest
 private struct Team: Codable, FetchableRecord, PersistableRecord {
     static let players = hasMany(Player.self)
     static let awards = hasMany(Award.self)
-    static let customPlayers = hasMany(Player.self, name: "custom")
+    static let customPlayers = hasMany(Player.self, key: "customPlayers")
     var id: Int64
     var name: String
 }
@@ -38,11 +38,11 @@ private struct TeamInfo: Decodable, FetchableRecord {
 
 private struct CustomTeamInfo: Decodable, FetchableRecord {
     var team: Team
-    var averageCustomScore: Double?
-    var customCount: Int?
-    var maxCustomScore: Int?
-    var minCustomScore: Int?
-    var customScoreSum: Int?
+    var averageCustomPlayerScore: Double?
+    var customPlayerCount: Int?
+    var maxCustomPlayerScore: Int?
+    var minCustomPlayerScore: Int?
+    var customPlayerScoreSum: Int?
 }
 
 class AssociationAggregateTests: GRDBTestCase {
@@ -416,7 +416,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 .asRequest(of: CustomTeamInfo.self)
             
             try assertEqualSQL(db, request, """
-                SELECT "team".*, AVG("player"."score") AS "averageCustomScore" \
+                SELECT "team".*, AVG("player"."score") AS "averageCustomPlayerScore" \
                 FROM "team" \
                 LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
                 GROUP BY "team"."id" \
@@ -428,19 +428,19 @@ class AssociationAggregateTests: GRDBTestCase {
             
             XCTAssertEqual(teamInfos[0].team.id, 1)
             XCTAssertEqual(teamInfos[0].team.name, "Reds")
-            XCTAssertEqual(teamInfos[0].averageCustomScore, 550)
+            XCTAssertEqual(teamInfos[0].averageCustomPlayerScore, 550)
             
             XCTAssertEqual(teamInfos[1].team.id, 2)
             XCTAssertEqual(teamInfos[1].team.name, "Blues")
-            XCTAssertEqual(teamInfos[1].averageCustomScore, 500)
+            XCTAssertEqual(teamInfos[1].averageCustomPlayerScore, 500)
             
             XCTAssertEqual(teamInfos[2].team.id, 3)
             XCTAssertEqual(teamInfos[2].team.name, "Greens")
-            XCTAssertNil(teamInfos[2].averageCustomScore)
+            XCTAssertNil(teamInfos[2].averageCustomPlayerScore)
             
             XCTAssertEqual(teamInfos[3].team.id, 4)
             XCTAssertEqual(teamInfos[3].team.name, "Oranges")
-            XCTAssertEqual(teamInfos[3].averageCustomScore, 0)
+            XCTAssertEqual(teamInfos[3].averageCustomPlayerScore, 0)
         }
     }
     
@@ -453,7 +453,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 .asRequest(of: CustomTeamInfo.self)
             
             try assertEqualSQL(db, request, """
-                SELECT "team".*, COUNT(DISTINCT "player"."rowid") AS "customCount" \
+                SELECT "team".*, COUNT(DISTINCT "player"."rowid") AS "customPlayerCount" \
                 FROM "team" \
                 LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
                 GROUP BY "team"."id" \
@@ -465,19 +465,19 @@ class AssociationAggregateTests: GRDBTestCase {
             
             XCTAssertEqual(teamInfos[0].team.id, 1)
             XCTAssertEqual(teamInfos[0].team.name, "Reds")
-            XCTAssertEqual(teamInfos[0].customCount, 2)
+            XCTAssertEqual(teamInfos[0].customPlayerCount, 2)
             
             XCTAssertEqual(teamInfos[1].team.id, 2)
             XCTAssertEqual(teamInfos[1].team.name, "Blues")
-            XCTAssertEqual(teamInfos[1].customCount, 3)
+            XCTAssertEqual(teamInfos[1].customPlayerCount, 3)
             
             XCTAssertEqual(teamInfos[2].team.id, 3)
             XCTAssertEqual(teamInfos[2].team.name, "Greens")
-            XCTAssertEqual(teamInfos[2].customCount, 0)
+            XCTAssertEqual(teamInfos[2].customPlayerCount, 0)
             
             XCTAssertEqual(teamInfos[3].team.id, 4)
             XCTAssertEqual(teamInfos[3].team.name, "Oranges")
-            XCTAssertEqual(teamInfos[3].customCount, 1)
+            XCTAssertEqual(teamInfos[3].customPlayerCount, 1)
         }
     }
     
@@ -490,7 +490,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 .asRequest(of: CustomTeamInfo.self)
             
             try assertEqualSQL(db, request, """
-                SELECT "team".*, MAX("player"."score") AS "maxCustomScore" \
+                SELECT "team".*, MAX("player"."score") AS "maxCustomPlayerScore" \
                 FROM "team" \
                 LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
                 GROUP BY "team"."id" \
@@ -502,19 +502,19 @@ class AssociationAggregateTests: GRDBTestCase {
             
             XCTAssertEqual(teamInfos[0].team.id, 1)
             XCTAssertEqual(teamInfos[0].team.name, "Reds")
-            XCTAssertEqual(teamInfos[0].maxCustomScore, 1000)
+            XCTAssertEqual(teamInfos[0].maxCustomPlayerScore, 1000)
             
             XCTAssertEqual(teamInfos[1].team.id, 2)
             XCTAssertEqual(teamInfos[1].team.name, "Blues")
-            XCTAssertEqual(teamInfos[1].maxCustomScore, 800)
+            XCTAssertEqual(teamInfos[1].maxCustomPlayerScore, 800)
             
             XCTAssertEqual(teamInfos[2].team.id, 3)
             XCTAssertEqual(teamInfos[2].team.name, "Greens")
-            XCTAssertNil(teamInfos[2].maxCustomScore)
+            XCTAssertNil(teamInfos[2].maxCustomPlayerScore)
             
             XCTAssertEqual(teamInfos[3].team.id, 4)
             XCTAssertEqual(teamInfos[3].team.name, "Oranges")
-            XCTAssertEqual(teamInfos[3].maxCustomScore, 0)
+            XCTAssertEqual(teamInfos[3].maxCustomPlayerScore, 0)
         }
     }
     
@@ -527,7 +527,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 .asRequest(of: CustomTeamInfo.self)
             
             try assertEqualSQL(db, request, """
-                SELECT "team".*, MIN("player"."score") AS "minCustomScore" \
+                SELECT "team".*, MIN("player"."score") AS "minCustomPlayerScore" \
                 FROM "team" \
                 LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
                 GROUP BY "team"."id" \
@@ -539,19 +539,19 @@ class AssociationAggregateTests: GRDBTestCase {
             
             XCTAssertEqual(teamInfos[0].team.id, 1)
             XCTAssertEqual(teamInfos[0].team.name, "Reds")
-            XCTAssertEqual(teamInfos[0].minCustomScore, 100)
+            XCTAssertEqual(teamInfos[0].minCustomPlayerScore, 100)
             
             XCTAssertEqual(teamInfos[1].team.id, 2)
             XCTAssertEqual(teamInfos[1].team.name, "Blues")
-            XCTAssertEqual(teamInfos[1].minCustomScore, 200)
+            XCTAssertEqual(teamInfos[1].minCustomPlayerScore, 200)
             
             XCTAssertEqual(teamInfos[2].team.id, 3)
             XCTAssertEqual(teamInfos[2].team.name, "Greens")
-            XCTAssertNil(teamInfos[2].minCustomScore)
+            XCTAssertNil(teamInfos[2].minCustomPlayerScore)
             
             XCTAssertEqual(teamInfos[3].team.id, 4)
             XCTAssertEqual(teamInfos[3].team.name, "Oranges")
-            XCTAssertEqual(teamInfos[3].minCustomScore, 0)
+            XCTAssertEqual(teamInfos[3].minCustomPlayerScore, 0)
         }
     }
     
@@ -564,7 +564,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 .asRequest(of: CustomTeamInfo.self)
             
             try assertEqualSQL(db, request, """
-                SELECT "team".*, SUM("player"."score") AS "customScoreSum" \
+                SELECT "team".*, SUM("player"."score") AS "customPlayerScoreSum" \
                 FROM "team" \
                 LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
                 GROUP BY "team"."id" \
@@ -576,19 +576,19 @@ class AssociationAggregateTests: GRDBTestCase {
             
             XCTAssertEqual(teamInfos[0].team.id, 1)
             XCTAssertEqual(teamInfos[0].team.name, "Reds")
-            XCTAssertEqual(teamInfos[0].customScoreSum, 1100)
+            XCTAssertEqual(teamInfos[0].customPlayerScoreSum, 1100)
             
             XCTAssertEqual(teamInfos[1].team.id, 2)
             XCTAssertEqual(teamInfos[1].team.name, "Blues")
-            XCTAssertEqual(teamInfos[1].customScoreSum, 1500)
+            XCTAssertEqual(teamInfos[1].customPlayerScoreSum, 1500)
             
             XCTAssertEqual(teamInfos[2].team.id, 3)
             XCTAssertEqual(teamInfos[2].team.name, "Greens")
-            XCTAssertNil(teamInfos[2].customScoreSum)
+            XCTAssertNil(teamInfos[2].customPlayerScoreSum)
             
             XCTAssertEqual(teamInfos[3].team.id, 4)
             XCTAssertEqual(teamInfos[3].team.name, "Oranges")
-            XCTAssertEqual(teamInfos[3].customScoreSum, 0)
+            XCTAssertEqual(teamInfos[3].customPlayerScoreSum, 0)
         }
     }
     
@@ -605,11 +605,11 @@ class AssociationAggregateTests: GRDBTestCase {
             
             try assertEqualSQL(db, request, """
                 SELECT "team".*, \
-                AVG("player"."score") AS "averageCustomScore", \
-                COUNT(DISTINCT "player"."rowid") AS "customCount", \
-                MIN("player"."score") AS "minCustomScore", \
-                MAX("player"."score") AS "maxCustomScore", \
-                SUM("player"."score") AS "customScoreSum" \
+                AVG("player"."score") AS "averageCustomPlayerScore", \
+                COUNT(DISTINCT "player"."rowid") AS "customPlayerCount", \
+                MIN("player"."score") AS "minCustomPlayerScore", \
+                MAX("player"."score") AS "maxCustomPlayerScore", \
+                SUM("player"."score") AS "customPlayerScoreSum" \
                 FROM "team" \
                 LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
                 GROUP BY "team"."id" \
@@ -621,35 +621,35 @@ class AssociationAggregateTests: GRDBTestCase {
             
             XCTAssertEqual(teamInfos[0].team.id, 1)
             XCTAssertEqual(teamInfos[0].team.name, "Reds")
-            XCTAssertEqual(teamInfos[0].averageCustomScore, 550)
-            XCTAssertEqual(teamInfos[0].customCount, 2)
-            XCTAssertEqual(teamInfos[0].maxCustomScore, 1000)
-            XCTAssertEqual(teamInfos[0].minCustomScore, 100)
-            XCTAssertEqual(teamInfos[0].customScoreSum, 1100)
+            XCTAssertEqual(teamInfos[0].averageCustomPlayerScore, 550)
+            XCTAssertEqual(teamInfos[0].customPlayerCount, 2)
+            XCTAssertEqual(teamInfos[0].maxCustomPlayerScore, 1000)
+            XCTAssertEqual(teamInfos[0].minCustomPlayerScore, 100)
+            XCTAssertEqual(teamInfos[0].customPlayerScoreSum, 1100)
             
             XCTAssertEqual(teamInfos[1].team.id, 2)
             XCTAssertEqual(teamInfos[1].team.name, "Blues")
-            XCTAssertEqual(teamInfos[1].averageCustomScore, 500)
-            XCTAssertEqual(teamInfos[1].customCount, 3)
-            XCTAssertEqual(teamInfos[1].maxCustomScore, 800)
-            XCTAssertEqual(teamInfos[1].minCustomScore, 200)
-            XCTAssertEqual(teamInfos[1].customScoreSum, 1500)
+            XCTAssertEqual(teamInfos[1].averageCustomPlayerScore, 500)
+            XCTAssertEqual(teamInfos[1].customPlayerCount, 3)
+            XCTAssertEqual(teamInfos[1].maxCustomPlayerScore, 800)
+            XCTAssertEqual(teamInfos[1].minCustomPlayerScore, 200)
+            XCTAssertEqual(teamInfos[1].customPlayerScoreSum, 1500)
             
             XCTAssertEqual(teamInfos[2].team.id, 3)
             XCTAssertEqual(teamInfos[2].team.name, "Greens")
-            XCTAssertNil(teamInfos[2].averageCustomScore)
-            XCTAssertEqual(teamInfos[2].customCount, 0)
-            XCTAssertNil(teamInfos[2].maxCustomScore)
-            XCTAssertNil(teamInfos[2].minCustomScore)
-            XCTAssertNil(teamInfos[2].customScoreSum)
+            XCTAssertNil(teamInfos[2].averageCustomPlayerScore)
+            XCTAssertEqual(teamInfos[2].customPlayerCount, 0)
+            XCTAssertNil(teamInfos[2].maxCustomPlayerScore)
+            XCTAssertNil(teamInfos[2].minCustomPlayerScore)
+            XCTAssertNil(teamInfos[2].customPlayerScoreSum)
             
             XCTAssertEqual(teamInfos[3].team.id, 4)
             XCTAssertEqual(teamInfos[3].team.name, "Oranges")
-            XCTAssertEqual(teamInfos[3].averageCustomScore, 0)
-            XCTAssertEqual(teamInfos[3].customCount, 1)
-            XCTAssertEqual(teamInfos[3].maxCustomScore, 0)
-            XCTAssertEqual(teamInfos[3].minCustomScore, 0)
-            XCTAssertEqual(teamInfos[3].customScoreSum, 0)
+            XCTAssertEqual(teamInfos[3].averageCustomPlayerScore, 0)
+            XCTAssertEqual(teamInfos[3].customPlayerCount, 1)
+            XCTAssertEqual(teamInfos[3].maxCustomPlayerScore, 0)
+            XCTAssertEqual(teamInfos[3].minCustomPlayerScore, 0)
+            XCTAssertEqual(teamInfos[3].customPlayerScoreSum, 0)
         }
     }
     
@@ -707,8 +707,8 @@ class AssociationAggregateTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             let request = Team
-                .annotated(with: Team.players.filter(Column("score") < 500).forKey("lowPlayer").count)
-                .annotated(with: Team.players.filter(Column("score") >= 500).forKey("highPlayer").count)
+                .annotated(with: Team.players.filter(Column("score") < 500).forKey("lowPlayers").count)
+                .annotated(with: Team.players.filter(Column("score") >= 500).forKey("highPlayers").count)
                 .orderByPrimaryKey()
                 .asRequest(of: TeamInfo.self)
             

--- a/Tests/GRDBTests/AssociationAggregateTests.swift
+++ b/Tests/GRDBTests/AssociationAggregateTests.swift
@@ -8,7 +8,7 @@ import XCTest
 private struct Team: Codable, FetchableRecord, PersistableRecord {
     static let players = hasMany(Player.self)
     static let awards = hasMany(Award.self)
-    static let customPlayers = hasMany(Player.self, key: "custom")
+    static let customPlayers = hasMany(Player.self, name: "custom")
     var id: Int64
     var name: String
 }

--- a/Tests/GRDBTests/AssociationBelongsToFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToFetchableRecordTests.swift
@@ -14,7 +14,7 @@ private struct Team: Codable, FetchableRecord, PersistableRecord {
 private struct Player: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "players"
     static let teamScope = "team"
-    static let team = Player.belongsTo(Team.self, name: teamScope)
+    static let team = Player.belongsTo(Team.self, key: teamScope)
     var id: Int64
     var teamId: Int64?
     var name: String

--- a/Tests/GRDBTests/AssociationBelongsToFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToFetchableRecordTests.swift
@@ -14,7 +14,7 @@ private struct Team: Codable, FetchableRecord, PersistableRecord {
 private struct Player: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "players"
     static let teamScope = "team"
-    static let team = Player.belongsTo(Team.self, key: teamScope)
+    static let team = Player.belongsTo(Team.self, name: teamScope)
     var id: Int64
     var teamId: Int64?
     var name: String

--- a/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
@@ -14,7 +14,7 @@ private struct Team: Codable, FetchableRecord, PersistableRecord {
 private struct Player: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "players"
     static let defaultTeam = belongsTo(Team.self)
-    static let customTeam = belongsTo(Team.self, name: "customTeam")
+    static let customTeam = belongsTo(Team.self, key: "customTeam")
     var id: Int64
     var teamId: Int64?
     var name: String

--- a/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
@@ -14,7 +14,7 @@ private struct Team: Codable, FetchableRecord, PersistableRecord {
 private struct Player: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "players"
     static let defaultTeam = belongsTo(Team.self)
-    static let customTeam = belongsTo(Team.self, key: "customTeam")
+    static let customTeam = belongsTo(Team.self, name: "customTeam")
     var id: Int64
     var teamId: Int64?
     var name: String
@@ -56,8 +56,8 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows[0].unscoped, ["id":1, "teamId":1, "name":"Arthur"])
-        XCTAssertEqual(Set(rows[0].scopes.names), ["teams"])
-        XCTAssertEqual(rows[0].scopes["teams"]!, ["id":1, "name":"Reds"])
+        XCTAssertEqual(Set(rows[0].scopes.names), ["team"])
+        XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
     }
     
     func testDefaultScopeIncludingOptional() throws {
@@ -66,11 +66,11 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
         XCTAssertEqual(rows.count, 2)
         XCTAssertEqual(rows[0].unscoped, ["id":1, "teamId":1, "name":"Arthur"])
-        XCTAssertEqual(Set(rows[0].scopes.names), ["teams"])
-        XCTAssertEqual(rows[0].scopes["teams"]!, ["id":1, "name":"Reds"])
+        XCTAssertEqual(Set(rows[0].scopes.names), ["team"])
+        XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
         XCTAssertEqual(rows[1].unscoped, ["id":2, "teamId":nil, "name":"Barbara"])
-        XCTAssertEqual(Set(rows[1].scopes.names), ["teams"])
-        XCTAssertEqual(rows[1].scopes["teams"]!, ["id":nil, "name":nil])
+        XCTAssertEqual(Set(rows[1].scopes.names), ["team"])
+        XCTAssertEqual(rows[1].scopes["team"]!, ["id":nil, "name":nil])
     }
     
     func testDefaultScopeJoiningRequired() throws {

--- a/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
@@ -117,7 +117,7 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
     }
     
     func testCustomPluralScopeIncludingRequired() throws {
-        // Make sure plural keys are preserved
+        // Make sure explicit plural keys are preserved
         let dbQueue = try makeDatabaseQueue()
         do {
             let request = Player.including(required: Player.belongsTo(Team.self, key: "teams"))
@@ -138,7 +138,7 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
     }
     
     func testCustomPluralScopeIncludingOptional() throws {
-        // Make sure plural keys are preserved
+        // Make sure explicit plural keys are preserved
         let dbQueue = try makeDatabaseQueue()
         do {
             let request = Player.including(optional: Player.belongsTo(Team.self, key: "teams"))

--- a/Tests/GRDBTests/AssociationHasManyRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyRowScopeTests.swift
@@ -72,7 +72,8 @@ class AssociationHasManyRowScopeTests: GRDBTestCase {
         }
         
         struct Parent : TableRecord {
-            static let children = hasMany(Child.self, key: "littlePuppies")
+            static let littlePuppies = hasMany(Child.self, key: "littlePuppies")
+            static let kittens = hasMany(Child.self).forKey("kittens")
         }
         
         let dbQueue = try makeDatabaseQueue()
@@ -89,10 +90,18 @@ class AssociationHasManyRowScopeTests: GRDBTestCase {
                 INSERT INTO child (id, parentId) VALUES (2, 1);
                 """)
             
-            let request = Parent.including(required: Parent.children)
-            let row = try Row.fetchOne(db, request)!
-            XCTAssertEqual(row.unscoped, ["id": 1])
-            XCTAssertEqual(row.scopes["littlePuppy"], ["id": 2, "parentId": 1])
+            do {
+                let request = Parent.including(required: Parent.littlePuppies)
+                let row = try Row.fetchOne(db, request)!
+                XCTAssertEqual(row.unscoped, ["id": 1])
+                XCTAssertEqual(row.scopes["littlePuppy"], ["id": 2, "parentId": 1])
+            }
+            do {
+                let request = Parent.including(required: Parent.kittens)
+                let row = try Row.fetchOne(db, request)!
+                XCTAssertEqual(row.unscoped, ["id": 1])
+                XCTAssertEqual(row.scopes["kitten"], ["id": 2, "parentId": 1])
+            }
         }
     }
 }

--- a/Tests/GRDBTests/AssociationHasManyRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyRowScopeTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    import GRDB
+#endif
+
+class AssociationHasManyRowScopeTests: GRDBTestCase {
+
+    func testSingularTable() throws {
+        struct Child : TableRecord {
+        }
+        
+        struct Parent : TableRecord {
+            static let children = hasMany(Child.self)
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "child") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("parentId", .integer).references("parent")
+            }
+            try db.execute(sql: """
+                INSERT INTO parent (id) VALUES (1);
+                INSERT INTO child (id, parentId) VALUES (2, 1);
+                """)
+            
+            let request = Parent.including(required: Parent.children)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 1])
+            XCTAssertEqual(row.scopes["child"], ["id": 2, "parentId": 1])
+        }
+    }
+    
+    func testPluralTable() throws {
+        struct Child : TableRecord {
+            static let databaseTableName = "children"
+        }
+        
+        struct Parent : TableRecord {
+            static let databaseTableName = "parents"
+            static let children = hasMany(Child.self)
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "parents") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "children") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("parentId", .integer).references("parents")
+            }
+            try db.execute(sql: """
+                INSERT INTO parents (id) VALUES (1);
+                INSERT INTO children (id, parentId) VALUES (2, 1);
+                """)
+            
+            let request = Parent.including(required: Parent.children)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 1])
+            XCTAssertEqual(row.scopes["child"], ["id": 2, "parentId": 1])
+        }
+    }
+    
+    func testCustomKey() throws {
+        struct Child : TableRecord {
+        }
+        
+        struct Parent : TableRecord {
+            static let children = hasMany(Child.self, key: "littlePuppies")
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "child") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("parentId", .integer).references("parent")
+            }
+            try db.execute(sql: """
+                INSERT INTO parent (id) VALUES (1);
+                INSERT INTO child (id, parentId) VALUES (2, 1);
+                """)
+            
+            let request = Parent.including(required: Parent.children)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 1])
+            XCTAssertEqual(row.scopes["littlePuppy"], ["id": 2, "parentId": 1])
+        }
+    }
+}

--- a/Tests/GRDBTests/AssociationHasManyThroughRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyThroughRowScopeTests.swift
@@ -1,0 +1,270 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    import GRDB
+#endif
+
+/// Test SQL generation
+
+class AssociationHasManyThroughRowScopeTests: GRDBTestCase {
+    
+    func testBelongsToHasManySingularTable() throws {
+        struct Parent: TableRecord {
+            static let child = belongsTo(Child.self)
+            static let grandChildren = hasMany(GrandChild.self, through: child, using: Child.grandChildren)
+        }
+        struct Child: TableRecord {
+            static let grandChildren = hasMany(GrandChild.self)
+        }
+        struct GrandChild: TableRecord {
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "child") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("childId").references("child")
+            }
+            try db.create(table: "grandChild") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("childId").references("child")
+            }
+            try db.execute(sql: """
+                INSERT INTO child (id) VALUES (1);
+                INSERT INTO parent (id, childId) VALUES (2, 1);
+                INSERT INTO grandChild (id, childId) VALUES (3, 1);
+                """)
+            
+            let request = Parent.including(required: Parent.grandChildren)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 2, "childId": 1])
+            XCTAssertEqual(Set(row.scopes.names), ["child"])
+            XCTAssertEqual(row.scopesTree["grandChild"], ["id": 3, "childId": 1])
+        }
+    }
+    
+    func testBelongsToHasManyPluralTable() throws {
+        struct Parent: TableRecord {
+            static let databaseTableName = "parents"
+            static let child = belongsTo(Child.self)
+            static let grandChildren = hasMany(GrandChild.self, through: child, using: Child.grandChildren)
+        }
+        struct Child: TableRecord {
+            static let databaseTableName = "children"
+            static let grandChildren = hasMany(GrandChild.self)
+        }
+        struct GrandChild: TableRecord {
+            static let databaseTableName = "grandChildren"
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "children") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "parents") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("childId").references("children")
+            }
+            try db.create(table: "grandChildren") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("childId").references("children")
+            }
+            try db.execute(sql: """
+                INSERT INTO children (id) VALUES (1);
+                INSERT INTO parents (id, childId) VALUES (2, 1);
+                INSERT INTO grandChildren (id, childId) VALUES (3, 1);
+                """)
+            
+            let request = Parent.including(required: Parent.grandChildren)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 2, "childId": 1])
+            XCTAssertEqual(Set(row.scopes.names), ["child"])
+            XCTAssertEqual(row.scopesTree["grandChild"], ["id": 3, "childId": 1])
+        }
+    }
+    
+    func testBelongsToHasManyCustomKey() throws {
+        struct Parent: TableRecord {
+            static let databaseTableName = "parents"
+            static let child = belongsTo(Child.self)
+            static let littlePuppies = hasMany(GrandChild.self, through: child, using: Child.grandChildren, key: "littlePuppies")
+            static let kittens = hasMany(GrandChild.self, through: child, using: Child.grandChildren).forKey("kittens")
+        }
+        struct Child: TableRecord {
+            static let databaseTableName = "children"
+            static let grandChildren = hasMany(GrandChild.self)
+        }
+        struct GrandChild: TableRecord {
+            static let databaseTableName = "grandChildren"
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "children") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "parents") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("childId").references("children")
+            }
+            try db.create(table: "grandChildren") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("childId").references("children")
+            }
+            try db.execute(sql: """
+                INSERT INTO children (id) VALUES (1);
+                INSERT INTO parents (id, childId) VALUES (2, 1);
+                INSERT INTO grandChildren (id, childId) VALUES (3, 1);
+                """)
+            
+            do {
+                let request = Parent.including(required: Parent.littlePuppies)
+                let row = try Row.fetchOne(db, request)!
+                XCTAssertEqual(row.unscoped, ["id": 2, "childId": 1])
+                XCTAssertEqual(Set(row.scopes.names), ["child"])
+                XCTAssertEqual(row.scopesTree["littlePuppy"], ["id": 3, "childId": 1])
+            }
+            
+            do {
+                let request = Parent.including(required: Parent.kittens)
+                let row = try Row.fetchOne(db, request)!
+                XCTAssertEqual(row.unscoped, ["id": 2, "childId": 1])
+                XCTAssertEqual(Set(row.scopes.names), ["child"])
+                XCTAssertEqual(row.scopesTree["kitten"], ["id": 3, "childId": 1])
+            }
+        }
+    }
+    
+    func testHasManyBelongsToSingularTable() throws {
+        struct Parent: TableRecord {
+            static let children = hasMany(Child.self)
+            static let grandChildren = hasMany(GrandChild.self, through: children, using: Child.grandChild)
+        }
+        struct Child: TableRecord {
+            static let grandChild = belongsTo(GrandChild.self)
+        }
+        struct GrandChild: TableRecord {
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "grandChild") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "child") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("parentId").references("parent")
+                t.column("grandChildId").references("grandChild")
+            }
+            try db.execute(sql: """
+                INSERT INTO parent (id) VALUES (1);
+                INSERT INTO grandChild (id) VALUES (2);
+                INSERT INTO child (id, parentId, grandChildId) VALUES (3, 1, 2);
+                """)
+            
+            let request = Parent.including(required: Parent.grandChildren)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 1])
+            XCTAssertEqual(Set(row.scopes.names), ["child"])
+            XCTAssertEqual(row.scopesTree["grandChild"], ["id": 2])
+        }
+    }
+    
+    func testHasManyBelongsToPluralTable() throws {
+        struct Parent: TableRecord {
+            static let databaseTableName = "parents"
+            static let children = hasMany(Child.self)
+            static let grandChildren = hasMany(GrandChild.self, through: children, using: Child.grandChild)
+        }
+        struct Child: TableRecord {
+            static let databaseTableName = "children"
+            static let grandChild = belongsTo(GrandChild.self)
+        }
+        struct GrandChild: TableRecord {
+            static let databaseTableName = "grandChildren"
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "parents") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "grandChildren") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "children") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("parentId").references("parents")
+                t.column("grandChildId").references("grandChildren")
+            }
+            try db.execute(sql: """
+                INSERT INTO parents (id) VALUES (1);
+                INSERT INTO grandChildren (id) VALUES (2);
+                INSERT INTO children (id, parentId, grandChildId) VALUES (3, 1, 2);
+                """)
+            
+            let request = Parent.including(required: Parent.grandChildren)
+            let row = try Row.fetchOne(db, request)!
+            XCTAssertEqual(row.unscoped, ["id": 1])
+            XCTAssertEqual(Set(row.scopes.names), ["child"])
+            XCTAssertEqual(row.scopesTree["grandChild"], ["id": 2])
+        }
+    }
+    
+    func testHasManyBelongsToCustomKey() throws {
+        struct Parent: TableRecord {
+            static let children = hasMany(Child.self)
+            static let littlePuppies = hasMany(GrandChild.self, through: children, using: Child.grandChild, key: "littlePuppies")
+            static let kittens = hasMany(GrandChild.self, through: children, using: Child.grandChild).forKey("kittens")
+        }
+        struct Child: TableRecord {
+            static let grandChild = belongsTo(GrandChild.self)
+        }
+        struct GrandChild: TableRecord {
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "grandChild") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "child") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("parentId").references("parent")
+                t.column("grandChildId").references("grandChild")
+            }
+            try db.execute(sql: """
+                INSERT INTO parent (id) VALUES (1);
+                INSERT INTO grandChild (id) VALUES (2);
+                INSERT INTO child (id, parentId, grandChildId) VALUES (3, 1, 2);
+                """)
+            
+            do {
+                let request = Parent.including(required: Parent.littlePuppies)
+                let row = try Row.fetchOne(db, request)!
+                XCTAssertEqual(row.unscoped, ["id": 1])
+                XCTAssertEqual(Set(row.scopes.names), ["child"])
+                XCTAssertEqual(row.scopesTree["littlePuppy"], ["id": 2])
+            }
+            
+            do {
+                let request = Parent.including(required: Parent.kittens)
+                let row = try Row.fetchOne(db, request)!
+                XCTAssertEqual(row.unscoped, ["id": 1])
+                XCTAssertEqual(Set(row.scopes.names), ["child"])
+                XCTAssertEqual(row.scopesTree["kitten"], ["id": 2])
+            }
+        }
+    }
+}

--- a/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
+++ b/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
@@ -11,8 +11,8 @@ private struct A: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "a"
     static let defaultB = belongsTo(B.self)
     static let defaultD = belongsTo(D.self)
-    static let customB = belongsTo(B.self, key: "customB")
-    static let customD = belongsTo(D.self, key: "customD")
+    static let customB = belongsTo(B.self, name: "customB")
+    static let customD = belongsTo(D.self, name: "customD")
     var id: Int64
     var bid: Int64?
     var did: Int64?
@@ -22,8 +22,8 @@ private struct A: Codable, FetchableRecord, PersistableRecord {
 private struct B: Codable, FetchableRecord, PersistableRecord {
     static let defaultA = hasOne(A.self)
     static let defaultC = hasOne(C.self)
-    static let customA = hasOne(A.self, key: "customA")
-    static let customC = hasOne(C.self, key: "customC")
+    static let customA = hasOne(A.self, name: "customA")
+    static let customC = hasOne(C.self, name: "customC")
     static let databaseTableName = "b"
     var id: Int64
     var name: String
@@ -38,7 +38,7 @@ private struct C: Codable, FetchableRecord, PersistableRecord {
 
 private struct D: Codable, FetchableRecord, PersistableRecord {
     static let defaultA = hasOne(A.self)
-    static let customA = hasOne(A.self, key: "customA")
+    static let customA = hasOne(A.self, name: "customA")
     static let databaseTableName = "d"
     var id: Int64
     var name: String

--- a/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
+++ b/Tests/GRDBTests/AssociationParallelRowScopesTests.swift
@@ -11,8 +11,8 @@ private struct A: Codable, FetchableRecord, PersistableRecord {
     static let databaseTableName = "a"
     static let defaultB = belongsTo(B.self)
     static let defaultD = belongsTo(D.self)
-    static let customB = belongsTo(B.self, name: "customB")
-    static let customD = belongsTo(D.self, name: "customD")
+    static let customB = belongsTo(B.self, key: "customB")
+    static let customD = belongsTo(D.self, key: "customD")
     var id: Int64
     var bid: Int64?
     var did: Int64?
@@ -22,8 +22,8 @@ private struct A: Codable, FetchableRecord, PersistableRecord {
 private struct B: Codable, FetchableRecord, PersistableRecord {
     static let defaultA = hasOne(A.self)
     static let defaultC = hasOne(C.self)
-    static let customA = hasOne(A.self, name: "customA")
-    static let customC = hasOne(C.self, name: "customC")
+    static let customA = hasOne(A.self, key: "customA")
+    static let customC = hasOne(C.self, key: "customC")
     static let databaseTableName = "b"
     var id: Int64
     var name: String
@@ -38,7 +38,7 @@ private struct C: Codable, FetchableRecord, PersistableRecord {
 
 private struct D: Codable, FetchableRecord, PersistableRecord {
     static let defaultA = hasOne(A.self)
-    static let customA = hasOne(A.self, name: "customA")
+    static let customA = hasOne(A.self, key: "customA")
     static let databaseTableName = "d"
     var id: Int64
     var name: String

--- a/Tests/GRDBTests/AssociationParallelSQLTests.swift
+++ b/Tests/GRDBTests/AssociationParallelSQLTests.swift
@@ -109,49 +109,49 @@ class AssociationParallelSQLTests: GRDBTestCase {
     func testParallelTwoIncludingIncludingOtherKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            try assertEqualSQL(db, A.including(required: A.b).including(required: A.b.forKey("altb")), """
+            try assertEqualSQL(db, A.including(required: A.b).including(required: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
                 JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
                 JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
                 """)
-            try assertEqualSQL(db, A.including(required: A.b).including(optional: A.b.forKey("altb")), """
+            try assertEqualSQL(db, A.including(required: A.b).including(optional: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
                 JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
                 LEFT JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
                 """)
-            try assertEqualSQL(db, A.including(optional: A.b).including(required: A.b.forKey("altb")), """
+            try assertEqualSQL(db, A.including(optional: A.b).including(required: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
                 LEFT JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
                 JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
                 """)
-            try assertEqualSQL(db, A.including(optional: A.b).including(optional: A.b.forKey("altb")), """
+            try assertEqualSQL(db, A.including(optional: A.b).including(optional: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
                 LEFT JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
                 LEFT JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
                 """)
-            try assertEqualSQL(db, B.including(required: B.a).including(required: B.a.forKey("alta")), """
+            try assertEqualSQL(db, B.including(required: B.a).including(required: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
                 JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
                 JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
                 """)
-            try assertEqualSQL(db, B.including(required: B.a).including(optional: B.a.forKey("alta")), """
+            try assertEqualSQL(db, B.including(required: B.a).including(optional: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
                 JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
                 LEFT JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
                 """)
-            try assertEqualSQL(db, B.including(optional: B.a).including(required: B.a.forKey("alta")), """
+            try assertEqualSQL(db, B.including(optional: B.a).including(required: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
                 LEFT JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
                 JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
                 """)
-            try assertEqualSQL(db, B.including(optional: B.a).including(optional: B.a.forKey("alta")), """
+            try assertEqualSQL(db, B.including(optional: B.a).including(optional: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
                 LEFT JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \

--- a/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
@@ -673,7 +673,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
         }
     }
     
-    func testIncludingAllHasManyThrough() throws {
+    func testIncludingAllHasManyThroughHasManyUsingHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             // Plain request

--- a/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
@@ -9,7 +9,7 @@ private struct A: TableRecord, FetchableRecord, Decodable, Equatable {
     var cola1: Int64
     var cola2: String
 }
-private struct B: TableRecord, FetchableRecord, Decodable, Hashable {
+private struct B: TableRecord, FetchableRecord, Decodable, Equatable, Hashable {
     var colb1: Int64
     var colb2: Int64?
     var colb3: String
@@ -89,8 +89,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(B.self)
-                        .orderByPrimaryKey()
-                        .forKey("bs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Array
@@ -244,10 +243,8 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                         .hasMany(C.self)
                         .including(all: C
                             .hasMany(D.self)
-                            .orderByPrimaryKey()
-                            .forKey("ds"))  // TODO: auto-pluralization
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Decodable, Equatable {
@@ -317,8 +314,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Decodable, Equatable {
@@ -478,8 +474,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Decodable, Equatable {
@@ -543,8 +538,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Decodable, Equatable {
@@ -592,12 +586,12 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
                             .orderByPrimaryKey()
-                            .forKey("d1"))
+                            .forKey("ds1"))
                         .including(required: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
                             .orderByPrimaryKey()
-                            .forKey("d2"))
+                            .forKey("ds2"))
                         .orderByPrimaryKey()
                         .forKey("cs1"))
                     .including(all: A
@@ -607,12 +601,12 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
                             .orderByPrimaryKey()
-                            .forKey("d1"))
+                            .forKey("ds1"))
                         .including(required: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
                             .orderByPrimaryKey()
-                            .forKey("d2"))
+                            .forKey("ds2"))
                         .orderByPrimaryKey()
                         .forKey("cs2"))
                     .orderByPrimaryKey()
@@ -687,8 +681,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Decodable, Equatable {
@@ -803,13 +796,12 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
         try dbQueue.read { db in
             // Plain request
             do {
-                let cs = A.hasMany(C.self).forKey("cs")
+                let cs = A.hasMany(C.self)
                 let request = A
                     .including(all: cs.orderByPrimaryKey())
                     .including(all: A
                         .hasMany(D.self, through: cs, using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Decodable, Equatable {
@@ -959,8 +951,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                         .belongsTo(A.self)
                         .including(all: A
                             .hasMany(C.self)
-                            .orderByPrimaryKey()
-                            .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
                     )
                     .orderByPrimaryKey()
                 

--- a/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
@@ -898,16 +898,16 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                 let request = A
                     .filter(Column("cola1") != 3)
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self).filter(Column("colc1") == 8), using: C.hasMany(D.self))
+                        .hasMany(D.self, through: A.hasMany(C.self).filter(Column("colc1") == 8).forKey("cs1"), using: C.hasMany(D.self))
                         .orderByPrimaryKey()
                         .forKey("ds1"))
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .hasMany(D.self, through: A.hasMany(C.self).forKey("cs2"), using: C.hasMany(D.self))
                         .filter(Column("cold1") != 11)
                         .orderByPrimaryKey()
                         .forKey("ds2"))
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .hasMany(D.self, through: A.hasMany(C.self).forKey("cs2"), using: C.hasMany(D.self))
                         .filter(Column("cold1") == 11)
                         .orderByPrimaryKey()
                         .forKey("ds3"))
@@ -968,177 +968,6 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                             D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
                         ],
                         ds3: []))
-                }
-            }
-        }
-    }
-    
-    func testIncludingAllHasManyThroughIsNotMergedWithHasMany() throws {
-        let dbQueue = try makeDatabaseQueue()
-        try dbQueue.read { db in
-            // Plain request
-            do {
-                let cs = A.hasMany(C.self)
-                let request = A
-                    .including(all: cs.orderByPrimaryKey())
-                    .including(all: A
-                        .hasMany(D.self, through: cs, using: C.hasMany(D.self))
-                        .orderByPrimaryKey())
-                    .orderByPrimaryKey()
-                
-                struct Record: FetchableRecord, Equatable {
-                    var a: A
-                    var cs: [C]
-                    var ds: [D]
-                    
-                    init(a: A, cs: [C], ds: [D]) {
-                        self.a = a
-                        self.cs = cs
-                        self.ds = ds
-                    }
-                    
-                    init(row: Row) {
-                        self.init(a: A(row: row), cs: row["cs"], ds: row["ds"])
-                    }
-                }
-                
-                // Record.fetchAll
-                do {
-                    let records = try Record.fetchAll(db, request)
-                    XCTAssertEqual(records, [
-                        Record(
-                            a: A(row: ["cola1": 1, "cola2": "a1"]),
-                            cs: [
-                                C(row: ["colc1": 7, "colc2": 1]),
-                            ],
-                            ds: [
-                                D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
-                            ]),
-                        Record(
-                            a: A(row: ["cola1": 2, "cola2": "a2"]),
-                            cs: [
-                                C(row: ["colc1": 8, "colc2": 2]),
-                                C(row: ["colc1": 9, "colc2": 2]),
-                            ],
-                            ds: [
-                                D(row: ["cold1": 11, "cold2": 8, "cold3": "d2"]),
-                                D(row: ["cold1": 12, "cold2": 8, "cold3": "d3"]),
-                                D(row: ["cold1": 13, "cold2": 9, "cold3": "d4"]),
-                            ]),
-                        Record(
-                            a: A(row: ["cola1": 3, "cola2": "a3"]),
-                            cs: [],
-                            ds: []),
-                        ])
-                }
-                
-                // Record.fetchOne
-                do {
-                    let record = try Record.fetchOne(db, request)!
-                    XCTAssertEqual(record, Record(
-                        a: A(row: ["cola1": 1, "cola2": "a1"]),
-                        cs: [
-                            C(row: ["colc1": 7, "colc2": 1]),
-                        ],
-                        ds: [
-                            D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
-                        ]))
-                }
-            }
-            
-            // Request with filters
-            do {
-                let cs1 = A.hasMany(C.self).forKey("cs1")
-                let cs2 = A.hasMany(C.self).forKey("cs2")
-                let request = A
-                    .filter(Column("cola1") != 3)
-                    .including(all: cs1
-                        .filter(Column("colc1") != 8)
-                        .orderByPrimaryKey())
-                    .including(all: A
-                        .hasMany(D.self, through: cs1, using: C.hasMany(D.self))
-                        .filter(Column("cold1") != 11)
-                        .orderByPrimaryKey()
-                        .forKey("ds1"))
-                    .including(all: cs2
-                        .filter(Column("colc1") != 9)
-                        .orderByPrimaryKey())
-                    .including(all: A
-                        .hasMany(D.self, through: cs2, using: C.hasMany(D.self))
-                        .filter(Column("cold1") == 11)
-                        .orderByPrimaryKey()
-                        .forKey("ds2"))
-                    .orderByPrimaryKey()
-                
-                struct Record: FetchableRecord, Equatable {
-                    var a: A
-                    var cs1: [C]
-                    var cs2: [C]
-                    var ds1: [D]
-                    var ds2: [D]
-                    
-                    init(a: A, cs1: [C], cs2: [C], ds1: [D], ds2: [D]) {
-                        self.a = a
-                        self.cs1 = cs1
-                        self.cs2 = cs2
-                        self.ds1 = ds1
-                        self.ds2 = ds2
-                    }
-                    
-                    init(row: Row) {
-                        self.init(a: A(row: row), cs1: row["cs1"], cs2: row["cs2"], ds1: row["ds1"], ds2: row["ds2"])
-                    }
-                }
-                
-                // Record.fetchAll
-                do {
-                    let records = try Record.fetchAll(db, request)
-                    XCTAssertEqual(records, [
-                        Record(
-                            a: A(row: ["cola1": 1, "cola2": "a1"]),
-                            cs1: [
-                                C(row: ["colc1": 7, "colc2": 1]),
-                            ],
-                            cs2: [
-                                C(row: ["colc1": 7, "colc2": 1]),
-                            ],
-                            ds1: [
-                                D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
-                            ],
-                            ds2: []),
-                        Record(
-                            a: A(row: ["cola1": 2, "cola2": "a2"]),
-                            cs1: [
-                                C(row: ["colc1": 9, "colc2": 2]),
-                            ],
-                            cs2: [
-                                C(row: ["colc1": 8, "colc2": 2]),
-                            ],
-                            ds1: [
-                                D(row: ["cold1": 12, "cold2": 8, "cold3": "d3"]),
-                                D(row: ["cold1": 13, "cold2": 9, "cold3": "d4"]),
-                            ],
-                            ds2: [
-                                D(row: ["cold1": 11, "cold2": 8, "cold3": "d2"]),
-                            ]),
-                        ])
-                }
-                
-                // Record.fetchOne
-                do {
-                    let record = try Record.fetchOne(db, request)!
-                    XCTAssertEqual(record, Record(
-                        a: A(row: ["cola1": 1, "cola2": "a1"]),
-                        cs1: [
-                            C(row: ["colc1": 7, "colc2": 1]),
-                        ],
-                        cs2: [
-                            C(row: ["colc1": 7, "colc2": 1]),
-                        ],
-                        ds1: [
-                            D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
-                        ],
-                        ds2: []))
                 }
             }
         }

--- a/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
@@ -841,7 +841,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
         }
     }
     
-    func testIncludingAllHasManyThrough() throws {
+    func testIncludingAllHasManyThroughHasManyUsingHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             // Plain request

--- a/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
@@ -111,8 +111,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(B.self)
-                        .orderByPrimaryKey()
-                        .forKey("bs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Array
@@ -294,10 +293,8 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                         .hasMany(C.self)
                         .including(all: C
                             .hasMany(D.self)
-                            .orderByPrimaryKey()
-                            .forKey("ds"))  // TODO: auto-pluralization
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Equatable {
@@ -385,8 +382,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Equatable {
@@ -584,8 +580,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Equatable {
@@ -667,8 +662,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Equatable {
@@ -849,8 +843,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Equatable {
@@ -985,13 +978,12 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
         try dbQueue.read { db in
             // Plain request
             do {
-                let cs = A.hasMany(C.self).forKey("cs")
+                let cs = A.hasMany(C.self)
                 let request = A
                     .including(all: cs.orderByPrimaryKey())
                     .including(all: A
                         .hasMany(D.self, through: cs, using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 struct Record: FetchableRecord, Equatable {
@@ -1163,8 +1155,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                         .belongsTo(A.self)
                         .including(all: A
                             .hasMany(C.self)
-                            .orderByPrimaryKey()
-                            .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
                     )
                     .orderByPrimaryKey()
                 

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -220,54 +220,16 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                 let request = A
                     .filter(Column("cola1") != 3)
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self).filter(Column("colc1") == 8), using: C.hasMany(D.self))
+                        .hasMany(D.self, through: A.hasMany(C.self).filter(Column("colc1") == 8).forKey("cs1"), using: C.hasMany(D.self))
                         .forKey("ds1"))
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .hasMany(D.self, through: A.hasMany(C.self).forKey("cs2"), using: C.hasMany(D.self))
                         .filter(Column("cold1") != 11)
                         .forKey("ds2"))
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .hasMany(D.self, through: A.hasMany(C.self).forKey("cs2"), using: C.hasMany(D.self))
                         .filter(Column("cold1") == 11)
                         .forKey("ds3"))
-                
-                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
-            }
-        }
-    }
-    
-    func testIncludingAllHasManyThroughIsNotMergedWithHasMany() throws {
-        let dbQueue = try makeDatabaseQueue()
-        try dbQueue.read { db in
-            // Plain request
-            do {
-                let cs = A.hasMany(C.self)
-                let request = A
-                    .including(all: cs)
-                    .including(all: A
-                        .hasMany(D.self, through: cs, using: C.hasMany(D.self)))
-                
-                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
-            }
-            
-            // Request with filters
-            do {
-                let cs1 = A.hasMany(C.self).forKey("cs1")
-                let cs2 = A.hasMany(C.self).forKey("cs2")
-                let request = A
-                    .filter(Column("cola1") != 3)
-                    .including(all: cs1
-                        .filter(Column("colc1") != 8))
-                    .including(all: A
-                        .hasMany(D.self, through: cs1, using: C.hasMany(D.self))
-                        .filter(Column("cold1") != 11)
-                        .forKey("ds1"))
-                    .including(all: cs2
-                        .filter(Column("colc1") != 9))
-                    .including(all: A
-                        .hasMany(D.self, through: cs2, using: C.hasMany(D.self))
-                        .filter(Column("cold1") == 11)
-                        .forKey("ds2"))
                 
                 try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -255,7 +255,7 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
         try dbQueue.read { db in
             // Plain request
             do {
-                let cs = A.hasMany(C.self).forKey("cs")
+                let cs = A.hasMany(C.self)
                 let request = A
                     .including(all: cs)
                     .including(all: A

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -287,7 +287,10 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                             .hasMany(C.self))
                     )
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "a(*),b(colb1,colb2,colb3),c(colc1,colc2)")
+                try XCTAssert([
+                    "a(*),b(colb1,colb2,colb3),c(colc1,colc2)",             // iOS 12
+                    "a(cola1,cola2),b(colb1,colb2,colb3),c(colc1,colc2)",   // iOS 9
+                    ].contains(request.databaseRegion(db).description))
             }
             
             // Request with filters

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -217,7 +217,7 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
         }
     }
     
-    func testIncludingAllHasManyThrough() throws {
+    func testIncludingAllHasManyThroughHasManyUsingHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             // Plain request

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -5,24 +5,10 @@ import XCTest
     import GRDB
 #endif
 
-private struct A: TableRecord, FetchableRecord, Decodable, Equatable {
-    var cola1: Int64
-    var cola2: String
-}
-private struct B: TableRecord, FetchableRecord, Decodable, Hashable {
-    var colb1: Int64
-    var colb2: Int64?
-    var colb3: String
-}
-private struct C: TableRecord, FetchableRecord, Decodable, Equatable {
-    var colc1: Int64
-    var colc2: Int64
-}
-private struct D: TableRecord, FetchableRecord, Decodable, Equatable {
-    var cold1: Int64
-    var cold2: Int64
-    var cold3: String
-}
+private struct A: TableRecord { }
+private struct B: TableRecord { }
+private struct C: TableRecord { }
+private struct D: TableRecord { }
 
 class AssociationPrefetchingObservationTests: GRDBTestCase {
     override func setup(_ dbWriter: DatabaseWriter) throws {

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -88,12 +88,9 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
             do {
                 let request = A
                     .including(all: A
-                        .hasMany(B.self)
-                        .orderByPrimaryKey()
-                        .forKey("bs"))  // TODO: auto-pluralization
-                    .orderByPrimaryKey()
+                        .hasMany(B.self))
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),b(colb1,colb2,colb3)")
             }
             
             // Request with filters
@@ -103,16 +100,23 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                     .including(all: A
                         .hasMany(B.self)
                         .filter(Column("colb1") == 4)
-                        .orderByPrimaryKey()
                         .forKey("bs1"))
                     .including(all: A
                         .hasMany(B.self)
                         .filter(Column("colb1") != 4)
-                        .orderByPrimaryKey()
                         .forKey("bs2"))
-                    .orderByPrimaryKey()
+
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),b(colb1,colb2,colb3)")
+            }
+            
+            // Request with altered selection
+            do {
+                let request = A
+                    .including(all: A
+                        .hasMany(B.self)
+                        .select(Column("colb1")))
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),b(colb1,colb2)")
             }
         }
     }
@@ -126,14 +130,9 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                     .including(all: A
                         .hasMany(C.self)
                         .including(all: C
-                            .hasMany(D.self)
-                            .orderByPrimaryKey()
-                            .forKey("ds"))  // TODO: auto-pluralization
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
-                    .orderByPrimaryKey()
+                            .hasMany(D.self)))
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
             
             // Request with filters
@@ -146,14 +145,11 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .including(all: C
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
-                            .orderByPrimaryKey()
                             .forKey("ds1"))
                         .including(all: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
-                            .orderByPrimaryKey()
                             .forKey("ds2"))
-                        .orderByPrimaryKey()
                         .forKey("cs1"))
                     .including(all: A
                         .hasMany(C.self)
@@ -161,18 +157,14 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .including(all: C
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
-                            .orderByPrimaryKey()
                             .forKey("ds1"))
                         .including(all: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
-                            .orderByPrimaryKey()
                             .forKey("ds2"))
-                        .orderByPrimaryKey()
                         .forKey("cs2"))
-                    .orderByPrimaryKey()
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
         }
     }
@@ -186,13 +178,9 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                     .including(all: A
                         .hasMany(C.self)
                         .including(required: C
-                            .hasMany(D.self)
-                            .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
-                    .orderByPrimaryKey()
+                            .hasMany(D.self)))
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
             
             // Request with filters
@@ -205,14 +193,11 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .including(optional: C
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
-                            .orderByPrimaryKey()
                             .forKey("d1"))
                         .including(required: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
-                            .orderByPrimaryKey()
                             .forKey("d2"))
-                        .orderByPrimaryKey()
                         .forKey("cs1"))
                     .including(all: A
                         .hasMany(C.self)
@@ -220,18 +205,14 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .including(optional: C
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
-                            .orderByPrimaryKey()
                             .forKey("d1"))
                         .including(required: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
-                            .orderByPrimaryKey()
                             .forKey("d2"))
-                        .orderByPrimaryKey()
                         .forKey("cs2"))
-                    .orderByPrimaryKey()
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
         }
     }
@@ -243,12 +224,9 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
             do {
                 let request = A
                     .including(all: A
-                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
-                    .orderByPrimaryKey()
+                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self)))
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
             
             // Request with filters
@@ -257,21 +235,17 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                     .filter(Column("cola1") != 3)
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self).filter(Column("colc1") == 8), using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
                         .forKey("ds1"))
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
                         .filter(Column("cold1") != 11)
-                        .orderByPrimaryKey()
                         .forKey("ds2"))
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
                         .filter(Column("cold1") == 11)
-                        .orderByPrimaryKey()
                         .forKey("ds3"))
-                    .orderByPrimaryKey()
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
         }
     }
@@ -283,14 +257,11 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
             do {
                 let cs = A.hasMany(C.self).forKey("cs")
                 let request = A
-                    .including(all: cs.orderByPrimaryKey())
+                    .including(all: cs)
                     .including(all: A
-                        .hasMany(D.self, through: cs, using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
-                    .orderByPrimaryKey()
+                        .hasMany(D.self, through: cs, using: C.hasMany(D.self)))
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
             
             // Request with filters
@@ -300,24 +271,19 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                 let request = A
                     .filter(Column("cola1") != 3)
                     .including(all: cs1
-                        .filter(Column("colc1") != 8)
-                        .orderByPrimaryKey())
+                        .filter(Column("colc1") != 8))
                     .including(all: A
                         .hasMany(D.self, through: cs1, using: C.hasMany(D.self))
                         .filter(Column("cold1") != 11)
-                        .orderByPrimaryKey()
                         .forKey("ds1"))
                     .including(all: cs2
-                        .filter(Column("colc1") != 9)
-                        .orderByPrimaryKey())
+                        .filter(Column("colc1") != 9))
                     .including(all: A
                         .hasMany(D.self, through: cs2, using: C.hasMany(D.self))
                         .filter(Column("cold1") == 11)
-                        .orderByPrimaryKey()
                         .forKey("ds2"))
-                    .orderByPrimaryKey()
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),c(colc1,colc2),d(cold1,cold2,cold3)")
             }
         }
     }
@@ -332,13 +298,10 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                     .including(optional: B
                         .belongsTo(A.self)
                         .including(all: A
-                            .hasMany(C.self)
-                            .orderByPrimaryKey()
-                            .forKey("cs"))  // TODO: auto-pluralization
+                            .hasMany(C.self))
                     )
-                    .orderByPrimaryKey()
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(*),b(colb1,colb2,colb3),c(colc1,colc2)")
             }
             
             // Request with filters
@@ -350,12 +313,10 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .including(all: A
                             .hasMany(C.self)
                             .filter(Column("colc1") == 9)
-                            .orderByPrimaryKey()
                             .forKey("cs1"))
                         .including(all: A
                             .hasMany(C.self)
                             .filter(Column("colc1") != 9)
-                            .orderByPrimaryKey()
                             .forKey("cs2"))
                         .forKey("a1"))
                     .including(optional: B
@@ -364,17 +325,14 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .including(all: A
                             .hasMany(C.self)
                             .filter(Column("colc1") == 9)
-                            .orderByPrimaryKey()
                             .forKey("cs1"))
                         .including(all: A
                             .hasMany(C.self)
                             .filter(Column("colc1") != 9)
-                            .orderByPrimaryKey()
                             .forKey("cs2"))
                         .forKey("a2"))
-                    .orderByPrimaryKey()
                 
-                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+                try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),b(colb1,colb2,colb3),c(colc1,colc2)")
             }
         }
     }

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -1,0 +1,381 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    import GRDB
+#endif
+
+private struct A: TableRecord, FetchableRecord, Decodable, Equatable {
+    var cola1: Int64
+    var cola2: String
+}
+private struct B: TableRecord, FetchableRecord, Decodable, Hashable {
+    var colb1: Int64
+    var colb2: Int64?
+    var colb3: String
+}
+private struct C: TableRecord, FetchableRecord, Decodable, Equatable {
+    var colc1: Int64
+    var colc2: Int64
+}
+private struct D: TableRecord, FetchableRecord, Decodable, Equatable {
+    var cold1: Int64
+    var cold2: Int64
+    var cold3: String
+}
+
+class AssociationPrefetchingObservationTests: GRDBTestCase {
+    override func setup(_ dbWriter: DatabaseWriter) throws {
+        try dbWriter.write { db in
+            try db.create(table: "a") { t in
+                t.autoIncrementedPrimaryKey("cola1")
+                t.column("cola2", .text)
+            }
+            try db.create(table: "b") { t in
+                t.autoIncrementedPrimaryKey("colb1")
+                t.column("colb2", .integer).references("a")
+                t.column("colb3", .text)
+            }
+            try db.create(table: "c") { t in
+                t.autoIncrementedPrimaryKey("colc1")
+                t.column("colc2", .integer).references("a")
+            }
+            try db.create(table: "d") { t in
+                t.autoIncrementedPrimaryKey("cold1")
+                t.column("cold2", .integer).references("c")
+                t.column("cold3", .text)
+            }
+            try db.execute(
+                sql: """
+                    INSERT INTO a (cola1, cola2) VALUES (?, ?);
+                    INSERT INTO a (cola1, cola2) VALUES (?, ?);
+                    INSERT INTO a (cola1, cola2) VALUES (?, ?);
+                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
+                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
+                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
+                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
+                    INSERT INTO c (colc1, colc2) VALUES (?, ?);
+                    INSERT INTO c (colc1, colc2) VALUES (?, ?);
+                    INSERT INTO c (colc1, colc2) VALUES (?, ?);
+                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
+                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
+                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
+                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
+                    """,
+                arguments: [
+                    1, "a1",
+                    2, "a2",
+                    3, "a3",
+                    4, 1, "b1",
+                    5, 1, "b2",
+                    6, 2, "b3",
+                    14, nil, "b4",
+                    7, 1,
+                    8, 2,
+                    9, 2,
+                    10, 7, "d1",
+                    11, 8, "d2",
+                    12, 8, "d3",
+                    13, 9, "d4",
+                ])
+        }
+    }
+    
+    func testIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            // Plain request
+            do {
+                let request = A
+                    .including(all: A
+                        .hasMany(B.self)
+                        .orderByPrimaryKey()
+                        .forKey("bs"))  // TODO: auto-pluralization
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+            
+            // Request with filters
+            do {
+                let request = A
+                    .filter(Column("cola1") != 3)
+                    .including(all: A
+                        .hasMany(B.self)
+                        .filter(Column("colb1") == 4)
+                        .orderByPrimaryKey()
+                        .forKey("bs1"))
+                    .including(all: A
+                        .hasMany(B.self)
+                        .filter(Column("colb1") != 4)
+                        .orderByPrimaryKey()
+                        .forKey("bs2"))
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+        }
+    }
+    
+    func testIncludingAllHasManyIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            // Plain request
+            do {
+                let request = A
+                    .including(all: A
+                        .hasMany(C.self)
+                        .including(all: C
+                            .hasMany(D.self)
+                            .orderByPrimaryKey()
+                            .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey()
+                        .forKey("cs"))  // TODO: auto-pluralization
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+            
+            // Request with filters
+            do {
+                let request = A
+                    .filter(Column("cola1") != 3)
+                    .including(all: A
+                        .hasMany(C.self)
+                        .filter(Column("colc1") > 7)
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") == 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds1"))
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") != 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds2"))
+                        .orderByPrimaryKey()
+                        .forKey("cs1"))
+                    .including(all: A
+                        .hasMany(C.self)
+                        .filter(Column("colc1") < 9)
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") == 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds1"))
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") != 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds2"))
+                        .orderByPrimaryKey()
+                        .forKey("cs2"))
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+        }
+    }
+    
+    func testIncludingAllHasManyIncludingRequiredOrOptionalHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            // Plain request
+            do {
+                let request = A
+                    .including(all: A
+                        .hasMany(C.self)
+                        .including(required: C
+                            .hasMany(D.self)
+                            .orderByPrimaryKey())
+                        .orderByPrimaryKey()
+                        .forKey("cs"))  // TODO: auto-pluralization
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+            
+            // Request with filters
+            do {
+                let request = A
+                    .filter(Column("cola1") != 3)
+                    .including(all: A
+                        .hasMany(C.self)
+                        .filter(Column("colc1") > 7)
+                        .including(optional: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") == 11)
+                            .orderByPrimaryKey()
+                            .forKey("d1"))
+                        .including(required: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") != 11)
+                            .orderByPrimaryKey()
+                            .forKey("d2"))
+                        .orderByPrimaryKey()
+                        .forKey("cs1"))
+                    .including(all: A
+                        .hasMany(C.self)
+                        .filter(Column("colc1") < 9)
+                        .including(optional: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") == 11)
+                            .orderByPrimaryKey()
+                            .forKey("d1"))
+                        .including(required: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") != 11)
+                            .orderByPrimaryKey()
+                            .forKey("d2"))
+                        .orderByPrimaryKey()
+                        .forKey("cs2"))
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+        }
+    }
+    
+    func testIncludingAllHasManyThrough() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            // Plain request
+            do {
+                let request = A
+                    .including(all: A
+                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .orderByPrimaryKey()
+                        .forKey("ds"))  // TODO: auto-pluralization
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+            
+            // Request with filters
+            do {
+                let request = A
+                    .filter(Column("cola1") != 3)
+                    .including(all: A
+                        .hasMany(D.self, through: A.hasMany(C.self).filter(Column("colc1") == 8), using: C.hasMany(D.self))
+                        .orderByPrimaryKey()
+                        .forKey("ds1"))
+                    .including(all: A
+                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .filter(Column("cold1") != 11)
+                        .orderByPrimaryKey()
+                        .forKey("ds2"))
+                    .including(all: A
+                        .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
+                        .filter(Column("cold1") == 11)
+                        .orderByPrimaryKey()
+                        .forKey("ds3"))
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+        }
+    }
+    
+    func testIncludingAllHasManyThroughIsNotMergedWithHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            // Plain request
+            do {
+                let cs = A.hasMany(C.self).forKey("cs")
+                let request = A
+                    .including(all: cs.orderByPrimaryKey())
+                    .including(all: A
+                        .hasMany(D.self, through: cs, using: C.hasMany(D.self))
+                        .orderByPrimaryKey()
+                        .forKey("ds"))  // TODO: auto-pluralization
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+            
+            // Request with filters
+            do {
+                let cs1 = A.hasMany(C.self).forKey("cs1")
+                let cs2 = A.hasMany(C.self).forKey("cs2")
+                let request = A
+                    .filter(Column("cola1") != 3)
+                    .including(all: cs1
+                        .filter(Column("colc1") != 8)
+                        .orderByPrimaryKey())
+                    .including(all: A
+                        .hasMany(D.self, through: cs1, using: C.hasMany(D.self))
+                        .filter(Column("cold1") != 11)
+                        .orderByPrimaryKey()
+                        .forKey("ds1"))
+                    .including(all: cs2
+                        .filter(Column("colc1") != 9)
+                        .orderByPrimaryKey())
+                    .including(all: A
+                        .hasMany(D.self, through: cs2, using: C.hasMany(D.self))
+                        .filter(Column("cold1") == 11)
+                        .orderByPrimaryKey()
+                        .forKey("ds2"))
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+        }
+    }
+    
+    // TODO: make a variant with joining(optional:)
+    func testIncludingOptionalBelongsToIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = B
+                    .including(optional: B
+                        .belongsTo(A.self)
+                        .including(all: A
+                            .hasMany(C.self)
+                            .orderByPrimaryKey()
+                            .forKey("cs"))  // TODO: auto-pluralization
+                    )
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+            
+            // Request with filters
+            do {
+                let request = B
+                    .including(optional: B
+                        .belongsTo(A.self)
+                        .filter(Column("cola2") == "a1")
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") == 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs1"))
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") != 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs2"))
+                        .forKey("a1"))
+                    .including(optional: B
+                        .belongsTo(A.self)
+                        .filter(Column("cola2") == "a2")
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") == 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs1"))
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") != 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs2"))
+                        .forKey("a2"))
+                    .orderByPrimaryKey()
+                
+                try XCTAssertEqual(request.databaseRegion(db).description, "TODO")
+            }
+        }
+    }
+}

--- a/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
@@ -116,8 +116,6 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                     XCTAssertEqual(row.prefetchedRows["bs"]![0], ["colb1": 4, "colb2": 1, "colb3": "b1", "grdb_colb2": 1])
                     XCTAssertEqual(row.prefetchedRows["bs"]![1], ["colb1": 5, "colb2": 1, "colb3": "b2", "grdb_colb2": 1])
                 }
-                
-                // TODO: Row.fetchCursor
             }
             
             // Request with avoided prefetch

--- a/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
@@ -123,7 +123,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                     .filter(false)
                     .including(all: A
                         .hasMany(B.self)
-                        .orderByPrimaryKey())  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll

--- a/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
@@ -75,8 +75,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(B.self)
-                        .orderByPrimaryKey()
-                        .forKey("bs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -201,10 +200,8 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                         .hasMany(C.self)
                         .including(all: C
                             .hasMany(D.self)
-                            .orderByPrimaryKey()
-                            .forKey("ds"))  // TODO: auto-pluralization
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -267,8 +264,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -415,8 +411,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -477,8 +472,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -526,12 +520,12 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
                             .orderByPrimaryKey()
-                            .forKey("d1"))
+                            .forKey("ds1"))
                         .including(required: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
                             .orderByPrimaryKey()
-                            .forKey("d2"))
+                            .forKey("ds2"))
                         .orderByPrimaryKey()
                         .forKey("cs1"))
                     .including(all: A
@@ -541,12 +535,12 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                             .hasMany(D.self)
                             .filter(Column("cold1") == 11)
                             .orderByPrimaryKey()
-                            .forKey("d1"))
+                            .forKey("ds1"))
                         .including(required: C
                             .hasMany(D.self)
                             .filter(Column("cold1") != 11)
                             .orderByPrimaryKey()
-                            .forKey("d2"))
+                            .forKey("ds2"))
                         .orderByPrimaryKey()
                         .forKey("cs2"))
                     .orderByPrimaryKey()
@@ -615,8 +609,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -730,13 +723,12 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
         try dbQueue.read { db in
             // Plain request
             do {
-                let cs = A.hasMany(C.self).forKey("cs")
+                let cs = A.hasMany(C.self)
                 let request = A
                     .including(all: cs.orderByPrimaryKey())
                     .including(all: A
                         .hasMany(D.self, through: cs, using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 // Row.fetchAll
@@ -877,8 +869,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                         .belongsTo(A.self)
                         .including(all: A
                             .hasMany(C.self)
-                            .orderByPrimaryKey()
-                            .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
                     )
                     .orderByPrimaryKey()
                 
@@ -1085,10 +1076,10 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
             let request1 = A
                 .orderByPrimaryKey()
             let request2 = A
-                .including(all: A.hasMany(B.self).orderByPrimaryKey().forKey("bs"))
+                .including(all: A.hasMany(B.self).orderByPrimaryKey())
                 .orderByPrimaryKey()
             let request3 = A
-                .including(all: A.hasMany(B.self).none().forKey("bs"))
+                .including(all: A.hasMany(B.self).none())
                 .orderByPrimaryKey()
             
             let row1 = try Row.fetchOne(db, request1)!
@@ -1134,10 +1125,10 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
             let request1 = A
                 .orderByPrimaryKey()
             let request2 = A
-                .including(all: A.hasMany(B.self).orderByPrimaryKey().forKey("bs"))
+                .including(all: A.hasMany(B.self).orderByPrimaryKey())
                 .orderByPrimaryKey()
             let request3 = A
-                .including(all: A.hasMany(B.self).none().forKey("bs"))
+                .including(all: A.hasMany(B.self).none())
                 .orderByPrimaryKey()
             
             let row1 = try Row.fetchOne(db, request1)!.copy()

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -433,7 +433,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
         }
     }
     
-    func testIncludingAllHasManyThrough() throws {
+    func testIncludingAllHasManyThroughHasManyUsingHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             // Plain request

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -75,8 +75,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(B.self)
-                        .orderByPrimaryKey()
-                        .forKey("bs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -166,10 +165,8 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                         .hasMany(C.self)
                         .including(all: C
                             .hasMany(D.self)
-                            .orderByPrimaryKey()
-                            .forKey("ds"))  // TODO: auto-pluralization
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -203,8 +200,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -321,8 +317,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -351,8 +346,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
-                        .orderByPrimaryKey()
-                        .forKey("cs"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -447,8 +441,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(D.self, through: A.hasMany(C.self), using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -526,13 +519,12 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
         try dbQueue.read { db in
             // Plain request
             do {
-                let cs = A.hasMany(C.self).forKey("cs")
+                let cs = A.hasMany(C.self)
                 let request = A
                     .including(all: cs.orderByPrimaryKey())
                     .including(all: A
                         .hasMany(D.self, through: cs, using: C.hasMany(D.self))
-                        .orderByPrimaryKey()
-                        .forKey("ds"))  // TODO: auto-pluralization
+                        .orderByPrimaryKey())
                     .orderByPrimaryKey()
                 
                 sqlQueries.removeAll()
@@ -631,8 +623,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                         .belongsTo(A.self)
                         .including(all: A
                             .hasMany(C.self)
-                            .orderByPrimaryKey()
-                            .forKey("cs"))  // TODO: auto-pluralization
+                            .orderByPrimaryKey())
                     )
                     .orderByPrimaryKey()
                 

--- a/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
+++ b/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
@@ -12,13 +12,13 @@ private struct A : TableRecord {
     static let databaseTableName = "a"
     static let parent = belongsTo(A.self)
     static let child = hasOne(A.self)
-    static let b1 = belongsTo(B.self, name: "b1", using: ForeignKey(["bid1"]))
-    static let b2 = belongsTo(B.self, name: "b2", using: ForeignKey(["bid2"]))
+    static let b1 = belongsTo(B.self, key: "b1", using: ForeignKey(["bid1"]))
+    static let b2 = belongsTo(B.self, key: "b2", using: ForeignKey(["bid2"]))
 }
 private struct B : TableRecord {
     static let databaseTableName = "b"
-    static let a1 = hasOne(A.self, name: "a1", using: ForeignKey(["bid1"]))
-    static let a2 = hasOne(A.self, name: "a1", using: ForeignKey(["bid2"]))
+    static let a1 = hasOne(A.self, key: "a1", using: ForeignKey(["bid1"]))
+    static let a2 = hasOne(A.self, key: "a1", using: ForeignKey(["bid2"]))
 }
 
 /// Tests for table name conflicts, recursive associations,

--- a/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
+++ b/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
@@ -12,13 +12,13 @@ private struct A : TableRecord {
     static let databaseTableName = "a"
     static let parent = belongsTo(A.self)
     static let child = hasOne(A.self)
-    static let b1 = belongsTo(B.self, key: "b1", using: ForeignKey(["bid1"]))
-    static let b2 = belongsTo(B.self, key: "b2", using: ForeignKey(["bid2"]))
+    static let b1 = belongsTo(B.self, name: "b1", using: ForeignKey(["bid1"]))
+    static let b2 = belongsTo(B.self, name: "b2", using: ForeignKey(["bid2"]))
 }
 private struct B : TableRecord {
     static let databaseTableName = "b"
-    static let a1 = hasOne(A.self, key: "a1", using: ForeignKey(["bid1"]))
-    static let a2 = hasOne(A.self, key: "a1", using: ForeignKey(["bid2"]))
+    static let a1 = hasOne(A.self, name: "a1", using: ForeignKey(["bid1"]))
+    static let a2 = hasOne(A.self, name: "a1", using: ForeignKey(["bid2"]))
 }
 
 /// Tests for table name conflicts, recursive associations,

--- a/Tests/GRDBTests/InflectionsTests.json
+++ b/Tests/GRDBTests/InflectionsTests.json
@@ -1,0 +1,123 @@
+{
+    "SingularToPlural": {
+        "search"      : "searches",
+        "switch"      : "switches",
+        "fix"         : "fixes",
+        "box"         : "boxes",
+        "process"     : "processes",
+        "address"     : "addresses",
+        "case"        : "cases",
+        "stack"       : "stacks",
+        "wish"        : "wishes",
+        "fish"        : "fish",
+        "jeans"       : "jeans",
+        "funky jeans" : "funky jeans",
+        "my money"    : "my money",
+        
+        "category"    : "categories",
+        "query"       : "queries",
+        "ability"     : "abilities",
+        "agency"      : "agencies",
+        "movie"       : "movies",
+        
+        "archive"     : "archives",
+        
+        "index"       : "indices",
+        
+        "wife"        : "wives",
+        "safe"        : "saves",
+        "half"        : "halves",
+        
+        "move"        : "moves",
+        
+        "salesperson" : "salespeople",
+        "person"      : "people",
+        
+        "spokesman"   : "spokesmen",
+        "man"         : "men",
+        "woman"       : "women",
+        
+        "basis"       : "bases",
+        "diagnosis"   : "diagnoses",
+        "diagnosis_a" : "diagnosis_as",
+        
+        "datum"       : "data",
+        "medium"      : "media",
+        "stadium"     : "stadia",
+        "analysis"    : "analyses",
+        "my_analysis" : "my_analyses",
+        
+        "node_child"  : "node_children",
+        "child"       : "children",
+        
+        "experience"  : "experiences",
+        "day"         : "days",
+        
+        "comment"     : "comments",
+        "foobar"      : "foobars",
+        "newsletter"  : "newsletters",
+        
+        "old_news"    : "old_news",
+        "news"        : "news",
+        
+        "series"      : "series",
+        "miniseries"  : "miniseries",
+        "species"     : "species",
+        
+        "quiz"        : "quizzes",
+        
+        "perspective" : "perspectives",
+        
+        "ox"          : "oxen",
+        "photo"       : "photos",
+        "buffalo"     : "buffaloes",
+        "tomato"      : "tomatoes",
+        "dwarf"       : "dwarves",
+        "elf"         : "elves",
+        "information" : "information",
+        "equipment"   : "equipment",
+        "bus"         : "buses",
+        "status"      : "statuses",
+        "status_code" : "status_codes",
+        "mouse"       : "mice",
+        
+        "louse"       : "lice",
+        "house"       : "houses",
+        "octopus"     : "octopi",
+        "virus"       : "viri",
+        "alias"       : "aliases",
+        "portfolio"   : "portfolios",
+        
+        "vertex"      : "vertices",
+        "matrix"      : "matrices",
+        "matrix_fu"   : "matrix_fus",
+        
+        "axis"        : "axes",
+        "taxi"        : "taxis",
+        "testis"      : "testes",
+        "crisis"      : "crises",
+        
+        "rice"        : "rice",
+        "shoe"        : "shoes",
+        
+        "horse"       : "horses",
+        "prize"       : "prizes",
+        "edge"        : "edges",
+        
+        "database"    : "databases",
+        
+        "slice"       : "slices",
+        "police"      : "police"
+    },
+    
+    "Irregularities": {
+        "person"      : "people",
+        "man"         : "men",
+        "child"       : "children",
+        "sex"         : "sexes",
+        "move"        : "moves",
+        "cow"         : "kine",
+        "zombie"      : "zombies",
+        "genus"       : "genera"
+    }
+}

--- a/Tests/GRDBTests/InflectionsTests.json
+++ b/Tests/GRDBTests/InflectionsTests.json
@@ -107,7 +107,9 @@
         "database"    : "databases",
         
         "slice"       : "slices",
-        "police"      : "police"
+        "police"      : "police",
+        
+        "specimen"    : "specimens"
     },
     
     "Irregularities": {

--- a/Tests/GRDBTests/InflectionsTests.json
+++ b/Tests/GRDBTests/InflectionsTests.json
@@ -10,6 +10,7 @@
         "stack"       : "stacks",
         "wish"        : "wishes",
         "fish"        : "fish",
+        "sheep"       : "sheep",
         "jeans"       : "jeans",
         "funky jeans" : "funky jeans",
         "my money"    : "my money",
@@ -109,7 +110,8 @@
         "slice"       : "slices",
         "police"      : "police",
         
-        "specimen"    : "specimens"
+        "specimen"    : "specimens",
+        "canvas"      : "canvases",
     },
     
     "Irregularities": {

--- a/Tests/GRDBTests/InflectionsTests.json
+++ b/Tests/GRDBTests/InflectionsTests.json
@@ -117,7 +117,14 @@
         "advice"      : "advice",
         "thesis"      : "theses",
         "dice"        : "dice",
-        "kudos"       : "kudos"
+        "kudos"       : "kudos",
+        "life"        : "lives",
+        "leaf"        : "leaves",
+        "proof"       : "proofs",
+        "hero"        : "heroes",
+        "foot"        : "feet",
+        "matrix"      : "matrices",
+        "watch"       : "watches"
     },
     
     "Irregularities": {

--- a/Tests/GRDBTests/InflectionsTests.json
+++ b/Tests/GRDBTests/InflectionsTests.json
@@ -112,6 +112,12 @@
         
         "specimen"    : "specimens",
         "canvas"      : "canvases",
+        "corps"       : "corps",
+        "offspring"   : "offspring",
+        "advice"      : "advice",
+        "thesis"      : "theses",
+        "dice"        : "dice",
+        "kudos"       : "kudos"
     },
     
     "Irregularities": {

--- a/Tests/GRDBTests/InflectionsTests.swift
+++ b/Tests/GRDBTests/InflectionsTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+    @testable import GRDBCustomSQLite
+#else
+    @testable import GRDB
+#endif
+
+// https://github.com/rails/rails/blob/v6.0.0.rc1/activesupport/test/inflector_test.rb
+class InflectionsTests: GRDBTestCase {
+    private var originalInflections: Inflections?
+
+    override func setUp() {
+        // Dups the singleton before each test, restoring the original inflections later.
+        originalInflections = Inflections.default
+    }
+    
+    override func tearDown() {
+        Inflections.default = originalInflections!
+    }
+    
+    private var inflectionTestCases: InflectionTestCases {
+        let url = Bundle(for: type(of: self)).url(forResource: "InflectionsTests", withExtension: "json")!
+        let data = try! Data(contentsOf: url)
+        return try! JSONDecoder().decode(InflectionTestCases.self, from: data)
+    }
+    
+    func testPluralizePlurals() {
+        XCTAssertEqual("plurals".pluralized, "plurals")
+        XCTAssertEqual("Plurals".pluralized, "Plurals")
+    }
+    
+    func testPluralizeEmptyString() {
+        XCTAssertEqual("".pluralized, "")
+    }
+    
+    func testUncountabilityOfASCIIWord() {
+        let word = "HTTP"
+        Inflections.default.uncountable(word)
+        XCTAssertEqual(word.pluralized, word)
+        XCTAssertEqual(word.singularized, word)
+        XCTAssertEqual(word.pluralized, word.singularized)
+    }
+    
+    func testUncountabilityOfNonASCIIWord() {
+        let word = "猫"
+        Inflections.default.uncountable(word)
+        XCTAssertEqual(word.pluralized, word)
+        XCTAssertEqual(word.singularized, word)
+        XCTAssertEqual(word.pluralized, word.singularized)
+    }
+
+    func testUncountableWords() {
+        for word in Inflections.default.uncountables {
+            XCTAssertEqual(word.pluralized, word)
+            XCTAssertEqual(word.singularized, word)
+            XCTAssertEqual(word.pluralized, word.singularized)
+        }
+    }
+    
+    func testUncountableCapitalizedWords() {
+        for word in Inflections.default.uncountables {
+            XCTAssertEqual(word.capitalized.pluralized, word.capitalized)
+            XCTAssertEqual(word.capitalized.singularized, word.capitalized)
+            XCTAssertEqual(word.capitalized.pluralized, word.capitalized.singularized)
+        }
+    }
+    
+    func testUncountableUppercasedWords() {
+        for word in Inflections.default.uncountables {
+            XCTAssertEqual(word.uppercased().pluralized, word.uppercased())
+            XCTAssertEqual(word.uppercased().singularized, word.uppercased())
+            XCTAssertEqual(word.uppercased().pluralized, word.uppercased().singularized)
+        }
+    }
+    
+    func testUncountableWordIsNotGreedy() {
+        let uncountableWord = "ors"
+        let countableWord = "sponsor"
+        
+        Inflections.default.uncountable(uncountableWord)
+        
+        XCTAssertEqual(uncountableWord.singularized, uncountableWord)
+        XCTAssertEqual(uncountableWord.pluralized, uncountableWord)
+        XCTAssertEqual(uncountableWord.pluralized, uncountableWord.singularized)
+
+        XCTAssertEqual(countableWord.singularized, "sponsor")
+        XCTAssertEqual(countableWord.pluralized, "sponsors")
+        XCTAssertEqual(countableWord.pluralized.singularized, "sponsor")
+    }
+    
+    func testPluralizeSingularWord() {
+        for (singular, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
+            XCTAssertEqual(singular.pluralized, plural)
+            XCTAssertEqual(singular.capitalized.pluralized, plural.capitalized)
+        }
+    }
+    
+    func testSingularizePluralWord() {
+        for (singular, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
+            XCTAssertEqual(plural.singularized, singular)
+            XCTAssertEqual(plural.capitalized.singularized, singular.capitalized)
+        }
+    }
+    
+    func testPluralizePluralWord() {
+        for (_, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
+            XCTAssertEqual(plural.pluralized, plural)
+            XCTAssertEqual(plural.capitalized.pluralized, plural.capitalized)
+        }
+    }
+    
+    func testSingularizeSingularWord() {
+        for (singular, _) in inflectionTestCases.testCases["SingularToPlural"]! {
+            XCTAssertEqual(singular.singularized, singular)
+            XCTAssertEqual(singular.capitalized.singularized, singular.capitalized)
+        }
+    }
+    
+    func testIrregularityBetweenSingularAndPlural() {
+        for (singular, plural) in inflectionTestCases.testCases["Irregularities"]! {
+            Inflections.default.irregular(singular, plural)
+            XCTAssertEqual(plural.singularized, singular)
+            XCTAssertEqual(singular.pluralized, plural)
+            XCTAssertEqual(singular.singularized, singular)
+            XCTAssertEqual(plural.pluralized, plural)
+        }
+    }
+}
+
+struct InflectionTestCases: Decodable {
+    var testCases: [String: [(String, String)]]
+    
+    struct AnyCodingKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { return nil }
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+        
+        init?(intValue: Int) {
+            return nil
+        }
+    }
+    
+    init(from decoder: Decoder) throws {
+        var testCases: [String: [(String, String)]] = [:]
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        for key in container.allKeys {
+            let nested = try container.nestedContainer(keyedBy: AnyCodingKey.self, forKey: key)
+            for wordKey in nested.allKeys {
+                let otherWord = try nested.decode(String.self, forKey: wordKey)
+                testCases[key.stringValue, default: []].append((wordKey.stringValue, otherWord))
+            }
+        }
+        self.testCases = testCases
+    }
+}

--- a/Tests/GRDBTests/InflectionsTests.swift
+++ b/Tests/GRDBTests/InflectionsTests.swift
@@ -8,7 +8,7 @@ import XCTest
 // https://github.com/rails/rails/blob/v6.0.0.rc1/activesupport/test/inflector_test.rb
 class InflectionsTests: GRDBTestCase {
     private var originalInflections: Inflections?
-
+    
     override func setUp() {
         // Dups the singleton before each test, restoring the original inflections later.
         originalInflections = Inflections.default
@@ -18,11 +18,14 @@ class InflectionsTests: GRDBTestCase {
         Inflections.default = originalInflections!
     }
     
+    // Until SPM tests can load resources, disable this test for SPM.
+    #if !SWIFT_PACKAGE
     private var inflectionTestCases: InflectionTestCases {
         let url = Bundle(for: type(of: self)).url(forResource: "InflectionsTests", withExtension: "json")!
         let data = try! Data(contentsOf: url)
         return try! JSONDecoder().decode(InflectionTestCases.self, from: data)
     }
+    #endif
     
     func testStartIndexOfLastWord() {
         func lastWord(_ string: String) -> String {
@@ -119,7 +122,7 @@ class InflectionsTests: GRDBTestCase {
         XCTAssertEqual(word.singularized, word)
         XCTAssertEqual(word.pluralized, word.singularized)
     }
-
+    
     func testUncountableWords() {
         for word in Inflections.default.uncountables {
             XCTAssertEqual(word.pluralized, word)
@@ -153,12 +156,14 @@ class InflectionsTests: GRDBTestCase {
         XCTAssertEqual(uncountableWord.singularized, uncountableWord)
         XCTAssertEqual(uncountableWord.pluralized, uncountableWord)
         XCTAssertEqual(uncountableWord.pluralized, uncountableWord.singularized)
-
+        
         XCTAssertEqual(countableWord.singularized, "sponsor")
         XCTAssertEqual(countableWord.pluralized, "sponsors")
         XCTAssertEqual(countableWord.pluralized.singularized, "sponsor")
     }
     
+    // Until SPM tests can load resources, disable this test for SPM.
+    #if !SWIFT_PACKAGE
     func testPluralizeSingularWord() {
         for (singular, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(singular.pluralized, plural)
@@ -173,7 +178,10 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(suffixedSingular.pluralized, suffixedPlural)
         }
     }
+    #endif
     
+    // Until SPM tests can load resources, disable this test for SPM.
+    #if !SWIFT_PACKAGE
     func testSingularizePluralWord() {
         for (singular, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(plural.singularized, singular)
@@ -188,7 +196,10 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(suffixedPlural.singularized, suffixedSingular)
         }
     }
+    #endif
     
+    // Until SPM tests can load resources, disable this test for SPM.
+    #if !SWIFT_PACKAGE
     func testPluralizePluralWord() {
         for (_, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(plural.pluralized, plural)
@@ -201,7 +212,10 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(suffixedPlural.pluralized, suffixedPlural)
         }
     }
+    #endif
     
+    // Until SPM tests can load resources, disable this test for SPM.
+    #if !SWIFT_PACKAGE
     func testSingularizeSingularWord() {
         for (singular, _) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(singular.singularized, singular)
@@ -214,7 +228,10 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(suffixedSingular.singularized, suffixedSingular)
         }
     }
+    #endif
     
+    // Until SPM tests can load resources, disable this test for SPM.
+    #if !SWIFT_PACKAGE
     func testIrregularityBetweenSingularAndPlural() {
         for (singular, plural) in inflectionTestCases.testCases["Irregularities"]! {
             Inflections.default.irregular(singular, plural)
@@ -238,15 +255,18 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(suffixedPlural.pluralized, suffixedPlural)
         }
     }
+    #endif
 }
 
+// Until SPM tests can load resources, disable this test for SPM.
+#if !SWIFT_PACKAGE
 struct InflectionTestCases: Decodable {
     var testCases: [String: [(String, String)]]
     
     struct AnyCodingKey: CodingKey {
         var stringValue: String
         var intValue: Int? { return nil }
-
+        
         init?(stringValue: String) {
             self.stringValue = stringValue
         }
@@ -269,3 +289,4 @@ struct InflectionTestCases: Decodable {
         self.testCases = testCases
     }
 }
+#endif

--- a/Tests/GRDBTests/InflectionsTests.swift
+++ b/Tests/GRDBTests/InflectionsTests.swift
@@ -24,6 +24,39 @@ class InflectionsTests: GRDBTestCase {
         return try! JSONDecoder().decode(InflectionTestCases.self, from: data)
     }
     
+    func testIndexOfLastWord() {
+        func lastWord(_ string: String) -> String {
+            return String(string.suffix(from: Inflections.indexOfLastWord(string)))
+        }
+        XCTAssertEqual(lastWord(""), "")
+        XCTAssertEqual(lastWord(" "), " ")
+        XCTAssertEqual(lastWord("_"), "_")
+        XCTAssertEqual(lastWord("foo"), "foo")
+        XCTAssertEqual(lastWord("Foo"), "Foo")
+        XCTAssertEqual(lastWord("FOO"), "FOO")
+        XCTAssertEqual(lastWord("foo bar"), "bar")
+        XCTAssertEqual(lastWord("Foo Bar"), "Bar")
+        XCTAssertEqual(lastWord("FOO BAR"), "BAR")
+        XCTAssertEqual(lastWord("foo_bar"), "bar")
+        XCTAssertEqual(lastWord("Foo_Bar"), "Bar")
+        XCTAssertEqual(lastWord("FOO_BAR"), "BAR")
+        XCTAssertEqual(lastWord("foobar"), "foobar")
+        XCTAssertEqual(lastWord("FooBar"), "Bar")
+        XCTAssertEqual(lastWord("FOOBAR"), "FOOBAR")
+        XCTAssertEqual(lastWord("foo1"), "foo1")
+        XCTAssertEqual(lastWord("Foo1"), "Foo1")
+        XCTAssertEqual(lastWord("FOO1"), "FOO1")
+        XCTAssertEqual(lastWord("foo bar1"), "bar1")
+        XCTAssertEqual(lastWord("Foo Bar1"), "Bar1")
+        XCTAssertEqual(lastWord("FOO BAR1"), "BAR1")
+        XCTAssertEqual(lastWord("foo_bar1"), "bar1")
+        XCTAssertEqual(lastWord("Foo_Bar1"), "Bar1")
+        XCTAssertEqual(lastWord("FOO_BAR1"), "BAR1")
+        XCTAssertEqual(lastWord("foobar1"), "foobar1")
+        XCTAssertEqual(lastWord("FooBar1"), "Bar1")
+        XCTAssertEqual(lastWord("FOOBAR1"), "FOOBAR1")
+    }
+    
     func testPluralizePlurals() {
         XCTAssertEqual("plurals".pluralized, "plurals")
         XCTAssertEqual("Plurals".pluralized, "Plurals")
@@ -92,6 +125,10 @@ class InflectionsTests: GRDBTestCase {
         for (singular, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(singular.pluralized, plural)
             XCTAssertEqual(singular.capitalized.pluralized, plural.capitalized)
+            
+            let prefixedSingular = "prefixed" + singular.capitalized
+            let prefixedPlural = "prefixed" + plural.capitalized
+            XCTAssertEqual(prefixedSingular.pluralized, prefixedPlural)
         }
     }
     
@@ -99,6 +136,10 @@ class InflectionsTests: GRDBTestCase {
         for (singular, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(plural.singularized, singular)
             XCTAssertEqual(plural.capitalized.singularized, singular.capitalized)
+            
+            let prefixedSingular = "prefixed" + singular.capitalized
+            let prefixedPlural = "prefixed" + plural.capitalized
+            XCTAssertEqual(prefixedPlural.singularized, prefixedSingular)
         }
     }
     
@@ -106,6 +147,9 @@ class InflectionsTests: GRDBTestCase {
         for (_, plural) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(plural.pluralized, plural)
             XCTAssertEqual(plural.capitalized.pluralized, plural.capitalized)
+            
+            let prefixedPlural = "prefixed" + plural.capitalized
+            XCTAssertEqual(prefixedPlural.pluralized, prefixedPlural)
         }
     }
     
@@ -113,6 +157,9 @@ class InflectionsTests: GRDBTestCase {
         for (singular, _) in inflectionTestCases.testCases["SingularToPlural"]! {
             XCTAssertEqual(singular.singularized, singular)
             XCTAssertEqual(singular.capitalized.singularized, singular.capitalized)
+            
+            let prefixedSingular = "prefixed" + singular.capitalized
+            XCTAssertEqual(prefixedSingular.singularized, prefixedSingular)
         }
     }
     
@@ -123,6 +170,13 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(singular.pluralized, plural)
             XCTAssertEqual(singular.singularized, singular)
             XCTAssertEqual(plural.pluralized, plural)
+            
+            let prefixedSingular = "prefixed" + singular.capitalized
+            let prefixedPlural = "prefixed" + plural.capitalized
+            XCTAssertEqual(prefixedPlural.singularized, prefixedSingular)
+            XCTAssertEqual(prefixedSingular.pluralized, prefixedPlural)
+            XCTAssertEqual(prefixedSingular.singularized, prefixedSingular)
+            XCTAssertEqual(prefixedPlural.pluralized, prefixedPlural)
         }
     }
 }

--- a/Tests/GRDBTests/InflectionsTests.swift
+++ b/Tests/GRDBTests/InflectionsTests.swift
@@ -24,37 +24,68 @@ class InflectionsTests: GRDBTestCase {
         return try! JSONDecoder().decode(InflectionTestCases.self, from: data)
     }
     
-    func testIndexOfLastWord() {
+    func testStartIndexOfLastWord() {
         func lastWord(_ string: String) -> String {
-            return String(string.suffix(from: Inflections.indexOfLastWord(string)))
+            return String(string.suffix(from: Inflections.startIndexOfLastWord(string)))
         }
         XCTAssertEqual(lastWord(""), "")
         XCTAssertEqual(lastWord(" "), " ")
         XCTAssertEqual(lastWord("_"), "_")
-        XCTAssertEqual(lastWord("foo"), "foo")
-        XCTAssertEqual(lastWord("Foo"), "Foo")
-        XCTAssertEqual(lastWord("FOO"), "FOO")
-        XCTAssertEqual(lastWord("foo bar"), "bar")
-        XCTAssertEqual(lastWord("Foo Bar"), "Bar")
-        XCTAssertEqual(lastWord("FOO BAR"), "BAR")
-        XCTAssertEqual(lastWord("foo_bar"), "bar")
-        XCTAssertEqual(lastWord("Foo_Bar"), "Bar")
-        XCTAssertEqual(lastWord("FOO_BAR"), "BAR")
-        XCTAssertEqual(lastWord("foobar"), "foobar")
-        XCTAssertEqual(lastWord("FooBar"), "Bar")
-        XCTAssertEqual(lastWord("FOOBAR"), "FOOBAR")
-        XCTAssertEqual(lastWord("foo1"), "foo1")
-        XCTAssertEqual(lastWord("Foo1"), "Foo1")
-        XCTAssertEqual(lastWord("FOO1"), "FOO1")
-        XCTAssertEqual(lastWord("foo bar1"), "bar1")
-        XCTAssertEqual(lastWord("Foo Bar1"), "Bar1")
-        XCTAssertEqual(lastWord("FOO BAR1"), "BAR1")
-        XCTAssertEqual(lastWord("foo_bar1"), "bar1")
-        XCTAssertEqual(lastWord("Foo_Bar1"), "Bar1")
-        XCTAssertEqual(lastWord("FOO_BAR1"), "BAR1")
-        XCTAssertEqual(lastWord("foobar1"), "foobar1")
-        XCTAssertEqual(lastWord("FooBar1"), "Bar1")
-        XCTAssertEqual(lastWord("FOOBAR1"), "FOOBAR1")
+        
+        XCTAssertEqual(lastWord("player"), "player")
+        XCTAssertEqual(lastWord("Player"), "Player")
+        XCTAssertEqual(lastWord("PLAYER"), "PLAYER")
+        
+        XCTAssertEqual(lastWord(" player"), "player")
+        XCTAssertEqual(lastWord(" Player"), "Player")
+        XCTAssertEqual(lastWord(" PLAYER"), "PLAYER")
+        
+        XCTAssertEqual(lastWord("_player"), "player")
+        XCTAssertEqual(lastWord("_Player"), "Player")
+        XCTAssertEqual(lastWord("_PLAYER"), "PLAYER")
+        
+        XCTAssertEqual(lastWord("player score"), "score")
+        XCTAssertEqual(lastWord("player Score"), "Score")
+        XCTAssertEqual(lastWord("Player Score"), "Score")
+        XCTAssertEqual(lastWord("PLAYER SCORE"), "SCORE")
+        
+        XCTAssertEqual(lastWord("player_score"), "score")
+        XCTAssertEqual(lastWord("player_Score"), "Score")
+        XCTAssertEqual(lastWord("Player_Score"), "Score")
+        XCTAssertEqual(lastWord("PLAYER_SCORE"), "SCORE")
+        
+        XCTAssertEqual(lastWord("playerScore"), "Score")
+        XCTAssertEqual(lastWord("PlayerScore"), "Score")
+        
+        XCTAssertEqual(lastWord("best player score"), "score")
+        XCTAssertEqual(lastWord("best player Score"), "Score")
+        XCTAssertEqual(lastWord("Best Player Score"), "Score")
+        XCTAssertEqual(lastWord("BEST PLAYER SCORE"), "SCORE")
+        
+        XCTAssertEqual(lastWord("best_player_score"), "score")
+        XCTAssertEqual(lastWord("best_player_Score"), "Score")
+        XCTAssertEqual(lastWord("Best_Player_Score"), "Score")
+        XCTAssertEqual(lastWord("BEST_PLAYER_SCORE"), "SCORE")
+        
+        XCTAssertEqual(lastWord("bestPlayerScore"), "Score")
+        XCTAssertEqual(lastWord("BestPlayerScore"), "Score")
+        
+        XCTAssertEqual(lastWord("player1"), "player1")
+        XCTAssertEqual(lastWord("Player1"), "Player1")
+        XCTAssertEqual(lastWord("PLAYER1"), "PLAYER1")
+        
+        XCTAssertEqual(lastWord("player score1"), "score1")
+        XCTAssertEqual(lastWord("player Score1"), "Score1")
+        XCTAssertEqual(lastWord("Player Score1"), "Score1")
+        XCTAssertEqual(lastWord("PLAYER SCORE1"), "SCORE1")
+        
+        XCTAssertEqual(lastWord("player_score1"), "score1")
+        XCTAssertEqual(lastWord("player_Score1"), "Score1")
+        XCTAssertEqual(lastWord("Player_Score1"), "Score1")
+        XCTAssertEqual(lastWord("PLAYER_SCORE1"), "SCORE1")
+        
+        XCTAssertEqual(lastWord("playerScore1"), "Score1")
+        XCTAssertEqual(lastWord("PlayerScore1"), "Score1")
     }
     
     func testPluralizePlurals() {

--- a/Tests/GRDBTests/InflectionsTests.swift
+++ b/Tests/GRDBTests/InflectionsTests.swift
@@ -88,6 +88,13 @@ class InflectionsTests: GRDBTestCase {
         XCTAssertEqual(lastWord("PlayerScore1"), "Score1")
     }
     
+    func testDigitlessRadical() {
+        XCTAssertEqual("".digitlessRadical, "")
+        XCTAssertEqual("player".digitlessRadical, "player")
+        XCTAssertEqual("player0".digitlessRadical, "player")
+        XCTAssertEqual("player123".digitlessRadical, "player")
+    }
+    
     func testPluralizePlurals() {
         XCTAssertEqual("plurals".pluralized, "plurals")
         XCTAssertEqual("Plurals".pluralized, "Plurals")
@@ -160,6 +167,10 @@ class InflectionsTests: GRDBTestCase {
             let prefixedSingular = "prefixed" + singular.capitalized
             let prefixedPlural = "prefixed" + plural.capitalized
             XCTAssertEqual(prefixedSingular.pluralized, prefixedPlural)
+            
+            let suffixedSingular = singular + "123"
+            let suffixedPlural = plural + "123"
+            XCTAssertEqual(suffixedSingular.pluralized, suffixedPlural)
         }
     }
     
@@ -171,6 +182,10 @@ class InflectionsTests: GRDBTestCase {
             let prefixedSingular = "prefixed" + singular.capitalized
             let prefixedPlural = "prefixed" + plural.capitalized
             XCTAssertEqual(prefixedPlural.singularized, prefixedSingular)
+            
+            let suffixedSingular = singular + "123"
+            let suffixedPlural = plural + "123"
+            XCTAssertEqual(suffixedPlural.singularized, suffixedSingular)
         }
     }
     
@@ -181,6 +196,9 @@ class InflectionsTests: GRDBTestCase {
             
             let prefixedPlural = "prefixed" + plural.capitalized
             XCTAssertEqual(prefixedPlural.pluralized, prefixedPlural)
+            
+            let suffixedPlural = plural + "123"
+            XCTAssertEqual(suffixedPlural.pluralized, suffixedPlural)
         }
     }
     
@@ -191,6 +209,9 @@ class InflectionsTests: GRDBTestCase {
             
             let prefixedSingular = "prefixed" + singular.capitalized
             XCTAssertEqual(prefixedSingular.singularized, prefixedSingular)
+            
+            let suffixedSingular = singular + "123"
+            XCTAssertEqual(suffixedSingular.singularized, suffixedSingular)
         }
     }
     
@@ -208,6 +229,13 @@ class InflectionsTests: GRDBTestCase {
             XCTAssertEqual(prefixedSingular.pluralized, prefixedPlural)
             XCTAssertEqual(prefixedSingular.singularized, prefixedSingular)
             XCTAssertEqual(prefixedPlural.pluralized, prefixedPlural)
+            
+            let suffixedSingular = singular + "123"
+            let suffixedPlural = plural + "123"
+            XCTAssertEqual(suffixedPlural.singularized, suffixedSingular)
+            XCTAssertEqual(suffixedSingular.pluralized, suffixedPlural)
+            XCTAssertEqual(suffixedSingular.singularized, suffixedSingular)
+            XCTAssertEqual(suffixedPlural.pluralized, suffixedPlural)
         }
     }
 }


### PR DESCRIPTION
This PR "completes" the associations feature set by allowing eager loading of HasMany and HasManyThrough associations:

```swift
// Setup
struct Author: TableRecord, FetchableRecord, Decodable {
    static let books = hasMany(Book.self)
    var id: Int64
    var name: String
}

struct Book: TableRecord, FetchableRecord, Decodable {
    var id: Int64
    var authorId: Int64
    var title: String
}

// Load all authors along with their books
struct AuthorInfo: FetchableRecord, Decodable {
    var author: Author
    var books: [Book]
}

let request = Author.including(all: Author.books)
let infos: [AuthorInfo] = try AuthorInfo.fetchAll(db, request)

for info in infos {
    print("\(info.author.name) wrote:")
    for book in info.books {
        print("- \(book.title)")
    }
}
```