### PR TITLE
ValueObservation.fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#537](https://github.com/groue/GRDB.swift/pull/537): Remove useless parenthesis from generated SQL
 - [#538](https://github.com/groue/GRDB.swift/pull/538) by [@Timac](https://github.com/Timac): Add FAQ to clarify "Wrong number of statement arguments" error with "like '%?%'"
 - [#539](https://github.com/groue/GRDB.swift/pull/539): Expose joining methods of both requests and associations
+- [#541](https://github.com/groue/GRDB.swift/pull/541): ValueObservation.fetch
 
 ### Documentation Diff
 

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -482,6 +482,8 @@
 		567F45AC1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		568068311EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568068351EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
+		5686050C22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686050B22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
+		5686050D22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686050B22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
 		568735A21CEDE16C009B9116 /* Betty.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 5687359E1CEDE16C009B9116 /* Betty.jpeg */; };
 		568D131F2207213E00674B58 /* SQLQueryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568D13182207213E00674B58 /* SQLQueryGenerator.swift */; };
 		568D13202207213E00674B58 /* SQLQueryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568D13182207213E00674B58 /* SQLQueryGenerator.swift */; };
@@ -1141,6 +1143,7 @@
 		567F0B2C220F0E2E00D111FB /* SQLInterpolationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLInterpolationTests.swift; sourceTree = "<group>"; };
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
+		5686050B22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationTrackingFetchTests.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		568D13182207213E00674B58 /* SQLQueryGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLQueryGenerator.swift; sourceTree = "<group>"; };
 		5690AFD72120589A001530EA /* InsertRecordCodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsertRecordCodableTests.swift; sourceTree = "<group>"; };
@@ -1640,6 +1643,7 @@
 				563B06BC2185CCD300B38F35 /* ValueObservationReducerTests.swift */,
 				563B0704218627F700B38F35 /* ValueObservationRowTests.swift */,
 				563B06C12185D29F00B38F35 /* ValueObservationSchedulingTests.swift */,
+				5686050B22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift */,
 			);
 			name = ValueObservation;
 			sourceTree = "<group>";
@@ -2951,6 +2955,7 @@
 				56CC9252201E093F00CB597E /* PrefixCursorTests.swift in Sources */,
 				563363B01C933FF8000BE133 /* MutablePersistableRecordTests.swift in Sources */,
 				5665FA152129C9D6004D8612 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
+				5686050C22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				5657AB421D108BA9006283EF /* FoundationNSDataTests.swift in Sources */,
 				56CC922D201DFFB900CB597E /* DropWhileCursorTests.swift in Sources */,
 				56D507621F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift in Sources */,
@@ -3150,6 +3155,7 @@
 				56D4965F1D81304E008276D7 /* FoundationNSURLTests.swift in Sources */,
 				562393301DEDFC5700A6B01F /* AnyCursorTests.swift in Sources */,
 				5665FA142129C9D6004D8612 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
