### PR TITLE
Remove useless parenthesis from generated SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
+[Next Release](#next-release)
+
 #### 4.x Releases
 
 - `4.0.x` Releases - [4.0.0](#400) | [4.0.1](#401)
@@ -45,6 +47,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 #### 0.x Releases
 
 - [0.110.0](#01100), ...
+
+
+## Next Release
+
+- [#537](https://github.com/groue/GRDB.swift/pull/537): Remove useless parenthesis from generated SQL
 
 
 ## 4.0.1

--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -231,7 +231,7 @@ extension DatabaseValue {
 extension DatabaseValue {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
-    public func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+    public func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
         // fast path for NULL
         if isNull {
             return "NULL"

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -75,27 +75,30 @@ public struct FTS5 : VirtualTableModule {
         }
         
         if let tokenizer = definition.tokenizer {
-            arguments.append("tokenize=\(tokenizer.components.joined(separator: " ").sqlExpression.quotedSQL())")
+            arguments.append("tokenize=\(tokenizer.components.joined(separator: " ").sqlExpression.quotedSQL(wrappedInParenthesis: false))")
         }
         
         switch definition.contentMode {
         case .raw(let content, let contentRowID):
             if let content = content {
-                arguments.append("content=\(content.sqlExpression.quotedSQL())")
+                let quotedContent = content.sqlExpression.quotedSQL(wrappedInParenthesis: false)
+                arguments.append("content=\(quotedContent)")
             }
             if let contentRowID = contentRowID {
-                arguments.append("content_rowid=\(contentRowID.sqlExpression.quotedSQL())")
+                let quotedContentRowID = contentRowID.sqlExpression.quotedSQL(wrappedInParenthesis: false)
+                arguments.append("content_rowid=\(quotedContentRowID)")
             }
         case .synchronized(let contentTable):
-            arguments.append("content=\(contentTable.sqlExpression.quotedSQL())")
+            arguments.append("content=\(contentTable.sqlExpression.quotedSQL(wrappedInParenthesis: false))")
             if let rowIDColumn = try db.primaryKey(contentTable).rowIDColumn {
-                arguments.append("content_rowid=\(rowIDColumn.sqlExpression.quotedSQL())")
+                let quotedRowID = rowIDColumn.sqlExpression.quotedSQL(wrappedInParenthesis: false)
+                arguments.append("content_rowid=\(quotedRowID)")
             }
         }
         
         
         if let prefixes = definition.prefixes {
-            arguments.append("prefix=\(prefixes.sorted().map { "\($0)" }.joined(separator: " ").sqlExpression.quotedSQL())")
+            arguments.append("prefix=\(prefixes.sorted().map { "\($0)" }.joined(separator: " ").sqlExpression.quotedSQL(wrappedInParenthesis: false))")
         }
         
         if let columnSize = definition.columnSize {

--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -60,7 +60,7 @@ public struct FTS5TokenizerDescriptor {
         if separators.isEmpty {
             return FTS5TokenizerDescriptor(components: ["ascii"])
         } else {
-            return FTS5TokenizerDescriptor(components: ["ascii", "separators", separators.map { String($0) }.joined(separator: "").sqlExpression.quotedSQL()])
+            return FTS5TokenizerDescriptor(components: ["ascii", "separators", separators.map { String($0) }.joined(separator: "").sqlExpression.quotedSQL(wrappedInParenthesis: false)])
         }
     }
     
@@ -119,7 +119,7 @@ public struct FTS5TokenizerDescriptor {
                     .map { String($0) }
                     .joined(separator: "")
                     .sqlExpression
-                    .quotedSQL()])
+                    .quotedSQL(wrappedInParenthesis: false)])
         }
         if !tokenCharacters.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as tokenCharacters, with both FTS3Pattern(matchingAnyTokenIn:tokenizer:) and Database.create(virtualTable:using:)
@@ -130,7 +130,7 @@ public struct FTS5TokenizerDescriptor {
                     .map { String($0) }
                     .joined(separator: "")
                     .sqlExpression
-                    .quotedSQL()])
+                    .quotedSQL(wrappedInParenthesis: false)])
         }
         return FTS5TokenizerDescriptor(components: components)
     }

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -373,7 +373,7 @@ extension QueryInterfaceRequest {
         // Prevent information loss
         GRDBPrecondition(!query.isDistinct, "Not implemented: join distinct queries")
         GRDBPrecondition(query.groupPromise == nil, "Can't join aggregated queries")
-        GRDBPrecondition(query.havingExpression == nil, "Can't join aggregated queries")
+        GRDBPrecondition(query.havingExpressions.isEmpty, "Can't join aggregated queries")
         GRDBPrecondition(query.limit == nil, "Can't join limited queries")
         
         return query.relation

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -363,15 +363,7 @@ extension AggregatingRequest {
     /// Creates a request with a new grouping.
     public func group(literal sqlLiteral: SQLLiteral) -> Self {
         // NOT TESTED
-        // This "expression" is not a real expression. We support raw sql which
-        // actually contains several expressions:
-        //
-        //   request = Player.group(sql: "teamId, level")
-        //
-        // This is why we use the "unsafeLiteral" initializer, so that the
-        // SQLExpressionLiteral does not wrap input in parentheses, and
-        // generates invalid SQL `GROUP BY (teamId, level)`.
-        return group(SQLExpressionLiteral(unsafeLiteral: sqlLiteral))
+        return group(SQLExpressionLiteral(literal: sqlLiteral))
     }
 
     /// Creates a request with the provided *sql* added to the
@@ -498,15 +490,7 @@ extension OrderedRequest {
     ///         .order(sql: "name")
     public func order(literal sqlLiteral: SQLLiteral) -> Self {
         // NOT TESTED
-        // This "expression" is not a real expression. We support raw sql which
-        // actually contains several expressions:
-        //
-        //   request = Player.order(sql: "teamId, level")
-        //
-        // This is why we use the "unsafeLiteral" initializer, so that the
-        // SQLExpressionLiteral does not wrap input in parentheses, and
-        // generates invalid SQL `ORDER BY (teamId, level)`.
-        return order(SQLExpressionLiteral(unsafeLiteral: sqlLiteral))
+        return order(SQLExpressionLiteral(literal: sqlLiteral))
     }
 }
 

--- a/GRDB/QueryInterface/SQL/Column.swift
+++ b/GRDB/QueryInterface/SQL/Column.swift
@@ -27,7 +27,7 @@ public protocol ColumnExpression: SQLExpression {
 extension ColumnExpression {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
-    public func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+    public func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
         return name.quotedDatabaseIdentifier
     }
     
@@ -73,7 +73,7 @@ struct QualifiedColumn: ColumnExpression {
         self.alias = alias
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
         if let qualifier = context.qualifier(for: alias) {
             return qualifier.quotedDatabaseIdentifier + "." + name.quotedDatabaseIdentifier
         }

--- a/GRDB/QueryInterface/SQL/SQLCollection.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollection.swift
@@ -45,7 +45,7 @@ struct SQLExpressionsArray : SQLCollection {
     }
     
     func collectionSQL(_ context: inout SQLGenerationContext) -> String {
-        return (expressions.map { $0.expressionSQL(&context) } as [String]).joined(separator: ", ")
+        return (expressions.map { $0.expressionSQL(&context, wrappedInParenthesis: false) } as [String]).joined(separator: ", ")
     }
     
     func contains(_ value: SQLExpressible) -> SQLExpression {

--- a/GRDB/QueryInterface/SQL/SQLExpressible.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpressible.swift
@@ -65,7 +65,7 @@ extension SQLExpressible where Self: SQLOrderingTerm {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
     public func orderingTermSQL(_ context: inout SQLGenerationContext) -> String {
-        return sqlExpression.expressionSQL(&context)
+        return sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
     }
 }
 
@@ -76,13 +76,13 @@ extension SQLExpressible where Self: SQLSelectable {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
     public func resultColumnSQL(_ context: inout SQLGenerationContext) -> String {
-        return sqlExpression.expressionSQL(&context)
+        return sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
     }
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
     public func countedSQL(_ context: inout SQLGenerationContext) -> String {
-        return sqlExpression.expressionSQL(&context)
+        return sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
     }
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)

--- a/GRDB/QueryInterface/SQL/SQLExpression+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression+QueryInterface.swift
@@ -275,6 +275,10 @@ struct SQLExpressionAnd : SQLExpression {
     }
     
     func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+        return expressionSQL(&context, wrappedInParenthesis: true)
+    }
+    
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
         guard let first = expressions.first else {
             // Ruby [].all? # => true
             return true.sqlExpression.expressionSQL(&context)
@@ -283,7 +287,11 @@ struct SQLExpressionAnd : SQLExpression {
             return first.expressionSQL(&context)
         }
         let expressionSQLs = expressions.map { $0.expressionSQL(&context) }
-        return "(" + expressionSQLs.joined(separator: " AND ") + ")"
+        if wrappedInParenthesis {
+            return "(" + expressionSQLs.joined(separator: " AND ") + ")"
+        } else {
+            return expressionSQLs.joined(separator: " AND ")
+        }
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {

--- a/GRDB/QueryInterface/SQL/SQLExpression+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression+QueryInterface.swift
@@ -8,16 +8,16 @@ extension SQLExpression {
     /// :nodoc:
     public var sqlLiteral: SQLLiteral {
         var context = SQLGenerationContext.literalGenerationContext(withArguments: true)
-        let sql = expressionSQL(&context)
+        let sql = expressionSQL(&context, wrappedInParenthesis: false)
         return SQLLiteral(sql: sql, arguments: context.arguments!)
     }
     
     /// The expression as a quoted SQL literal (not public in order to avoid abuses)
     ///
-    ///     "foo'bar".databaseValue.quotedSQL() // "'foo''bar'""
-    func quotedSQL() -> String {
+    ///     "foo'bar".databaseValue.quotedSQL(wrappedInParenthesis: true) // "'foo''bar'""
+    func quotedSQL(wrappedInParenthesis: Bool) -> String {
         var context = SQLGenerationContext.literalGenerationContext(withArguments: false)
-        return expressionSQL(&context)
+        return expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
     }
 }
 
@@ -35,7 +35,6 @@ extension SQLExpression {
 ///     SQLExpressionLiteral(sql: ":one + :two", arguments: ["one": 1, "two": 2])
 public struct SQLExpressionLiteral : SQLExpression {
     private let sqlLiteral: SQLLiteral
-    
     public var sql: String { return sqlLiteral.sql }
     public var arguments: StatementArguments { return sqlLiteral.arguments }
     
@@ -63,22 +62,18 @@ public struct SQLExpressionLiteral : SQLExpression {
     ///
     ///     SQLExpressionLiteral(literal: "\(1) + \(2)")
     public init(literal sqlLiteral: SQLLiteral) {
-        self.init(unsafeLiteral: sqlLiteral.mapSQL { "(\($0))" })
-    }
-    
-    /// Creates an SQL literal expression without wrapping the SQL literal
-    /// inside parentheses. It is unsafe because the result expression can not
-    /// be safely composed with other expressions.
-    init(unsafeLiteral sqlLiteral: SQLLiteral) {
         self.sqlLiteral = sqlLiteral
     }
-
+    
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
-    public func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+    public func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
         if context.append(arguments: sqlLiteral.arguments) == false {
             // GRDB limitation: we don't know how to look for `?` in sql and
-            // replace them with with literals.
+            // replace them with literals.
             fatalError("Not implemented")
         }
         return sqlLiteral.sql
@@ -151,8 +146,11 @@ public struct SQLExpressionUnary : SQLExpression {
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
-    public func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return op.sql + (op.needsRightSpace ? " " : "") + expression.expressionSQL(&context)
+    public func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return op.sql + (op.needsRightSpace ? " " : "") + expression.expressionSQL(&context, wrappedInParenthesis: true)
     }
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
@@ -244,10 +242,17 @@ public struct SQLExpressionBinary : SQLExpression {
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
-    public func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "(" + lhs.expressionSQL(&context) + " " + op.sql + " " + rhs.expressionSQL(&context) + ")"
+    public func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return """
+            \(lhs.expressionSQL(&context, wrappedInParenthesis: true)) \
+            \(op.sql) \
+            \(rhs.expressionSQL(&context, wrappedInParenthesis: true))
+            """
     }
-    
+
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
     public var negated: SQLExpression {
@@ -274,24 +279,19 @@ struct SQLExpressionAnd : SQLExpression {
         self.expressions = expressions
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return expressionSQL(&context, wrappedInParenthesis: true)
-    }
-    
     func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
         guard let first = expressions.first else {
             // Ruby [].all? # => true
-            return true.sqlExpression.expressionSQL(&context)
+            return true.sqlExpression.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
         }
         if expressions.count == 1 {
-            return first.expressionSQL(&context)
+            return first.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
         }
-        let expressionSQLs = expressions.map { $0.expressionSQL(&context) }
-        if wrappedInParenthesis {
-            return "(" + expressionSQLs.joined(separator: " AND ") + ")"
-        } else {
-            return expressionSQLs.joined(separator: " AND ")
-        }
+        let expressionSQLs = expressions.map { $0.expressionSQL(&context, wrappedInParenthesis: true) }
+        return expressionSQLs.joined(separator: " AND ")
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
@@ -318,16 +318,19 @@ struct SQLExpressionOr : SQLExpression {
         self.expressions = expressions
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
         guard let first = expressions.first else {
             // Ruby [].any? # => false
-            return false.sqlExpression.expressionSQL(&context)
+            return false.sqlExpression.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
         }
         if expressions.count == 1 {
-            return first.expressionSQL(&context)
+            return first.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
         }
-        let expressionSQLs = expressions.map { $0.expressionSQL(&context) }
-        return "(" + expressionSQLs.joined(separator: " OR ") + ")"
+        let expressionSQLs = expressions.map { $0.expressionSQL(&context, wrappedInParenthesis: true) }
+        return expressionSQLs.joined(separator: " OR ")
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
@@ -378,14 +381,15 @@ struct SQLExpressionEqual: SQLExpression {
         }
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "(" +
-            lhs.expressionSQL(&context) +
-            " " +
-            op.rawValue +
-            " " +
-            rhs.expressionSQL(&context) +
-        ")"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return """
+            \(lhs.expressionSQL(&context, wrappedInParenthesis: true)) \
+            \(op.rawValue) \
+            \(rhs.expressionSQL(&context, wrappedInParenthesis: true))
+            """
     }
     
     var negated: SQLExpression {
@@ -448,12 +452,15 @@ struct SQLExpressionContains : SQLExpression {
         self.isNegated = negated
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "(" +
-            expression.expressionSQL(&context) +
-            (isNegated ? " NOT IN (" : " IN (") +
-            collection.collectionSQL(&context) +
-        "))"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return """
+            \(expression.expressionSQL(&context, wrappedInParenthesis: true)) \
+            \(isNegated ? "NOT IN" : "IN") \
+            (\(collection.collectionSQL(&context)))
+            """
     }
     
     var negated: SQLExpression {
@@ -513,14 +520,17 @@ struct SQLExpressionBetween : SQLExpression {
         self.isNegated = negated
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "(" +
-            expression.expressionSQL(&context) +
-            (isNegated ? " NOT BETWEEN " : " BETWEEN ") +
-            lowerBound.expressionSQL(&context) +
-            " AND " +
-            upperBound.expressionSQL(&context) +
-        ")"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return """
+            \(expression.expressionSQL(&context, wrappedInParenthesis: true)) \
+            \(isNegated ? "NOT BETWEEN" : "BETWEEN") \
+            \(lowerBound.expressionSQL(&context, wrappedInParenthesis: true)) \
+            AND \
+            \(upperBound.expressionSQL(&context, wrappedInParenthesis: true))
+            """
     }
 
     var negated: SQLExpression {
@@ -603,8 +613,12 @@ public struct SQLExpressionFunction : SQLExpression {
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     /// :nodoc:
-    public func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return functionName.sql + "(" + (self.arguments.map { $0.expressionSQL(&context) } as [String]).joined(separator: ", ")  + ")"
+    public func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        return """
+            \(functionName.sql)(\
+            \((arguments.map { $0.expressionSQL(&context, wrappedInParenthesis: false) } as [String]).joined(separator: ", "))\
+            )
+            """
     }
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
@@ -628,7 +642,7 @@ struct SQLExpressionCount : SQLExpression {
         self.counted = counted
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
         return "COUNT(" + counted.countedSQL(&context) + ")"
     }
     
@@ -650,8 +664,8 @@ struct SQLExpressionCountDistinct : SQLExpression {
         self.counted = counted
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "COUNT(DISTINCT " + counted.expressionSQL(&context) + ")"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        return "COUNT(DISTINCT " + counted.expressionSQL(&context, wrappedInParenthesis: false) + ")"
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
@@ -678,12 +692,14 @@ struct SQLExpressionIsEmpty : SQLExpression {
         return SQLExpressionIsEmpty(countExpression, isEmpty: !isEmpty)
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        if isEmpty {
-            return "(" + countExpression.expressionSQL(&context) + " = 0)"
-        } else {
-            return "(" + countExpression.expressionSQL(&context) + " > 0)"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
         }
+        return """
+            \(countExpression.expressionSQL(&context, wrappedInParenthesis: true)) \
+            \(isEmpty ? "= 0" : "> 0")
+            """
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
@@ -697,8 +713,15 @@ struct TableMatchExpression: SQLExpression {
     var alias: TableAlias
     var pattern: SQLExpression
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "(" + context.resolvedName(for: alias).quotedDatabaseIdentifier + " MATCH " + pattern.expressionSQL(&context) + ")"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return """
+            \(context.resolvedName(for: alias).quotedDatabaseIdentifier) \
+            MATCH \
+            \(pattern.expressionSQL(&context, wrappedInParenthesis: true))
+            """
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
@@ -723,13 +746,16 @@ struct SQLExpressionCollate : SQLExpression {
         self.collationName = collationName
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        let sql = expression.expressionSQL(&context)
-        if sql.last! == ")" {
-            return String(sql.prefix(upTo: sql.index(sql.endIndex, offsetBy: -1))) + " COLLATE " + collationName.rawValue + ")"
-        } else {
-            return sql + " COLLATE " + collationName.rawValue
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
         }
+        let sql = expression.expressionSQL(&context, wrappedInParenthesis: false)
+        return """
+            \(sql) \
+            COLLATE \
+            \(collationName.rawValue)
+            """
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {

--- a/GRDB/QueryInterface/SQL/SQLExpression+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression+QueryInterface.swift
@@ -280,9 +280,6 @@ struct SQLExpressionAnd : SQLExpression {
     }
     
     func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
-        if wrappedInParenthesis {
-            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
-        }
         guard let first = expressions.first else {
             // Ruby [].all? # => true
             return true.sqlExpression.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
@@ -291,7 +288,11 @@ struct SQLExpressionAnd : SQLExpression {
             return first.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
         }
         let expressionSQLs = expressions.map { $0.expressionSQL(&context, wrappedInParenthesis: true) }
-        return expressionSQLs.joined(separator: " AND ")
+        if wrappedInParenthesis {
+            return "(\(expressionSQLs.joined(separator: " AND ")))"
+        } else {
+            return expressionSQLs.joined(separator: " AND ")
+        }
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {
@@ -319,9 +320,6 @@ struct SQLExpressionOr : SQLExpression {
     }
     
     func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
-        if wrappedInParenthesis {
-            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
-        }
         guard let first = expressions.first else {
             // Ruby [].any? # => false
             return false.sqlExpression.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
@@ -330,7 +328,11 @@ struct SQLExpressionOr : SQLExpression {
             return first.expressionSQL(&context, wrappedInParenthesis: wrappedInParenthesis)
         }
         let expressionSQLs = expressions.map { $0.expressionSQL(&context, wrappedInParenthesis: true) }
-        return expressionSQLs.joined(separator: " OR ")
+        if wrappedInParenthesis {
+            return "(\(expressionSQLs.joined(separator: " OR ")))"
+        } else {
+            return expressionSQLs.joined(separator: " OR ")
+        }
     }
     
     func qualifiedExpression(with alias: TableAlias) -> SQLExpression {

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -23,7 +23,12 @@ public protocol SQLExpression : SQLSpecificExpressible, SQLSelectable, SQLOrderi
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
     /// Returns an SQL string that represents the expression.
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String
+    ///
+    /// - parameter context: An SQL generation context which accepts
+    ///   statement arguments.
+    /// - parameter wrappedInParenthesis: If true, the returned SQL should be
+    ///   wrapped inside parenthesis.
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String
     
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
@@ -133,8 +138,11 @@ struct SQLExpressionNot : SQLExpression {
         self.expression = expression
     }
     
-    func expressionSQL(_ context: inout SQLGenerationContext) -> String {
-        return "NOT \(expression.expressionSQL(&context))"
+    func expressionSQL(_ context: inout SQLGenerationContext, wrappedInParenthesis: Bool) -> String {
+        if wrappedInParenthesis {
+            return "(\(expressionSQL(&context, wrappedInParenthesis: false)))"
+        }
+        return "NOT \(expression.expressionSQL(&context, wrappedInParenthesis: true))"
     }
     
     var negated: SQLExpression {

--- a/GRDB/QueryInterface/SQL/SQLOrdering.swift
+++ b/GRDB/QueryInterface/SQL/SQLOrdering.swift
@@ -39,9 +39,9 @@ enum SQLOrdering : SQLOrderingTerm {
     func orderingTermSQL(_ context: inout SQLGenerationContext) -> String {
         switch self {
         case .asc(let expression):
-            return expression.expressionSQL(&context) + " ASC"
+            return expression.expressionSQL(&context, wrappedInParenthesis: false) + " ASC"
         case .desc(let expression):
-            return expression.expressionSQL(&context) + " DESC"
+            return expression.expressionSQL(&context, wrappedInParenthesis: false) + " DESC"
         }
     }
     

--- a/GRDB/QueryInterface/SQL/SQLQuery.swift
+++ b/GRDB/QueryInterface/SQL/SQLQuery.swift
@@ -7,7 +7,7 @@ struct SQLQuery {
     var expectsSingleResult: Bool
     var groupPromise: DatabasePromise<[SQLExpression]>?
     // Having clause is an array of expressions that we'll join with
-    // SQLExpressionAnd. This gives nicer output in generated SQL:
+    // the AND operator. This gives nicer output in generated SQL:
     // `(a AND b AND c)` instead of `((a AND b) AND c)`.
     var havingExpressions: [SQLExpression]
     var limit: SQLLimit?

--- a/GRDB/QueryInterface/SQL/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQL/SQLRelation.swift
@@ -153,7 +153,7 @@ struct SQLRelation {
     
     var source: SQLSource
     var selection: [SQLSelectable]
-    // Filter is an array of expressions that we'll join with SQLExpressionAnd.
+    // Filter is an array of expressions that we'll join with the AND operator.
     // This gives nicer output in generated SQL: `(a AND b AND c)` instead of
     // `((a AND b) AND c)`.
     var filtersPromise: DatabasePromise<[SQLExpression]>
@@ -567,7 +567,7 @@ struct SQLAssociationCondition: Equatable {
         }
     }
     
-    /// Resolves the condition into an SQL expression which involves both left
+    /// Resolves the condition into SQL expressions which involve both left
     /// and right tables.
     ///
     ///     SELECT * FROM left JOIN right ON (right.a = left.b)
@@ -578,11 +578,12 @@ struct SQLAssociationCondition: Equatable {
     ///   JOIN operator.
     /// - parameter rightAlias: A TableAlias for the table on the right of the
     ///   JOIN operator.
-    /// - Returns: An SQL expression.
-    func joinExpression(_ db: Database, leftAlias: TableAlias, rightAlias: TableAlias) throws -> SQLExpression {
-        return try columnMappings(db)
-            .map { QualifiedColumn($0.right, alias: rightAlias) == QualifiedColumn($0.left, alias: leftAlias) }
-            .joined(operator: .and)
+    /// - Returns: An array of SQL expression that should be joined with
+    ///   the AND operator.
+    func expressions(_ db: Database, leftAlias: TableAlias, rightAlias: TableAlias) throws -> [SQLExpression] {
+        return try columnMappings(db).map {
+            QualifiedColumn($0.right, alias: rightAlias) == QualifiedColumn($0.left, alias: leftAlias)
+        }
     }
     
     /// Resolves the condition into an SQL expression which involves only the

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -458,18 +458,17 @@ private struct SQLQualifiedJoin {
         case .leftJoin:
             allowsInnerJoin = false
         }
-        sql += kind.rawValue
-        sql += try " " + relation.source.sql(db, &context)
+        sql += try "\(kind.rawValue) \(relation.source.sql(db, &context))"
         
         let rightAlias = relation.alias
-        var filters = try [condition.joinExpression(db, leftAlias: leftAlias, rightAlias: rightAlias)]
-        try filters.append(contentsOf: relation.filtersPromise.resolve(db))
+        let filters = try condition.expressions(db, leftAlias: leftAlias, rightAlias: rightAlias)
+            + relation.filtersPromise.resolve(db)
         if filters.isEmpty == false {
-            sql += " ON " + SQLExpressionAnd(filters).expressionSQL(&context, wrappedInParenthesis: false)
+            sql += " ON \(SQLExpressionAnd(filters).expressionSQL(&context, wrappedInParenthesis: false))"
         }
         
         for (_, join) in relation.joins {
-            sql += try " " + join.sql(db, &context, leftAlias: rightAlias, allowingInnerJoin: allowsInnerJoin)
+            sql += try " \(join.sql(db, &context, leftAlias: rightAlias, allowingInnerJoin: allowsInnerJoin))"
         }
         
         return sql

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -3,7 +3,7 @@ struct SQLQueryGenerator {
     fileprivate let relation: SQLQualifiedRelation
     private let isDistinct: Bool
     private let groupPromise: DatabasePromise<[SQLExpression]>?
-    private let havingExpression: SQLExpression?
+    private let havingExpressions: [SQLExpression]
     private let limit: SQLLimit?
     
     init(_ query: SQLQuery) {
@@ -36,7 +36,7 @@ struct SQLQueryGenerator {
         // `HAVING MAX(year) < 2000` INTO `HAVING MAX(book.year) < 2000`.
         let alias = relation.alias
         groupPromise = query.groupPromise?.map { [alias] in $0.map { $0.qualifiedExpression(with: alias) } }
-        havingExpression = query.havingExpression?.qualifiedExpression(with: alias)
+        havingExpressions = query.havingExpressions.map { $0.qualifiedExpression(with: alias) }
         
         // Preserve other flags
         isDistinct = query.isDistinct
@@ -60,16 +60,17 @@ struct SQLQueryGenerator {
             sql += try " " + join.sql(db, &context, leftAlias: relation.alias)
         }
         
-        if let filter = try relation.filterPromise.resolve(db) {
-            sql += " WHERE " + filter.expressionSQL(&context)
+        let filters = try relation.filtersPromise.resolve(db)
+        if filters.isEmpty == false {
+            sql += " WHERE " + SQLExpressionAnd(filters).expressionSQL(&context, wrappedInParenthesis: false)
         }
         
         if let groupExpressions = try groupPromise?.resolve(db), !groupExpressions.isEmpty {
             sql += " GROUP BY " + groupExpressions.map { $0.expressionSQL(&context) }.joined(separator: ", ")
         }
         
-        if let havingExpression = havingExpression {
-            sql += " HAVING " + havingExpression.expressionSQL(&context)
+        if havingExpressions.isEmpty == false {
+            sql += " HAVING " + SQLExpressionAnd(havingExpressions).expressionSQL(&context, wrappedInParenthesis: false)
         }
         
         let orderings = try relation.ordering.resolve(db)
@@ -106,13 +107,9 @@ struct SQLQueryGenerator {
             return databaseRegion
         }
         
-        // Give up unless there is a where clause
-        guard let filter = try relation.filterPromise.resolve(db) else {
-            return databaseRegion
-        }
-        
-        // The filter knows better
-        guard let rowIds = filter.matchedRowIds(rowIdName: primaryKeyInfo.rowIDColumn) else {
+        // The filters knows better
+        let filters = try relation.filtersPromise.resolve(db)
+        guard let rowIds = SQLExpressionAnd(filters).matchedRowIds(rowIdName: primaryKeyInfo.rowIDColumn) else {
             return databaseRegion
         }
         
@@ -127,7 +124,7 @@ struct SQLQueryGenerator {
             fatalError("Can't delete query with GROUP BY clause")
         }
         
-        guard havingExpression == nil else {
+        guard havingExpressions.isEmpty else {
             // Programmer error
             fatalError("Can't delete query with HAVING clause")
         }
@@ -146,8 +143,9 @@ struct SQLQueryGenerator {
         
         var sql = try "DELETE FROM " + relation.source.sql(db, &context)
         
-        if let filter = try relation.filterPromise.resolve(db) {
-            sql += " WHERE " + filter.expressionSQL(&context)
+        let filters = try relation.filtersPromise.resolve(db)
+        if filters.isEmpty == false {
+            sql += " WHERE " + SQLExpressionAnd(filters).expressionSQL(&context, wrappedInParenthesis: false)
         }
         
         if let limit = limit {
@@ -267,8 +265,8 @@ private struct SQLQualifiedRelation {
     ///
     ///     SELECT ... FROM ... AS ... JOIN ... WHERE ... ORDER BY ...
     ///                                               |
-    ///                                               • filterPromise
-    let filterPromise: DatabasePromise<SQLExpression?>
+    ///                                               • filtersPromise
+    let filtersPromise: DatabasePromise<[SQLExpression]>
     
     /// The ordering, not including ordering of joined relations
     private let ownOrdering: SQLRelation.Ordering
@@ -321,7 +319,7 @@ private struct SQLQualifiedRelation {
                 relation: SQLQualifiedRelation(child.relation))
         }
         ownSelection = relation.selection.map { $0.qualifiedSelectable(with: alias) }
-        filterPromise = relation.filterPromise.map { [alias] in $0?.qualifiedExpression(with: alias) }
+        filtersPromise = relation.filtersPromise.map { [alias] in $0.map { $0.qualifiedExpression(with: alias) } }
         ownOrdering = relation.ordering.qualified(with: alias)
     }
     
@@ -464,12 +462,10 @@ private struct SQLQualifiedJoin {
         sql += try " " + relation.source.sql(db, &context)
         
         let rightAlias = relation.alias
-        let filters = try [
-            condition.joinExpression(db, leftAlias: leftAlias, rightAlias: rightAlias),
-            relation.filterPromise.resolve(db)
-            ].compactMap { $0 }
-        if !filters.isEmpty {
-            sql += " ON " + filters.joined(operator: .and).expressionSQL(&context)
+        var filters = try [condition.joinExpression(db, leftAlias: leftAlias, rightAlias: rightAlias)]
+        try filters.append(contentsOf: relation.filtersPromise.resolve(db))
+        if filters.isEmpty == false {
+            sql += " ON " + SQLExpressionAnd(filters).expressionSQL(&context, wrappedInParenthesis: false)
         }
         
         for (_, join) in relation.joins {

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -66,7 +66,7 @@ struct SQLQueryGenerator {
         }
         
         if let groupExpressions = try groupPromise?.resolve(db), !groupExpressions.isEmpty {
-            sql += " GROUP BY " + groupExpressions.map { $0.expressionSQL(&context) }.joined(separator: ", ")
+            sql += " GROUP BY " + groupExpressions.map { $0.expressionSQL(&context, wrappedInParenthesis: false) }.joined(separator: ", ")
         }
         
         if havingExpressions.isEmpty == false {

--- a/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
@@ -35,7 +35,7 @@ extension SQLInterpolation {
     ///         SELECT \(Column("name")) FROM player
     ///         """
     public mutating func appendInterpolation(_ expressible: SQLExpressible & SQLSelectable & SQLOrderingTerm) {
-        sql += expressible.sqlExpression.expressionSQL(&context)
+        sql += expressible.sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
     }
     
     /// Appends the name of the coding key.
@@ -45,7 +45,7 @@ extension SQLInterpolation {
     ///         SELECT \(CodingKey.name) FROM player
     ///         """
     public mutating func appendInterpolation(_ codingKey: SQLExpressible & SQLSelectable & SQLOrderingTerm & CodingKey) {
-        sql += codingKey.sqlExpression.expressionSQL(&context)
+        sql += codingKey.sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
     }
     
     /// Appends the expression SQL, or NULL if it is nil.
@@ -57,7 +57,7 @@ extension SQLInterpolation {
     ///         """
     public mutating func appendInterpolation<T: SQLExpressible>(_ expressible: T?) {
         if let expressible = expressible {
-            sql += expressible.sqlExpression.expressionSQL(&context)
+            sql += expressible.sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
         } else {
             sql += "NULL"
         }

--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -416,9 +416,7 @@ public final class TableDefinition {
     ///
     /// - parameter sql: An SQL snippet
     public func check(sql: String) {
-        // We do not want to wrap the SQL snippet inside parentheses around the
-        // checked SQL. This is why we use the "unsafeLiteral" initializer.
-        checkConstraints.append(SQLExpressionLiteral(unsafeLiteral: SQLLiteral(sql: sql)))
+        checkConstraints.append(SQLExpressionLiteral(sql: sql))
     }
     
     fileprivate func sql(_ db: Database) throws -> String {
@@ -506,8 +504,7 @@ public final class TableDefinition {
                 
                 for checkExpression in checkConstraints {
                     var chunks: [String] = []
-                    chunks.append("CHECK")
-                    chunks.append("(" + checkExpression.quotedSQL() + ")")
+                    chunks.append("CHECK (\(checkExpression.quotedSQL(wrappedInParenthesis: false)))")
                     items.append(chunks.joined(separator: " "))
                 }
                 
@@ -721,9 +718,7 @@ public final class ColumnDefinition {
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func check(sql: String) -> Self {
-        // We do not want to wrap the SQL snippet inside parentheses around the
-        // checked SQL. This is why we use the "unsafeLiteral" initializer.
-        checkConstraints.append(SQLExpressionLiteral(unsafeLiteral: SQLLiteral(sql: sql)))
+        checkConstraints.append(SQLExpressionLiteral(sql: sql))
         return self
     }
     
@@ -755,9 +750,7 @@ public final class ColumnDefinition {
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func defaults(sql: String) -> Self {
-        // We do not want to wrap the SQL snippet inside parentheses around the
-        // checked SQL. This is why we use the "unsafeLiteral" initializer.
-        defaultExpression = SQLExpressionLiteral(unsafeLiteral: SQLLiteral(sql: sql))
+        defaultExpression = SQLExpressionLiteral(sql: sql)
         return self
     }
     
@@ -860,13 +853,11 @@ public final class ColumnDefinition {
         }
         
         for checkConstraint in checkConstraints {
-            chunks.append("CHECK")
-            chunks.append("(" + checkConstraint.quotedSQL() + ")")
+            chunks.append("CHECK (\(checkConstraint.quotedSQL(wrappedInParenthesis: false)))")
         }
         
         if let defaultExpression = defaultExpression {
-            chunks.append("DEFAULT")
-            chunks.append(defaultExpression.quotedSQL())
+            chunks.append("DEFAULT \(defaultExpression.quotedSQL(wrappedInParenthesis: false))")
         }
         
         if let collationName = collationName {
@@ -942,8 +933,7 @@ private struct IndexDefinition {
         chunks.append("ON")
         chunks.append("\(table.quotedDatabaseIdentifier)(\((columns.map { $0.quotedDatabaseIdentifier } as [String]).joined(separator: ", ")))")
         if let condition = condition {
-            chunks.append("WHERE")
-            chunks.append(condition.quotedSQL())
+            chunks.append("WHERE \(condition.quotedSQL(wrappedInParenthesis: false))")
         }
         return chunks.joined(separator: " ")
     }

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Documentation
 #### Records and the Query Interface
 
 - [Records](#records): Fetching and persistence methods for your custom structs and class hierarchies
-- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema) &bull; [requests](#requests) • [associations](Documentation/AssociationsBasics.md) between record types
+- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema) &bull; [requests](#requests) • [associations between record types](Documentation/AssociationsBasics.md)
 
 #### Application Tools
 

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ Documentation
 
 #### Records and the Query Interface
 
-- [Records](#records): Fetching and persistence methods for your custom structs and class hierarchies.
-- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema) &bull; [requests](#requests)
+- [Records](#records): Fetching and persistence methods for your custom structs and class hierarchies
+- [Query Interface](#the-query-interface): A swift way to generate SQL &bull; [table creation](#database-schema) &bull; [requests](#requests) • [associations](Documentation/AssociationsBasics.md) between record types
 
 #### Application Tools
 
@@ -3658,6 +3658,8 @@ try dbQueue.write { db in
 ```
 
 So don't miss the [SQL API](#sqlite-api).
+
+> :point_up: **Note**: the generated SQL may change between GRDB releases, without notice: don't have your application rely on any specific SQL output.
 
 - [Database Schema](#database-schema)
 - [Requests](#requests)
@@ -8585,6 +8587,8 @@ try dbQueue.read { db in
     // Prints SELECT * FROM wine WHERE origin = 'Burgundy' ORDER BY price
 }
 ```
+
+> :point_up: **Note**: the generated SQL may change between GRDB releases, without notice: don't have your application rely on any specific SQL output.
 
 
 ### Generic parameter 'T' could not be inferred

--- a/Tests/CocoaPods/SQLCipher3/Podfile.lock
+++ b/Tests/CocoaPods/SQLCipher3/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GRDB.swift/SQLCipher (4.0.0):
+  - GRDB.swift/SQLCipher (4.0.1):
     - SQLCipher (>= 3.4.0)
   - SQLCipher (3.4.2):
     - SQLCipher/standard (= 3.4.2)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: "../../.."
 
 SPEC CHECKSUMS:
-  GRDB.swift: 28cd703910fece722090ca801f6e6f3317424628
+  GRDB.swift: ceaaa49a1655250b024a8f4f77fdfdb2dca49aec
   SQLCipher: f9fcf29b2e59ced7defc2a2bdd0ebe79b40d4990
 
 PODFILE CHECKSUM: 0290f13f2c78fc84b4b43adb2d412c376454e26d

--- a/Tests/CocoaPods/SQLCipher4/Podfile.lock
+++ b/Tests/CocoaPods/SQLCipher4/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GRDB.swift/SQLCipher (4.0.0):
+  - GRDB.swift/SQLCipher (4.0.1):
     - SQLCipher (>= 3.4.0)
   - SQLCipher (4.1.0):
     - SQLCipher/standard (= 4.1.0)
@@ -20,7 +20,7 @@ EXTERNAL SOURCES:
     :path: "../../.."
 
 SPEC CHECKSUMS:
-  GRDB.swift: 28cd703910fece722090ca801f6e6f3317424628
+  GRDB.swift: ceaaa49a1655250b024a8f4f77fdfdb2dca49aec
   SQLCipher: efbdb52cdbe340bcd892b1b14297df4e07241b7f
 
 PODFILE CHECKSUM: 5ab9c3045c2a97c4e89f0fadd6eab1455e79e2de

--- a/Tests/GRDBTests/AssociationAggregateTests.swift
+++ b/Tests/GRDBTests/AssociationAggregateTests.swift
@@ -94,7 +94,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, COUNT(DISTINCT "custom"."rowid") AS "playerCount" \
                 FROM "team" \
-                JOIN "player" "custom" ON (("custom"."teamId" = "team"."id") AND (custom.score < 500)) \
+                JOIN "player" "custom" ON ("custom"."teamId" = "team"."id") AND (custom.score < 500) \
                 GROUP BY "team"."id"
                 """)
         }
@@ -717,8 +717,8 @@ class AssociationAggregateTests: GRDBTestCase {
                 COUNT(DISTINCT "player1"."rowid") AS "lowPlayerCount", \
                 COUNT(DISTINCT "player2"."rowid") AS "highPlayerCount" \
                 FROM "team" \
-                LEFT JOIN "player" "player1" ON (("player1"."teamId" = "team"."id") AND ("player1"."score" < 500)) \
-                LEFT JOIN "player" "player2" ON (("player2"."teamId" = "team"."id") AND ("player2"."score" >= 500)) \
+                LEFT JOIN "player" "player1" ON ("player1"."teamId" = "team"."id") AND ("player1"."score" < 500) \
+                LEFT JOIN "player" "player2" ON ("player2"."teamId" = "team"."id") AND ("player2"."score" >= 500) \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)

--- a/Tests/GRDBTests/AssociationAggregateTests.swift
+++ b/Tests/GRDBTests/AssociationAggregateTests.swift
@@ -111,7 +111,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team"."name", COUNT(DISTINCT "player"."rowid") AS "playerCount" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."name"
                 """)
         }
@@ -128,7 +128,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, AVG("player"."score") AS "averagePlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -165,7 +165,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, COUNT(DISTINCT "player"."rowid") AS "playerCount" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -206,8 +206,8 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "player".*, COUNT(DISTINCT "award"."rowid") AS "awardCount" \
                 FROM "player" \
-                LEFT JOIN "team" ON ("team"."id" = "player"."teamId") \
-                LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                LEFT JOIN "team" ON "team"."id" = "player"."teamId" \
+                LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                 GROUP BY "player"."id" \
                 ORDER BY "player"."id"
                 """)
@@ -246,7 +246,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, MAX("player"."score") AS "maxPlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -283,7 +283,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, MIN("player"."score") AS "minPlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -320,7 +320,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, SUM("player"."score") AS "playerScoreSum" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -365,7 +365,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 MAX("player"."score") AS "maxPlayerScore", \
                 SUM("player"."score") AS "playerScoreSum" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -418,7 +418,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, AVG("player"."score") AS "averageCustomPlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -455,7 +455,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, COUNT(DISTINCT "player"."rowid") AS "customPlayerCount" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -492,7 +492,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, MAX("player"."score") AS "maxCustomPlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -529,7 +529,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, MIN("player"."score") AS "minCustomPlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -566,7 +566,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, SUM("player"."score") AS "customPlayerScoreSum" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -611,7 +611,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 MAX("player"."score") AS "maxCustomPlayerScore", \
                 SUM("player"."score") AS "customPlayerScoreSum" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)
@@ -671,7 +671,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 MIN("player"."score") AS "a4", \
                 SUM("player"."score") AS "a5" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id"
                 """)
         }
@@ -687,12 +687,12 @@ class AssociationAggregateTests: GRDBTestCase {
                 .annotated(with: Team.players.sum(Column("score") * Column("score")).aliased("a5"))
             try assertEqualSQL(db, request, """
                 SELECT "team".*, \
-                AVG(("player"."score" * "player"."score")) AS "a1", \
-                MAX(("player"."score" * 10)) AS "a3", \
+                AVG("player"."score" * "player"."score") AS "a1", \
+                MAX("player"."score" * 10) AS "a3", \
                 MIN(-"player"."score") AS "a4", \
-                SUM(("player"."score" * "player"."score")) AS "a5" \
+                SUM("player"."score" * "player"."score") AS "a5" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id"
                 """)
         }
@@ -754,9 +754,9 @@ class AssociationAggregateTests: GRDBTestCase {
             do {
                 let request = Team.annotated(with: Team.players.isEmpty)
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") = 0) AS "hasNoPlayer" \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") = 0 AS "hasNoPlayer" \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 4)
@@ -765,9 +765,9 @@ class AssociationAggregateTests: GRDBTestCase {
             do {
                 let request = Team.annotated(with: !Team.players.isEmpty)
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") > 0) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") > 0 \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 4)
@@ -778,9 +778,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") = 0)
+                    HAVING COUNT(DISTINCT "player"."rowid") = 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 1)
                 try XCTAssertEqual(request.fetchCount(db), 1)
@@ -790,9 +790,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") > 0)
+                    HAVING COUNT(DISTINCT "player"."rowid") > 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 3)
                 try XCTAssertEqual(request.fetchCount(db), 3)
@@ -802,9 +802,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") > 0)
+                    HAVING COUNT(DISTINCT "player"."rowid") > 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 3)
                 try XCTAssertEqual(request.fetchCount(db), 3)
@@ -814,9 +814,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") = 0)
+                    HAVING COUNT(DISTINCT "player"."rowid") = 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 1)
                 try XCTAssertEqual(request.fetchCount(db), 1)
@@ -832,10 +832,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "player".* \
                     FROM "player" \
-                    LEFT JOIN "team" ON ("team"."id" = "player"."teamId") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "team" ON "team"."id" = "player"."teamId" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "player"."id" \
-                    HAVING (COUNT(DISTINCT "award"."rowid") = 0)
+                    HAVING COUNT(DISTINCT "award"."rowid") = 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 1)
                 try XCTAssertEqual(request.fetchCount(db), 1)
@@ -845,10 +845,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "player".* \
                     FROM "player" \
-                    LEFT JOIN "team" ON ("team"."id" = "player"."teamId") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "team" ON "team"."id" = "player"."teamId" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "player"."id" \
-                    HAVING (COUNT(DISTINCT "award"."rowid") > 0)
+                    HAVING COUNT(DISTINCT "award"."rowid") > 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 5)
                 try XCTAssertEqual(request.fetchCount(db), 5)
@@ -858,10 +858,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "player".* \
                     FROM "player" \
-                    LEFT JOIN "team" ON ("team"."id" = "player"."teamId") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "team" ON "team"."id" = "player"."teamId" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "player"."id" \
-                    HAVING (COUNT(DISTINCT "award"."rowid") > 0)
+                    HAVING COUNT(DISTINCT "award"."rowid") > 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 5)
                 try XCTAssertEqual(request.fetchCount(db), 5)
@@ -871,10 +871,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "player".* \
                     FROM "player" \
-                    LEFT JOIN "team" ON ("team"."id" = "player"."teamId") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "team" ON "team"."id" = "player"."teamId" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "player"."id" \
-                    HAVING (COUNT(DISTINCT "award"."rowid") = 0)
+                    HAVING COUNT(DISTINCT "award"."rowid") = 0
                     """)
                 try XCTAssertEqual(request.fetchAll(db).count, 1)
                 try XCTAssertEqual(request.fetchCount(db), 1)
@@ -891,9 +891,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") = 2)
+                    HAVING COUNT(DISTINCT "player"."rowid") = 2
                     """)
             }
             do {
@@ -902,9 +902,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (2 = COUNT(DISTINCT "player"."rowid"))
+                    HAVING 2 = COUNT(DISTINCT "player"."rowid")
                     """)
             }
             do {
@@ -913,10 +913,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") = COUNT(DISTINCT "award"."rowid"))
+                    HAVING COUNT(DISTINCT "player"."rowid") = COUNT(DISTINCT "award"."rowid")
                     """)
             }
         }
@@ -931,9 +931,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") <> 2)
+                    HAVING COUNT(DISTINCT "player"."rowid") <> 2
                     """)
             }
             do {
@@ -942,9 +942,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (2 <> COUNT(DISTINCT "player"."rowid"))
+                    HAVING 2 <> COUNT(DISTINCT "player"."rowid")
                     """)
             }
             do {
@@ -953,10 +953,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") <> COUNT(DISTINCT "award"."rowid"))
+                    HAVING COUNT(DISTINCT "player"."rowid") <> COUNT(DISTINCT "award"."rowid")
                     """)
             }
         }
@@ -971,9 +971,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") >= 2)
+                    HAVING COUNT(DISTINCT "player"."rowid") >= 2
                     """)
             }
             do {
@@ -982,9 +982,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (2 >= COUNT(DISTINCT "player"."rowid"))
+                    HAVING 2 >= COUNT(DISTINCT "player"."rowid")
                     """)
             }
             do {
@@ -993,10 +993,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") >= COUNT(DISTINCT "award"."rowid"))
+                    HAVING COUNT(DISTINCT "player"."rowid") >= COUNT(DISTINCT "award"."rowid")
                     """)
             }
         }
@@ -1011,9 +1011,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") > 2)
+                    HAVING COUNT(DISTINCT "player"."rowid") > 2
                     """)
             }
             do {
@@ -1022,9 +1022,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (2 > COUNT(DISTINCT "player"."rowid"))
+                    HAVING 2 > COUNT(DISTINCT "player"."rowid")
                     """)
             }
             do {
@@ -1033,10 +1033,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") > COUNT(DISTINCT "award"."rowid"))
+                    HAVING COUNT(DISTINCT "player"."rowid") > COUNT(DISTINCT "award"."rowid")
                     """)
             }
         }
@@ -1051,9 +1051,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") <= 2)
+                    HAVING COUNT(DISTINCT "player"."rowid") <= 2
                     """)
             }
             do {
@@ -1062,9 +1062,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (2 <= COUNT(DISTINCT "player"."rowid"))
+                    HAVING 2 <= COUNT(DISTINCT "player"."rowid")
                     """)
             }
             do {
@@ -1073,10 +1073,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") <= COUNT(DISTINCT "award"."rowid"))
+                    HAVING COUNT(DISTINCT "player"."rowid") <= COUNT(DISTINCT "award"."rowid")
                     """)
             }
         }
@@ -1091,9 +1091,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") < 2)
+                    HAVING COUNT(DISTINCT "player"."rowid") < 2
                     """)
             }
             do {
@@ -1102,9 +1102,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (2 < COUNT(DISTINCT "player"."rowid"))
+                    HAVING 2 < COUNT(DISTINCT "player"."rowid")
                     """)
             }
             do {
@@ -1113,10 +1113,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING (COUNT(DISTINCT "player"."rowid") < COUNT(DISTINCT "award"."rowid"))
+                    HAVING COUNT(DISTINCT "player"."rowid") < COUNT(DISTINCT "award"."rowid")
                     """)
             }
         }
@@ -1131,10 +1131,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING ((COUNT(DISTINCT "player"."rowid") = 0) AND (COUNT(DISTINCT "award"."rowid") = 0))
+                    HAVING (COUNT(DISTINCT "player"."rowid") = 0) AND (COUNT(DISTINCT "award"."rowid") = 0)
                     """)
             }
             do {
@@ -1143,10 +1143,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
-                    HAVING ((COUNT(DISTINCT "player"."rowid") = 0) OR (COUNT(DISTINCT "award"."rowid") = 0))
+                    HAVING (COUNT(DISTINCT "player"."rowid") = 0) OR (COUNT(DISTINCT "award"."rowid") = 0)
                     """)
             }
             do {
@@ -1155,10 +1155,22 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".* \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id" \
                     HAVING NOT ((COUNT(DISTINCT "player"."rowid") = 0) OR (COUNT(DISTINCT "award"."rowid") = 0))
+                    """)
+            }
+            do {
+                let request = Team.having(!(Team.players.count > 3) || Team.awards.isEmpty)
+                
+                try assertEqualSQL(db, request, """
+                    SELECT "team".* \
+                    FROM "team" \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
+                    GROUP BY "team"."id" \
+                    HAVING (NOT (COUNT(DISTINCT "player"."rowid") > 3)) OR (COUNT(DISTINCT "award"."rowid") = 0)
                     """)
             }
         }
@@ -1173,7 +1185,7 @@ class AssociationAggregateTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "team".*, -COUNT(DISTINCT "player"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1187,9 +1199,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count + 2)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") + 2) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") + 2 \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1197,9 +1209,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: 2 + Team.players.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (2 + COUNT(DISTINCT "player"."rowid")) \
+                    SELECT "team".*, 2 + COUNT(DISTINCT "player"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1207,10 +1219,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count + Team.awards.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") + COUNT(DISTINCT "award"."rowid")) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") + COUNT(DISTINCT "award"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1224,9 +1236,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count - 2)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") - 2) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") - 2 \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1234,9 +1246,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: 2 - Team.players.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (2 - COUNT(DISTINCT "player"."rowid")) \
+                    SELECT "team".*, 2 - COUNT(DISTINCT "player"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1244,10 +1256,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count - Team.awards.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") - COUNT(DISTINCT "award"."rowid")) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") - COUNT(DISTINCT "award"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1261,9 +1273,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count * 2)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") * 2) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") * 2 \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1271,9 +1283,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: 2 * Team.players.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (2 * COUNT(DISTINCT "player"."rowid")) \
+                    SELECT "team".*, 2 * COUNT(DISTINCT "player"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1281,10 +1293,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count * Team.awards.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") * COUNT(DISTINCT "award"."rowid")) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") * COUNT(DISTINCT "award"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1298,9 +1310,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count / 2)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") / 2) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") / 2 \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1308,9 +1320,9 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: 2 / Team.players.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (2 / COUNT(DISTINCT "player"."rowid")) \
+                    SELECT "team".*, 2 / COUNT(DISTINCT "player"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1318,10 +1330,10 @@ class AssociationAggregateTests: GRDBTestCase {
                 let request = Team.annotated(with: Team.players.count / Team.awards.count)
                 
                 try assertEqualSQL(db, request, """
-                    SELECT "team".*, (COUNT(DISTINCT "player"."rowid") / COUNT(DISTINCT "award"."rowid")) \
+                    SELECT "team".*, COUNT(DISTINCT "player"."rowid") / COUNT(DISTINCT "award"."rowid") \
                     FROM "team" \
-                    LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
-                    LEFT JOIN "award" ON ("award"."teamId" = "team"."id") \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    LEFT JOIN "award" ON "award"."teamId" = "team"."id" \
                     GROUP BY "team"."id"
                     """)
             }
@@ -1339,7 +1351,7 @@ class AssociationAggregateTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "team".*, IFNULL(MIN("player"."score"), 0) AS "minPlayerScore" \
                 FROM "team" \
-                LEFT JOIN "player" ON ("player"."teamId" = "team"."id") \
+                LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
                 GROUP BY "team"."id" \
                 ORDER BY "team"."id"
                 """)

--- a/Tests/GRDBTests/AssociationBelongsToDecodableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToDecodableRecordTests.swift
@@ -130,7 +130,7 @@ class AssociationBelongsToDecodableRecordTests: GRDBTestCase {
         XCTAssertEqual(lastSQLQuery, """
             SELECT "players".*, "teams"."name", "teams"."id" \
             FROM "players" \
-            JOIN "teams" ON (("teams"."id" = "players"."teamId") AND ("teams"."name" = 'Reds')) \
+            JOIN "teams" ON ("teams"."id" = "players"."teamId") AND ("teams"."name" = 'Reds') \
             ORDER BY "teams"."name", "players"."name"
             """)
         XCTAssertEqual(records.count, 1)

--- a/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
@@ -113,7 +113,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."id" = "a"."bid") AND ("b"."name" IS NOT NULL))
+                    JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."name" IS NOT NULL)
                     """)
             }
             do {
@@ -121,7 +121,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."id" = "a"."bid") AND ("b"."id" = 1))
+                    JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."id" = 1)
                     """)
             }
             do {
@@ -129,7 +129,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."id" = "a"."bid") AND ("b"."id" IN (1, 2, 3)))
+                    JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."id" IN (1, 2, 3))
                     """)
             }
             do {
@@ -137,7 +137,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."id" = "a"."bid") AND ("b"."id" = 1))
+                    JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."id" = 1)
                     """)
             }
             do {
@@ -145,7 +145,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."id" = "a"."bid") AND (("b"."id" = 1) OR ("b"."id" = 2)))
+                    JOIN "b" ON ("b"."id" = "a"."bid") AND (("b"."id" = 1) OR ("b"."id" = 2))
                     """)
             }
             do {
@@ -156,7 +156,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "customB".* \
                     FROM "a" \
-                    JOIN "b" "customB" ON (("customB"."id" = "a"."bid") AND (customB.name = 'foo'))
+                    JOIN "b" "customB" ON ("customB"."id" = "a"."bid") AND (customB.name = 'foo')
                     """)
             }
         }

--- a/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
@@ -50,17 +50,17 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(required: A.restrictedB), """
                 SELECT "a".*, "b"."name" \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(required: A.extendedB), """
                 SELECT "a".*, "b".*, "b"."rowid" \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
         }
     }
@@ -74,7 +74,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b"."name" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bid")
+                    JOIN "b" ON "b"."id" = "a"."bid"
                     """)
             }
             do {
@@ -85,7 +85,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".*, "b"."rowid" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bid")
+                    JOIN "b" ON "b"."id" = "a"."bid"
                     """)
             }
             do {
@@ -97,9 +97,9 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                         Column("name"),
                         (Column("id") + aAlias[Column("id")]).aliased("foo")))
                 try assertEqualSQL(db, request, """
-                    SELECT "a".*, "b"."name", ("b"."id" + "a"."id") AS "foo" \
+                    SELECT "a".*, "b"."name", "b"."id" + "a"."id" AS "foo" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bid")
+                    JOIN "b" ON "b"."id" = "a"."bid"
                     """)
             }
         }
@@ -172,8 +172,8 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                WHERE ("b"."name" IS NOT NULL)
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                WHERE "b"."name" IS NOT NULL
                 """)
         }
     }
@@ -219,8 +219,8 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
             let prefix = """
                 SELECT "a".*, "ab".*, "aba".* \
                 FROM "a" \
-                JOIN "b" "ab" ON ("ab"."id" = "a"."bid") \
-                JOIN "a" "aba" ON ("aba"."bid" = "ab"."id")
+                JOIN "b" "ab" ON "ab"."id" = "a"."bid" \
+                JOIN "a" "aba" ON "aba"."bid" = "ab"."id"
                 """
             let orderClauses = sqls.map { sql -> String in
                 let prefixEndIndex = sql.index(sql.startIndex, offsetBy: prefix.count)

--- a/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
@@ -36,28 +36,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."rowid" = "children"."parentId")
+                    JOIN "parents" ON "parents"."rowid" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."rowid" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."rowid" = "children"."parentId")
+                    JOIN "parents" ON "parents"."rowid" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."rowid" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"rowid\" = 1)
+                    SELECT * FROM "parents" WHERE "rowid" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"rowid\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."rowid" = 1
                     """)
             }
             do {
@@ -65,28 +65,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
         }
@@ -120,28 +120,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
             do {
@@ -149,28 +149,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
         }
@@ -204,28 +204,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
             do {
@@ -233,28 +233,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
             do {
@@ -262,28 +262,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
         }
@@ -319,28 +319,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
             do {
@@ -348,28 +348,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 1)
+                    SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 1)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 1
                     """)
             }
             do {
@@ -377,28 +377,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 2)
+                    SELECT * FROM "parents" WHERE "id" = 2
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 2)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 2
                     """)
             }
             do {
@@ -406,28 +406,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id")
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE (\"id\" = 2)
+                    SELECT * FROM "parents" WHERE "id" = 2
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE (\"custom\".\"id\" = 2)
+                    SELECT "custom".* FROM "parents" "custom" WHERE "custom"."id" = 2
                     """)
             }
         }
@@ -464,28 +464,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
         }
@@ -523,28 +523,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children\".\"parentB\"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children\".\"parentB\"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
             do {
@@ -552,28 +552,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
         }
@@ -612,28 +612,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
             do {
@@ -641,28 +641,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
             do {
@@ -670,28 +670,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
         }
@@ -735,28 +735,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
             do {
@@ -764,28 +764,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 1) AND (\"b\" = 2))
+                    SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 1) AND (\"custom\".\"b\" = 2))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 1) AND ("custom"."b" = 2)
                     """)
             }
             do {
@@ -793,28 +793,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 3) AND (\"b\" = 4))
+                    SELECT * FROM "parents" WHERE ("a" = 3) AND ("b" = 4)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 3) AND (\"custom\".\"b\" = 4))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 3) AND ("custom"."b" = 4)
                     """)
             }
             do {
@@ -822,28 +822,28 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child.including(required: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child.including(optional: association), """
                     SELECT "children".*, "parents".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child.joining(required: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child.joining(optional: association), """
                     SELECT "children".* \
                     FROM "children" \
-                    LEFT JOIN "parents" ON (("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B"))
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
-                    SELECT * FROM \"parents\" WHERE ((\"a\" = 3) AND (\"b\" = 4))
+                    SELECT * FROM "parents" WHERE ("a" = 3) AND ("b" = 4)
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
-                    SELECT \"custom\".* FROM \"parents\" \"custom\" WHERE ((\"custom\".\"a\" = 3) AND (\"custom\".\"b\" = 4))
+                    SELECT "custom".* FROM "parents" "custom" WHERE ("custom"."a" = 3) AND ("custom"."b" = 4)
                     """)
             }
         }

--- a/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
@@ -24,6 +24,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.create(table: "parents") { t in
                 t.column("id", .integer)
+                t.column("name", .text)
             }
             try db.create(table: "children") { t in
                 t.column("parentId", .integer)
@@ -52,6 +53,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."rowid" = "children"."parentId") AND ("parents"."name" = 'foo')
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "rowid" = 1
@@ -82,7 +88,12 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
-                try assertEqualSQL(db, Child().request(for: association), """
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
+               try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
                 try assertEqualSQL(db, Child().request(for: association).aliased(TableAlias(name: "custom")), """
@@ -108,6 +119,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.create(table: "parents") { t in
                 t.column("id", .integer).primaryKey()
+                t.column("name", .text)
             }
             try db.create(table: "children") { t in
                 t.column("parentId", .integer)
@@ -137,6 +149,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -166,6 +183,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -192,6 +214,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.create(table: "parents") { t in
                 t.column("id", .integer).primaryKey()
+                t.column("name", .text)
             }
             try db.create(table: "children") { t in
                 t.column("parentId", .integer).references("parents")
@@ -220,6 +243,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -250,6 +278,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -279,6 +312,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -306,6 +344,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.create(table: "parents") { t in
                 t.column("id", .integer).primaryKey()
+                t.column("name", .text)
             }
             try db.create(table: "children") { t in
                 t.column("parent1Id", .integer).references("parents")
@@ -336,6 +375,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -364,6 +408,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id") AND ("parents"."name" = 'foo')
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -394,6 +443,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 2
                     """)
@@ -423,6 +477,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 2
                     """)
@@ -451,6 +510,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
             try db.create(table: "parents") { t in
                 t.column("a", .integer)
                 t.column("b", .integer)
+                t.column("name", .text)
             }
             try db.create(table: "children") { t in
                 t.column("parentA", .integer)
@@ -481,6 +541,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -509,6 +574,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
             try db.create(table: "parents") { t in
                 t.column("a", .integer)
                 t.column("b", .integer)
+                t.column("name", .text)
                 t.primaryKey(["a", "b"])
             }
             try db.create(table: "children") { t in
@@ -540,6 +606,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -569,6 +640,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -597,6 +673,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
             try db.create(table: "parents") { t in
                 t.column("a", .integer)
                 t.column("b", .integer)
+                t.column("name", .text)
                 t.primaryKey(["a", "b"])
             }
             try db.create(table: "children") { t in
@@ -629,6 +706,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -658,6 +740,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -686,6 +773,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -717,6 +809,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
             try db.create(table: "parents") { t in
                 t.column("a", .integer)
                 t.column("b", .integer)
+                t.column("name", .text)
                 t.primaryKey(["a", "b"])
             }
             try db.create(table: "children") { t in
@@ -752,6 +845,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -780,6 +878,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B") AND ("parents"."name" = 'foo')
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -810,6 +913,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B") AND ("parents"."name" = 'foo')
+                    """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 3) AND ("b" = 4)
                     """)
@@ -838,6 +946,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                try assertEqualSQL(db, Child.joining(optional: association.filter(Column("name") == "foo")), """
+                    SELECT "children".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B") AND ("parents"."name" = 'foo')
                     """)
                 try assertEqualSQL(db, Child().request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 3) AND ("b" = 4)

--- a/Tests/GRDBTests/AssociationChainSQLTests.swift
+++ b/Tests/GRDBTests/AssociationChainSQLTests.swift
@@ -92,13 +92,13 @@ class AssociationChainSQLTests: GRDBTestCase {
                 SELECT "c".*, "d".* \
                 FROM "c" \
                 JOIN "d" ON ("d"."id" = "c"."did") \
-                JOIN "b" ON (("b"."id" = "c"."bid") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.c.including(optional: C.d)), """
                 SELECT "c".*, "d".* \
                 FROM "c" \
                 LEFT JOIN "d" ON ("d"."id" = "c"."did") \
-                JOIN "b" ON (("b"."id" = "c"."bid") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -335,13 +335,13 @@ class AssociationChainSQLTests: GRDBTestCase {
                 SELECT "c".* \
                 FROM "c" \
                 JOIN "d" ON ("d"."id" = "c"."did") \
-                JOIN "b" ON (("b"."id" = "c"."bid") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.c.joining(optional: C.d)), """
                 SELECT "c".* \
                 FROM "c" \
                 LEFT JOIN "d" ON ("d"."id" = "c"."did") \
-                JOIN "b" ON (("b"."id" = "c"."bid") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
         }
     }

--- a/Tests/GRDBTests/AssociationChainSQLTests.swift
+++ b/Tests/GRDBTests/AssociationChainSQLTests.swift
@@ -61,43 +61,43 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.b.including(required: B.c)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                WHERE ("b"."id" = 1)
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                WHERE "b"."id" = 1
                 """)
             try assertEqualSQL(db, A().request(for: A.b.including(optional: B.c)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                WHERE ("b"."id" = 1)
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                WHERE "b"."id" = 1
                 """)
             
             // Direct, Through
             try assertEqualSQL(db, A().request(for: A.b.including(required: B.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
             try assertEqualSQL(db, A().request(for: A.b.including(optional: B.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
             
             // Through, Through
             try assertEqualSQL(db, A().request(for: A.c.including(required: C.d)), """
                 SELECT "c".*, "d".* \
                 FROM "c" \
-                JOIN "d" ON ("d"."id" = "c"."did") \
+                JOIN "d" ON "d"."id" = "c"."did" \
                 JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.c.including(optional: C.d)), """
                 SELECT "c".*, "d".* \
                 FROM "c" \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did") \
+                LEFT JOIN "d" ON "d"."id" = "c"."did" \
                 JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
         }
@@ -109,42 +109,42 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c)), "TODO")
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d)), "TODO")
             try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -155,26 +155,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).including(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).including(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c).including(required: B.c)), "TODO")
@@ -183,32 +183,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).including(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).including(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d).including(required: C.d)), "TODO")
@@ -217,8 +217,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -229,26 +229,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).joining(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).joining(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c).joining(required: B.c)), "TODO")
@@ -257,32 +257,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).joining(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(required: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).joining(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.including(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.including(optional: B.c.including(required: C.d).joining(required: C.d)), "TODO")
@@ -291,8 +291,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.including(optional: B.c.including(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -304,43 +304,43 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.b.joining(required: B.c)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                WHERE ("b"."id" = 1)
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                WHERE "b"."id" = 1
                 """)
             try assertEqualSQL(db, A().request(for: A.b.joining(optional: B.c)), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                WHERE ("b"."id" = 1)
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                WHERE "b"."id" = 1
                 """)
             
             // Direct, Through
             try assertEqualSQL(db, A().request(for: A.b.joining(required: B.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
             try assertEqualSQL(db, A().request(for: A.b.joining(optional: B.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
             
             // Through, Through
             try assertEqualSQL(db, A().request(for: A.c.joining(required: C.d)), """
                 SELECT "c".* \
                 FROM "c" \
-                JOIN "d" ON ("d"."id" = "c"."did") \
+                JOIN "d" ON "d"."id" = "c"."did" \
                 JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.c.joining(optional: C.d)), """
                 SELECT "c".* \
                 FROM "c" \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did") \
+                LEFT JOIN "d" ON "d"."id" = "c"."did" \
                 JOIN "b" ON ("b"."id" = "c"."bid") AND ("b"."id" = 1)
                 """)
         }
@@ -352,42 +352,42 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c)), "")
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d)), "TODO")
             try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -398,26 +398,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).including(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).including(required: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c).including(required: B.c)), "TODO")
@@ -426,32 +426,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).including(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).including(required: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d).including(required: C.d)), "TODO")
@@ -460,8 +460,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -472,26 +472,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).joining(required: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).joining(required: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c).joining(required: B.c)), "")
@@ -500,32 +500,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).joining(required: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(required: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).joining(required: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.c.joining(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.including(optional: B.c.joining(required: C.d).joining(required: C.d)), "TODO")
@@ -534,8 +534,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.including(optional: B.c.joining(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -546,42 +546,42 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c)), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d)), "TODO")
             try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -592,26 +592,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).including(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).including(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c).including(required: B.c)), "TODO")
@@ -620,32 +620,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).including(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).including(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d).including(required: C.d)), "TODO")
@@ -654,8 +654,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -666,26 +666,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).joining(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).joining(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c).joining(required: B.c)), "TODO")
@@ -694,32 +694,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).joining(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(required: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).joining(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.including(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.joining(optional: B.c.including(required: C.d).joining(required: C.d)), "TODO")
@@ -728,8 +728,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.joining(optional: B.c.including(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -740,42 +740,42 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c)), "TODO")
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d)), "TODO")
             try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -786,26 +786,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).including(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).including(required: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c).including(required: B.c)), "TODO")
@@ -814,32 +814,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c).including(optional: B.c)), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).including(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).including(required: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d).including(required: C.d)), "TODO")
@@ -848,8 +848,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d).including(optional: C.d)), """
                 SELECT "b".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -860,26 +860,26 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).joining(required: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c).joining(optional: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).joining(required: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c).joining(required: B.c)), "TODO")
@@ -888,32 +888,32 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c).joining(optional: B.c)), """
                 SELECT "a".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).joining(required: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(required: C.d).joining(optional: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).joining(required: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.c.joining(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, B.joining(optional: B.c.joining(required: C.d).joining(required: C.d)), "TODO")
@@ -922,8 +922,8 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, B.joining(optional: B.c.joining(optional: C.d).joining(optional: C.d)), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -934,25 +934,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.b.including(required: B.c.including(required: C.d))), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
             try assertEqualSQL(db, A().request(for: A.b.including(required: B.c.including(optional: C.d))), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A().request(for: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A().request(for: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "b".*, "c".*, "d".* \
                 FROM "b" \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did") \
-                WHERE ("b"."id" = 1)
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did" \
+                WHERE "b"."id" = 1
                 """)
         }
     }
@@ -963,25 +963,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c.including(required: C.d))), """
                 SELECT "a".*, "b".*, "c".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.including(required: C.d))), "TODO")
@@ -990,9 +990,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1003,25 +1003,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c.joining(required: C.d))), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.including(required: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.including(required: B.c.joining(required: C.d))), "TODO")
@@ -1030,9 +1030,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1043,25 +1043,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c.including(required: C.d))), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.including(required: C.d))), "TODO")
@@ -1070,9 +1070,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1083,25 +1083,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c.joining(required: C.d))), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.including(required: A.b.joining(required: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.including(required: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.including(optional: A.b.joining(required: B.c.joining(required: C.d))), "TODO")
@@ -1110,9 +1110,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(optional: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1123,25 +1123,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c.including(required: C.d))), """
                 SELECT "a".*, "c".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c.including(optional: C.d))), """
                 SELECT "a".*, "c".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "c".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.including(required: C.d))), "TODO")
@@ -1150,9 +1150,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "c".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1163,25 +1163,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c.joining(required: C.d))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.including(required: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.including(required: B.c.joining(required: C.d))), "TODO")
@@ -1190,9 +1190,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.including(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1203,25 +1203,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c.including(required: C.d))), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c.including(optional: C.d))), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.including(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.including(required: C.d))), "TODO")
@@ -1230,9 +1230,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.including(optional: C.d))), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }
@@ -1243,25 +1243,25 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c.joining(required: C.d))), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                JOIN "d" ON "d"."id" = "c"."did"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b.joining(required: B.c.joining(optional: C.d))), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.joining(required: C.d))), "TODO")
             try assertEqualSQL(db, A.joining(required: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
             // TODO: chainOptionalRequired
             // try assertEqualSQL(db, A.joining(optional: A.b.joining(required: B.c.joining(required: C.d))), "TODO")
@@ -1270,9 +1270,9 @@ class AssociationChainSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(optional: A.b.joining(optional: B.c.joining(optional: C.d))), """
                 SELECT "a".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id") \
-                LEFT JOIN "d" ON ("d"."id" = "c"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id" \
+                LEFT JOIN "d" ON "d"."id" = "c"."did"
                 """)
         }
     }

--- a/Tests/GRDBTests/AssociationHasManySQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManySQLTests.swift
@@ -37,48 +37,48 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 2)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 2")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentId")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
         }
     }
@@ -111,48 +111,48 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentId")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
         }
     }
@@ -185,72 +185,72 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentId")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentId")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
         }
     }
@@ -284,96 +284,96 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent1Id\" = 1")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parent1Id")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent1Id\" = 1")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parent2Id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent2Id\" = 1")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parent2Id")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent2Id\" = 1")
             }
         }
     }
@@ -409,24 +409,24 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
         }
     }
@@ -463,48 +463,48 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentA"), Column("parentB")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
         }
     }
@@ -542,72 +542,72 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentA"), Column("parentB")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parentA"), Column("parentB")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
         }
     }
@@ -648,96 +648,96 @@ class AssociationHasManySQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent1A\" = 1) AND (\"parent1B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1A\" = 1) AND (\"parent1B\" = 2)")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parent1A"), Column("parent1B")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent1A\" = 1) AND (\"parent1B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1A\" = 1) AND (\"parent1B\" = 2)")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parent2A"), Column("parent2B")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent2A\" = 1) AND (\"parent2B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2A\" = 1) AND (\"parent2B\" = 2)")
             }
             do {
                 let association = Parent.hasMany(Child.self, using: ForeignKey([Column("parent2A"), Column("parent2B")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent2A\" = 1) AND (\"parent2B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2A\" = 1) AND (\"parent2B\" = 2)")
             }
         }
     }

--- a/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
@@ -44,7 +44,7 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -84,7 +84,7 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -124,7 +124,7 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -164,7 +164,7 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
     }

--- a/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
@@ -39,8 +39,8 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try testHasManyWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -79,8 +79,8 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try testHasManyWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -119,8 +119,8 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try testHasManyWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -159,8 +159,8 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
             
             try testHasManyWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \

--- a/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
@@ -113,7 +113,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL))
+                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL)
                     """)
             }
             do {
@@ -121,7 +121,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."id" = 1))
+                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."id" = 1)
                     """)
             }
             do {
@@ -129,7 +129,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."id" IN (1, 2, 3)))
+                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."id" IN (1, 2, 3))
                     """)
             }
             do {
@@ -137,7 +137,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."id" = 1))
+                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."id" = 1)
                     """)
             }
             do {
@@ -145,7 +145,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".* \
                     FROM "a" \
-                    JOIN "b" ON (("b"."aid" = "a"."id") AND (("b"."id" = 1) OR ("b"."id" = 2)))
+                    JOIN "b" ON ("b"."aid" = "a"."id") AND (("b"."id" = 1) OR ("b"."id" = 2))
                     """)
             }
             do {
@@ -156,7 +156,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "customB".* \
                     FROM "a" \
-                    JOIN "b" "customB" ON (("customB"."aid" = "a"."id") AND (customB.name = 'foo'))
+                    JOIN "b" "customB" ON ("customB"."aid" = "a"."id") AND (customB.name = 'foo')
                     """)
             }
         }

--- a/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
@@ -50,17 +50,17 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."aid" = "a"."id")
+                JOIN "b" ON "b"."aid" = "a"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.restrictedB), """
                 SELECT "a".*, "b"."name" \
                 FROM "a" \
-                JOIN "b" ON ("b"."aid" = "a"."id")
+                JOIN "b" ON "b"."aid" = "a"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.extendedB), """
                 SELECT "a".*, "b".*, "b"."rowid" \
                 FROM "a" \
-                JOIN "b" ON ("b"."aid" = "a"."id")
+                JOIN "b" ON "b"."aid" = "a"."id"
                 """)
         }
     }
@@ -74,7 +74,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b"."name" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."aid" = "a"."id")
+                    JOIN "b" ON "b"."aid" = "a"."id"
                     """)
             }
             do {
@@ -85,7 +85,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".*, "b"."rowid" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."aid" = "a"."id")
+                    JOIN "b" ON "b"."aid" = "a"."id"
                     """)
             }
             do {
@@ -97,9 +97,9 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                         Column("name"),
                         (Column("id") + aAlias[Column("id")]).aliased("foo")))
                 try assertEqualSQL(db, request, """
-                    SELECT "a".*, "b"."name", ("b"."id" + "a"."id") AS "foo" \
+                    SELECT "a".*, "b"."name", "b"."id" + "a"."id" AS "foo" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."aid" = "a"."id")
+                    JOIN "b" ON "b"."aid" = "a"."id"
                     """)
             }
         }
@@ -172,8 +172,8 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."aid" = "a"."id") \
-                WHERE ("b"."name" IS NOT NULL)
+                JOIN "b" ON "b"."aid" = "a"."id" \
+                WHERE "b"."name" IS NOT NULL
                 """)
         }
     }
@@ -219,8 +219,8 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
             let prefix = """
                 SELECT "a".*, "ab".*, "aba".* \
                 FROM "a" \
-                JOIN "b" "ab" ON ("ab"."aid" = "a"."id") \
-                JOIN "a" "aba" ON ("aba"."id" = "ab"."aid")
+                JOIN "b" "ab" ON "ab"."aid" = "a"."id" \
+                JOIN "a" "aba" ON "aba"."id" = "ab"."aid"
                 """
             let orderClauses = sqls.map { sql -> String in
                 let prefixEndIndex = sql.index(sql.startIndex, offsetBy: prefix.count)
@@ -368,7 +368,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
 //                try assertEqualSQL(db, request, """
 //                    SELECT "a".*, "b".* \
 //                    FROM "a" \
-//                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL)) \
+//                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL) \
 //                    ORDER BY "b"."id"
 //                    """)
 //            }
@@ -381,7 +381,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
 //                try assertEqualSQL(db, request, """
 //                    SELECT "a".*, "b"."name" \
 //                    FROM "a" \
-//                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL)) \
+//                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL) \
 //                    ORDER BY "b"."id"
 //                    """)
 //            }
@@ -395,7 +395,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
 //                try assertEqualSQL(db, request, """
 //                    SELECT "a".*, "b"."name" \
 //                    FROM "a" \
-//                    JOIN "b" ON (("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL)) \
+//                    JOIN "b" ON ("b"."aid" = "a"."id") AND ("b"."name" IS NOT NULL) \
 //                    ORDER BY "b"."id"
 //                    """)
 //            }

--- a/Tests/GRDBTests/AssociationHasOneSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneSQLTests.swift
@@ -37,48 +37,48 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."rowid")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."rowid"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 2)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 2")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentId")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
         }
     }
@@ -111,48 +111,48 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentId")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
         }
     }
@@ -185,72 +185,72 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentId")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentId")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parentId" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parentId" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentId\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parentId\" = 1")
             }
         }
     }
@@ -284,96 +284,96 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent1Id\" = 1")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parent1Id")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent1Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent1Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent1Id\" = 1")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parent2Id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent2Id\" = 1")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parent2Id")], to: [Column("id")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON ("children"."parent2Id" = "parents"."id")
+                    LEFT JOIN "children" ON "children"."parent2Id" = "parents"."id"
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2Id\" = 1)")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE \"parent2Id\" = 1")
             }
         }
     }
@@ -409,24 +409,24 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
         }
     }
@@ -463,48 +463,48 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentA"), Column("parentB")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
         }
     }
@@ -542,72 +542,72 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentA"), Column("parentB")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parentA"), Column("parentB")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parentA" = "parents"."a") AND ("children"."parentB" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parentA\" = 1) AND (\"parentB\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parentA\" = 1) AND (\"parentB\" = 2)")
             }
         }
     }
@@ -648,96 +648,96 @@ class AssociationHasOneSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent1A\" = 1) AND (\"parent1B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1A\" = 1) AND (\"parent1B\" = 2)")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parent1A"), Column("parent1B")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent1A" = "parents"."a") AND ("children"."parent1B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent1A\" = 1) AND (\"parent1B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent1A\" = 1) AND (\"parent1B\" = 2)")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parent2A"), Column("parent2B")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent2A\" = 1) AND (\"parent2B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2A\" = 1) AND (\"parent2B\" = 2)")
             }
             do {
                 let association = Parent.hasOne(Child.self, using: ForeignKey([Column("parent2A"), Column("parent2B")], to: [Column("a"), Column("b")]))
                 try assertEqualSQL(db, Parent.all().including(required: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().including(optional: association), """
                     SELECT "parents".*, "children".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(required: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
                 try assertEqualSQL(db, Parent.all().joining(optional: association), """
                     SELECT "parents".* \
                     FROM "parents" \
-                    LEFT JOIN "children" ON (("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b"))
+                    LEFT JOIN "children" ON ("children"."parent2A" = "parents"."a") AND ("children"."parent2B" = "parents"."b")
                     """)
-                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE ((\"parent2A\" = 1) AND (\"parent2B\" = 2))")
+                try assertEqualSQL(db, Parent().request(for: association), "SELECT * FROM \"children\" WHERE (\"parent2A\" = 1) AND (\"parent2B\" = 2)")
             }
         }
     }

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
@@ -127,7 +127,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     SELECT "a".*, "c".* \
                     FROM "a" \
                     JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON (("c"."id" = "b"."cId") AND ("c"."name" IS NOT NULL))
+                    JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."name" IS NOT NULL)
                     """)
             }
             do {
@@ -136,7 +136,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     SELECT "a".*, "c".* \
                     FROM "a" \
                     JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON (("c"."id" = "b"."cId") AND ("c"."id" = 1))
+                    JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."id" = 1)
                     """)
             }
             do {
@@ -145,7 +145,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     SELECT "a".*, "c".* \
                     FROM "a" \
                     JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON (("c"."id" = "b"."cId") AND ("c"."id" IN (1, 2, 3)))
+                    JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."id" IN (1, 2, 3))
                     """)
             }
             do {
@@ -154,7 +154,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     SELECT "a".*, "c".* \
                     FROM "a" \
                     JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON (("c"."id" = "b"."cId") AND ("c"."id" = 1))
+                    JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."id" = 1)
                     """)
             }
             do {
@@ -163,7 +163,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     SELECT "a".*, "c".* \
                     FROM "a" \
                     JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON (("c"."id" = "b"."cId") AND (("c"."id" = 1) OR ("c"."id" = 2)))
+                    JOIN "c" ON ("c"."id" = "b"."cId") AND (("c"."id" = 1) OR ("c"."id" = 2))
                     """)
             }
             do {
@@ -175,7 +175,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     SELECT "a".*, "customC".* \
                     FROM "a" \
                     JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" "customC" ON (("customC"."id" = "b"."cId") AND (customC.name = 'foo'))
+                    JOIN "c" "customC" ON ("customC"."id" = "b"."cId") AND (customC.name = 'foo')
                     """)
             }
         }

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
@@ -57,20 +57,20 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.c), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId")
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId"
                 """)
             try assertEqualSQL(db, A.including(required: A.restrictedC), """
                 SELECT "a".*, "c"."name" \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId")
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId"
                 """)
             try assertEqualSQL(db, A.including(required: A.extendedC), """
                 SELECT "a".*, "c".*, "c"."rowid" \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId")
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId"
                 """)
         }
     }
@@ -84,8 +84,8 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c"."name" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON ("c"."id" = "b"."cId")
+                    JOIN "b" ON "b"."id" = "a"."bId" \
+                    JOIN "c" ON "c"."id" = "b"."cId"
                     """)
             }
             do {
@@ -96,8 +96,8 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".*, "c"."rowid" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON ("c"."id" = "b"."cId")
+                    JOIN "b" ON "b"."id" = "a"."bId" \
+                    JOIN "c" ON "c"."id" = "b"."cId"
                     """)
             }
             do {
@@ -109,10 +109,10 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                             Column("name"),
                             (Column("id") + aAlias[Column("id")]).aliased("foo")))
                 try assertEqualSQL(db, request, """
-                    SELECT "a".*, "c"."name", ("c"."id" + "a"."id") AS "foo" \
+                    SELECT "a".*, "c"."name", "c"."id" + "a"."id" AS "foo" \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON ("c"."id" = "b"."cId")
+                    JOIN "b" ON "b"."id" = "a"."bId" \
+                    JOIN "c" ON "c"."id" = "b"."cId"
                     """)
             }
         }
@@ -126,7 +126,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
+                    JOIN "b" ON "b"."id" = "a"."bId" \
                     JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."name" IS NOT NULL)
                     """)
             }
@@ -135,7 +135,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
+                    JOIN "b" ON "b"."id" = "a"."bId" \
                     JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."id" = 1)
                     """)
             }
@@ -144,7 +144,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
+                    JOIN "b" ON "b"."id" = "a"."bId" \
                     JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."id" IN (1, 2, 3))
                     """)
             }
@@ -153,7 +153,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
+                    JOIN "b" ON "b"."id" = "a"."bId" \
                     JOIN "c" ON ("c"."id" = "b"."cId") AND ("c"."id" = 1)
                     """)
             }
@@ -162,7 +162,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
+                    JOIN "b" ON "b"."id" = "a"."bId" \
                     JOIN "c" ON ("c"."id" = "b"."cId") AND (("c"."id" = 1) OR ("c"."id" = 2))
                     """)
             }
@@ -174,7 +174,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "customC".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
+                    JOIN "b" ON "b"."id" = "a"."bId" \
                     JOIN "c" "customC" ON ("customC"."id" = "b"."cId") AND (customC.name = 'foo')
                     """)
             }
@@ -191,9 +191,9 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
-                WHERE ("c"."name" IS NOT NULL)
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
+                WHERE "c"."name" IS NOT NULL
                 """)
         }
     }
@@ -204,57 +204,57 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.c.order(Column("name"))), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "c"."name"
                 """)
             try assertEqualSQL(db, A.including(required: A.c.orderByPrimaryKey()), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "c"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.c.orderByPrimaryKey()).orderByPrimaryKey(), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "a"."id", "c"."id"
                 """)
             try assertEqualSQL(db, A.including(required: A.c.orderByPrimaryKey().reversed()).orderByPrimaryKey(), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "a"."id", "c"."id" DESC
                 """)
             try assertEqualSQL(db, A.including(required: A.c.order(Column("name"))).reversed(), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "c"."name" DESC
                 """)
             try assertEqualSQL(db, A.including(required: A.c.orderByPrimaryKey()).reversed(), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "c"."id" DESC
                 """)
             try assertEqualSQL(db, A.including(required: A.c.orderByPrimaryKey()).orderByPrimaryKey().reversed(), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "a"."id" DESC, "c"."id" DESC
                 """)
             try assertEqualSQL(db, A.including(required: A.c.orderByPrimaryKey().reversed()).orderByPrimaryKey().reversed(), """
                 SELECT "a".*, "c".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bId") \
-                JOIN "c" ON ("c"."id" = "b"."cId") \
+                JOIN "b" ON "b"."id" = "a"."bId" \
+                JOIN "c" ON "c"."id" = "b"."cId" \
                 ORDER BY "a"."id" DESC, "c"."id"
                 """)
         }

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
@@ -41,8 +41,8 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -81,8 +81,8 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -121,8 +121,8 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -161,8 +161,8 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithTwoSteps(
                 db, ab: A.b, ac: A.c,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
@@ -358,18 +358,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")",
-                dCondition: "(\"d\".\"id\" = \"c\".\"dId\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"",
+                dCondition: "\"d\".\"id\" = \"c\".\"dId\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
         }
@@ -415,18 +415,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")",
-                dCondition: "(\"d\".\"cId\" = \"c\".\"id\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"",
+                dCondition: "\"d\".\"cId\" = \"c\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
         }
@@ -472,18 +472,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")",
-                dCondition: "(\"d\".\"id\" = \"c\".\"dId\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"",
+                dCondition: "\"d\".\"id\" = \"c\".\"dId\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
         }
@@ -529,18 +529,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"id\" = \"a\".\"bId\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")",
-                dCondition: "(\"d\".\"cId\" = \"c\".\"id\")")
+                bCondition: "\"b\".\"id\" = \"a\".\"bId\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"",
+                dCondition: "\"d\".\"cId\" = \"c\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
         }
@@ -586,18 +586,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")",
-                dCondition: "(\"d\".\"id\" = \"c\".\"dId\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"",
+                dCondition: "\"d\".\"id\" = \"c\".\"dId\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
         }
@@ -643,18 +643,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"id\" = \"b\".\"cId\")",
-                dCondition: "(\"d\".\"cId\" = \"c\".\"id\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"id\" = \"b\".\"cId\"",
+                dCondition: "\"d\".\"cId\" = \"c\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
         }
@@ -700,18 +700,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")",
-                dCondition: "(\"d\".\"id\" = \"c\".\"dId\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"",
+                dCondition: "\"d\".\"id\" = \"c\".\"dId\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."dId" = "d"."id") \
+                JOIN "c" ON "c"."dId" = "d"."id" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
@@ -757,18 +757,18 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try testHasOneWithThreeSteps(
                 db, b: A.b, c: A.c, dThroughC: A.dThroughC, dThroughB: A.dThroughB,
-                bCondition: "(\"b\".\"aId\" = \"a\".\"id\")",
-                cCondition: "(\"c\".\"bId\" = \"b\".\"id\")",
-                dCondition: "(\"d\".\"cId\" = \"c\".\"id\")")
+                bCondition: "\"b\".\"aId\" = \"a\".\"id\"",
+                cCondition: "\"c\".\"bId\" = \"b\".\"id\"",
+                dCondition: "\"d\".\"cId\" = \"c\".\"id\"")
             
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
-                JOIN "c" ON ("c"."id" = "d"."cId") \
+                JOIN "c" ON "c"."id" = "d"."cId" \
                 JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
@@ -1324,40 +1324,40 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, A.including(required: association), """
                     SELECT "a".*, "e".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON ("c"."id" = "b"."cId") \
-                    JOIN "d" ON ("d"."id" = "c"."dId") \
-                    JOIN "e" ON ("e"."id" = "d"."eId")
+                    JOIN "b" ON "b"."id" = "a"."bId" \
+                    JOIN "c" ON "c"."id" = "b"."cId" \
+                    JOIN "d" ON "d"."id" = "c"."dId" \
+                    JOIN "e" ON "e"."id" = "d"."eId"
                     """)
                 try assertEqualSQL(db, A.including(optional: association), """
                     SELECT "a".*, "e".* \
                     FROM "a" \
-                    LEFT JOIN "b" ON ("b"."id" = "a"."bId") \
-                    LEFT JOIN "c" ON ("c"."id" = "b"."cId") \
-                    LEFT JOIN "d" ON ("d"."id" = "c"."dId") \
-                    LEFT JOIN "e" ON ("e"."id" = "d"."eId")
+                    LEFT JOIN "b" ON "b"."id" = "a"."bId" \
+                    LEFT JOIN "c" ON "c"."id" = "b"."cId" \
+                    LEFT JOIN "d" ON "d"."id" = "c"."dId" \
+                    LEFT JOIN "e" ON "e"."id" = "d"."eId"
                     """)
                 try assertEqualSQL(db, A.joining(required: association), """
                     SELECT "a".* \
                     FROM "a" \
-                    JOIN "b" ON ("b"."id" = "a"."bId") \
-                    JOIN "c" ON ("c"."id" = "b"."cId") \
-                    JOIN "d" ON ("d"."id" = "c"."dId") \
-                    JOIN "e" ON ("e"."id" = "d"."eId")
+                    JOIN "b" ON "b"."id" = "a"."bId" \
+                    JOIN "c" ON "c"."id" = "b"."cId" \
+                    JOIN "d" ON "d"."id" = "c"."dId" \
+                    JOIN "e" ON "e"."id" = "d"."eId"
                     """)
                 try assertEqualSQL(db, A.joining(optional: association), """
                     SELECT "a".* \
                     FROM "a" \
-                    LEFT JOIN "b" ON ("b"."id" = "a"."bId") \
-                    LEFT JOIN "c" ON ("c"."id" = "b"."cId") \
-                    LEFT JOIN "d" ON ("d"."id" = "c"."dId") \
-                    LEFT JOIN "e" ON ("e"."id" = "d"."eId")
+                    LEFT JOIN "b" ON "b"."id" = "a"."bId" \
+                    LEFT JOIN "c" ON "c"."id" = "b"."cId" \
+                    LEFT JOIN "d" ON "d"."id" = "c"."dId" \
+                    LEFT JOIN "e" ON "e"."id" = "d"."eId"
                     """)
                 try assertEqualSQL(db, A().request(for: association), """
                     SELECT "e".* \
                     FROM "e" \
-                    JOIN "d" ON ("d"."eId" = "e"."id") \
-                    JOIN "c" ON ("c"."dId" = "d"."id") \
+                    JOIN "d" ON "d"."eId" = "e"."id" \
+                    JOIN "c" ON "c"."dId" = "d"."id" \
                     JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                     """)
             }

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
@@ -46,7 +46,7 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -86,7 +86,7 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -126,7 +126,7 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -166,7 +166,7 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             
             try assertEqualSQL(db, A().request(for: A.c), """
                 SELECT "c".* FROM "c" \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -365,12 +365,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -422,12 +422,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -479,12 +479,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -536,12 +536,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."id" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."id" = 1)
                 """)
         }
     }
@@ -593,12 +593,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -650,12 +650,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -707,12 +707,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."dId" = "d"."id") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -764,12 +764,12 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A().request(for: A.dThroughC), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
             try assertEqualSQL(db, A().request(for: A.dThroughB), """
                 SELECT "d".* FROM "d" \
                 JOIN "c" ON ("c"."id" = "d"."cId") \
-                JOIN "b" ON (("b"."id" = "c"."bId") AND ("b"."aId" = 1))
+                JOIN "b" ON ("b"."id" = "c"."bId") AND ("b"."aId" = 1)
                 """)
         }
     }
@@ -1358,7 +1358,7 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                     FROM "e" \
                     JOIN "d" ON ("d"."eId" = "e"."id") \
                     JOIN "c" ON ("c"."dId" = "d"."id") \
-                    JOIN "b" ON (("b"."cId" = "c"."id") AND ("b"."id" = 1))
+                    JOIN "b" ON ("b"."cId" = "c"."id") AND ("b"."id" = 1)
                     """)
             }
         }

--- a/Tests/GRDBTests/AssociationParallelSQLTests.swift
+++ b/Tests/GRDBTests/AssociationParallelSQLTests.swift
@@ -58,50 +58,50 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b).including(required: A.d), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.including(required: A.b).including(optional: A.d), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).including(required: A.d), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).including(optional: A.d), """
                 SELECT "a".*, "b".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).including(required: B.c), """
                 SELECT "b".*, "a".*, "c".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).including(optional: B.c), """
                 SELECT "b".*, "a".*, "c".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).including(required: B.c), """
                 SELECT "b".*, "a".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).including(optional: B.c), """
                 SELECT "b".*, "a".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
         }
     }
@@ -112,50 +112,50 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b).including(required: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
-                JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
-                JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
+                JOIN "b" "b1" ON "b1"."id" = "a"."bid" \
+                JOIN "b" "b2" ON "b2"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(required: A.b).including(optional: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
-                JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
-                LEFT JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
+                JOIN "b" "b1" ON "b1"."id" = "a"."bid" \
+                LEFT JOIN "b" "b2" ON "b2"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).including(required: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
-                LEFT JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
-                JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
+                LEFT JOIN "b" "b1" ON "b1"."id" = "a"."bid" \
+                JOIN "b" "b2" ON "b2"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).including(optional: A.b.forKey("customB")), """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
-                LEFT JOIN "b" "b1" ON ("b1"."id" = "a"."bid") \
-                LEFT JOIN "b" "b2" ON ("b2"."id" = "a"."bid")
+                LEFT JOIN "b" "b1" ON "b1"."id" = "a"."bid" \
+                LEFT JOIN "b" "b2" ON "b2"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).including(required: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
-                JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
-                JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
+                JOIN "a" "a1" ON "a1"."bid" = "b"."id" \
+                JOIN "a" "a2" ON "a2"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).including(optional: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
-                JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
-                LEFT JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
+                JOIN "a" "a1" ON "a1"."bid" = "b"."id" \
+                LEFT JOIN "a" "a2" ON "a2"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).including(required: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
-                LEFT JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
-                JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
+                LEFT JOIN "a" "a1" ON "a1"."bid" = "b"."id" \
+                JOIN "a" "a2" ON "a2"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).including(optional: B.a.forKey("customA")), """
                 SELECT "b".*, "a1".*, "a2".* \
                 FROM "b" \
-                LEFT JOIN "a" "a1" ON ("a1"."bid" = "b"."id") \
-                LEFT JOIN "a" "a2" ON ("a2"."bid" = "b"."id")
+                LEFT JOIN "a" "a1" ON "a1"."bid" = "b"."id" \
+                LEFT JOIN "a" "a2" ON "a2"."bid" = "b"."id"
                 """)
         }
     }
@@ -166,42 +166,42 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b).including(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(required: A.b).including(optional: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).including(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).including(optional: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).including(required: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).including(optional: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).including(required: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).including(optional: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id"
                 """)
         }
     }
@@ -212,50 +212,50 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b).joining(required: A.d), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.including(required: A.b).joining(optional: A.d), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).joining(required: A.d), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).joining(optional: A.d), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).joining(required: B.c), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).joining(optional: B.c), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).joining(required: B.c), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).joining(optional: B.c), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
         }
     }
@@ -266,42 +266,42 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.b).joining(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(required: A.b).joining(optional: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).joining(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.including(optional: A.b).joining(optional: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).joining(required: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(required: B.a).joining(optional: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).joining(required: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.including(optional: B.a).joining(optional: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id"
                 """)
         }
     }
@@ -312,50 +312,50 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b).including(required: A.d), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b).including(optional: A.d), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).including(required: A.d), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).including(optional: A.d), """
                 SELECT "a".*, "d".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).including(required: B.c), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).including(optional: B.c), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).including(required: B.c), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).including(optional: B.c), """
                 SELECT "b".*, "c".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
         }
     }
@@ -366,42 +366,42 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b).including(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b).including(optional: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).including(required: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).including(optional: A.b), """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).including(required: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).including(optional: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).including(required: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).including(optional: B.a), """
                 SELECT "b".*, "a".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id"
                 """)
         }
     }
@@ -412,50 +412,50 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b).joining(required: A.d), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b).joining(optional: A.d), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).joining(required: A.d), """
                 SELECT "a".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).joining(optional: A.d), """
                 SELECT "a".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid") \
-                LEFT JOIN "d" ON ("d"."id" = "a"."did")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid" \
+                LEFT JOIN "d" ON "d"."id" = "a"."did"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).joining(required: B.c), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).joining(optional: B.c), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).joining(required: B.c), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                JOIN "c" ON "c"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).joining(optional: B.c), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id") \
-                LEFT JOIN "c" ON ("c"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id" \
+                LEFT JOIN "c" ON "c"."bid" = "b"."id"
                 """)
         }
     }
@@ -466,42 +466,42 @@ class AssociationParallelSQLTests: GRDBTestCase {
             try assertEqualSQL(db, A.joining(required: A.b).joining(required: A.b), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.joining(required: A.b).joining(optional: A.b), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).joining(required: A.b), """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, A.joining(optional: A.b).joining(optional: A.b), """
                 SELECT "a".* \
                 FROM "a" \
-                LEFT JOIN "b" ON ("b"."id" = "a"."bid")
+                LEFT JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).joining(required: B.a), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(required: B.a).joining(optional: B.a), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).joining(required: B.a), """
                 SELECT "b".* \
                 FROM "b" \
-                JOIN "a" ON ("a"."bid" = "b"."id")
+                JOIN "a" ON "a"."bid" = "b"."id"
                 """)
             try assertEqualSQL(db, B.joining(optional: B.a).joining(optional: B.a), """
                 SELECT "b".* \
                 FROM "b" \
-                LEFT JOIN "a" ON ("a"."bid" = "b"."id")
+                LEFT JOIN "a" ON "a"."bid" = "b"."id"
                 """)
         }
     }
@@ -552,7 +552,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "b" ON "b"."id" = "a"."bid" \
                 ORDER BY "b"."id"
                 """)
             }
@@ -563,7 +563,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "b" ON "b"."id" = "a"."bid" \
                 ORDER BY "b"."id" DESC
                 """)
             }
@@ -574,7 +574,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid") \
+                JOIN "b" ON "b"."id" = "a"."bid" \
                 ORDER BY "b"."id" DESC
                 """)
             }
@@ -592,7 +592,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -602,7 +602,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -612,7 +612,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             
@@ -624,7 +624,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -634,7 +634,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b"."id", 2 \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -644,7 +644,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b"."id", 2 \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             
@@ -656,7 +656,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b"."id", 1 \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -666,7 +666,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -676,7 +676,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b"."id", 1 \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             
@@ -688,7 +688,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b".* \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -698,7 +698,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b"."id", 2 \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
             do {
@@ -708,7 +708,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".*, "b"."id", 2 \
                 FROM "a" \
-                JOIN "b" ON ("b"."id" = "a"."bid")
+                JOIN "b" ON "b"."id" = "a"."bid"
                 """)
             }
         }

--- a/Tests/GRDBTests/AssociationParallelSQLTests.swift
+++ b/Tests/GRDBTests/AssociationParallelSQLTests.swift
@@ -516,7 +516,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON (("b"."id" = "a"."bid") AND ("b"."id" > 1))
+                JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."id" > 1)
                 """)
             }
             do {
@@ -526,7 +526,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON (("b"."id" = "a"."bid") AND ("b"."id" < 3))
+                JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."id" < 3)
                 """)
             }
             do {
@@ -536,7 +536,7 @@ class AssociationParallelSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, request, """
                 SELECT "a".* \
                 FROM "a" \
-                JOIN "b" ON (("b"."id" = "a"."bid") AND (("b"."id" > 1) AND ("b"."id" < 3)))
+                JOIN "b" ON ("b"."id" = "a"."bid") AND ("b"."id" > 1) AND ("b"."id" < 3)
                 """)
             }
         }

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -89,7 +89,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT *, "colb2" AS "grdb_colb2" \
                     FROM "b" \
-                    WHERE ("colb2" IN (1, 2, 3)) \
+                    WHERE "colb2" IN (1, 2, 3) \
                     ORDER BY "colb1"
                     """])
             }
@@ -136,7 +136,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" \
-                    WHERE ("cola1" <> 3) \
+                    WHERE "cola1" <> 3 \
                     ORDER BY "cola1"
                     """,
                     """
@@ -198,7 +198,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT *, "parentA" AS "grdb_parentA", "parentB" AS "grdb_parentB" \
                     FROM "child" \
-                    WHERE ((("parentA" = 'baz') AND ("parentB" = 'qux')) OR (("parentA" = 'foo') AND ("parentB" = 'bar')))
+                    WHERE (("parentA" = 'baz') AND ("parentB" = 'qux')) OR (("parentA" = 'foo') AND ("parentB" = 'bar'))
                     """])
             }
             
@@ -247,13 +247,13 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT *, "colc2" AS "grdb_colc2" \
                     FROM "c" \
-                    WHERE ("colc2" IN (1, 2, 3)) \
+                    WHERE "colc2" IN (1, 2, 3) \
                     ORDER BY "colc1"
                     """,
                     """
                     SELECT *, "cold2" AS "grdb_cold2" \
                     FROM "d" \
-                    WHERE ("cold2" IN (7, 8, 9)) \
+                    WHERE "cold2" IN (7, 8, 9) \
                     ORDER BY "cold1"
                     """])
             }
@@ -330,7 +330,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT * \
                     FROM "a" \
-                    WHERE ("cola1" <> 3) \
+                    WHERE "cola1" <> 3 \
                     ORDER BY "cola1"
                     """,
                     """
@@ -398,8 +398,8 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "c"."colc2" AS "grdb_colc2", "d".* \
                     FROM "c" \
-                    JOIN "d" ON ("d"."cold2" = "c"."colc1") \
-                    WHERE ("c"."colc2" IN (1, 2, 3)) \
+                    JOIN "d" ON "d"."cold2" = "c"."colc1" \
+                    WHERE "c"."colc2" IN (1, 2, 3) \
                     ORDER BY "c"."colc1", "d"."cold1"
                     """])
             }
@@ -427,7 +427,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "c"."colc2" AS "grdb_colc2", "d".* \
                     FROM "c" \
-                    JOIN "d" ON ("d"."cold2" = "c"."colc1") \
+                    JOIN "d" ON "d"."cold2" = "c"."colc1" \
                     WHERE 0 AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "c"."colc1", "d"."cold1"
                     """])
@@ -477,7 +477,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT * \
                     FROM "a" \
-                    WHERE ("cola1" <> 3) \
+                    WHERE "cola1" <> 3 \
                     ORDER BY "cola1"
                     """,
                     """
@@ -554,7 +554,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" \
-                    WHERE ("cola1" <> 3) \
+                    WHERE "cola1" <> 3 \
                     ORDER BY "cola1"
                     """,
                     """
@@ -567,14 +567,14 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
                     JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2)) \
-                    WHERE ("d"."cold1" <> 11) \
+                    WHERE "d"."cold1" <> 11 \
                     ORDER BY "d"."cold1"
                     """,
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
                     JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2)) \
-                    WHERE ("d"."cold1" = 11) \
+                    WHERE "d"."cold1" = 11 \
                     ORDER BY "d"."cold1"
                     """])
             }
@@ -795,7 +795,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     ORDER BY "d"."cold1"
                     """,
                     """
-                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE ("colc2" IN (1, 2, 3))
+                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE "colc2" IN (1, 2, 3)
                     """])
             }
             
@@ -843,7 +843,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     ORDER BY "d"."cold1"
                     """,
                     """
-                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE ("colc2" IN (1, 2, 3))
+                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE "colc2" IN (1, 2, 3)
                     """])
             }
 
@@ -889,7 +889,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     ORDER BY "d"."cold1"
                     """,
                     """
-                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE ("colc2" IN (1, 2, 3))
+                    SELECT *, "colc2" AS "grdb_colc2" FROM "c" WHERE "colc2" IN (1, 2, 3)
                     """])
             }
         }
@@ -918,7 +918,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "b".*, "a".* \
                     FROM "b" \
-                    LEFT JOIN "a" ON ("a"."cola1" = "b"."colb2") \
+                    LEFT JOIN "a" ON "a"."cola1" = "b"."colb2" \
                     ORDER BY "b"."colb1"
                     """,
                     """
@@ -978,28 +978,28 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
                     JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
-                    WHERE ("c"."colc1" = 9) \
+                    WHERE "c"."colc1" = 9 \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
                     JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
-                    WHERE ("c"."colc1" <> 9) \
+                    WHERE "c"."colc1" <> 9 \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
                     JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)) \
-                    WHERE ("c"."colc1" = 9) \
+                    WHERE "c"."colc1" = 9 \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
                     JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)) \
-                    WHERE ("c"."colc1" <> 9) \
+                    WHERE "c"."colc1" <> 9 \
                     ORDER BY "c"."colc1"
                     """])
             }

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -142,13 +142,13 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT *, "colb2" AS "grdb_colb2" \
                     FROM "b" \
-                    WHERE (("colb1" = 4) AND ("colb2" IN (1, 2))) \
+                    WHERE ("colb1" = 4) AND ("colb2" IN (1, 2)) \
                     ORDER BY "colb1"
                     """,
                     """
                     SELECT *, "colb2" AS "grdb_colb2" \
                     FROM "b" \
-                    WHERE (("colb1" <> 4) AND ("colb2" IN (1, 2))) \
+                    WHERE ("colb1" <> 4) AND ("colb2" IN (1, 2)) \
                     ORDER BY "colb1"
                     """])
             }
@@ -281,7 +281,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT *, "colc2" AS "grdb_colc2" \
                     FROM "c" \
-                    WHERE (0 AND ("colc2" IN (1, 2, 3))) \
+                    WHERE 0 AND ("colc2" IN (1, 2, 3)) \
                     ORDER BY "colc1"
                     """])
             }
@@ -336,37 +336,37 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT *, "colc2" AS "grdb_colc2" \
                     FROM "c" \
-                    WHERE (("colc1" > 7) AND ("colc2" IN (1, 2))) \
+                    WHERE ("colc1" > 7) AND ("colc2" IN (1, 2)) \
                     ORDER BY "colc1"
                     """,
                     """
                     SELECT *, "cold2" AS "grdb_cold2" \
                     FROM "d" \
-                    WHERE (("cold1" = 11) AND ("cold2" IN (8, 9))) \
+                    WHERE ("cold1" = 11) AND ("cold2" IN (8, 9)) \
                     ORDER BY "cold1"
                     """,
                     """
                     SELECT *, "cold2" AS "grdb_cold2" \
                     FROM "d" \
-                    WHERE (("cold1" <> 11) AND ("cold2" IN (8, 9))) \
+                    WHERE ("cold1" <> 11) AND ("cold2" IN (8, 9)) \
                     ORDER BY "cold1"
                     """,
                     """
                     SELECT *, "colc2" AS "grdb_colc2" \
                     FROM "c" \
-                    WHERE (("colc1" < 9) AND ("colc2" IN (1, 2))) \
+                    WHERE ("colc1" < 9) AND ("colc2" IN (1, 2)) \
                     ORDER BY "colc1"
                     """,
                     """
                     SELECT *, "cold2" AS "grdb_cold2" \
                     FROM "d" \
-                    WHERE (("cold1" = 11) AND ("cold2" IN (7, 8))) \
+                    WHERE ("cold1" = 11) AND ("cold2" IN (7, 8)) \
                     ORDER BY "cold1"
                     """,
                     """
                     SELECT *, "cold2" AS "grdb_cold2" \
                     FROM "d" \
-                    WHERE (("cold1" <> 11) AND ("cold2" IN (7, 8))) \
+                    WHERE ("cold1" <> 11) AND ("cold2" IN (7, 8)) \
                     ORDER BY "cold1"
                     """])
             }
@@ -428,7 +428,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     SELECT "c".*, "c"."colc2" AS "grdb_colc2", "d".* \
                     FROM "c" \
                     JOIN "d" ON ("d"."cold2" = "c"."colc1") \
-                    WHERE (0 AND ("c"."colc2" IN (1, 2, 3))) \
+                    WHERE 0 AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "c"."colc1", "d"."cold1"
                     """])
             }
@@ -483,17 +483,17 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "c"."colc2" AS "grdb_colc2", "d1".*, "d2".* \
                     FROM "c" \
-                    LEFT JOIN "d" "d1" ON (("d1"."cold2" = "c"."colc1") AND ("d1"."cold1" = 11)) \
-                    JOIN "d" "d2" ON (("d2"."cold2" = "c"."colc1") AND ("d2"."cold1" <> 11)) \
-                    WHERE (("c"."colc1" > 7) AND ("c"."colc2" IN (1, 2))) \
+                    LEFT JOIN "d" "d1" ON ("d1"."cold2" = "c"."colc1") AND ("d1"."cold1" = 11) \
+                    JOIN "d" "d2" ON ("d2"."cold2" = "c"."colc1") AND ("d2"."cold1" <> 11) \
+                    WHERE ("c"."colc1" > 7) AND ("c"."colc2" IN (1, 2)) \
                     ORDER BY "c"."colc1", "d1"."cold1", "d2"."cold1"
                     """,
                     """
                     SELECT "c".*, "c"."colc2" AS "grdb_colc2", "d1".*, "d2".* \
                     FROM "c" \
-                    LEFT JOIN "d" "d1" ON (("d1"."cold2" = "c"."colc1") AND ("d1"."cold1" = 11)) \
-                    JOIN "d" "d2" ON (("d2"."cold2" = "c"."colc1") AND ("d2"."cold1" <> 11)) \
-                    WHERE (("c"."colc1" < 9) AND ("c"."colc2" IN (1, 2))) \
+                    LEFT JOIN "d" "d1" ON ("d1"."cold2" = "c"."colc1") AND ("d1"."cold1" = 11) \
+                    JOIN "d" "d2" ON ("d2"."cold2" = "c"."colc1") AND ("d2"."cold1" <> 11) \
+                    WHERE ("c"."colc1" < 9) AND ("c"."colc2" IN (1, 2)) \
                     ORDER BY "c"."colc1", "d1"."cold1", "d2"."cold1"
                     """])
             }
@@ -522,7 +522,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2, 3))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """])
             }
@@ -560,20 +560,20 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND (("c"."colc1" = 8) AND ("c"."colc2" IN (1, 2)))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 8) AND ("c"."colc2" IN (1, 2)) \
                     ORDER BY "d"."cold1"
                     """,
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2)) \
                     WHERE ("d"."cold1" <> 11) \
                     ORDER BY "d"."cold1"
                     """,
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2)) \
                     WHERE ("d"."cold1" = 11) \
                     ORDER BY "d"."cold1"
                     """])
@@ -601,7 +601,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
-                    FROM "c" JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ("a"."cola1" IN (1, 2))) \
+                    FROM "c" JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """])
             }
@@ -637,7 +637,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ((("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1')) AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1') AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """])
             }
@@ -675,13 +675,13 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ((("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1')) AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1') AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ((("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1')) AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola2" <> 'a1') AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """])
             }
@@ -717,13 +717,13 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND (("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND (("a"."cola2" <> 'a1') AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" <> 'a1') AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """])
             }
@@ -751,7 +751,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2, 3))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """])
             }
@@ -791,7 +791,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ((("c"."colc1" = 7) AND ("c"."colc1" <> 7)) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 7) AND ("c"."colc1" <> 7) AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """,
                     """
@@ -833,13 +833,13 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ((("c"."colc1" = 7) AND ("c"."colc1" <> 7)) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 7) AND ("c"."colc1" <> 7) AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """,
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND ((("c"."colc1" = 7) AND ("c"."colc1" <> 7)) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 7) AND ("c"."colc1" <> 7) AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """,
                     """
@@ -879,13 +879,13 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND (("c"."colc1" = 7) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 7) AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """,
                     """
                     SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
                     FROM "d" \
-                    JOIN "c" ON (("c"."colc1" = "d"."cold2") AND (("c"."colc1" <> 7) AND ("c"."colc2" IN (1, 2, 3)))) \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" <> 7) AND ("c"."colc2" IN (1, 2, 3)) \
                     ORDER BY "d"."cold1"
                     """,
                     """
@@ -924,7 +924,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND ("a"."cola1" IN (1, 2))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola1" IN (1, 2)) \
                     ORDER BY "c"."colc1"
                     """])
             }
@@ -970,35 +970,35 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     SELECT "b".*, "a1".*, "a2".* \
                     FROM "b" \
-                    LEFT JOIN "a" "a1" ON (("a1"."cola1" = "b"."colb2") AND ("a1"."cola2" = 'a1')) \
-                    LEFT JOIN "a" "a2" ON (("a2"."cola1" = "b"."colb2") AND ("a2"."cola2" = 'a2')) \
+                    LEFT JOIN "a" "a1" ON ("a1"."cola1" = "b"."colb2") AND ("a1"."cola2" = 'a1') \
+                    LEFT JOIN "a" "a2" ON ("a2"."cola1" = "b"."colb2") AND ("a2"."cola2" = 'a2') \
                     ORDER BY "b"."colb1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND (("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
                     WHERE ("c"."colc1" = 9) \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND (("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
                     WHERE ("c"."colc1" <> 9) \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND (("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)) \
                     WHERE ("c"."colc1" = 9) \
                     ORDER BY "c"."colc1"
                     """,
                     """
                     SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
                     FROM "c" \
-                    JOIN "a" ON (("a"."cola1" = "c"."colc2") AND (("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)))) \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)) \
                     WHERE ("c"."colc1" <> 9) \
                     ORDER BY "c"."colc1"
                     """])

--- a/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
+++ b/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
@@ -131,12 +131,12 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             try assertEqualSQL(db, A.including(required: A.parent), """
                 SELECT "a1".*, "a2".* \
                 FROM "a" "a1" \
-                JOIN "a" "a2" ON ("a2"."id" = "a1"."parentId")
+                JOIN "a" "a2" ON "a2"."id" = "a1"."parentId"
                 """)
             try assertEqualSQL(db, A.including(required: A.child), """
                 SELECT "a1".*, "a2".* \
                 FROM "a" "a1" \
-                JOIN "a" "a2" ON ("a2"."parentId" = "a1"."id")
+                JOIN "a" "a2" ON "a2"."parentId" = "a1"."id"
                 """)
         }
     }
@@ -152,8 +152,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "a1".*, "b".*, "a2".* \
                 FROM "a" "a1" \
-                JOIN "b" ON ("b"."id" = "a1"."bid1") \
-                JOIN "a" "a2" ON ("a2"."bid2" = "b"."id")
+                JOIN "b" ON "b"."id" = "a1"."bid1" \
+                JOIN "a" "a2" ON "a2"."bid2" = "b"."id"
                 """)
         }
     }
@@ -171,8 +171,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "a".*, "b1".*, "b2".* \
                 FROM "a" \
-                JOIN "b" "b1" ON ("b1"."id" = "a"."bid1") \
-                JOIN "b" "b2" ON ("b2"."id" = "a"."bid2")
+                JOIN "b" "b1" ON "b1"."id" = "a"."bid1" \
+                JOIN "b" "b2" ON "b2"."id" = "a"."bid2"
                 """)
         }
     }
@@ -192,10 +192,10 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             try assertEqualSQL(db, request, """
                 SELECT "a1".*, "b1".*, "a2".*, "b2".*, "a3".* \
                 FROM "a" "a1" \
-                JOIN "b" "b1" ON ("b1"."id" = "a1"."bid1") \
-                JOIN "a" "a2" ON ("a2"."bid2" = "b1"."id") \
-                JOIN "b" "b2" ON ("b2"."id" = "a1"."bid2") \
-                JOIN "a" "a3" ON ("a3"."bid1" = "b2"."id")
+                JOIN "b" "b1" ON "b1"."id" = "a1"."bid1" \
+                JOIN "a" "a2" ON "a2"."bid2" = "b1"."id" \
+                JOIN "b" "b2" ON "b2"."id" = "a1"."bid2" \
+                JOIN "a" "a3" ON "a3"."bid1" = "b2"."id"
                 """)
         }
     }
@@ -213,8 +213,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             let expectedSQL = """
                 SELECT "customA1".*, "customB".*, "customA2".* \
                 FROM "a" "customA1" \
-                JOIN "b" "customB" ON ("customB"."id" = "customA1"."bid1") \
-                JOIN "a" "customA2" ON ("customA2"."bid2" = "customB"."id")
+                JOIN "b" "customB" ON "customB"."id" = "customA1"."bid1" \
+                JOIN "a" "customA2" ON "customA2"."bid2" = "customB"."id"
                 """
             
             do {
@@ -253,7 +253,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a1".*, "a".* \
                     FROM "a" "a1" \
-                    JOIN "b" "a" ON ("a"."id" = "a1"."bid1")
+                    JOIN "b" "a" ON "a"."id" = "a1"."bid1"
                     """)
             }
             do {
@@ -262,7 +262,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "a1".*, "A".* \
                     FROM "a" "a1" \
-                    JOIN "b" "A" ON ("A"."id" = "a1"."bid1")
+                    JOIN "b" "A" ON "A"."id" = "a1"."bid1"
                     """)
             }
             do {
@@ -271,7 +271,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "b".*, "b1".* \
                     FROM "a" "b" \
-                    JOIN "b" "b1" ON ("b1"."id" = "b"."bid1")
+                    JOIN "b" "b1" ON "b1"."id" = "b"."bid1"
                     """)
             }
             do {
@@ -280,7 +280,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request, """
                     SELECT "B".*, "b1".* \
                     FROM "a" "B" \
-                    JOIN "b" "b1" ON ("b1"."id" = "B"."bid1")
+                    JOIN "b" "b1" ON "b1"."id" = "B"."bid1"
                     """)
             }
         }
@@ -303,11 +303,11 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
             let expectedSQL = """
                 SELECT "a1".*, "b1".*, "a2".*, "b2".*, "a3".* \
                 FROM "a" "a1" \
-                JOIN "b" "b1" ON ("b1"."id" = "a1"."bid1") \
-                JOIN "a" "a2" ON ("a2"."bid2" = "b1"."id") \
-                JOIN "b" "b2" ON ("b2"."id" = "a1"."bid2") \
-                JOIN "a" "a3" ON ("a3"."bid1" = "b2"."id") \
-                WHERE ((("a1"."name" IS NOT NULL) AND ("a1"."name" > "a3"."name")) AND ("a2"."name" = 'foo'))
+                JOIN "b" "b1" ON "b1"."id" = "a1"."bid1" \
+                JOIN "a" "a2" ON "a2"."bid2" = "b1"."id" \
+                JOIN "b" "b2" ON "b2"."id" = "a1"."bid2" \
+                JOIN "a" "a3" ON "a3"."bid1" = "b2"."id" \
+                WHERE (("a1"."name" IS NOT NULL) AND ("a1"."name" > "a3"."name")) AND ("a2"."name" = 'foo')
                 """
             
             do {
@@ -361,8 +361,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request3, """
                     SELECT "a1".*, "a2".* \
                     FROM "a" "a1" \
-                    JOIN "a" "a2" ON ("a2"."id" = "a1"."parentId") \
-                    WHERE ("a2"."name" = 'foo') \
+                    JOIN "a" "a2" ON "a2"."id" = "a1"."parentId" \
+                    WHERE "a2"."name" = 'foo' \
                     ORDER BY "a2"."name"
                     """)
             }
@@ -388,8 +388,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request3, """
                     SELECT "a".*, "parent".* \
                     FROM "a" \
-                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
-                    WHERE ("parent"."name" = 'foo') \
+                    JOIN "a" "parent" ON "parent"."id" = "a"."parentId" \
+                    WHERE "parent"."name" = 'foo' \
                     ORDER BY "parent"."name"
                     """)
             }
@@ -415,8 +415,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request3, """
                     SELECT "a".*, "parent".* \
                     FROM "a" \
-                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
-                    WHERE ("parent"."name" = 'foo') \
+                    JOIN "a" "parent" ON "parent"."id" = "a"."parentId" \
+                    WHERE "parent"."name" = 'foo' \
                     ORDER BY "parent"."name"
                     """)
             }
@@ -442,8 +442,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request3, """
                     SELECT "a".*, "parent".* \
                     FROM "a" \
-                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
-                    WHERE ("parent"."name" = 'foo') \
+                    JOIN "a" "parent" ON "parent"."id" = "a"."parentId" \
+                    WHERE "parent"."name" = 'foo' \
                     ORDER BY "parent"."name"
                     """)
             }
@@ -470,8 +470,8 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 try assertEqualSQL(db, request3, """
                     SELECT "a".*, "parent".* \
                     FROM "a" \
-                    JOIN "a" "parent" ON ("parent"."id" = "a"."parentId") \
-                    WHERE ("parent"."name" = 'foo') \
+                    JOIN "a" "parent" ON "parent"."id" = "a"."parentId" \
+                    WHERE "parent"."name" = 'foo' \
                     ORDER BY "parent"."name"
                     """)
             }

--- a/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
+++ b/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
@@ -53,7 +53,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 let expectedSQL = """
                     SELECT "name" \
                     FROM "a" \
-                    WHERE (("id" = 1) AND (("name" IS NOT NULL) AND ("name" = 'foo'))) \
+                    WHERE ("id" = 1) AND (("name" IS NOT NULL) AND ("name" = 'foo')) \
                     GROUP BY "name" \
                     HAVING "name" \
                     ORDER BY "name"
@@ -90,7 +90,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                 let expectedSQL = """
                     SELECT "customA"."name" \
                     FROM "a" "customA" \
-                    WHERE (("customA"."id" = 1) AND (("customA"."name" IS NOT NULL) AND ("customA"."name" = 'foo'))) \
+                    WHERE ("customA"."id" = 1) AND (("customA"."name" IS NOT NULL) AND ("customA"."name" = 'foo')) \
                     GROUP BY "customA"."name" \
                     HAVING "customA"."name" \
                     ORDER BY "customA"."name"

--- a/Tests/GRDBTests/ColumnExpressionTests.swift
+++ b/Tests/GRDBTests/ColumnExpressionTests.swift
@@ -69,7 +69,7 @@ class ColumnExpressionTests: GRDBTestCase {
             // Test FTS3 match expression
             let expression = try Player.Columns.name.match(FTS3Pattern(rawPattern: "foo"))
             let sqlLiteral = expression.sqlLiteral
-            XCTAssertEqual(sqlLiteral.sql, "(\"name\" MATCH ?)")
+            XCTAssertEqual(sqlLiteral.sql, "\"name\" MATCH ?")
             XCTAssertEqual(sqlLiteral.arguments, ["foo"])
         }
     }
@@ -130,7 +130,7 @@ class ColumnExpressionTests: GRDBTestCase {
             // Test FTS3 match expression
             let expression = try Player.Columns.name.match(FTS3Pattern(rawPattern: "foo"))
             let sqlLiteral = expression.sqlLiteral
-            XCTAssertEqual(sqlLiteral.sql, "(\"name\" MATCH ?)")
+            XCTAssertEqual(sqlLiteral.sql, "\"name\" MATCH ?")
             XCTAssertEqual(sqlLiteral.arguments, ["foo"])
         }
     }
@@ -185,7 +185,7 @@ class ColumnExpressionTests: GRDBTestCase {
             // Test FTS3 match expression
             let expression = try Player.Columns.name.match(FTS3Pattern(rawPattern: "foo"))
             let sqlLiteral = expression.sqlLiteral
-            XCTAssertEqual(sqlLiteral.sql, "(\"full_name\" MATCH ?)")
+            XCTAssertEqual(sqlLiteral.sql, "\"full_name\" MATCH ?")
             XCTAssertEqual(sqlLiteral.arguments, ["foo"])
         }
     }
@@ -234,7 +234,7 @@ class ColumnExpressionTests: GRDBTestCase {
             // Test FTS3 match expression
             let expression = try Player.CodingKeys.name.match(FTS3Pattern(rawPattern: "foo"))
             let sqlLiteral = expression.sqlLiteral
-            XCTAssertEqual(sqlLiteral.sql, "(\"full_name\" MATCH ?)")
+            XCTAssertEqual(sqlLiteral.sql, "\"full_name\" MATCH ?")
             XCTAssertEqual(sqlLiteral.arguments, ["foo"])
         }
     }

--- a/Tests/GRDBTests/DatabaseValueConvertibleEscapingTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConvertibleEscapingTests.swift
@@ -9,27 +9,27 @@ import XCTest
 class DatabaseValueConvertibleEscapingTests: GRDBTestCase {
 
     func testText() {
-        XCTAssertEqual("".databaseValue.quotedSQL(), "''")
-        XCTAssertEqual("foo".databaseValue.quotedSQL(), "'foo'")
-        XCTAssertEqual("\"foo\"".databaseValue.quotedSQL(), "'\"foo\"'")
-        XCTAssertEqual("'foo'".databaseValue.quotedSQL(), "'''foo'''")
+        XCTAssertEqual("".databaseValue.quotedSQL(wrappedInParenthesis: false), "''")
+        XCTAssertEqual("foo".databaseValue.quotedSQL(wrappedInParenthesis: false), "'foo'")
+        XCTAssertEqual("\"foo\"".databaseValue.quotedSQL(wrappedInParenthesis: false), "'\"foo\"'")
+        XCTAssertEqual("'foo'".databaseValue.quotedSQL(wrappedInParenthesis: false), "'''foo'''")
     }
     
     func testInteger() {
-        XCTAssertEqual(0.databaseValue.quotedSQL(), "0")
-        XCTAssertEqual(Int64.min.databaseValue.quotedSQL(), "-9223372036854775808")
-        XCTAssertEqual(Int64.max.databaseValue.quotedSQL(), "9223372036854775807")
+        XCTAssertEqual(0.databaseValue.quotedSQL(wrappedInParenthesis: false), "0")
+        XCTAssertEqual(Int64.min.databaseValue.quotedSQL(wrappedInParenthesis: false), "-9223372036854775808")
+        XCTAssertEqual(Int64.max.databaseValue.quotedSQL(wrappedInParenthesis: false), "9223372036854775807")
     }
     
     func testDouble() {
-        XCTAssertEqual(0.0.databaseValue.quotedSQL(), "0.0")
-        XCTAssertEqual(1.0.databaseValue.quotedSQL(), "1.0")
-        XCTAssertEqual((-1.0).databaseValue.quotedSQL(), "-1.0")
-        XCTAssertEqual(1.5.databaseValue.quotedSQL(), "1.5")
+        XCTAssertEqual(0.0.databaseValue.quotedSQL(wrappedInParenthesis: false), "0.0")
+        XCTAssertEqual(1.0.databaseValue.quotedSQL(wrappedInParenthesis: false), "1.0")
+        XCTAssertEqual((-1.0).databaseValue.quotedSQL(wrappedInParenthesis: false), "-1.0")
+        XCTAssertEqual(1.5.databaseValue.quotedSQL(wrappedInParenthesis: false), "1.5")
     }
     
     func testBlob() {
-        XCTAssertEqual(Data().databaseValue.quotedSQL(), "X''")
-        XCTAssertEqual("foo".data(using: .utf8)!.databaseValue.quotedSQL(), "X'666F6F'")
+        XCTAssertEqual(Data().databaseValue.quotedSQL(wrappedInParenthesis: false), "X''")
+        XCTAssertEqual("foo".data(using: .utf8)!.databaseValue.quotedSQL(wrappedInParenthesis: false), "X'666F6F'")
     }
 }

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -148,7 +148,7 @@ class DerivableRequestTests: GRDBTestCase {
             XCTAssertEqual(bookTitles, ["Du côté de chez Swann", "Moby-Dick"])
             XCTAssertEqual(lastSQLQuery, """
                 SELECT "book".* FROM "book" \
-                JOIN "author" ON ("author"."id" = "book"."authorId") \
+                JOIN "author" ON "author"."id" = "book"."authorId" \
                 ORDER BY \
                 "book"."title" COLLATE swiftLocalizedCaseInsensitiveCompare, \
                 "author"."lastName" COLLATE swiftLocalizedCaseInsensitiveCompare, \
@@ -165,7 +165,7 @@ class DerivableRequestTests: GRDBTestCase {
             XCTAssertEqual(reversedBookTitles, ["Moby-Dick", "Du côté de chez Swann"])
             XCTAssertEqual(lastSQLQuery, """
                 SELECT "book".* FROM "book" \
-                JOIN "author" ON ("author"."id" = "book"."authorId") \
+                JOIN "author" ON "author"."id" = "book"."authorId" \
                 ORDER BY \
                 "book"."title" COLLATE swiftLocalizedCaseInsensitiveCompare DESC, \
                 "author"."lastName" COLLATE swiftLocalizedCaseInsensitiveCompare DESC, \
@@ -180,7 +180,7 @@ class DerivableRequestTests: GRDBTestCase {
                 .fetchAll(db)
             XCTAssertEqual(lastSQLQuery, """
                 SELECT "book".* FROM "book" \
-                JOIN "author" ON ("author"."id" = "book"."authorId")
+                JOIN "author" ON "author"."id" = "book"."authorId"
                 """)
         }
     }

--- a/Tests/GRDBTests/FTS3RecordTests.swift
+++ b/Tests/GRDBTests/FTS3RecordTests.swift
@@ -119,7 +119,7 @@ class FTS3RecordTests: GRDBTestCase {
             
             let pattern = try FTS3Pattern(rawPattern: "Herman Melville")
             XCTAssertEqual(try Book.matching(pattern).fetchCount(db), 1)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\" WHERE (\"books\" MATCH 'Herman Melville')")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\" WHERE \"books\" MATCH 'Herman Melville'")
             
             XCTAssertEqual(try Book.fetchCount(db), 1)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\"")

--- a/Tests/GRDBTests/FTS4RecordTests.swift
+++ b/Tests/GRDBTests/FTS4RecordTests.swift
@@ -119,7 +119,7 @@ class FTS4RecordTests: GRDBTestCase {
             
             let pattern = try FTS3Pattern(rawPattern: "Herman Melville")
             XCTAssertEqual(try Book.matching(pattern).fetchCount(db), 1)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\" WHERE (\"books\" MATCH 'Herman Melville')")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\" WHERE \"books\" MATCH 'Herman Melville'")
             
             XCTAssertEqual(try Book.fetchCount(db), 1)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\"")

--- a/Tests/GRDBTests/FTS5RecordTests.swift
+++ b/Tests/GRDBTests/FTS5RecordTests.swift
@@ -115,7 +115,7 @@ class FTS5RecordTests: GRDBTestCase {
             
             let pattern = FTS5Pattern(matchingAllTokensIn: "Herman Melville")!
             XCTAssertEqual(try Book.matching(pattern).fetchCount(db), 1)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\" WHERE (\"books\" MATCH 'herman melville')")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\" WHERE \"books\" MATCH 'herman melville'")
             
             XCTAssertEqual(try Book.fetchCount(db), 1)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"books\"")

--- a/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
@@ -35,7 +35,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             var deleted = try Hacker.deleteOne(db, key: 1)
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"hackers\" WHERE (\"rowid\" = 1)")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"hackers\" WHERE \"rowid\" = 1")
             XCTAssertFalse(deleted)
             
             try db.execute(sql: "INSERT INTO hackers (rowid, name) VALUES (?, ?)", arguments: [1, "Arthur"])
@@ -47,7 +47,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
             try db.execute(sql: "INSERT INTO hackers (rowid, name) VALUES (?, ?)", arguments: [2, "Barbara"])
             try db.execute(sql: "INSERT INTO hackers (rowid, name) VALUES (?, ?)", arguments: [3, "Craig"])
             let deletedCount = try Hacker.deleteAll(db, keys: [2, 3, 4])
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"hackers\" WHERE (\"rowid\" IN (2, 3, 4))")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"hackers\" WHERE \"rowid\" IN (2, 3, 4)")
             XCTAssertEqual(deletedCount, 2)
             XCTAssertEqual(try Hacker.fetchCount(db), 1)
         }
@@ -57,7 +57,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             var deleted = try Person.deleteOne(db, key: 1)
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (\"id\" = 1)")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE \"id\" = 1")
             XCTAssertFalse(deleted)
             
             try db.execute(sql: "INSERT INTO persons (id, name, email) VALUES (?, ?, ?)", arguments: [1, "Arthur", "arthur@example.com"])
@@ -69,7 +69,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (id, name, email) VALUES (?, ?, ?)", arguments: [2, "Barbara", "barbara@example.com"])
             try db.execute(sql: "INSERT INTO persons (id, name, email) VALUES (?, ?, ?)", arguments: [3, "Craig", "craig@example.com"])
             let deletedCount = try Person.deleteAll(db, keys: [2, 3, 4])
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (\"id\" IN (2, 3, 4))")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE \"id\" IN (2, 3, 4)")
             XCTAssertEqual(deletedCount, 2)
             XCTAssertEqual(try Person.fetchCount(db), 1)
         }
@@ -79,7 +79,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             var deleted = try Citizenship.deleteOne(db, key: ["personId": 1, "countryIsoCode": "FR"])
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"citizenships\" WHERE ((\"personId\" = 1) AND (\"countryIsoCode\" = 'FR'))")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"citizenships\" WHERE (\"personId\" = 1) AND (\"countryIsoCode\" = 'FR')")
             XCTAssertFalse(deleted)
             
             try db.execute(sql: "INSERT INTO citizenships (personId, countryIsoCode) VALUES (?, ?)", arguments: [1, "FR"])
@@ -100,7 +100,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             var deleted = try Person.deleteOne(db, key: ["email": "arthur@example.com"])
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (\"email\" = 'arthur@example.com')")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE \"email\" = 'arthur@example.com'")
             XCTAssertFalse(deleted)
             
             try db.execute(sql: "INSERT INTO persons (id, name, email) VALUES (?, ?, ?)", arguments: [1, "Arthur", "arthur@example.com"])
@@ -121,7 +121,7 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             var deleted = try Person.deleteOne(db, key: ["id": 1])
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (\"id\" = 1)")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE \"id\" = 1")
             XCTAssertFalse(deleted)
             
             try db.execute(sql: "INSERT INTO persons (id, name, email) VALUES (?, ?, ?)", arguments: [1, "Arthur", "arthur@example.com"])
@@ -146,11 +146,14 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\"")
             
             try Person.filter(Column("name") == "Arthur").deleteAll(db)
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (\"name\" = 'Arthur')")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE \"name\" = 'Arthur'")
             
             try Person.filter(sql: "id = 1").deleteAll(db)
-            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (id = 1)")
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE id = 1")
             
+            try Person.filter(sql: "id = 1").filter(Column("name") == "Arthur").deleteAll(db)
+            XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\" WHERE (id = 1) AND (\"name\" = 'Arthur')")
+
             try Person.select(Column("name")).deleteAll(db)
             XCTAssertEqual(self.lastSQLQuery, "DELETE FROM \"persons\"")
             

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -753,14 +753,32 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter([].joined(operator: .and))),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([].joined(operator: .and) || false)),
+            "SELECT * FROM \"readers\" WHERE 1 OR 0")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([false.databaseValue].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE 0")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([false.databaseValue].joined(operator: .and) || false)),
+            "SELECT * FROM \"readers\" WHERE 0 OR 0")
+        XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .and))),
             "SELECT * FROM \"readers\" WHERE \"id\" = 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .and) || false)),
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1) OR 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .and))),
             "SELECT * FROM \"readers\" WHERE (\"id\" = 1) AND (\"name\" IS NOT NULL)")
         XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .and) || false)),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) AND (\"name\" IS NOT NULL)) OR 0")
+        XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .and))),
             "SELECT * FROM \"readers\" WHERE (\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .and) || false)),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL)) OR 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(![Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .and))),
             "SELECT * FROM \"readers\" WHERE NOT ((\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL))")
@@ -773,14 +791,32 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter([].joined(operator: .or))),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([].joined(operator: .or) && true)),
+            "SELECT * FROM \"readers\" WHERE 0 AND 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([true.databaseValue].joined(operator: .or))),
+            "SELECT * FROM \"readers\" WHERE 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([true.databaseValue].joined(operator: .or) && true)),
+            "SELECT * FROM \"readers\" WHERE 1 AND 1")
+        XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .or))),
             "SELECT * FROM \"readers\" WHERE \"id\" = 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .or) && true)),
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1) AND 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .or))),
             "SELECT * FROM \"readers\" WHERE (\"id\" = 1) OR (\"name\" IS NOT NULL)")
         XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .or) && true)),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) OR (\"name\" IS NOT NULL)) AND 1")
+        XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .or))),
             "SELECT * FROM \"readers\" WHERE (\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .or) && true)),
+            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL)) AND 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(![Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .or))),
             "SELECT * FROM \"readers\" WHERE NOT ((\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL))")

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -65,17 +65,17 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         // Array.contains(): = operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([1].contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+            "SELECT * FROM \"readers\" WHERE \"id\" = 1")
         
         // Array.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([1,2,3].contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" IN (1, 2, 3))")
+            "SELECT * FROM \"readers\" WHERE \"id\" IN (1, 2, 3)")
         
         // Array.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id].contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = \"id\")")
+            "SELECT * FROM \"readers\" WHERE \"id\" = \"id\"")
         
         // EmptyCollection.contains(): 0
         XCTAssertEqual(
@@ -90,77 +90,77 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         // Sequence.contains(): = operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence([1]).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+            "SELECT * FROM \"readers\" WHERE \"id\" = 1")
         
         // Sequence.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence([1,2,3]).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" IN (1, 2, 3))")
+            "SELECT * FROM \"readers\" WHERE \"id\" IN (1, 2, 3)")
         
         // Sequence.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence([Col.id]).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = \"id\")")
+            "SELECT * FROM \"readers\" WHERE \"id\" = \"id\"")
         
         // !Sequence.contains(): <> operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(![1].contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" <> 1)")
+            "SELECT * FROM \"readers\" WHERE \"id\" <> 1")
         
         // !Sequence.contains(): NOT IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(![1,2,3].contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" NOT IN (1, 2, 3))")
+            "SELECT * FROM \"readers\" WHERE \"id\" NOT IN (1, 2, 3)")
         
         // !!Sequence.contains(): = operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(![1].contains(Col.id)))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+            "SELECT * FROM \"readers\" WHERE \"id\" = 1")
         
         // !!Sequence.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(![1,2,3].contains(Col.id)))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" IN (1, 2, 3))")
+            "SELECT * FROM \"readers\" WHERE \"id\" IN (1, 2, 3)")
         
         // CountableRange.contains(): min <= x < max
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((1..<10).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE ((\"id\" >= 1) AND (\"id\" < 10))")
+            "SELECT * FROM \"readers\" WHERE (\"id\" >= 1) AND (\"id\" < 10)")
         
         // CountableClosedRange.contains(): BETWEEN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((1...10).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" BETWEEN 1 AND 10)")
+            "SELECT * FROM \"readers\" WHERE \"id\" BETWEEN 1 AND 10")
         
         // !CountableClosedRange.contains(): BETWEEN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(1...10).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" NOT BETWEEN 1 AND 10)")
+            "SELECT * FROM \"readers\" WHERE \"id\" NOT BETWEEN 1 AND 10")
         
         // Range.contains(): min <= x < max
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((1.1..<10.9).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE ((\"id\" >= 1.1) AND (\"id\" < 10.9))")
+            "SELECT * FROM \"readers\" WHERE (\"id\" >= 1.1) AND (\"id\" < 10.9)")
         
         // Range.contains(): min <= x < max
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(("A"..<"z").contains(Col.name))),
-            "SELECT * FROM \"readers\" WHERE ((\"name\" >= 'A') AND (\"name\" < 'z'))")
+            "SELECT * FROM \"readers\" WHERE (\"name\" >= 'A') AND (\"name\" < 'z')")
         
         // ClosedRange.contains(): BETWEEN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((1.1...10.9).contains(Col.id))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" BETWEEN 1.1 AND 10.9)")
+            "SELECT * FROM \"readers\" WHERE \"id\" BETWEEN 1.1 AND 10.9")
         
         // ClosedRange.contains(): BETWEEN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(("A"..."z").contains(Col.name))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" BETWEEN 'A' AND 'z')")
+            "SELECT * FROM \"readers\" WHERE \"name\" BETWEEN 'A' AND 'z'")
         
         // !ClosedRange.contains(): NOT BETWEEN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!("A"..."z").contains(Col.name))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" NOT BETWEEN 'A' AND 'z')")
+            "SELECT * FROM \"readers\" WHERE \"name\" NOT BETWEEN 'A' AND 'z'")
     }
     
     func testContainsWithCollation() throws {
@@ -169,17 +169,17 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         // Array.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(["arthur", "barbara"].contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IN ('arthur', 'barbara') COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IN ('arthur', 'barbara') COLLATE NOCASE")
         
         // Sequence.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence(["arthur", "barbara"]).contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IN ('arthur', 'barbara') COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IN ('arthur', 'barbara') COLLATE NOCASE")
         
         // Sequence.contains(): = operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence([Col.name]).contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" = \"name\" COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" = \"name\" COLLATE NOCASE")
         
         // Sequence.contains(): false
         XCTAssertEqual(
@@ -190,13 +190,13 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         let closedInterval = "A"..."z"
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(closedInterval.contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" BETWEEN 'A' AND 'z' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" BETWEEN 'A' AND 'z' COLLATE NOCASE")
         
         // HalfOpenInterval:  min <= x < max
         let halfOpenInterval = "A"..<"z"
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(halfOpenInterval.contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE ((\"name\" >= 'A' COLLATE NOCASE) AND (\"name\" < 'z' COLLATE NOCASE))")
+            "SELECT * FROM \"readers\" WHERE (\"name\" >= 'A' COLLATE NOCASE) AND (\"name\" < 'z' COLLATE NOCASE)")
     }
     
     func testGreaterThan() throws {
@@ -204,33 +204,33 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age > 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" > 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" > 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 > Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 > \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 > \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 > 10)),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age > Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" > \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" > \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name > "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" > 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" > 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" > Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' > \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' > \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" > "B")),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name > Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" > \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" > \"name\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(average(Col.age) + 10 > 20)),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING ((AVG(\"age\") + 10) > 20)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (AVG(\"age\") + 10) > 20")
     }
     
     func testGreaterThanWithCollation() throws {
@@ -238,10 +238,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) > "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" > 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" > 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) > "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" > 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" > 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testGreaterThanOrEqual() throws {
@@ -249,33 +249,33 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age >= 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" >= 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" >= 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 >= Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 >= \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 >= \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 >= 10)),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age >= Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" >= \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" >= \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name >= "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" >= 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" >= 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" >= Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' >= \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' >= \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" >= "B")),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name >= Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" >= \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" >= \"name\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(average(Col.age) + 10 >= 20)),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING ((AVG(\"age\") + 10) >= 20)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (AVG(\"age\") + 10) >= 20")
     }
     
     func testGreaterThanOrEqualWithCollation() throws {
@@ -283,10 +283,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) >= "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" >= 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" >= 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) >= "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" >= 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" >= 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testLessThan() throws {
@@ -294,33 +294,33 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age < 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" < 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" < 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 < Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 < \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 < \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 < 10)),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age < Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" < \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" < \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name < "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" < 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" < 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" < Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' < \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' < \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" < "B")),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name < Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" < \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" < \"name\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(average(Col.age) + 10 < 20)),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING ((AVG(\"age\") + 10) < 20)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (AVG(\"age\") + 10) < 20")
     }
     
     func testLessThanWithCollation() throws {
@@ -328,10 +328,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) < "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" < 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" < 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) < "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" < 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" < 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testLessThanOrEqual() throws {
@@ -339,33 +339,33 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age <= 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <= 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" <= 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 <= Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 <= \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 <= \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 <= 10)),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age <= Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <= \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" <= \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name <= "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <= 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" <= 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" <= Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' <= \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' <= \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" <= "B")),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name <= Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <= \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" <= \"name\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(average(Col.age) + 10 <= 20)),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING ((AVG(\"age\") + 10) <= 20)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (AVG(\"age\") + 10) <= 20")
     }
     
     func testLessThanOrEqualWithCollation() throws {
@@ -373,10 +373,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) <= "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <= 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" <= 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) <= "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <= 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" <= 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testEqual() throws {
@@ -384,51 +384,51 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" = 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" = 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == (10 as Int?))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" = 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" = 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 == Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 = \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 = \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((10 as Int?) == Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 = \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 = \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 == 10)),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" = \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" = \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == nil)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == DatabaseValue.null)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(nil == Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(DatabaseValue.null == Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" = \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" = \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name == "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" = 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" = 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" == Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' = \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' = \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" == "B")),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name == Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" = \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" = \"name\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == true)),
@@ -458,19 +458,19 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) == "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" = 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" = 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) == ("fOo" as String?))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" = 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" = 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) == nil)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NULL COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NULL COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) == DatabaseValue.null)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NULL COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NULL COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) == "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" = 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" = 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testNotEqual() throws {
@@ -478,51 +478,51 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != (10 as Int?))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 != Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 <> \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((10 as Int?) != Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 <> \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 != 10)),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != nil)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != DatabaseValue.null)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(nil != Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(DatabaseValue.null != Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name != "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <> 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" <> 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" != Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' <> \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' <> \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" != "B")),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name != Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <> \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" <> \"name\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != true)),
@@ -552,19 +552,19 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) != "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <> 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" <> 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) != ("fOo" as String?))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <> 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" <> 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) != nil)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT NULL COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NOT NULL COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) != DatabaseValue.null)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT NULL COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NOT NULL COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) != "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" <> 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" <> 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testNotEqualWithSwiftNotOperator() throws {
@@ -572,32 +572,32 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == 10))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(10 == Col.age))),
-            "SELECT * FROM \"readers\" WHERE (10 <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 <> \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(10 == 10))),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == nil))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == DatabaseValue.null))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(nil == Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(DatabaseValue.null == Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" <> \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" <> \"age\"")
     }
     
     func testIs() throws {
@@ -605,33 +605,33 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age === 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 === Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 IS \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 IS \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age === Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age === nil)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(nil === Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age === Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name === "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" === Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' IS \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' IS \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name === Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS \"name\"")
     }
     
     func testIsWithCollation() throws {
@@ -639,10 +639,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) === "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) === "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testIsNot() throws {
@@ -650,33 +650,33 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age !== 10)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(10 !== Col.age)),
-            "SELECT * FROM \"readers\" WHERE (10 IS NOT \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 IS NOT \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age !== Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age !== nil)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(nil !== Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age !== Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name !== "B")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT 'B')")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NOT 'B'")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter("B" !== Col.name)),
-            "SELECT * FROM \"readers\" WHERE ('B' IS NOT \"name\")")
+            "SELECT * FROM \"readers\" WHERE 'B' IS NOT \"name\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name !== Col.name)),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT \"name\")")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NOT \"name\"")
     }
     
     func testIsNotWithCollation() throws {
@@ -684,10 +684,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(.nocase) !== "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT 'fOo' COLLATE NOCASE)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NOT 'fOo' COLLATE NOCASE")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.collating(collation) !== "fOo")),
-            "SELECT * FROM \"readers\" WHERE (\"name\" IS NOT 'fOo' COLLATE localized_case_insensitive)")
+            "SELECT * FROM \"readers\" WHERE \"name\" IS NOT 'fOo' COLLATE localized_case_insensitive")
     }
     
     func testIsNotWithSwiftNotOperator() throws {
@@ -695,23 +695,23 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age === 10))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(10 === Col.age))),
-            "SELECT * FROM \"readers\" WHERE (10 IS NOT \"age\")")
+            "SELECT * FROM \"readers\" WHERE 10 IS NOT \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age === Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT \"age\"")
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age === nil))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(nil === Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL)")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT NULL")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age === Col.age))),
-            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" IS NOT \"age\"")
     }
     
     func testLogicalOperators() throws {
@@ -722,28 +722,28 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT * FROM \"readers\" WHERE NOT \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age && true)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" AND 1)")
+            "SELECT * FROM \"readers\" WHERE \"age\" AND 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(true && Col.age)),
-            "SELECT * FROM \"readers\" WHERE (1 AND \"age\")")
+            "SELECT * FROM \"readers\" WHERE 1 AND \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age || false)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" OR 0)")
+            "SELECT * FROM \"readers\" WHERE \"age\" OR 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(false || Col.age)),
-            "SELECT * FROM \"readers\" WHERE (0 OR \"age\")")
+            "SELECT * FROM \"readers\" WHERE 0 OR \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(Col.age != nil || Col.name != nil)),
-            "SELECT * FROM \"readers\" WHERE ((\"age\" IS NOT NULL) OR (\"name\" IS NOT NULL))")
+            sql(dbQueue, tableRequest.filter(Col.age != nil || Col.name == nil)),
+            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL) OR (\"name\" IS NULL)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != nil || Col.name != nil && Col.id != nil)),
-            "SELECT * FROM \"readers\" WHERE ((\"age\" IS NOT NULL) OR ((\"name\" IS NOT NULL) AND (\"id\" IS NOT NULL)))")
+            "SELECT * FROM \"readers\" WHERE (\"age\" IS NOT NULL) OR ((\"name\" IS NOT NULL) AND (\"id\" IS NOT NULL))")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((Col.age != nil || Col.name != nil) && Col.id != nil)),
-            "SELECT * FROM \"readers\" WHERE (((\"age\" IS NOT NULL) OR (\"name\" IS NOT NULL)) AND (\"id\" IS NOT NULL))")
+            "SELECT * FROM \"readers\" WHERE ((\"age\" IS NOT NULL) OR (\"name\" IS NOT NULL)) AND (\"id\" IS NOT NULL)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age > 18) && !(Col.name > "foo"))),
-            "SELECT * FROM \"readers\" WHERE (NOT (\"age\" > 18) AND NOT (\"name\" > 'foo'))")
+            "SELECT * FROM \"readers\" WHERE (NOT (\"age\" > 18)) AND (NOT (\"name\" > 'foo'))")
     }
     
     func testJoinedOperatorAnd() throws {
@@ -754,13 +754,16 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .and))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+            "SELECT * FROM \"readers\" WHERE \"id\" = 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .and))),
-            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) AND (\"name\" IS NOT NULL))")
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1) AND (\"name\" IS NOT NULL)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .and))),
-            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL))")
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(![Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE NOT ((\"id\" = 1) AND (\"name\" IS NOT NULL) AND (\"age\" IS NULL))")
     }
     
     func testJoinedOperatorOr() throws {
@@ -771,13 +774,16 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1].joined(operator: .or))),
-            "SELECT * FROM \"readers\" WHERE (\"id\" = 1)")
+            "SELECT * FROM \"readers\" WHERE \"id\" = 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil].joined(operator: .or))),
-            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) OR (\"name\" IS NOT NULL))")
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1) OR (\"name\" IS NOT NULL)")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter([Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .or))),
-            "SELECT * FROM \"readers\" WHERE ((\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL))")
+            "SELECT * FROM \"readers\" WHERE (\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(![Col.id == 1, Col.name != nil, Col.age == nil].joined(operator: .or))),
+            "SELECT * FROM \"readers\" WHERE NOT ((\"id\" = 1) OR (\"name\" IS NOT NULL) OR (\"age\" IS NULL))")
     }
 
     
@@ -818,6 +824,12 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(-Col.age)),
             "SELECT * FROM \"readers\" WHERE -\"age\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(-(Col.age + 1))),
+            "SELECT * FROM \"readers\" WHERE -(\"age\" + 1)")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(-(-Col.age + 1))),
+            "SELECT * FROM \"readers\" WHERE -((-\"age\") + 1)")
     }
     
     func testInfixMinusOperator() throws {
@@ -825,16 +837,22 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age - 2)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" - 2)")
+            "SELECT * FROM \"readers\" WHERE \"age\" - 2")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 - Col.age)),
-            "SELECT * FROM \"readers\" WHERE (2 - \"age\")")
+            "SELECT * FROM \"readers\" WHERE 2 - \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 - 2)),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age - Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" - \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" - \"age\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter((Col.age - Col.age) - 1)),
+            "SELECT * FROM \"readers\" WHERE (\"age\" - \"age\") - 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(1 - [Col.age > 1, Col.age == nil].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE 1 - ((\"age\" > 1) AND (\"age\" IS NULL))")
     }
     
     func testInfixPlusOperator() throws {
@@ -842,16 +860,22 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age + 2)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" + 2)")
+            "SELECT * FROM \"readers\" WHERE \"age\" + 2")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 + Col.age)),
-            "SELECT * FROM \"readers\" WHERE (2 + \"age\")")
+            "SELECT * FROM \"readers\" WHERE 2 + \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 + 2)),
             "SELECT * FROM \"readers\" WHERE 4")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age + Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" + \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" + \"age\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(1 + (Col.age + Col.age))),
+            "SELECT * FROM \"readers\" WHERE 1 + (\"age\" + \"age\")")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(1 + [Col.age > 1, Col.age == nil].joined(operator: .and))),
+            "SELECT * FROM \"readers\" WHERE 1 + ((\"age\" > 1) AND (\"age\" IS NULL))")
     }
     
     func testInfixMultiplyOperator() throws {
@@ -859,16 +883,19 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age * 2)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" * 2)")
+            "SELECT * FROM \"readers\" WHERE \"age\" * 2")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 * Col.age)),
-            "SELECT * FROM \"readers\" WHERE (2 * \"age\")")
+            "SELECT * FROM \"readers\" WHERE 2 * \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 * 2)),
             "SELECT * FROM \"readers\" WHERE 4")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age * Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" * \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" * \"age\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(2 * (Col.age * Col.age))),
+            "SELECT * FROM \"readers\" WHERE 2 * (\"age\" * \"age\")")
     }
     
     func testInfixDivideOperator() throws {
@@ -876,16 +903,19 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age / 2)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" / 2)")
+            "SELECT * FROM \"readers\" WHERE \"age\" / 2")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 / Col.age)),
-            "SELECT * FROM \"readers\" WHERE (2 / \"age\")")
+            "SELECT * FROM \"readers\" WHERE 2 / \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2 / 2)),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age / Col.age)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" / \"age\")")
+            "SELECT * FROM \"readers\" WHERE \"age\" / \"age\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(1 / (Col.age / Col.age))),
+            "SELECT * FROM \"readers\" WHERE 1 / (\"age\" / \"age\")")
     }
     
     func testCompoundArithmeticExpression() throws {
@@ -894,17 +924,17 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         // Int / Double
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age / 2.0)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" / 2.0)")
+            "SELECT * FROM \"readers\" WHERE \"age\" / 2.0")
         // Double / Int
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(2.0 / Col.age)),
-            "SELECT * FROM \"readers\" WHERE (2.0 / \"age\")")
+            "SELECT * FROM \"readers\" WHERE 2.0 / \"age\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age + 2 * 5)),
-            "SELECT * FROM \"readers\" WHERE (\"age\" + 10)")
+            "SELECT * FROM \"readers\" WHERE \"age\" + 10")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age * 2 + 5)),
-            "SELECT * FROM \"readers\" WHERE ((\"age\" * 2) + 5)")
+            "SELECT * FROM \"readers\" WHERE (\"age\" * 2) + 5")
     }
     
     
@@ -946,7 +976,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT COUNT(DISTINCT \"age\") FROM \"readers\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.select(count(distinct: Col.age / Col.age))),
-            "SELECT COUNT(DISTINCT (\"age\" / \"age\")) FROM \"readers\"")
+            "SELECT COUNT(DISTINCT \"age\" / \"age\") FROM \"readers\"")
     }
     
     func testAvgExpression() throws {
@@ -957,7 +987,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT AVG(\"age\") FROM \"readers\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.select(average(Col.age / 2))),
-            "SELECT AVG((\"age\" / 2)) FROM \"readers\"")
+            "SELECT AVG(\"age\" / 2) FROM \"readers\"")
     }
     
     func testLengthExpression() throws {
@@ -976,7 +1006,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT MIN(\"age\") FROM \"readers\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.select(min(Col.age / 2))),
-            "SELECT MIN((\"age\" / 2)) FROM \"readers\"")
+            "SELECT MIN(\"age\" / 2) FROM \"readers\"")
     }
     
     func testMaxExpression() throws {
@@ -987,7 +1017,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT MAX(\"age\") FROM \"readers\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.select(max(Col.age / 2))),
-            "SELECT MAX((\"age\" / 2)) FROM \"readers\"")
+            "SELECT MAX(\"age\" / 2) FROM \"readers\"")
     }
     
     func testSumExpression() throws {
@@ -998,7 +1028,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT SUM(\"age\") FROM \"readers\"")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.select(sum(Col.age / 2))),
-            "SELECT SUM((\"age\" / 2)) FROM \"readers\"")
+            "SELECT SUM(\"age\" / 2) FROM \"readers\"")
     }
     
     
@@ -1009,7 +1039,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name.like("%foo"))),
-            "SELECT * FROM \"readers\" WHERE (\"name\" LIKE '%foo')")
+            "SELECT * FROM \"readers\" WHERE \"name\" LIKE '%foo'")
     }
     
     

--- a/Tests/GRDBTests/QueryInterfaceExtensibilityTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExtensibilityTests.swift
@@ -99,15 +99,22 @@ class QueryInterfaceExtensibilityTests: GRDBTestCase {
             
             try db.execute(sql: "INSERT INTO records (text) VALUES (?)", arguments: ["foo"])
             
-            let request = Record.select(cast(Column("text"), as: .blob))
-            let dbValue = try DatabaseValue.fetchOne(db, request)!
-            switch dbValue.storage {
-            case .blob:
-                break
-            default:
-                XCTFail("Expected data blob")
+            do {
+                let request = Record.select(cast(Column("text"), as: .blob))
+                let dbValue = try DatabaseValue.fetchOne(db, request)!
+                switch dbValue.storage {
+                case .blob:
+                    break
+                default:
+                    XCTFail("Expected data blob")
+                }
+                XCTAssertEqual(self.lastSQLQuery, "SELECT CAST(\"text\" AS BLOB) FROM \"records\" LIMIT 1")
             }
-            XCTAssertEqual(self.lastSQLQuery, "SELECT (CAST(\"text\" AS BLOB)) FROM \"records\" LIMIT 1")
+            do {
+                let request = Record.select(cast(Column("text"), as: .blob) && true)
+                _ = try DatabaseValue.fetchOne(db, request)!
+                XCTAssertEqual(self.lastSQLQuery, "SELECT (CAST(\"text\" AS BLOB)) AND 1 FROM \"records\" LIMIT 1")
+            }
         }
     }
 }

--- a/Tests/GRDBTests/QueryInterfacePromiseTests.swift
+++ b/Tests/GRDBTests/QueryInterfacePromiseTests.swift
@@ -30,7 +30,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                 let request = Node
                     .filter(key: 1)
                 let sql = """
-                    SELECT * FROM "node" WHERE ("id" = 1)
+                    SELECT * FROM "node" WHERE "id" = 1
                     """
                 try assertEqualSQL(db, request, sql)
                 try assertEqualSQL(db, request.asRequest(of: Row.self), sql)
@@ -43,7 +43,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                     SELECT "node1".* \
                     FROM "node" "node1" \
                     LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2) \
-                    WHERE ("node1"."id" = 1)
+                    WHERE "node1"."id" = 1
                     """
                 try assertEqualSQL(db, request, sql)
                 try assertEqualSQL(db, request.asRequest(of: Row.self), sql)
@@ -56,7 +56,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                     SELECT "node1".* \
                     FROM "node" "node1" \
                     LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2) \
-                    WHERE ("node1"."id" = 1)
+                    WHERE "node1"."id" = 1
                     """
                 try assertEqualSQL(db, request, sql)
                 try assertEqualSQL(db, request.asRequest(of: Row.self), sql)
@@ -80,7 +80,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                 let sql = """
                     SELECT "node1".* \
                     FROM "node" "node1" \
-                    LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") \
+                    LEFT JOIN "node" "node2" ON "node2"."id" = "node1"."parentId" \
                     ORDER BY "node1"."id", "node2"."id"
                     """
                 try assertEqualSQL(db, request, sql)
@@ -109,7 +109,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                     .asRequest(of: NotARecord.self)
                     .filter(key: 1)
                 let sql = """
-                    SELECT * FROM "node" WHERE ("id" = 1)
+                    SELECT * FROM "node" WHERE "id" = 1
                     """
                 try assertEqualSQL(db, request, sql)
                 try assertEqualSQL(db, request.asRequest(of: Row.self), sql)
@@ -123,7 +123,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                     SELECT "node1".* \
                     FROM "node" "node1" \
                     LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2) \
-                    WHERE ("node1"."id" = 1)
+                    WHERE "node1"."id" = 1
                     """
                 try assertEqualSQL(db, request, sql)
                 try assertEqualSQL(db, request.asRequest(of: Row.self), sql)

--- a/Tests/GRDBTests/QueryInterfacePromiseTests.swift
+++ b/Tests/GRDBTests/QueryInterfacePromiseTests.swift
@@ -42,7 +42,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                 let sql = """
                     SELECT "node1".* \
                     FROM "node" "node1" \
-                    LEFT JOIN "node" "node2" ON (("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2)) \
+                    LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2) \
                     WHERE ("node1"."id" = 1)
                     """
                 try assertEqualSQL(db, request, sql)
@@ -55,7 +55,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                 let sql = """
                     SELECT "node1".* \
                     FROM "node" "node1" \
-                    LEFT JOIN "node" "node2" ON (("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2)) \
+                    LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2) \
                     WHERE ("node1"."id" = 1)
                     """
                 try assertEqualSQL(db, request, sql)
@@ -122,7 +122,7 @@ class QueryInterfacePromiseTests: GRDBTestCase {
                 let sql = """
                     SELECT "node1".* \
                     FROM "node" "node1" \
-                    LEFT JOIN "node" "node2" ON (("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2)) \
+                    LEFT JOIN "node" "node2" ON ("node2"."id" = "node1"."parentId") AND ("node2"."id" = 2) \
                     WHERE ("node1"."id" = 1)
                     """
                 try assertEqualSQL(db, request, sql)

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -108,7 +108,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT * FROM \"readers\" LIMIT 10)")
             
             XCTAssertEqual(try tableRequest.filter(Col.age == 42).fetchCount(db), 0)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\" WHERE (\"age\" = 42)")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\" WHERE \"age\" = 42")
             
             XCTAssertEqual(try tableRequest.distinct().fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT DISTINCT * FROM \"readers\")")
@@ -120,10 +120,10 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"name\") FROM \"readers\"")
             
             XCTAssertEqual(try tableRequest.select(Col.age * 2).distinct().fetchCount(db), 0)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT (\"age\" * 2)) FROM \"readers\"")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
             XCTAssertEqual(try tableRequest.select((Col.age * 2).aliased("ignored")).distinct().fetchCount(db), 0)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT (\"age\" * 2)) FROM \"readers\"")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
             XCTAssertEqual(try tableRequest.select(Col.name, Col.age).fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\"")
@@ -220,7 +220,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             
             let request = tableRequest.select(Col.name, Col.id - 1)
             let rows = try Row.fetchAll(db, request)
-            XCTAssertEqual(lastSQLQuery, "SELECT \"name\", (\"id\" - 1) FROM \"readers\"")
+            XCTAssertEqual(lastSQLQuery, "SELECT \"name\", \"id\" - 1 FROM \"readers\"")
             XCTAssertEqual(rows.count, 2)
             XCTAssertEqual(rows[0][0] as String, "Arthur")
             XCTAssertEqual(rows[0][1] as Int64, 0)
@@ -236,7 +236,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             
             let request = tableRequest.select(Col.name.aliased("nom"), (Col.age + 1).aliased("agePlusOne"))
             let row = try Row.fetchOne(db, request)!
-            XCTAssertEqual(lastSQLQuery, "SELECT \"name\" AS \"nom\", (\"age\" + 1) AS \"agePlusOne\" FROM \"readers\" LIMIT 1")
+            XCTAssertEqual(lastSQLQuery, "SELECT \"name\" AS \"nom\", \"age\" + 1 AS \"agePlusOne\" FROM \"readers\" LIMIT 1")
             XCTAssertEqual(row["nom"] as String, "Arthur")
             XCTAssertEqual(row["agePlusOne"] as Int, 43)
         }
@@ -248,32 +248,32 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             do {
                 let request = Reader.annotated(with: [Col.id - 1])
                 _ = try Row.fetchAll(db, request)
-                XCTAssertEqual(lastSQLQuery, "SELECT *, (\"id\" - 1) FROM \"readers\"")
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"id\" - 1 FROM \"readers\"")
             }
             do {
                 let request = Reader.annotated(with: Col.id - 1, Col.id + 1)
                 _ = try Row.fetchAll(db, request)
-                XCTAssertEqual(lastSQLQuery, "SELECT *, (\"id\" - 1), (\"id\" + 1) FROM \"readers\"")
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"id\" - 1, \"id\" + 1 FROM \"readers\"")
             }
             do {
                 let request = tableRequest.annotated(with: [Col.id - 1])
                 _ = try Row.fetchAll(db, request)
-                XCTAssertEqual(lastSQLQuery, "SELECT *, (\"id\" - 1) FROM \"readers\"")
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"id\" - 1 FROM \"readers\"")
             }
             do {
                 let request = tableRequest.annotated(with: Col.id - 1, Col.id + 1)
                 _ = try Row.fetchAll(db, request)
-                XCTAssertEqual(lastSQLQuery, "SELECT *, (\"id\" - 1), (\"id\" + 1) FROM \"readers\"")
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"id\" - 1, \"id\" + 1 FROM \"readers\"")
             }
             do {
                 let request = tableRequest.select(Col.name).annotated(with: [Col.id - 1])
                 _ = try Row.fetchAll(db, request)
-                XCTAssertEqual(lastSQLQuery, "SELECT \"name\", (\"id\" - 1) FROM \"readers\"")
+                XCTAssertEqual(lastSQLQuery, "SELECT \"name\", \"id\" - 1 FROM \"readers\"")
             }
             do {
                 let request = tableRequest.select(Col.name).annotated(with: Col.id - 1, Col.id + 1)
                 _ = try Row.fetchAll(db, request)
-                XCTAssertEqual(lastSQLQuery, "SELECT \"name\", (\"id\" - 1), (\"id\" + 1) FROM \"readers\"")
+                XCTAssertEqual(lastSQLQuery, "SELECT \"name\", \"id\" - 1, \"id\" + 1 FROM \"readers\"")
             }
         }
     }
@@ -487,21 +487,30 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(sql: "id <> 1")),
-            "SELECT * FROM \"readers\" WHERE (id <> 1)")
+            "SELECT * FROM \"readers\" WHERE id <> 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(sql: "id <> 1").filter(true)),
+            "SELECT * FROM \"readers\" WHERE (id <> 1) AND 1")
     }
     
     func testFilterLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(sql: "id <> ?", arguments: [1])),
-            "SELECT * FROM \"readers\" WHERE (id <> 1)")
+            "SELECT * FROM \"readers\" WHERE id <> 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(sql: "id <> ?", arguments: [1]).filter(true)),
+            "SELECT * FROM \"readers\" WHERE (id <> 1) AND 1")
     }
     
     func testFilterLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(sql: "id <> :id", arguments: ["id": 1])),
-            "SELECT * FROM \"readers\" WHERE (id <> 1)")
+            "SELECT * FROM \"readers\" WHERE id <> 1")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(sql: "id <> :id", arguments: ["id": 1]).filter(true)),
+            "SELECT * FROM \"readers\" WHERE (id <> 1) AND 1")
     }
     
     func testFilterLiteralWithMixedArguments() throws {
@@ -580,28 +589,28 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(sql: "min(age) > 18")),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (min(age) > 18)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING min(age) > 18")
     }
     
     func testHavingLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(sql: "min(age) > ?", arguments: [18])),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (min(age) > 18)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING min(age) > 18")
     }
     
     func testHavingLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(sql: "min(age) > :age", arguments: ["age": 18])),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (min(age) > 18)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING min(age) > 18")
     }
     
     func testHaving() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(min(Col.age) > 18)),
-            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (MIN(\"age\") > 18)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING MIN(\"age\") > 18")
     }
     
     func testMultipleHaving() throws {

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -510,12 +510,12 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest
                 .filter(sql: "age > :age", arguments: ["age": 20])
                 .filter(sql: "name = ?", arguments: ["arthur"])),
-            "SELECT * FROM \"readers\" WHERE ((age > 20) AND (name = 'arthur'))")
+            "SELECT * FROM \"readers\" WHERE (age > 20) AND (name = 'arthur')")
         XCTAssertEqual(
             sql(dbQueue, tableRequest
                 .filter(sql: "age > ?", arguments: [20])
                 .filter(sql: "name = :name", arguments: ["name": "arthur"])),
-            "SELECT * FROM \"readers\" WHERE ((age > 20) AND (name = 'arthur'))")
+            "SELECT * FROM \"readers\" WHERE (age > 20) AND (name = 'arthur')")
     }
 
     func testFilter() throws {
@@ -529,7 +529,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(true).filter(false)),
-            "SELECT * FROM \"readers\" WHERE (1 AND 0)")
+            "SELECT * FROM \"readers\" WHERE 1 AND 0")
     }
     
     
@@ -608,7 +608,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(min(Col.age) > 18).having(max(Col.age) < 50)),
-                "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING ((MIN(\"age\") > 18) AND (MAX(\"age\") < 50))")
+                "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (MIN(\"age\") > 18) AND (MAX(\"age\") < 50)")
     }
     
     

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -308,7 +308,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             
             let fetchedRecord = try MinimalRowID.fetchOne(db, key: ["id": record.id])!
             XCTAssertTrue(fetchedRecord.id == record.id)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE (\"id\" = \(record.id!))")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
         }
     }
 
@@ -379,7 +379,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             
             let fetchedRecord = try MinimalRowID.filter(key: ["id": record.id]).fetchOne(db)!
             XCTAssertTrue(fetchedRecord.id == record.id)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE (\"id\" = \(record.id!))")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
         }
     }
     
@@ -460,7 +460,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             do {
                 let fetchedRecord = try MinimalRowID.fetchOne(db, key: record.id)!
                 XCTAssertTrue(fetchedRecord.id == record.id)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE (\"id\" = \(record.id!))")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
             }
         }
     }
@@ -530,7 +530,7 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             do {
                 let fetchedRecord = try MinimalRowID.filter(key: record.id).fetchOne(db)!
                 XCTAssertTrue(fetchedRecord.id == record.id)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE (\"id\" = \(record.id!))")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
             }
         }
     }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
@@ -319,7 +319,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             
             let fetchedRecord = try MinimalSingle.fetchOne(db, key: ["UUID": record.UUID])!
             XCTAssertTrue(fetchedRecord.UUID == record.UUID)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE (\"UUID\" = '\(record.UUID!)')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"UUID\" = '\(record.UUID!)'")
         }
     }
 
@@ -395,7 +395,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             
             let fetchedRecord = try MinimalSingle.filter(key: ["UUID": record.UUID]).fetchOne(db)!
             XCTAssertTrue(fetchedRecord.UUID == record.UUID)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE (\"UUID\" = '\(record.UUID!)')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"UUID\" = '\(record.UUID!)'")
         }
     }
     
@@ -481,7 +481,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             do {
                 let fetchedRecord = try MinimalSingle.fetchOne(db, key: record.UUID)!
                 XCTAssertTrue(fetchedRecord.UUID == record.UUID)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE (\"UUID\" = '\(record.UUID!)')")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"UUID\" = '\(record.UUID!)'")
             }
         }
     }
@@ -556,7 +556,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             do {
                 let fetchedRecord = try MinimalSingle.filter(key: record.UUID).fetchOne(db)!
                 XCTAssertTrue(fetchedRecord.UUID == record.UUID)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE (\"UUID\" = '\(record.UUID!)')")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"UUID\" = '\(record.UUID!)'")
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -391,7 +391,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(fetchedRecord.name == record.name)
             XCTAssertTrue(fetchedRecord.age == record.age)
             XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-            XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE (\"rowid\" = \(record.id!))")
+            XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
         }
     }
 
@@ -465,7 +465,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(fetchedRecord.name == record.name)
             XCTAssertTrue(fetchedRecord.age == record.age)
             XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-            XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE (\"rowid\" = \(record.id!))")
+            XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
         }
     }
     
@@ -549,7 +549,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
                 XCTAssertTrue(fetchedRecord.name == record.name)
                 XCTAssertTrue(fetchedRecord.age == record.age)
                 XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-                XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE (\"rowid\" = \(record.id!))")
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
             }
         }
     }
@@ -622,7 +622,7 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
                 XCTAssertTrue(fetchedRecord.name == record.name)
                 XCTAssertTrue(fetchedRecord.age == record.age)
                 XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-                XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE (\"rowid\" = \(record.id!))")
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
@@ -345,7 +345,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.personName == record.personName)
             XCTAssertTrue(fetchedRecord.countryName == record.countryName)
             XCTAssertTrue(fetchedRecord.native == record.native)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"citizenships\" WHERE ((\"personName\" = '\(record.personName!)') AND (\"countryName\" = '\(record.countryName!)'))")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"citizenships\" WHERE (\"personName\" = '\(record.personName!)') AND (\"countryName\" = '\(record.countryName!)')")
         }
     }
 
@@ -418,7 +418,7 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.personName == record.personName)
             XCTAssertTrue(fetchedRecord.countryName == record.countryName)
             XCTAssertTrue(fetchedRecord.native == record.native)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"citizenships\" WHERE ((\"personName\" = '\(record.personName!)') AND (\"countryName\" = '\(record.countryName!)'))")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"citizenships\" WHERE (\"personName\" = '\(record.personName!)') AND (\"countryName\" = '\(record.countryName!)')")
         }
     }
     

--- a/Tests/GRDBTests/RecordPrimaryKeyNoneTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyNoneTests.swift
@@ -98,7 +98,7 @@ class RecordPrimaryKeyNoneTests: GRDBTestCase {
             
             let fetchedRecord = try Item.fetchOne(db, key: ["email": record.email])!
             XCTAssertTrue(fetchedRecord.email == record.email)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE (\"email\" = 'item@example.com')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE \"email\" = 'item@example.com'")
         }
     }
 
@@ -113,7 +113,7 @@ class RecordPrimaryKeyNoneTests: GRDBTestCase {
             
             let fetchedRecord = try Item.filter(key: ["email": record.email]).fetchOne(db)!
             XCTAssertTrue(fetchedRecord.email == record.email)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE (\"email\" = 'item@example.com')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE \"email\" = 'item@example.com'")
         }
     }
     
@@ -203,7 +203,7 @@ class RecordPrimaryKeyNoneTests: GRDBTestCase {
             do {
                 let fetchedRecord = try Item.fetchOne(db, key: id)!
                 XCTAssertTrue(fetchedRecord.name == record.name)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE (\"rowid\" = \(id))")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE \"rowid\" = \(id)")
             }
         }
     }
@@ -282,7 +282,7 @@ class RecordPrimaryKeyNoneTests: GRDBTestCase {
             do {
                 let fetchedRecord = try Item.filter(key: id).fetchOne(db)!
                 XCTAssertTrue(fetchedRecord.name == record.name)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE (\"rowid\" = \(id))")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"items\" WHERE \"rowid\" = \(id)")
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
@@ -387,7 +387,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.name == record.name)
             XCTAssertTrue(fetchedRecord.age == record.age)
             XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE (\"id\" = \(record.id!))")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE \"id\" = \(record.id!)")
         }
     }
 
@@ -461,7 +461,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             XCTAssertTrue(fetchedRecord.name == record.name)
             XCTAssertTrue(fetchedRecord.age == record.age)
             XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE (\"id\" = \(record.id!))")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE \"id\" = \(record.id!)")
         }
     }
     
@@ -545,7 +545,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
                 XCTAssertTrue(fetchedRecord.name == record.name)
                 XCTAssertTrue(fetchedRecord.age == record.age)
                 XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE (\"id\" = \(record.id!))")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE \"id\" = \(record.id!)")
             }
         }
     }
@@ -618,7 +618,7 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
                 XCTAssertTrue(fetchedRecord.name == record.name)
                 XCTAssertTrue(fetchedRecord.age == record.age)
                 XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE (\"id\" = \(record.id!))")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE \"id\" = \(record.id!)")
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
@@ -337,7 +337,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             let fetchedRecord = try Pet.fetchOne(db, key: ["UUID": record.UUID])!
             XCTAssertTrue(fetchedRecord.UUID == record.UUID)
             XCTAssertTrue(fetchedRecord.name == record.name)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE (\"UUID\" = '\(record.UUID!)')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE \"UUID\" = '\(record.UUID!)'")
         }
     }
 
@@ -409,7 +409,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             let fetchedRecord = try Pet.filter(key: ["UUID": record.UUID]).fetchOne(db)!
             XCTAssertTrue(fetchedRecord.UUID == record.UUID)
             XCTAssertTrue(fetchedRecord.name == record.name)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE (\"UUID\" = '\(record.UUID!)')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE \"UUID\" = '\(record.UUID!)'")
         }
     }
     
@@ -491,7 +491,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
                 let fetchedRecord = try Pet.fetchOne(db, key: record.UUID)!
                 XCTAssertTrue(fetchedRecord.UUID == record.UUID)
                 XCTAssertTrue(fetchedRecord.name == record.name)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE (\"UUID\" = '\(record.UUID!)')")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE \"UUID\" = '\(record.UUID!)'")
             }
         }
     }
@@ -562,7 +562,7 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
                 let fetchedRecord = try Pet.filter(key: record.UUID).fetchOne(db)!
                 XCTAssertTrue(fetchedRecord.UUID == record.UUID)
                 XCTAssertTrue(fetchedRecord.name == record.name)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE (\"UUID\" = '\(record.UUID!)')")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE \"UUID\" = '\(record.UUID!)'")
             }
         }
     }

--- a/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
@@ -326,7 +326,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             
             let fetchedRecord = try Email.fetchOne(db, key: ["email": record.email])!
             XCTAssertTrue(fetchedRecord.email == record.email)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE (\"email\" = '\(record.email!)')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE \"email\" = '\(record.email!)'")
         }
     }
 
@@ -402,7 +402,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             
             let fetchedRecord = try Email.filter(key: ["email": record.email]).fetchOne(db)!
             XCTAssertTrue(fetchedRecord.email == record.email)
-            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE (\"email\" = '\(record.email!)')")
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE \"email\" = '\(record.email!)'")
         }
     }
     
@@ -488,7 +488,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             do {
                 let fetchedRecord = try Email.fetchOne(db, key: record.email)!
                 XCTAssertTrue(fetchedRecord.email == record.email)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE (\"email\" = '\(record.email!)')")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE \"email\" = '\(record.email!)'")
             }
         }
     }
@@ -563,7 +563,7 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             do {
                 let fetchedRecord = try Email.filter(key: record.email).fetchOne(db)!
                 XCTAssertTrue(fetchedRecord.email == record.email)
-                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE (\"email\" = '\(record.email!)')")
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE \"email\" = '\(record.email!)'")
             }
         }
     }

--- a/Tests/GRDBTests/SQLExpressionLiteralTests.swift
+++ b/Tests/GRDBTests/SQLExpressionLiteralTests.swift
@@ -11,7 +11,7 @@ class SQLExpressionLiteralTests: GRDBTestCase {
     func testWithArguments() {
         let expression = Column("foo").collating(.nocase) == "'fooéı👨👨🏿🇫🇷🇨🇮'" && Column("baz") >= 1
         var context = SQLGenerationContext.literalGenerationContext(withArguments: true)
-        let sql = expression.expressionSQL(&context)
+        let sql = expression.expressionSQL(&context, wrappedInParenthesis: true)
         XCTAssertEqual(sql, "((\"foo\" = ? COLLATE NOCASE) AND (\"baz\" >= ?))")
         let values = context.arguments!.values
         XCTAssertEqual(values.count, 2)
@@ -22,7 +22,7 @@ class SQLExpressionLiteralTests: GRDBTestCase {
     func testWithoutArguments() {
         let expression = Column("foo").collating(.nocase) == "'fooéı👨👨🏿🇫🇷🇨🇮'" && Column("baz") >= 1
         var context = SQLGenerationContext.literalGenerationContext(withArguments: false)
-        let sql = expression.expressionSQL(&context)
+        let sql = expression.expressionSQL(&context, wrappedInParenthesis: true)
         XCTAssertNil(context.arguments)
         XCTAssertEqual(sql, "((\"foo\" = '''fooéı👨👨🏿🇫🇷🇨🇮''' COLLATE NOCASE) AND (\"baz\" >= 1))")
     }

--- a/Tests/GRDBTests/SQLInterpolationTests.swift
+++ b/Tests/GRDBTests/SQLInterpolationTests.swift
@@ -67,12 +67,12 @@ class SQLInterpolationTests: GRDBTestCase {
         
         XCTAssertEqual(sql.sql, """
             "a"
-            ("a" + ?)
-            ("a" < "b")
+            "a" + ?
+            "a" < "b"
             ?
             ?
             NULL
-            ("a" IS NULL)
+            "a" IS NULL
             """)
         XCTAssertEqual(sql.arguments, [1, 1, 2])
     }
@@ -132,7 +132,7 @@ class SQLInterpolationTests: GRDBTestCase {
         XCTAssertEqual(sql.sql, """
             (?)
             (?,?,?)
-            ("a",("b" + ?))
+            ("a","b" + ?)
             (SELECT NULL WHERE NULL)
             """)
         XCTAssertEqual(sql.arguments, [1, "foo", "bar", "baz", 2])

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -198,12 +198,12 @@ extension SQLLiteralTests {
         XCTAssertEqual(query.sql, """
             SELECT
               "a",
-              ("a" + ?),
-              ("a" < "b"),
+              "a" + ?,
+              "a" < "b",
               ?,
               ?,
               NULL,
-              ("a" IS NULL)
+              "a" IS NULL
             """)
         XCTAssertEqual(query.arguments, [1, 1, 2])
     }
@@ -265,7 +265,7 @@ extension SQLLiteralTests {
             SELECT * FROM player
             WHERE teamId IN (?)
               AND name IN (?,?,?)
-              AND c IN ("a",("b" + ?))
+              AND c IN ("a","b" + ?)
               AND d IN (SELECT NULL WHERE NULL)
             """)
         XCTAssertEqual(query.arguments, [1, "foo", "bar", "baz", 2])

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -188,9 +188,9 @@ class TableDefinitionTests: GRDBTestCase {
             assertEqualSQL(
                 lastSQLQuery,
                 ("CREATE TABLE \"test\" (" +
-                    "\"a\" INTEGER CHECK ((\"a\" > 0)), " +
+                    "\"a\" INTEGER CHECK (\"a\" > 0), " +
                     "\"b\" INTEGER CHECK (b <> 2), " +
-                    "\"c\" INTEGER CHECK ((\"c\" > 0)) CHECK ((\"c\" < 10))" +
+                    "\"c\" INTEGER CHECK (\"c\" > 0) CHECK (\"c\" < 10)" +
                     ")") as String)
             
             // Sanity check
@@ -383,7 +383,7 @@ class TableDefinitionTests: GRDBTestCase {
                 ("CREATE TABLE \"test\" (" +
                     "\"a\" INTEGER, " +
                     "\"b\" INTEGER, " +
-                    "CHECK (((\"a\" + \"b\") < 10)), " +
+                    "CHECK ((\"a\" + \"b\") < 10), " +
                     "CHECK (a + b < 10)" +
                     ")") as String)
             
@@ -548,7 +548,7 @@ class TableDefinitionTests: GRDBTestCase {
             }
             
             try db.create(index: "test_on_a_b", on: "test", columns: ["a", "b"], unique: true, ifNotExists: true, condition: Column("a") == 1)
-            assertEqualSQL(lastSQLQuery, "CREATE UNIQUE INDEX IF NOT EXISTS \"test_on_a_b\" ON \"test\"(\"a\", \"b\") WHERE (\"a\" = 1)")
+            assertEqualSQL(lastSQLQuery, "CREATE UNIQUE INDEX IF NOT EXISTS \"test_on_a_b\" ON \"test\"(\"a\", \"b\") WHERE \"a\" = 1")
             
             // Sanity check
             XCTAssertEqual(try Set(db.indexes(on: "test").map { $0.name }), ["test_on_a_b"])

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -214,7 +214,7 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(true).filter(false)),
-            "SELECT * FROM \"readers\" WHERE (1 AND 0)")
+            "SELECT * FROM \"readers\" WHERE 1 AND 0")
     }
     
     

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -51,7 +51,7 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT * FROM \"readers\" LIMIT 10)")
             
             XCTAssertEqual(try Reader.filter(Col.age == 42).fetchCount(db), 0)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\" WHERE (\"age\" = 42)")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\" WHERE \"age\" = 42")
             
             XCTAssertEqual(try Reader.all().distinct().fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT DISTINCT * FROM \"readers\")")
@@ -63,10 +63,10 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"name\") FROM \"readers\"")
             
             XCTAssertEqual(try Reader.select(Col.age * 2).distinct().fetchCount(db), 0)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT (\"age\" * 2)) FROM \"readers\"")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
             XCTAssertEqual(try Reader.select((Col.age * 2).aliased("ignored")).distinct().fetchCount(db), 0)
-            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT (\"age\" * 2)) FROM \"readers\"")
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
             XCTAssertEqual(try Reader.select(Col.name, Col.age).fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\"")
@@ -163,7 +163,7 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             
             let request = Reader.select(Col.name, Col.id - 1)
             let rows = try Row.fetchAll(db, request)
-            XCTAssertEqual(lastSQLQuery, "SELECT \"name\", (\"id\" - 1) FROM \"readers\"")
+            XCTAssertEqual(lastSQLQuery, "SELECT \"name\", \"id\" - 1 FROM \"readers\"")
             XCTAssertEqual(rows.count, 2)
             XCTAssertEqual(rows[0][0] as String, "Arthur")
             XCTAssertEqual(rows[0][1] as Int64, 0)
@@ -186,21 +186,21 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(sql: "id <> 1")),
-            "SELECT * FROM \"readers\" WHERE (id <> 1)")
+            "SELECT * FROM \"readers\" WHERE id <> 1")
     }
     
     func testFilterLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(sql: "id <> ?", arguments: [1])),
-            "SELECT * FROM \"readers\" WHERE (id <> 1)")
+            "SELECT * FROM \"readers\" WHERE id <> 1")
     }
     
     func testFilterLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, Reader.filter(sql: "id <> :id", arguments: ["id": 1])),
-            "SELECT * FROM \"readers\" WHERE (id <> 1)")
+            "SELECT * FROM \"readers\" WHERE id <> 1")
     }
     
     func testFilter() throws {


### PR DESCRIPTION
This is a purely aesthetic PR: it just removes many useless parenthesis from generated SQL:

```swift
// Before: SELECT * FROM "player" WHERE ("id" = 1)
// After:  SELECT * FROM "player" WHERE "id" = 1
try Player.fetchOne(key: 1)
```

It also documents that the SQL generated by the query interface is out of the scope of semantic versioning: GRDB needs to be able to freely change its SQL output for any useful purpose.