### PR TITLE
Fix eager loading of HasManyThrough associations

### DIFF
--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -644,6 +644,50 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
             
             // Request with filters
             do {
+                // Another example of what users are unlikely to want, still
+                // because of the shared key between the two different pivot
+                // associations, and despite the distinct hasMany keys.
+                let request = B
+                    .including(all: B
+                        .hasMany(
+                            C.self,
+                            through: B.belongsTo(A.self).filter(Column("cola2") == "a1"),
+                            using: A.hasMany(C.self))
+                        .forKey("a1")
+                        .orderByPrimaryKey())
+                    .including(all: B
+                        .hasMany(
+                            C.self,
+                            through: B.belongsTo(A.self).filter(Column("cola2") != "a1"),
+                            using: A.hasMany(C.self))
+                        .forKey("nota1")
+                        .orderByPrimaryKey())
+                    .orderByPrimaryKey()
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT * FROM "b" ORDER BY "colb1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ((("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1')) AND ("a"."cola1" IN (1, 2)))) \
+                    ORDER BY "c"."colc1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ((("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1')) AND ("a"."cola1" IN (1, 2)))) \
+                    ORDER BY "c"."colc1"
+                    """])
+            }
+
+            // Request with filters
+            do {
                 // This request is a "fixed" version of the previous request,
                 // where the two different pivot associations do not share the
                 // same key.
@@ -755,6 +799,54 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """])
             }
             
+            // Request with filters
+            do {
+                // Another example of what users are unlikely to want, still
+                // because of the shared key between the two different pivot
+                // associations, and despite the distinct hasMany keys.
+                let request = A
+                    .including(all: A
+                        .hasMany(
+                            D.self,
+                            through: A.hasOne(C.self).filter(Column("colc1") == 7),
+                            using: C.hasMany(D.self))
+                        .forKey("c7")
+                        .orderByPrimaryKey())
+                    .including(all: A
+                        .hasMany(
+                            D.self,
+                            through: A.hasOne(C.self).filter(Column("colc1") != 7),
+                            using: C.hasMany(D.self))
+                        .forKey("notc7")
+                        .orderByPrimaryKey())
+                    .including(all: A.hasMany(C.self))
+                    .orderByPrimaryKey()
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT * FROM "a" ORDER BY "cola1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ((("c"."colc1" = 7) AND ("c"."colc1" <> 7)) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ((("c"."colc1" = 7) AND ("c"."colc1" <> 7)) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE ("colc2" IN (1, 2, 3))
+                    """])
+            }
+
             // Request with filters
             do {
                 // This request is a "fixed" version of the previous request,


### PR DESCRIPTION
This pull request fixes some bugs with eager loading of HasManyThrough associations.

The bugs may occur when two conditions are met:

- One of the intermediate steps of the HasManyThrough association is a "to-one" association (belongsTo, hasOne, hasOneThrough).
- The HasManyThrough association is eager-loaded in a request that also involves that to-one association.

For example, given this schema:

1. A player belongs to a team
2. A team has many competitions
3. A player has many competitions through its team.

```swift
extension Player {
    static let team = belongsTo(Team.self)
    static let competitions = hasMany(
        Competition.self,
        through: team,
        using: Team.competitions)
}
```

Using both `Player.team` and `Player.competitions` is a single request may lead to unexpected or inconsistent behaviors.

A sample request which was not behaving correctly:

```swift
// WRONG
let buggyRequest = Player
    .including(required: Player.team)
    .including(all: Player.competitions)
```

After this PR is merged, buggyRequest will fatalError, complaining that the association key "team" is used in incompatible ways. Future GRDB versions may handle it, but GRDB 4.0 does not.

One possible fix is to include the competitions from the team:

```swift
// CORRECT
let fixedRequest = Player
    .including(required: Player.team
        .including(all: Team.competitions))
```

Another way to mix `Player.team` and `Player.competitions` in a single request is to make sure both teams (the one from `Player.team`, and the one hidden inside `Player.competitions`) use different association keys. For example:

```swift
// CORRECT
let request = Player
    .including(required: Player.team
        .filter(Team.Columns.isSelected == true)
        .forKey("selectedTeam"))         // "selectedTeam"
    .including(all: Player.competitions) // "team"
```