+				5686050D22A01A9700CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				56CC9251201E093F00CB597E /* PrefixCursorTests.swift in Sources */,
 				56D4965E1D81304E008276D7 /* FoundationNSStringTests.swift in Sources */,
 				5698AC891DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -162,7 +162,20 @@ public final class Database {
     
     private var functions = Set<DatabaseFunction>()
     private var collations = Set<DatabaseCollation>()
-    
+    private var readOnlyDepth = 0 {
+        didSet {
+            // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
+            // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
+            // Assume those pragmas never fail
+            switch readOnlyDepth {
+            case 0:
+                try! internalCachedUpdateStatement(sql: "PRAGMA query_only = 0").execute()
+            case 1:
+                try! internalCachedUpdateStatement(sql: "PRAGMA query_only = 1").execute()
+            default: break
+            }
+        }
+    }
     private var isClosed: Bool = false
 
     // MARK: - Initializer
@@ -541,11 +554,8 @@ extension Database {
             return try block()
         }
         
-        // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
-        // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
-        // Assume those pragmas never fail
-        try! internalCachedUpdateStatement(sql: "PRAGMA query_only = 1").execute()
-        defer { try! internalCachedUpdateStatement(sql: "PRAGMA query_only = 0").execute() }
+        readOnlyDepth += 1
+        defer { readOnlyDepth -= 1 }
         return try block()
     }
 }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -167,10 +167,10 @@ public final class Database {
             // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
             // It is available from iOS 8.2 and OS X 10.10 https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
             // Assume those pragmas never fail
-            switch readOnlyDepth {
-            case 0:
+            switch (oldValue, readOnlyDepth) {
+            case (1, 0):
                 try! internalCachedUpdateStatement(sql: "PRAGMA query_only = 0").execute()
-            case 1:
+            case (0, 1):
                 try! internalCachedUpdateStatement(sql: "PRAGMA query_only = 1").execute()
             default: break
             }

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -107,28 +107,25 @@ extension DatabaseSnapshot {
         // Deal with initial value
         switch observation.scheduling {
         case .mainQueue:
-            if let value = try unsafeReentrantRead(observation.initialValue) {
-                if DispatchQueue.isMain {
+            let value = try unsafeReentrantRead(observation.fetch)
+            if DispatchQueue.isMain {
+                onChange(value)
+            } else {
+                DispatchQueue.main.async {
                     onChange(value)
-                } else {
-                    DispatchQueue.main.async {
-                        onChange(value)
-                    }
                 }
             }
         case let .async(onQueue: queue, startImmediately: startImmediately):
             if startImmediately {
-                if let value = try unsafeReentrantRead(observation.initialValue) {
-                    queue.async {
-                        onChange(value)
-                    }
+                let value = try unsafeReentrantRead(observation.fetch)
+                queue.async {
+                    onChange(value)
                 }
             }
         case let .unsafe(startImmediately: startImmediately):
             if startImmediately {
-                if let value = try unsafeReentrantRead(observation.initialValue) {
-                    onChange(value)
-                }
+                let value = try unsafeReentrantRead(observation.fetch)
+                onChange(value)
             }
         }
         
@@ -138,15 +135,6 @@ extension DatabaseSnapshot {
     
     public func remove(transactionObserver: TransactionObserver) {
         // Can't remove an observer which could not be added :-)
-    }
-}
-
-extension ValueObservation where Reducer: ValueReducer {
-    /// Helper method for DatabaseSnapshot.add(observation:onError:onChange:)
-    fileprivate func initialValue(_ db: Database) throws -> Reducer.Value? {
-        var reducer = try makeReducer(db)
-        let fetched = try reducer.fetch(db)
-        return reducer.value(fetched)
     }
 }
 

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -107,7 +107,7 @@ extension DatabaseSnapshot {
         // Deal with initial value
         switch observation.scheduling {
         case .mainQueue:
-            if let value = try unsafeReentrantRead(observation.fetch) {
+            if let value = try unsafeReentrantRead(observation.fetchFirst) {
                 if DispatchQueue.isMain {
                     onChange(value)
                 } else {
@@ -118,7 +118,7 @@ extension DatabaseSnapshot {
             }
         case let .async(onQueue: queue, startImmediately: startImmediately):
             if startImmediately {
-                if let value = try unsafeReentrantRead(observation.fetch) {
+                if let value = try unsafeReentrantRead(observation.fetchFirst) {
                     queue.async {
                         onChange(value)
                     }
@@ -126,7 +126,7 @@ extension DatabaseSnapshot {
             }
         case let .unsafe(startImmediately: startImmediately):
             if startImmediately {
-                if let value = try unsafeReentrantRead(observation.fetch) {
+                if let value = try unsafeReentrantRead(observation.fetchFirst) {
                     onChange(value)
                 }
             }

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -107,25 +107,28 @@ extension DatabaseSnapshot {
         // Deal with initial value
         switch observation.scheduling {
         case .mainQueue:
-            let value = try unsafeReentrantRead(observation.fetch)
-            if DispatchQueue.isMain {
-                onChange(value)
-            } else {
-                DispatchQueue.main.async {
+            if let value = try unsafeReentrantRead(observation.fetch) {
+                if DispatchQueue.isMain {
                     onChange(value)
+                } else {
+                    DispatchQueue.main.async {
+                        onChange(value)
+                    }
                 }
             }
         case let .async(onQueue: queue, startImmediately: startImmediately):
             if startImmediately {
-                let value = try unsafeReentrantRead(observation.fetch)
-                queue.async {
-                    onChange(value)
+                if let value = try unsafeReentrantRead(observation.fetch) {
+                    queue.async {
+                        onChange(value)
+                    }
                 }
             }
         case let .unsafe(startImmediately: startImmediately):
             if startImmediately {
-                let value = try unsafeReentrantRead(observation.fetch)
-                onChange(value)
+                if let value = try unsafeReentrantRead(observation.fetch) {
+                    onChange(value)
+                }
             }
         }
         

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -203,7 +203,7 @@ extension DatabaseWriter {
             // any future transaction can trigger a change.
             switch observation.scheduling {
             case .mainQueue:
-                if let value = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess) {
+                if let value = try reducer.fetchNext(db, requiringWriteAccess: observation.requiresWriteAccess) {
                     if calledOnMainQueue {
                         startValue = value
                     } else {
@@ -212,13 +212,13 @@ extension DatabaseWriter {
                 }
             case let .async(onQueue: queue, startImmediately: startImmediately):
                 if startImmediately {
-                    if let value = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess) {
+                    if let value = try reducer.fetchNext(db, requiringWriteAccess: observation.requiresWriteAccess) {
                         queue.async { onChange(value) }
                     }
                 }
             case let .unsafe(startImmediately: startImmediately):
                 if startImmediately {
-                    startValue = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess)
+                    startValue = try reducer.fetchNext(db, requiringWriteAccess: observation.requiresWriteAccess)
                 }
             }
             

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -203,16 +203,18 @@ extension DatabaseWriter {
             // any future transaction can trigger a change.
             switch observation.scheduling {
             case .mainQueue:
-                let value = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess)
-                if calledOnMainQueue {
-                    startValue = value
-                } else {
-                    DispatchQueue.main.async { onChange(value) }
+                if let value = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess) {
+                    if calledOnMainQueue {
+                        startValue = value
+                    } else {
+                        DispatchQueue.main.async { onChange(value) }
+                    }
                 }
             case let .async(onQueue: queue, startImmediately: startImmediately):
                 if startImmediately {
-                    let value = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess)
-                    queue.async { onChange(value) }
+                    if let value = try reducer.fetchInitialValue(db, requiringWriteAccess: observation.requiresWriteAccess) {
+                        queue.async { onChange(value) }
+                    }
                 }
             case let .unsafe(startImmediately: startImmediately):
                 if startImmediately {

--- a/GRDB/ValueObservation/ValueObservation+Combine.swift
+++ b/GRDB/ValueObservation/ValueObservation+Combine.swift
@@ -1,114 +1,30 @@
-extension ValueObservation where Reducer == Void {
-    public static func combine<R1: ValueReducer, R2: ValueReducer>(
-        _ o1: ValueObservation<R1>,
-        _ o2: ValueObservation<R2>)
-        -> ValueObservation<AnyValueReducer<
-        (R1.Fetched, R2.Fetched),
-        (R1.Value, R2.Value)>>
-    {
-        return ValueObservation<AnyValueReducer<
-            (R1.Fetched, R2.Fetched),
-            (R1.Value, R2.Value)>>(
-                tracking: { try DatabaseRegion.union(
-                    o1.observedRegion($0),
-                    o2.observedRegion($0)) },
-                reducer: { try _combine(
-                    o1.makeReducer($0),
-                    o2.makeReducer($0)) })
-    }
-    
-    public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer>(
-        _ o1: ValueObservation<R1>,
-        _ o2: ValueObservation<R2>,
-        _ o3: ValueObservation<R3>)
-        -> ValueObservation<AnyValueReducer<
-        (R1.Fetched, R2.Fetched, R3.Fetched),
-        (R1.Value, R2.Value, R3.Value)>>
-    {
-        return ValueObservation<AnyValueReducer<
-            (R1.Fetched, R2.Fetched, R3.Fetched),
-            (R1.Value, R2.Value, R3.Value)>>(
-                tracking: { try DatabaseRegion.union(
-                    o1.observedRegion($0),
-                    o2.observedRegion($0),
-                    o3.observedRegion($0)) },
-                reducer: { try _combine(
-                    o1.makeReducer($0),
-                    o2.makeReducer($0),
-                    o3.makeReducer($0)) })
-    }
-    
-    public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer>(
-        _ o1: ValueObservation<R1>,
-        _ o2: ValueObservation<R2>,
-        _ o3: ValueObservation<R3>,
-        _ o4: ValueObservation<R4>)
-        -> ValueObservation<AnyValueReducer<
-        (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched),
-        (R1.Value, R2.Value, R3.Value, R4.Value)>>
-    {
-        return ValueObservation<AnyValueReducer<
-            (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched),
-            (R1.Value, R2.Value, R3.Value, R4.Value)>>(
-                tracking: { try DatabaseRegion.union(
-                    o1.observedRegion($0),
-                    o2.observedRegion($0),
-                    o3.observedRegion($0),
-                    o4.observedRegion($0)) },
-                reducer: { try _combine(
-                    o1.makeReducer($0),
-                    o2.makeReducer($0),
-                    o3.makeReducer($0),
-                    o4.makeReducer($0)) })
-    }
-    
-    public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer, R5: ValueReducer>(
-        _ o1: ValueObservation<R1>,
-        _ o2: ValueObservation<R2>,
-        _ o3: ValueObservation<R3>,
-        _ o4: ValueObservation<R4>,
-        _ o5: ValueObservation<R5>)
-        -> ValueObservation<AnyValueReducer<
-        (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched),
-        (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)>>
-    {
-        return ValueObservation<AnyValueReducer<
-            (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched),
-            (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)>>(
-                tracking: { try DatabaseRegion.union(
-                    o1.observedRegion($0),
-                    o2.observedRegion($0),
-                    o3.observedRegion($0),
-                    o4.observedRegion($0),
-                    o5.observedRegion($0)) },
-                reducer: { try _combine(
-                    o1.makeReducer($0),
-                    o2.makeReducer($0),
-                    o3.makeReducer($0),
-                    o4.makeReducer($0),
-                    o5.makeReducer($0)) })
-    }
-}
+// MARK: - Combine 2 Reducers
 
-private func _combine<R1: ValueReducer, R2: ValueReducer>(
-    _ r1: R1,
-    _ r2: R2)
-    -> AnyValueReducer<
-    (R1.Fetched, R2.Fetched),
-    (R1.Value, R2.Value)>
+public struct CombinedValueReducer2<
+    Base1: ValueReducer,
+    Base2: ValueReducer>: ValueReducer
 {
-    var r1 = r1
-    var r2 = r2
-    var prev1: R1.Value?
-    var prev2: R2.Value?
-    func fetch(db: Database) throws -> (R1.Fetched, R2.Fetched) {
-        return try (
-            r1.fetch(db),
-            r2.fetch(db))
+    public typealias Fetched = (Base1.Fetched, Base2.Fetched)
+    public typealias Value = (Base1.Value, Base2.Value)
+    var base1: Base1
+    var base2: Base2
+    private var prev1: Base1.Value? = nil
+    private var prev2: Base2.Value? = nil
+    
+    init(base1: Base1, base2: Base2) {
+        self.base1 = base1
+        self.base2 = base2
     }
-    func value(tuple: (R1.Fetched, R2.Fetched)) -> (R1.Value, R2.Value)? {
-        let v1 = r1.value(tuple.0)
-        let v2 = r2.value(tuple.1)
+    
+    public func fetch(_ db: Database) throws -> Fetched {
+        return try (
+            base1.fetch(db),
+            base2.fetch(db))
+    }
+    
+    mutating public func value(_ fetched: Fetched) -> Value? {
+        let v1 = base1.value(fetched.0)
+        let v2 = base2.value(fetched.1)
         defer {
             if let v1 = v1 { prev1 = v1 }
             if let v2 = v2 { prev2 = v2 }
@@ -122,33 +38,62 @@ private func _combine<R1: ValueReducer, R2: ValueReducer>(
             return nil
         }
     }
-    return AnyValueReducer(fetch: fetch, value: value)
 }
 
-private func _combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer>(
-    _ r1: R1,
-    _ r2: R2,
-    _ r3: R3)
-    -> AnyValueReducer<
-    (R1.Fetched, R2.Fetched, R3.Fetched),
-    (R1.Value, R2.Value, R3.Value)>
-{
-    var r1 = r1
-    var r2 = r2
-    var r3 = r3
-    var prev1: R1.Value?
-    var prev2: R2.Value?
-    var prev3: R3.Value?
-    func fetch(db: Database) throws -> (R1.Fetched, R2.Fetched, R3.Fetched) {
-        return try (
-            r1.fetch(db),
-            r2.fetch(db),
-            r3.fetch(db))
+extension CombinedValueReducer2: ImmediateValueReducer where
+    Base1: ImmediateValueReducer,
+    Base2: ImmediateValueReducer
+{ }
+
+extension ValueObservation where Reducer == Void {
+    public static func combine<R1: ValueReducer, R2: ValueReducer>(
+        _ o1: ValueObservation<R1>,
+        _ o2: ValueObservation<R2>)
+        -> ValueObservation<CombinedValueReducer2<R1, R2>>
+    {
+        return ValueObservation<CombinedValueReducer2<R1, R2>>(
+            tracking: { try DatabaseRegion.union(
+                o1.observedRegion($0),
+                o2.observedRegion($0)) },
+            reducer: { try CombinedValueReducer2(
+                base1: o1.makeReducer($0),
+                base2: o2.makeReducer($0)) })
     }
-    func value(tuple: (R1.Fetched, R2.Fetched, R3.Fetched)) -> (R1.Value, R2.Value, R3.Value)? {
-        let v1 = r1.value(tuple.0)
-        let v2 = r2.value(tuple.1)
-        let v3 = r3.value(tuple.2)
+}
+
+// MARK: - Combine 3 Reducers
+
+public struct CombinedValueReducer3<
+    Base1: ValueReducer,
+    Base2: ValueReducer,
+    Base3: ValueReducer>: ValueReducer
+{
+    public typealias Fetched = (Base1.Fetched, Base2.Fetched, Base3.Fetched)
+    public typealias Value = (Base1.Value, Base2.Value, Base3.Value)
+    var base1: Base1
+    var base2: Base2
+    var base3: Base3
+    private var prev1: Base1.Value? = nil
+    private var prev2: Base2.Value? = nil
+    private var prev3: Base3.Value? = nil
+
+    init(base1: Base1, base2: Base2, base3: Base3) {
+        self.base1 = base1
+        self.base2 = base2
+        self.base3 = base3
+    }
+    
+    public func fetch(_ db: Database) throws -> Fetched {
+        return try (
+            base1.fetch(db),
+            base2.fetch(db),
+            base3.fetch(db))
+    }
+    
+    mutating public func value(_ fetched: Fetched) -> Value? {
+        let v1 = base1.value(fetched.0)
+        let v2 = base2.value(fetched.1)
+        let v3 = base3.value(fetched.2)
         defer {
             if let v1 = v1 { prev1 = v1 }
             if let v2 = v2 { prev2 = v2 }
@@ -164,38 +109,72 @@ private func _combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer>(
             return nil
         }
     }
-    return AnyValueReducer(fetch: fetch, value: value)
 }
 
-private func _combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer>(
-    _ r1: R1,
-    _ r2: R2,
-    _ r3: R3,
-    _ r4: R4)
-    -> AnyValueReducer<
-    (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched),
-    (R1.Value, R2.Value, R3.Value, R4.Value)>
-{
-    var r1 = r1
-    var r2 = r2
-    var r3 = r3
-    var r4 = r4
-    var prev1: R1.Value?
-    var prev2: R2.Value?
-    var prev3: R3.Value?
-    var prev4: R4.Value?
-    func fetch(db: Database) throws -> (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched) {
-        return try (
-            r1.fetch(db),
-            r2.fetch(db),
-            r3.fetch(db),
-            r4.fetch(db))
+extension CombinedValueReducer3: ImmediateValueReducer where
+    Base1: ImmediateValueReducer,
+    Base2: ImmediateValueReducer,
+    Base3: ImmediateValueReducer
+{ }
+
+extension ValueObservation where Reducer == Void {
+    public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer>(
+        _ o1: ValueObservation<R1>,
+        _ o2: ValueObservation<R2>,
+        _ o3: ValueObservation<R3>)
+        -> ValueObservation<CombinedValueReducer3<R1, R2, R3>>
+    {
+        return ValueObservation<CombinedValueReducer3<R1, R2, R3>>(
+            tracking: { try DatabaseRegion.union(
+                o1.observedRegion($0),
+                o2.observedRegion($0),
+                o3.observedRegion($0)) },
+            reducer: { try CombinedValueReducer3(
+                base1: o1.makeReducer($0),
+                base2: o2.makeReducer($0),
+                base3: o3.makeReducer($0)) })
     }
-    func value(tuple: (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched)) -> (R1.Value, R2.Value, R3.Value, R4.Value)? {
-        let v1 = r1.value(tuple.0)
-        let v2 = r2.value(tuple.1)
-        let v3 = r3.value(tuple.2)
-        let v4 = r4.value(tuple.3)
+}
+
+// MARK: - Combine 4 Reducers
+
+public struct CombinedValueReducer4<
+    Base1: ValueReducer,
+    Base2: ValueReducer,
+    Base3: ValueReducer,
+    Base4: ValueReducer>: ValueReducer
+{
+    public typealias Fetched = (Base1.Fetched, Base2.Fetched, Base3.Fetched, Base4.Fetched)
+    public typealias Value = (Base1.Value, Base2.Value, Base3.Value, Base4.Value)
+    var base1: Base1
+    var base2: Base2
+    var base3: Base3
+    var base4: Base4
+    private var prev1: Base1.Value? = nil
+    private var prev2: Base2.Value? = nil
+    private var prev3: Base3.Value? = nil
+    private var prev4: Base4.Value? = nil
+
+    init(base1: Base1, base2: Base2, base3: Base3, base4: Base4) {
+        self.base1 = base1
+        self.base2 = base2
+        self.base3 = base3
+        self.base4 = base4
+    }
+    
+    public func fetch(_ db: Database) throws -> Fetched {
+        return try (
+            base1.fetch(db),
+            base2.fetch(db),
+            base3.fetch(db),
+            base4.fetch(db))
+    }
+    
+    mutating public func value(_ fetched: Fetched) -> Value? {
+        let v1 = base1.value(fetched.0)
+        let v2 = base2.value(fetched.1)
+        let v3 = base3.value(fetched.2)
+        let v4 = base4.value(fetched.3)
         defer {
             if let v1 = v1 { prev1 = v1 }
             if let v2 = v2 { prev2 = v2 }
@@ -213,43 +192,82 @@ private func _combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: 
             return nil
         }
     }
-    return AnyValueReducer(fetch: fetch, value: value)
 }
 
-private func _combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer, R5: ValueReducer>(
-    _ r1: R1,
-    _ r2: R2,
-    _ r3: R3,
-    _ r4: R4,
-    _ r5: R5)
-    -> AnyValueReducer<
-    (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched),
-    (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)>
-{
-    var r1 = r1
-    var r2 = r2
-    var r3 = r3
-    var r4 = r4
-    var r5 = r5
-    var prev1: R1.Value?
-    var prev2: R2.Value?
-    var prev3: R3.Value?
-    var prev4: R4.Value?
-    var prev5: R5.Value?
-    func fetch(db: Database) throws -> (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched) {
-        return try (
-            r1.fetch(db),
-            r2.fetch(db),
-            r3.fetch(db),
-            r4.fetch(db),
-            r5.fetch(db))
+extension CombinedValueReducer4: ImmediateValueReducer where
+    Base1: ImmediateValueReducer,
+    Base2: ImmediateValueReducer,
+    Base3: ImmediateValueReducer,
+    Base4: ImmediateValueReducer
+{ }
+
+extension ValueObservation where Reducer == Void {
+    public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer>(
+        _ o1: ValueObservation<R1>,
+        _ o2: ValueObservation<R2>,
+        _ o3: ValueObservation<R3>,
+        _ o4: ValueObservation<R4>)
+        -> ValueObservation<CombinedValueReducer4<R1, R2, R3, R4>>
+    {
+        return ValueObservation<CombinedValueReducer4<R1, R2, R3, R4>>(
+            tracking: { try DatabaseRegion.union(
+                o1.observedRegion($0),
+                o2.observedRegion($0),
+                o3.observedRegion($0),
+                o4.observedRegion($0)) },
+            reducer: { try CombinedValueReducer4(
+                base1: o1.makeReducer($0),
+                base2: o2.makeReducer($0),
+                base3: o3.makeReducer($0),
+                base4: o4.makeReducer($0)) })
     }
-    func value(tuple: (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched)) -> (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)? {
-        let v1 = r1.value(tuple.0)
-        let v2 = r2.value(tuple.1)
-        let v3 = r3.value(tuple.2)
-        let v4 = r4.value(tuple.3)
-        let v5 = r5.value(tuple.4)
+}
+
+// MARK: - Combine 5 Reducers
+
+public struct CombinedValueReducer5<
+    Base1: ValueReducer,
+    Base2: ValueReducer,
+    Base3: ValueReducer,
+    Base4: ValueReducer,
+    Base5: ValueReducer>: ValueReducer
+{
+    public typealias Fetched = (Base1.Fetched, Base2.Fetched, Base3.Fetched, Base4.Fetched, Base5.Fetched)
+    public typealias Value = (Base1.Value, Base2.Value, Base3.Value, Base4.Value, Base5.Value)
+    var base1: Base1
+    var base2: Base2
+    var base3: Base3
+    var base4: Base4
+    var base5: Base5
+    private var prev1: Base1.Value? = nil
+    private var prev2: Base2.Value? = nil
+    private var prev3: Base3.Value? = nil
+    private var prev4: Base4.Value? = nil
+    private var prev5: Base5.Value? = nil
+
+    init(base1: Base1, base2: Base2, base3: Base3, base4: Base4, base5: Base5) {
+        self.base1 = base1
+        self.base2 = base2
+        self.base3 = base3
+        self.base4 = base4
+        self.base5 = base5
+    }
+    
+    public func fetch(_ db: Database) throws -> Fetched {
+        return try (
+            base1.fetch(db),
+            base2.fetch(db),
+            base3.fetch(db),
+            base4.fetch(db),
+            base5.fetch(db))
+    }
+    
+    mutating public func value(_ fetched: Fetched) -> Value? {
+        let v1 = base1.value(fetched.0)
+        let v2 = base2.value(fetched.1)
+        let v3 = base3.value(fetched.2)
+        let v4 = base4.value(fetched.3)
+        let v5 = base5.value(fetched.4)
         defer {
             if let v1 = v1 { prev1 = v1 }
             if let v2 = v2 { prev2 = v2 }
@@ -269,5 +287,37 @@ private func _combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: 
             return nil
         }
     }
-    return AnyValueReducer(fetch: fetch, value: value)
+}
+
+extension CombinedValueReducer5: ImmediateValueReducer where
+    Base1: ImmediateValueReducer,
+    Base2: ImmediateValueReducer,
+    Base3: ImmediateValueReducer,
+    Base4: ImmediateValueReducer,
+    Base5: ImmediateValueReducer
+{ }
+
+extension ValueObservation where Reducer == Void {
+    public static func combine<R1: ValueReducer, R2: ValueReducer, R3: ValueReducer, R4: ValueReducer, R5: ValueReducer>(
+        _ o1: ValueObservation<R1>,
+        _ o2: ValueObservation<R2>,
+        _ o3: ValueObservation<R3>,
+        _ o4: ValueObservation<R4>,
+        _ o5: ValueObservation<R5>)
+        -> ValueObservation<CombinedValueReducer5<R1, R2, R3, R4, R5>>
+    {
+        return ValueObservation<CombinedValueReducer5<R1, R2, R3, R4, R5>>(
+            tracking: { try DatabaseRegion.union(
+                o1.observedRegion($0),
+                o2.observedRegion($0),
+                o3.observedRegion($0),
+                o4.observedRegion($0),
+                o5.observedRegion($0)) },
+            reducer: { try CombinedValueReducer5(
+                base1: o1.makeReducer($0),
+                base2: o2.makeReducer($0),
+                base3: o3.makeReducer($0),
+                base4: o4.makeReducer($0),
+                base5: o5.makeReducer($0)) })
+    }
 }

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -107,7 +107,7 @@ extension ValueObservation where Reducer == Void {
 /// identical database values.
 ///
 /// :nodoc:
-public struct DatabaseValuesReducer<Request: FetchRequest>: ValueReducer
+public struct DatabaseValuesReducer<Request: FetchRequest>: ImmediateValueReducer
     where Request.RowDecoder: DatabaseValueConvertible
 {
     public let request: Request
@@ -139,7 +139,7 @@ public struct DatabaseValuesReducer<Request: FetchRequest>: ValueReducer
 /// identical database values.
 ///
 /// :nodoc:
-public struct DatabaseValueReducer<Request: FetchRequest>: ValueReducer
+public struct DatabaseValueReducer<Request: FetchRequest>: ImmediateValueReducer
     where Request.RowDecoder: DatabaseValueConvertible
 {
     public let request: Request
@@ -181,7 +181,7 @@ public struct DatabaseValueReducer<Request: FetchRequest>: ValueReducer
 /// identical database values.
 ///
 /// :nodoc:
-public struct OptionalDatabaseValuesReducer<Request: FetchRequest>: ValueReducer
+public struct OptionalDatabaseValuesReducer<Request: FetchRequest>: ImmediateValueReducer
     where
     Request.RowDecoder: _OptionalProtocol,
     Request.RowDecoder._Wrapped: DatabaseValueConvertible

--- a/GRDB/ValueObservation/ValueObservation+DistinctUntilChanged.swift
+++ b/GRDB/ValueObservation/ValueObservation+DistinctUntilChanged.swift
@@ -45,3 +45,5 @@ public struct DistinctUntilChangedValueReducer<Base: ValueReducer>: ValueReducer
         return value
     }
 }
+
+extension DistinctUntilChangedValueReducer: ImmediateValueReducer where Base: ImmediateValueReducer { }

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -137,7 +137,7 @@ extension ValueObservation where Reducer == Void {
 /// identical database rows.
 ///
 /// :nodoc:
-public struct FetchableRecordsReducer<RowDecoder>: ValueReducer
+public struct FetchableRecordsReducer<RowDecoder>: ImmediateValueReducer
     where RowDecoder: FetchableRecord
 {
     private let _fetch: (Database) throws -> [Row]
@@ -167,7 +167,7 @@ public struct FetchableRecordsReducer<RowDecoder>: ValueReducer
 /// identical database rows.
 ///
 /// :nodoc:
-public struct FetchableRecordReducer<RowDecoder>: ValueReducer
+public struct FetchableRecordReducer<RowDecoder>: ImmediateValueReducer
     where RowDecoder: FetchableRecord
 {
     private let _fetch: (Database) throws -> Row?

--- a/GRDB/ValueObservation/ValueObservation+Map.swift
+++ b/GRDB/ValueObservation/ValueObservation+Map.swift
@@ -45,3 +45,5 @@ public struct MapValueReducer<Base: ValueReducer, T>: ValueReducer {
         return transform(value)
     }
 }
+
+extension MapValueReducer: ImmediateValueReducer where Base: ImmediateValueReducer { }

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -135,7 +135,7 @@ extension ValueObservation where Reducer == Void {
 /// consecutive identical arrays.
 ///
 /// :nodoc:
-public struct RowsReducer: ValueReducer {
+public struct RowsReducer: ImmediateValueReducer {
     private let _fetch: (Database) throws -> [Row]
     private var previousRows: [Row]?
     
@@ -163,7 +163,7 @@ public struct RowsReducer: ValueReducer {
 /// identical database rows.
 ///
 /// :nodoc:
-public struct RowReducer: ValueReducer {
+public struct RowReducer: ImmediateValueReducer {
     private let _fetch: (Database) throws -> Row?
     private var previousRow: Row??
     

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -199,8 +199,8 @@ extension ValueObservation where Reducer: ValueReducer {
     
     // MARK: - Fetching Values
     
-    /// Returns newly fetched values
-    public func fetch(_ db: Database) throws -> Reducer.Value {
+    /// Returns newly fetched value, if any
+    public func fetch(_ db: Database) throws -> Reducer.Value? {
         var reducer = try makeReducer(db)
         return try reducer.fetchInitialValue(db, requiringWriteAccess: requiresWriteAccess)
     }

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -201,6 +201,8 @@ extension ValueObservation where Reducer: ValueReducer {
     
     /// Returns the observed value.
     ///
+    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+    ///
     /// This method returns nil if observation would not notify any
     /// initial value.
     ///
@@ -228,6 +230,8 @@ extension ValueObservation where Reducer: ImmediateValueReducer {
     // MARK: - Fetching Values
     
     /// Returns the observed value.
+    ///
+    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
     /// For example:
     ///

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -196,6 +196,14 @@ extension ValueObservation where Reducer: ValueReducer {
     {
         return try reader.add(observation: self, onError: onError, onChange: onChange)
     }
+    
+    // MARK: - Fetching Values
+    
+    /// Returns newly fetched values
+    public func fetch(_ db: Database) throws -> Reducer.Value {
+        var reducer = try makeReducer(db)
+        return try reducer.fetchInitialValue(db, requiringWriteAccess: requiresWriteAccess)
+    }
 }
 
 extension ValueObservation {

--- a/GRDB/ValueObservation/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer.swift
@@ -14,6 +14,21 @@ public protocol ValueReducer {
     /// Transforms a fetched value into an eventual observed value. Returns nil
     /// when observer should not be notified.
     ///
+    /// The returned value MUST NOT be nil on the first invocation of the
+    /// reducer. This means that the following assert must always pass:
+    ///
+    ///     // 1st fetch and reduce
+    ///     var reducer = /* some newly initialized ValueReducer */
+    ///     let fetched = try reducer.fetch(db)
+    ///     let value = reducer.value(fetched)
+    ///     assert(value != nil)
+    ///
+    /// Subsequent values may be nil:
+    ///
+    ///     // subsequent fetches and reduce
+    ///     let fetched = try reducer.fetch(db)
+    ///     let value = reducer.value(fetched) // can be nil
+    ///
     /// This method runs inside a private dispatch queue.
     mutating func value(_ fetched: Fetched) -> Value?
 }

--- a/GRDB/ValueObservation/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer.swift
@@ -34,7 +34,7 @@ public protocol ValueReducer {
 }
 
 extension ValueReducer {
-    mutating func fetchInitialValue(_ db: Database, requiringWriteAccess: Bool) throws -> Value {
+    mutating func fetchInitialValue(_ db: Database, requiringWriteAccess: Bool) throws -> Value? {
         var fetchedValue: Fetched!
         if requiringWriteAccess {
             try db.inSavepoint {
@@ -47,11 +47,7 @@ extension ValueReducer {
             }
         }
         
-        guard let value = value(fetchedValue) else {
-            fatalError("Broken contract: reducer must return a non-nil initial value: \(self)")
-        }
-        
-        return value
+        return value(fetchedValue)
     }
 }
 

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -331,6 +331,8 @@
 		567F45AF1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		568068341EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		568068381EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
+		5686050922A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686050722A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
+		5686050A22A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686050722A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
 		5690C3291D23E6D800E59934 /* FoundationDateComponentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */; };
 		5690C32D1D23E6D800E59934 /* FoundationDateComponentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */; };
 		5690C33A1D23E7D200E59934 /* FoundationDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C3361D23E7D200E59934 /* FoundationDateTests.swift */; };
@@ -902,6 +904,7 @@
 		567F0B2F220F196300D111FB /* SQLInterpolationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLInterpolationTests.swift; sourceTree = "<group>"; };
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
+		5686050722A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationTrackingFetchTests.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateComponentsTests.swift; sourceTree = "<group>"; };
 		5690C3361D23E7D200E59934 /* FoundationDateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateTests.swift; sourceTree = "<group>"; };
@@ -1321,6 +1324,7 @@
 				563B06CF2185E04600B38F35 /* ValueObservationReducerTests.swift */,
 				563B0701218627DE00B38F35 /* ValueObservationRowTests.swift */,
 				563B06D02185E04600B38F35 /* ValueObservationSchedulingTests.swift */,
+				5686050722A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift */,
 			);
 			name = ValueObservation;
 			sourceTree = "<group>";
@@ -2275,6 +2279,7 @@
 				5698AC501DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
 				5665FA1F2129D807004D8612 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
 				F3BA80FD1CFB3024003DC1BA /* TransactionObserverSavepointsTests.swift in Sources */,
+				5686050A22A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				F3BA811F1CFB3063003DC1BA /* RecordMinimalPrimaryKeySingleTests.swift in Sources */,
 				5657AB451D108BA9006283EF /* FoundationNSDataTests.swift in Sources */,
 				56CC9255201E094600CB597E /* PrefixCursorTests.swift in Sources */,
@@ -2607,6 +2612,7 @@
 				F3BA80FF1CFB3025003DC1BA /* TransactionObserverSavepointsTests.swift in Sources */,
 				5665FA1E2129D807004D8612 /* DatabaseDateDecodingStrategyTests.swift in Sources */,
 				5698AC4C1DA2D48A0056AF8C /* FTS3RecordTests.swift in Sources */,
+				5686050922A0135500CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				F3BA80EF1CFB3017003DC1BA /* RowFromStatementTests.swift in Sources */,
 				5657AB511D108BA9006283EF /* FoundationNSNumberTests.swift in Sources */,
 				56CC9254201E094600CB597E /* PrefixCursorTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -383,13 +383,15 @@
 		564A2151226B8E18001F64F1 /* Betty.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 564A1F6F226B89D6001F64F1 /* Betty.jpeg */; };
 		5656A802229474DD001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
 		5656A803229474DD001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
+		5686050F22A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686050E22A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
+		5686051022A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686050E22A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
 		569BBA31228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA32228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		56DF0027228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF0028228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF0029228DE00900D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF002A228DE00900D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */; };
-		5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5B33E6E34F941B4C839A714F /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		98AB0B01EB11B33719AE412E /* Pods_GRDBTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE2436BF42B9FCD6552E7076 /* Pods_GRDBTests.framework */; };
 		F2B3C4250D67969FF3948955 /* Pods_GRDBTestsEncrypted.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D5C7999E7D9CE7145687F5D /* Pods_GRDBTestsEncrypted.framework */; };
 /* End PBXBuildFile section */
@@ -589,6 +591,7 @@
 		564A1FDD226B89E1001F64F1 /* FTS5RecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5RecordTests.swift; sourceTree = "<group>"; };
 		564A2156226B8E18001F64F1 /* GRDBTestsEncrypted.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTestsEncrypted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationQueryInterfaceRequestTests.swift; sourceTree = "<group>"; };
+		5686050E22A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationTrackingFetchTests.swift; sourceTree = "<group>"; };
 		569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
@@ -603,7 +606,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */,
+				5B33E6E34F941B4C839A714F /* (null) in Frameworks */,
 				98AB0B01EB11B33719AE412E /* Pods_GRDBTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -833,6 +836,7 @@
 				564A1F87226B89D8001F64F1 /* ValueObservationReducerTests.swift */,
 				564A1F9C226B89DA001F64F1 /* ValueObservationRowTests.swift */,
 				564A1F48226B89D1001F64F1 /* ValueObservationSchedulingTests.swift */,
+				5686050E22A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift */,
 				564A1FBA226B89DD001F64F1 /* VirtualTableModuleTests.swift */,
 			);
 			name = GRDBTests;
@@ -1067,6 +1071,7 @@
 				564A2082226B89E1001F64F1 /* PersistableRecordTests.swift in Sources */,
 				564A2016226B89E1001F64F1 /* QueryInterfacePromiseTests.swift in Sources */,
 				564A207E226B89E1001F64F1 /* DatabaseTests.swift in Sources */,
+				5686050F22A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				564A2033226B89E1001F64F1 /* AssociationHasManySQLTests.swift in Sources */,
 				564A204A226B89E1001F64F1 /* RawRepresentable+DatabaseValueConvertibleTests.swift in Sources */,
 				564A207B226B89E1001F64F1 /* FTS5TokenizerTests.swift in Sources */,
@@ -1264,6 +1269,7 @@
 				564A20B0226B8E18001F64F1 /* PersistableRecordTests.swift in Sources */,
 				564A20B1226B8E18001F64F1 /* QueryInterfacePromiseTests.swift in Sources */,
 				564A20B2226B8E18001F64F1 /* DatabaseTests.swift in Sources */,
+				5686051022A01AB800CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				564A20B3226B8E18001F64F1 /* AssociationHasManySQLTests.swift in Sources */,
 				564A20B4226B8E18001F64F1 /* RawRepresentable+DatabaseValueConvertibleTests.swift in Sources */,
 				564A20B5226B8E18001F64F1 /* FTS5TokenizerTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -385,13 +385,15 @@
 		564A215A226C8F25001F64F1 /* db.SQLCipher3 in Resources */ = {isa = PBXBuildFile; fileRef = 564A2158226C8F24001F64F1 /* db.SQLCipher3 */; };
 		5656A805229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
 		5656A806229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
+		5686051222A01AD900CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686051122A01AD800CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
+		5686051322A01AD900CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5686051122A01AD800CD4C12 /* ValueObservationTrackingFetchTests.swift */; };
 		569BBA2E228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA2F228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		56DF0021228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF0022228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF0023228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF0024228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
-		5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5B33E6E34F941B4C839A714F /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		E158370AAEED49ECD53CE24A /* Pods_GRDBTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67377FE4CDAD675809F93AD4 /* Pods_GRDBTests.framework */; };
 		F2B3C4250D67969FF3948955 /* Pods_GRDBTestsEncrypted.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D5C7999E7D9CE7145687F5D /* Pods_GRDBTestsEncrypted.framework */; };
 /* End PBXBuildFile section */
@@ -592,6 +594,7 @@
 		564A2156226B8E18001F64F1 /* GRDBTestsEncrypted.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTestsEncrypted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A2158226C8F24001F64F1 /* db.SQLCipher3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = db.SQLCipher3; sourceTree = SOURCE_ROOT; };
 		5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationQueryInterfaceRequestTests.swift; sourceTree = "<group>"; };
+		5686051122A01AD800CD4C12 /* ValueObservationTrackingFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationTrackingFetchTests.swift; sourceTree = "<group>"; };
 		569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
 		56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
@@ -606,7 +609,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */,
+				5B33E6E34F941B4C839A714F /* (null) in Frameworks */,
 				E158370AAEED49ECD53CE24A /* Pods_GRDBTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -837,6 +840,7 @@
 				564A1F87226B89D8001F64F1 /* ValueObservationReducerTests.swift */,
 				564A1F9C226B89DA001F64F1 /* ValueObservationRowTests.swift */,
 				564A1F48226B89D1001F64F1 /* ValueObservationSchedulingTests.swift */,
+				5686051122A01AD800CD4C12 /* ValueObservationTrackingFetchTests.swift */,
 				564A1FBA226B89DD001F64F1 /* VirtualTableModuleTests.swift */,
 			);
 			name = GRDBTests;
@@ -1073,6 +1077,7 @@
 				564A2016226B89E1001F64F1 /* QueryInterfacePromiseTests.swift in Sources */,
 				564A207E226B89E1001F64F1 /* DatabaseTests.swift in Sources */,
 				564A2033226B89E1001F64F1 /* AssociationHasManySQLTests.swift in Sources */,
+				5686051222A01AD900CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				564A204A226B89E1001F64F1 /* RawRepresentable+DatabaseValueConvertibleTests.swift in Sources */,
 				56DF0021228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */,
 				564A207B226B89E1001F64F1 /* FTS5TokenizerTests.swift in Sources */,
@@ -1270,6 +1275,7 @@
 				564A20B1226B8E18001F64F1 /* QueryInterfacePromiseTests.swift in Sources */,
 				564A20B2226B8E18001F64F1 /* DatabaseTests.swift in Sources */,
 				564A20B3226B8E18001F64F1 /* AssociationHasManySQLTests.swift in Sources */,
+				5686051322A01AD900CD4C12 /* ValueObservationTrackingFetchTests.swift in Sources */,
 				564A20B4226B8E18001F64F1 /* RawRepresentable+DatabaseValueConvertibleTests.swift in Sources */,
 				56DF0022228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */,
 				564A20B5226B8E18001F64F1 /* FTS5TokenizerTests.swift in Sources */,

--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -2,6 +2,11 @@ import XCTest
 #if GRDBCUSTOMSQLITE
     @testable import GRDBCustomSQLite
 #else
+    #if SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
     @testable import GRDB
 #endif
 

--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+    @testable import GRDBCustomSQLite
 #else
-    import GRDB
+    @testable import GRDB
 #endif
 
 class DatabaseTests : GRDBTestCase {
@@ -309,6 +309,52 @@ class DatabaseTests : GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "BEGIN IMMEDIATE TRANSACTION")
             try db.commit()
             XCTAssertEqual(lastSQLQuery, "COMMIT TRANSACTION")
+        }
+    }
+    
+    // Test an internal API
+    func testReadOnly() throws {
+        // query_only pragma was added in SQLite 3.8.0 http://www.sqlite.org/changes.html#version_3_8_0
+        guard sqlite3_libversion_number() >= 3008000 else {
+            return
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id INTEGER PRIMARY KEY)")
+            
+            // Write access OK
+            try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+            
+            try db.readOnly {
+                do {
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                    XCTFail()
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_READONLY)
+                }
+                
+                // Reentrancy
+                try db.readOnly {
+                    do {
+                        try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                        XCTFail()
+                    } catch let error as DatabaseError {
+                        XCTAssertEqual(error.resultCode, .SQLITE_READONLY)
+                    }
+                }
+                
+                // Still read-only
+                do {
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                    XCTFail()
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_READONLY)
+                }
+            }
+            
+            // Write access OK
+            try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
         }
     }
 }

--- a/Tests/GRDBTests/ValueObservationCombineTests.swift
+++ b/Tests/GRDBTests/ValueObservationCombineTests.swift
@@ -30,8 +30,8 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation1 = ValueObservation.trackingCount(T1.all())
         let observation2 = ValueObservation.trackingCount(T2.all())
         let observation = ValueObservation.combine(observation1, observation2)
-        let observer = try observation.start(in: dbQueue) { value in
-            values.append(value)
+        let observer = try observation.start(in: dbQueue) { value1, value2 in
+            values.append((value1, value2))
             notificationExpectation.fulfill()
         }
         try withExtendedLifetime(observer) {
@@ -90,8 +90,8 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation2 = ValueObservation.trackingCount(T2.all())
         let observation3 = ValueObservation.trackingCount(T3.all())
         let observation = ValueObservation.combine(observation1, observation2, observation3)
-        let observer = try observation.start(in: dbQueue) { value in
-            values.append(value)
+        let observer = try observation.start(in: dbQueue) { value1, value2, value3 in
+            values.append((value1, value2, value3))
             notificationExpectation.fulfill()
         }
         try withExtendedLifetime(observer) {
@@ -164,8 +164,8 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation3 = ValueObservation.trackingCount(T3.all())
         let observation4 = ValueObservation.trackingCount(T4.all())
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4)
-        let observer = try observation.start(in: dbQueue) { value in
-            values.append(value)
+        let observer = try observation.start(in: dbQueue) { value1, value2, value3, value4 in
+            values.append((value1, value2, value3, value4))
             notificationExpectation.fulfill()
         }
         try withExtendedLifetime(observer) {
@@ -252,8 +252,8 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation4 = ValueObservation.trackingCount(T4.all())
         let observation5 = ValueObservation.trackingCount(T5.all())
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5)
-        let observer = try observation.start(in: dbQueue) { value in
-            values.append(value)
+        let observer = try observation.start(in: dbQueue) { value1, value2, value3, value4, value5 in
+            values.append((value1, value2, value3, value4, value5))
             notificationExpectation.fulfill()
         }
         try withExtendedLifetime(observer) {

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -30,7 +30,7 @@ class ValueObservationFetchTests: GRDBTestCase {
         try dbQueue.read { db in
             let request = SQLRequest<Row>(sql: "SELECT * FROM player")
             let observation = ValueObservation.trackingCount(request)
-            let count: Int = try observation.fetch(db)!
+            let count: Int = try observation.fetch(db)
             XCTAssertEqual(count, 3)
         }
     }
@@ -41,7 +41,7 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player WHERE NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let row: Row? = try observation.fetch(db)!
+                let row: Row? = try observation.fetch(db)
                 XCTAssertNil(row)
             }
             do {
@@ -53,7 +53,7 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let rows: [Row] = try observation.fetch(db)!
+                let rows: [Row] = try observation.fetch(db)
                 XCTAssertEqual(rows, [
                     ["id": 1, "name": "Arthur"],
                     ["id": 2, "name": "Barbara"],
@@ -69,31 +69,31 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)!
+                let name: String? = try observation.fetch(db)
                 XCTAssertNil(name)
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)!
+                let name: String? = try observation.fetch(db)
                 XCTAssertNil(name)
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)!
+                let name: String? = try observation.fetch(db)
                 XCTAssertEqual(name, "Arthur")
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let names: [String] = try observation.fetch(db)!
+                let names: [String] = try observation.fetch(db)
                 XCTAssertEqual(names, ["Arthur", "Barbara"])
             }
             do {
                 let request = SQLRequest<String?>(sql: "SELECT name FROM player ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let names: [String?] = try observation.fetch(db)!
+                let names: [String?] = try observation.fetch(db)
                 XCTAssertEqual(names, ["Arthur", "Barbara", nil])
             }
         }
@@ -119,19 +119,19 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = Player.none()
                 let observation = ValueObservation.trackingOne(request)
-                let player: Player? = try observation.fetch(db)!
+                let player: Player? = try observation.fetch(db)
                 XCTAssertNil(player)
             }
             do {
                 let request = Player.orderByPrimaryKey()
                 let observation = ValueObservation.trackingOne(request)
-                let player: Player? = try observation.fetch(db)!
+                let player: Player? = try observation.fetch(db)
                 XCTAssertEqual(player, Player(id: 1, name: "Arthur"))
             }
             do {
                 let request = Player.orderByPrimaryKey()
                 let observation = ValueObservation.trackingAll(request)
-                let players: [Player] = try observation.fetch(db)!
+                let players: [Player] = try observation.fetch(db)
                 XCTAssertEqual(players, [
                     Player(id: 1, name: "Arthur"),
                     Player(id: 2, name: "Barbara"),
@@ -151,7 +151,7 @@ class ValueObservationFetchTests: GRDBTestCase {
                     .map { rows in
                     rows.map { row in row["id"] as Int64 }
                 }
-                let ids: [Int64] = try observation.fetch(db)!
+                let ids: [Int64] = try observation.fetch(db)
                 XCTAssertEqual(ids, [1, 2, 3])
             }
         }
@@ -171,7 +171,7 @@ class ValueObservationFetchTests: GRDBTestCase {
                 let observation1 = ValueObservation.trackingOne(request1)
                 let observation2 = ValueObservation.trackingOne(request2)
                 let observation = ValueObservation.combine(observation1, observation2)
-                let players = try observation.fetch(db)!
+                let players = try observation.fetch(db)
                 XCTAssertEqual(players.0, Player(id: 1, name: "Arthur"))
                 XCTAssertEqual(players.1, Player(id: 2, name: "Barbara"))
             }
@@ -186,7 +186,7 @@ class ValueObservationFetchTests: GRDBTestCase {
                 let observation = ValueObservation
                     .trackingOne(request)
                     .compactMap { row -> Row? in nil }
-                let row = try observation.fetch(db)
+                let row = try observation.fetchFirst(db)
                 XCTAssertNil(row)
             }
         }

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -11,76 +11,133 @@ import XCTest
 #endif
 
 class ValueObservationFetchTests: GRDBTestCase {
-    func testRegionsAPI() {
-        // single region
-        _ = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
-        // variadic
-        _ = ValueObservation.tracking(DatabaseRegion(), DatabaseRegion(), fetch: { _ in })
-        // array
-        _ = ValueObservation.tracking([DatabaseRegion()], fetch: { _ in })
+    override func setup(_ dbWriter: DatabaseWriter) throws {
+        try dbWriter.write { db in
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("name", .text)
+            }
+            try db.execute(sql: """
+                INSERT INTO player (name) VALUES ('Arthur');
+                INSERT INTO player (name) VALUES ('Barbara');
+                INSERT INTO player (name) VALUES (NULL);
+                """)
+        }
     }
     
-    func testFetch() throws {
-        func test(_ dbWriter: DatabaseWriter) throws {
-            try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
-            
-            var counts: [Int] = []
-            let notificationExpectation = expectation(description: "notification")
-            notificationExpectation.assertForOverFulfill = true
-            notificationExpectation.expectedFulfillmentCount = 4
-            
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
-                try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
-            let observer = try observation.start(in: dbWriter) { count in
-                counts.append(count)
-                notificationExpectation.fulfill()
-            }
-            try withExtendedLifetime(observer) {
-                try dbWriter.writeWithoutTransaction { db in
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                    try db.execute(sql: "UPDATE t SET id = id")
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                }
-                
-                waitForExpectations(timeout: 1, handler: nil)
-                XCTAssertEqual(counts, [0, 1, 1, 2])
-            }
+    func testFetchCount() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            let request = SQLRequest<Row>(sql: "SELECT * FROM player")
+            let observation = ValueObservation.trackingCount(request)
+            let count: Int = try observation.fetch(db)
+            XCTAssertEqual(count, 3)
         }
-        
-        try test(makeDatabaseQueue())
-        try test(makeDatabasePool())
     }
     
-    func testDistinctUntilChanged() throws {
-        func test(_ dbWriter: DatabaseWriter) throws {
-            try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
-            
-            var counts: [Int] = []
-            let notificationExpectation = expectation(description: "notification")
-            notificationExpectation.assertForOverFulfill = true
-            notificationExpectation.expectedFulfillmentCount = 3
-            
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
-                try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            }).distinctUntilChanged()
-            let observer = try observation.start(in: dbWriter) { count in
-                counts.append(count)
-                notificationExpectation.fulfill()
+    func testFetchRow() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            do {
+                let request = SQLRequest<Row>(sql: "SELECT * FROM player WHERE NULL")
+                let observation = ValueObservation.trackingOne(request)
+                let row: Row? = try observation.fetch(db)
+                XCTAssertNil(row)
             }
-            try withExtendedLifetime(observer) {
-                try dbWriter.writeWithoutTransaction { db in
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                    try db.execute(sql: "UPDATE t SET id = id")
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                }
-                
-                waitForExpectations(timeout: 1, handler: nil)
-                XCTAssertEqual(counts, [0, 1, 2])
+            do {
+                let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
+                let observation = ValueObservation.trackingOne(request)
+                let row: Row? = try observation.fetch(db)
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
+            }
+            do {
+                let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
+                let observation = ValueObservation.trackingAll(request)
+                let rows: [Row] = try observation.fetch(db)
+                XCTAssertEqual(rows, [
+                    ["id": 1, "name": "Arthur"],
+                    ["id": 2, "name": "Barbara"],
+                    ["id": 3, "name": nil],
+                    ])
             }
         }
-        
-        try test(makeDatabaseQueue())
-        try test(makeDatabasePool())
+    }
+    
+    func testFetchDatabaseValueConvertible() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            do {
+                let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE NULL")
+                let observation = ValueObservation.trackingOne(request)
+                let name: String? = try observation.fetch(db)
+                XCTAssertNil(name)
+            }
+            do {
+                let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NULL")
+                let observation = ValueObservation.trackingOne(request)
+                let name: String? = try observation.fetch(db)
+                XCTAssertNil(name)
+            }
+            do {
+                let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
+                let observation = ValueObservation.trackingOne(request)
+                let name: String? = try observation.fetch(db)
+                XCTAssertEqual(name, "Arthur")
+            }
+            do {
+                let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
+                let observation = ValueObservation.trackingAll(request)
+                let names: [String] = try observation.fetch(db)
+                XCTAssertEqual(names, ["Arthur", "Barbara"])
+            }
+            do {
+                let request = SQLRequest<String?>(sql: "SELECT name FROM player ORDER BY id")
+                let observation = ValueObservation.trackingAll(request)
+                let names: [String?] = try observation.fetch(db)
+                XCTAssertEqual(names, ["Arthur", "Barbara", nil])
+            }
+        }
+    }
+    
+    func testFetchFetchableRecord() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            struct Player: FetchableRecord, TableRecord, Equatable {
+                var id: Int64
+                var name: String?
+                
+                init(id: Int64, name: String?) {
+                    self.id = id
+                    self.name = name
+                }
+                
+                init(row: Row) {
+                    id = row["id"]
+                    name = row["name"]
+                }
+            }
+            do {
+                let request = Player.none()
+                let observation = ValueObservation.trackingOne(request)
+                let player: Player? = try observation.fetch(db)
+                XCTAssertNil(player)
+            }
+            do {
+                let request = Player.orderByPrimaryKey()
+                let observation = ValueObservation.trackingOne(request)
+                let player: Player? = try observation.fetch(db)
+                XCTAssertEqual(player, Player(id: 1, name: "Arthur"))
+            }
+            do {
+                let request = Player.orderByPrimaryKey()
+                let observation = ValueObservation.trackingAll(request)
+                let players: [Player] = try observation.fetch(db)
+                XCTAssertEqual(players, [
+                    Player(id: 1, name: "Arthur"),
+                    Player(id: 2, name: "Barbara"),
+                    Player(id: 3, name: nil),
+                    ])
+            }
+        }
     }
 }

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -30,7 +30,7 @@ class ValueObservationFetchTests: GRDBTestCase {
         try dbQueue.read { db in
             let request = SQLRequest<Row>(sql: "SELECT * FROM player")
             let observation = ValueObservation.trackingCount(request)
-            let count: Int = try observation.fetch(db)
+            let count: Int = try observation.fetch(db)!
             XCTAssertEqual(count, 3)
         }
     }
@@ -41,19 +41,19 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player WHERE NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let row: Row? = try observation.fetch(db)
+                let row: Row? = try observation.fetch(db)!
                 XCTAssertNil(row)
             }
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
                 let observation = ValueObservation.trackingOne(request)
-                let row: Row? = try observation.fetch(db)
+                let row: Row? = try observation.fetch(db)!
                 XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
             }
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let rows: [Row] = try observation.fetch(db)
+                let rows: [Row] = try observation.fetch(db)!
                 XCTAssertEqual(rows, [
                     ["id": 1, "name": "Arthur"],
                     ["id": 2, "name": "Barbara"],
@@ -69,31 +69,31 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)
+                let name: String? = try observation.fetch(db)!
                 XCTAssertNil(name)
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)
+                let name: String? = try observation.fetch(db)!
                 XCTAssertNil(name)
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)
+                let name: String? = try observation.fetch(db)!
                 XCTAssertEqual(name, "Arthur")
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let names: [String] = try observation.fetch(db)
+                let names: [String] = try observation.fetch(db)!
                 XCTAssertEqual(names, ["Arthur", "Barbara"])
             }
             do {
                 let request = SQLRequest<String?>(sql: "SELECT name FROM player ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let names: [String?] = try observation.fetch(db)
+                let names: [String?] = try observation.fetch(db)!
                 XCTAssertEqual(names, ["Arthur", "Barbara", nil])
             }
         }
@@ -119,19 +119,19 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = Player.none()
                 let observation = ValueObservation.trackingOne(request)
-                let player: Player? = try observation.fetch(db)
+                let player: Player? = try observation.fetch(db)!
                 XCTAssertNil(player)
             }
             do {
                 let request = Player.orderByPrimaryKey()
                 let observation = ValueObservation.trackingOne(request)
-                let player: Player? = try observation.fetch(db)
+                let player: Player? = try observation.fetch(db)!
                 XCTAssertEqual(player, Player(id: 1, name: "Arthur"))
             }
             do {
                 let request = Player.orderByPrimaryKey()
                 let observation = ValueObservation.trackingAll(request)
-                let players: [Player] = try observation.fetch(db)
+                let players: [Player] = try observation.fetch(db)!
                 XCTAssertEqual(players, [
                     Player(id: 1, name: "Arthur"),
                     Player(id: 2, name: "Barbara"),
@@ -151,7 +151,7 @@ class ValueObservationFetchTests: GRDBTestCase {
                     .map { rows in
                     rows.map { row in row["id"] as Int64 }
                 }
-                let ids: [Int64] = try observation.fetch(db)
+                let ids: [Int64] = try observation.fetch(db)!
                 XCTAssertEqual(ids, [1, 2, 3])
             }
         }
@@ -171,7 +171,7 @@ class ValueObservationFetchTests: GRDBTestCase {
                 let observation1 = ValueObservation.trackingOne(request1)
                 let observation2 = ValueObservation.trackingOne(request2)
                 let observation = ValueObservation.combine(observation1, observation2)
-                let players = try observation.fetch(db)
+                let players = try observation.fetch(db)!
                 XCTAssertEqual(players.0, Player(id: 1, name: "Arthur"))
                 XCTAssertEqual(players.1, Player(id: 2, name: "Barbara"))
             }
@@ -186,8 +186,8 @@ class ValueObservationFetchTests: GRDBTestCase {
                 let observation = ValueObservation
                     .trackingOne(request)
                     .compactMap { row -> Row? in nil }
-                // FIXME: Crasher!!
-                _ = try observation.fetch(db)
+                let row = try observation.fetch(db)
+                XCTAssertNil(row)
             }
         }
     }

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -30,7 +30,7 @@ class ValueObservationFetchTests: GRDBTestCase {
         try dbQueue.read { db in
             let request = SQLRequest<Row>(sql: "SELECT * FROM player")
             let observation = ValueObservation.trackingCount(request)
-            let count: Int = try observation.fetch(db)
+            let count = try observation.fetch(db)
             XCTAssertEqual(count, 3)
         }
     }
@@ -41,19 +41,19 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player WHERE NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let row: Row? = try observation.fetch(db)
+                let row = try observation.fetch(db)
                 XCTAssertNil(row)
             }
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
                 let observation = ValueObservation.trackingOne(request)
-                let row: Row? = try observation.fetch(db)!
+                let row = try observation.fetch(db)
                 XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
             }
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let rows: [Row] = try observation.fetch(db)
+                let rows = try observation.fetch(db)
                 XCTAssertEqual(rows, [
                     ["id": 1, "name": "Arthur"],
                     ["id": 2, "name": "Barbara"],
@@ -69,31 +69,31 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)
+                let name = try observation.fetch(db)
                 XCTAssertNil(name)
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NULL")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)
+                let name = try observation.fetch(db)
                 XCTAssertNil(name)
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
                 let observation = ValueObservation.trackingOne(request)
-                let name: String? = try observation.fetch(db)
+                let name = try observation.fetch(db)
                 XCTAssertEqual(name, "Arthur")
             }
             do {
                 let request = SQLRequest<String>(sql: "SELECT name FROM player WHERE name IS NOT NULL ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let names: [String] = try observation.fetch(db)
+                let names = try observation.fetch(db)
                 XCTAssertEqual(names, ["Arthur", "Barbara"])
             }
             do {
                 let request = SQLRequest<String?>(sql: "SELECT name FROM player ORDER BY id")
                 let observation = ValueObservation.trackingAll(request)
-                let names: [String?] = try observation.fetch(db)
+                let names = try observation.fetch(db)
                 XCTAssertEqual(names, ["Arthur", "Barbara", nil])
             }
         }
@@ -119,19 +119,19 @@ class ValueObservationFetchTests: GRDBTestCase {
             do {
                 let request = Player.none()
                 let observation = ValueObservation.trackingOne(request)
-                let player: Player? = try observation.fetch(db)
+                let player = try observation.fetch(db)
                 XCTAssertNil(player)
             }
             do {
                 let request = Player.orderByPrimaryKey()
                 let observation = ValueObservation.trackingOne(request)
-                let player: Player? = try observation.fetch(db)
+                let player = try observation.fetch(db)
                 XCTAssertEqual(player, Player(id: 1, name: "Arthur"))
             }
             do {
                 let request = Player.orderByPrimaryKey()
                 let observation = ValueObservation.trackingAll(request)
-                let players: [Player] = try observation.fetch(db)
+                let players = try observation.fetch(db)
                 XCTAssertEqual(players, [
                     Player(id: 1, name: "Arthur"),
                     Player(id: 2, name: "Barbara"),
@@ -148,10 +148,8 @@ class ValueObservationFetchTests: GRDBTestCase {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
                 let observation = ValueObservation
                     .trackingAll(request)
-                    .map { rows in
-                    rows.map { row in row["id"] as Int64 }
-                }
-                let ids: [Int64] = try observation.fetch(db)
+                    .map { rows in rows.map { row in row["id"] as Int64 } }
+                let ids = try observation.fetch(db)
                 XCTAssertEqual(ids, [1, 2, 3])
             }
         }

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -146,7 +146,9 @@ class ValueObservationFetchTests: GRDBTestCase {
         try dbQueue.read { db in
             do {
                 let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
-                let observation = ValueObservation.trackingAll(request).map { rows in
+                let observation = ValueObservation
+                    .trackingAll(request)
+                    .map { rows in
                     rows.map { row in row["id"] as Int64 }
                 }
                 let ids: [Int64] = try observation.fetch(db)
@@ -172,6 +174,20 @@ class ValueObservationFetchTests: GRDBTestCase {
                 let players = try observation.fetch(db)
                 XCTAssertEqual(players.0, Player(id: 1, name: "Arthur"))
                 XCTAssertEqual(players.1, Player(id: 2, name: "Barbara"))
+            }
+        }
+    }
+    
+    func testFetchCompactMap() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.read { db in
+            do {
+                let request = SQLRequest<Row>(sql: "SELECT * FROM player ORDER BY id")
+                let observation = ValueObservation
+                    .trackingOne(request)
+                    .compactMap { row -> Row? in nil }
+                // FIXME: Crasher!!
+                _ = try observation.fetch(db)
             }
         }
     }

--- a/Tests/GRDBTests/ValueObservationTrackingFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationTrackingFetchTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    #if SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
+    import GRDB
+#endif
+
+class ValueObservationTrackingFetchTests: GRDBTestCase {
+    func testRegionsAPI() {
+        // single region
+        _ = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
+        // variadic
+        _ = ValueObservation.tracking(DatabaseRegion(), DatabaseRegion(), fetch: { _ in })
+        // array
+        _ = ValueObservation.tracking([DatabaseRegion()], fetch: { _ in })
+    }
+    
+    func testFetch() throws {
+        func test(_ dbWriter: DatabaseWriter) throws {
+            try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
+            
+            var counts: [Int] = []
+            let notificationExpectation = expectation(description: "notification")
+            notificationExpectation.assertForOverFulfill = true
+            notificationExpectation.expectedFulfillmentCount = 4
+            
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+                try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
+            })
+            let observer = try observation.start(in: dbWriter) { count in
+                counts.append(count)
+                notificationExpectation.fulfill()
+            }
+            try withExtendedLifetime(observer) {
+                try dbWriter.writeWithoutTransaction { db in
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                    try db.execute(sql: "UPDATE t SET id = id")
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1, 1, 2])
+            }
+        }
+        
+        try test(makeDatabaseQueue())
+        try test(makeDatabasePool())
+    }
+    
+    func testDistinctUntilChanged() throws {
+        func test(_ dbWriter: DatabaseWriter) throws {
+            try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
+            
+            var counts: [Int] = []
+            let notificationExpectation = expectation(description: "notification")
+            notificationExpectation.assertForOverFulfill = true
+            notificationExpectation.expectedFulfillmentCount = 3
+            
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+                try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
+            }).distinctUntilChanged()
+            let observer = try observation.start(in: dbWriter) { count in
+                counts.append(count)
+                notificationExpectation.fulfill()
+            }
+            try withExtendedLifetime(observer) {
+                try dbWriter.writeWithoutTransaction { db in
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                    try db.execute(sql: "UPDATE t SET id = id")
+                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
+                }
+                
+                waitForExpectations(timeout: 1, handler: nil)
+                XCTAssertEqual(counts, [0, 1, 2])
+            }
+        }
+        
+        try test(makeDatabaseQueue())
+        try test(makeDatabasePool())
+    }
+}


### PR DESCRIPTION
This PR adds the `fetch` and `fetchFirst` methods to [ValueObservation](https://github.com/groue/GRDB.swift/blob/master/README.md#valueobservation).

`fetch` returns the observed value:

```swift
let observation = ValueObservation.trackingAll(Player.all())
let players: [Player] = try dbQueue.read { db in
    try observation.fetch(db)
}
```

Not all observations are guaranteed to emit values. The `compactMap` operator, for example, can mute an observation. This is why the `fetch` method is not available on all observations.

> Implementation-wise, `fetch` is defined on observations whose reducer conforms to the ImmediateValueReducer protocol. CompactMapValueReducer does not conform to this protocol.

When `fetch` is not available, one can still use `fetchFirst`, which returns an optional:

```swift
let observation = ValueObservation
    .trackingOne(Player.filter(key: 42))
    .compactMap { $0 } // filters out non-existing player
let player: Player? = try dbQueue.read { db in
    try observation.fetchFirst(db)
}
```

Until we figure out if those new ValueObservation `fetch` and `fetchFirst` methods are actually sound and interesting, they will be marked [**:fire: EXPERIMENTAL**](http://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features), and remain undocumented in the main README.

They are an experiment inspired by [Room](https://developer.android.com/topic/libraries/architecture/room) the Android database library. In Room, the developer can easily expose APIs that returns values, LiveData, or RxJava Observables ([documentation](https://developer.android.com/training/data-storage/room/accessing-data)):

```kotlin
@Dao
interface PlayerDao {
    // Simple queries
    @Query("SELECT * FROM player")
    fun loadAllPlayers(): List<Player>
    
    // Observable queries with LiveData
    @Query("SELECT * FROM player")
    fun loadAllPlayers(): LiveData<List<Player>>
    
    // Reactive queries with RxJava
    @Query("SELECT * FROM player")
    fun loadAllPlayers(): Flowable<List<Player>>
)
```

I want to see if ValueObservation can bring this versatility to GRDB and [RxGRDB](https://github.com/RxSwiftCommunity/RxGRDB) as well:

```swift
extension PlayerManager {
    // Define one observation
    private let playersObservation = ValueObservation.trackingAll(Player.all())
    
    // Use it to fetch
    func players() throws -> [Player] {
        return try dbQueue.read { db in
            try playersObservation.fetch(db)
        }
    }
    
    // Use it with RxGRDB
    func players() -> Observable<[Player]> {
        return playersObservation.rx.fetch(in: dbQueue)
    }
}
```

ValueObservation is a versatile type, thanks to its `map`, `combine`, etc. [transformation methods](https://github.com/groue/GRDB.swift/blob/master/README.md#valueobservation-transformations). ValueObservation has a great potential:

```swift
extension PlayerManager {
    struct HallOfFame {
        var totalPlayerCount: Int
        var bestPlayers: [Player]
    }
    
    private let hallOfFameObservation =
        ValueObservation
            .combine(
                ValueObservation.trackingCount(Player.all()),
                ValueObservation.trackingAll(Player
                    .order(Column("score").desc)
                    .limit(10)))
            .map { totalPlayerCount, bestPlayers in
                HallOfFame(
                    totalPlayerCount: totalPlayerCount,
                    bestPlayers: bestPlayers)
            }
    
    // Use it to fetch
    func hallOfFame() throws -> HallOfFame {
        return try dbQueue.read { db in
            try hallOfFameObservation.fetch(db)
        }
    }
    
    // Use it with RxGRDB
    func hallOfFame() -> Observable<HallOfFame> {
        return hallOfFameObservation.rx.fetch(in: dbQueue)
    }
}
```

There are several problems:

- The type of PlayerManager.hallOfFameObservation is an awful behemoth: ` ValueObservation<DistinctUntilChangedValueReducer<MapValueReducer<CombinedValueReducer2<DistinctUntilChangedValueReducer<RawValueReducer<Int>>, FetchableRecordsReducer<Player>>, PlayerManager.HallOfFame>>>`.
    
    Because of their complex types, observations can not easily be used in contexts where Swift requires explicit types (functions, computed properties...).
    
    And we thus can not build complex observations step by step.
    
    This is why the sample code above defines a huge expression. Difficult to build. Difficult to debug. Difficult to read. It just looks too smart to be good. And its inner components can not be reused elsewhere.
    
    We may have to wait for [SE-0244 Opaque Result Types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md) in Swift 5.1 in order to address the root problem of the observation types.

- ValueObservation apis are heavy and verbose. We need to bring a little taste there :sweat_smile: