### PR TITLE
Asynchronous Database Access Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#542](https://github.com/groue/GRDB.swift/pull/542): Move eager loading of hasMany associations to FetchRequest
 - [#546](https://github.com/groue/GRDB.swift/pull/546) by [@robcas3](https://github.com/robcas3): Fix SPM errors with Xcode 11 beta
 - [#549](https://github.com/groue/GRDB.swift/pull/549) Support for Combine
+- [#550](https://github.com/groue/GRDB.swift/pull/550) Asynchronous Database Access Methods
 
 ### Documentation Diff
 

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -372,9 +372,9 @@
 		5659F4981EA8D989004A4992 /* Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F4971EA8D989004A4992 /* Pool.swift */; };
 		5659F49B1EA8D989004A4992 /* Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F4971EA8D989004A4992 /* Pool.swift */; };
 		5659F49E1EA8D989004A4992 /* Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F4971EA8D989004A4992 /* Pool.swift */; };
-		5659F4A01EA8D997004A4992 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* Result.swift */; };
-		5659F4A31EA8D997004A4992 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* Result.swift */; };
-		5659F4A61EA8D997004A4992 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* Result.swift */; };
+		5659F4A01EA8D997004A4992 /* DatabaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* DatabaseResult.swift */; };
+		5659F4A31EA8D997004A4992 /* DatabaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* DatabaseResult.swift */; };
+		5659F4A61EA8D997004A4992 /* DatabaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* DatabaseResult.swift */; };
 		565B0FF01BBC7D980098DE03 /* FetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565B0FEE1BBC7D980098DE03 /* FetchableRecordTests.swift */; };
 		565D5D721BBC694D00DC9BD4 /* Row+FoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565D5D701BBC694D00DC9BD4 /* Row+FoundationTests.swift */; };
 		565D5D751BBC70AE00DC9BD4 /* StatementArguments+FoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565D5D731BBC70AE00DC9BD4 /* StatementArguments+FoundationTests.swift */; };
@@ -1087,7 +1087,7 @@
 		5659F4871EA8D94E004A4992 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteBox.swift; sourceTree = "<group>"; };
 		5659F4971EA8D989004A4992 /* Pool.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pool.swift; sourceTree = "<group>"; };
-		5659F49F1EA8D997004A4992 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		5659F49F1EA8D997004A4992 /* DatabaseResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseResult.swift; sourceTree = "<group>"; };
 		565B0FEE1BBC7D980098DE03 /* FetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchableRecordTests.swift; sourceTree = "<group>"; };
 		565D5D701BBC694D00DC9BD4 /* Row+FoundationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Row+FoundationTests.swift"; sourceTree = "<group>"; };
 		565D5D731BBC70AE00DC9BD4 /* StatementArguments+FoundationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatementArguments+FoundationTests.swift"; sourceTree = "<group>"; };
@@ -1740,12 +1740,12 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5659F49F1EA8D997004A4992 /* DatabaseResult.swift */,
 				563EF4492161F179007DAACD /* Inflections.swift */,
 				569BBA482291707D00478429 /* Inflections+English.swift */,
 				563EF414215F87EB007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
 				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
-				5659F49F1EA8D997004A4992 /* Result.swift */,
 				5659F4871EA8D94E004A4992 /* Utils.swift */,
 			);
 			path = Utils;
@@ -2675,7 +2675,7 @@
 				56D91AAB2205F2F100770D8D /* DatabasePromise.swift in Sources */,
 				566475A01D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
 				565490BB1D5AE236005622CB /* DatabaseReader.swift in Sources */,
-				5659F4A61EA8D997004A4992 /* Result.swift in Sources */,
+				5659F4A61EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				5674A6F81F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				565490C31D5AE236005622CB /* RowAdapter.swift in Sources */,
 				5698AD3B1DABAF4A0056AF8C /* FTS5CustomTokenizer.swift in Sources */,
@@ -2840,7 +2840,7 @@
 				5605F15E1C672E4000235C62 /* DatabaseDateComponents.swift in Sources */,
 				5695962A222C462D002CB7C9 /* HasManyThroughAssociation.swift in Sources */,
 				563363C11C942C04000BE133 /* DatabaseReader.swift in Sources */,
-				5659F4A31EA8D997004A4992 /* Result.swift in Sources */,
+				5659F4A31EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				56B964BC1DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
 				5605F1661C672E4000235C62 /* NSNull.swift in Sources */,
 				5656A8AE2295BFD7001FF3FF /* TableRecord+Association.swift in Sources */,
@@ -3323,7 +3323,7 @@
 				5605F1591C672E4000235C62 /* CGFloat.swift in Sources */,
 				5674A7031F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
 				564CE52021B3129A00652B19 /* ValueObservation+MapReducer.swift in Sources */,
-				5659F4A01EA8D997004A4992 /* Result.swift in Sources */,
+				5659F4A01EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				5605F1631C672E4000235C62 /* Date.swift in Sources */,
 				5605F1711C672E4000235C62 /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
 				56A2387B1B9C75030082EB20 /* Configuration.swift in Sources */,

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -187,7 +187,9 @@ extension DatabaseQueue {
     ///
     /// - parameter block: A block that accesses the database.
     public func asyncRead(_ block: @escaping (Result<Database, Error>) -> Void) {
-        writer.async { block(.success($0)) }
+        writer.async { db in
+            db.readOnly { block(.success(db)) }
+        }
     }
     #endif
 

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -33,14 +33,14 @@ public protocol DatabaseReader : class {
     ///
     ///     try reader.read { db in
     ///         // Those two values are guaranteed to be equal, even if the
-    ///         // `wine` table is modified between the two requests:
-    ///         let count1 = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
-    ///         let count2 = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
+    ///         // `player` table is modified between the two requests:
+    ///         let count1 = try Player.fetchCount(db)
+    ///         let count2 = try Player.fetchCount(db)
     ///     }
     ///
     ///     try reader.read { db in
     ///         // Now this value may be different:
-    ///         let count = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
+    ///         let count = try Player.fetchCount(db)
     ///     }
     ///
     /// Guarantee 2: Starting iOS 8.2, OSX 10.10, and with custom SQLite builds
@@ -52,6 +52,33 @@ public protocol DatabaseReader : class {
     ///   happen while establishing the read access to the database.
     func read<T>(_ block: (Database) throws -> T) throws -> T
     
+    #if compiler(>=5.0)
+    /// Asynchronously executes a read-only block that takes a
+    /// database connection.
+    ///
+    /// Guarantee 1: the block argument is isolated. Eventual concurrent
+    /// database updates are not visible inside the block:
+    ///
+    ///     try reader.asyncRead { result in
+    ///         do (
+    ///             let db = try result.get()
+    ///             // Those two values are guaranteed to be equal, even if the
+    ///             // `player` table is modified between the two requests:
+    ///             let count1 = try Player.fetchCount(db)
+    ///             let count2 = try Player.fetchCount(db)
+    ///         } catch {
+    ///             // handle error
+    ///         }
+    ///     }
+    ///
+    /// Guarantee 2: Starting iOS 8.2, OSX 10.10, and with custom SQLite builds
+    /// and SQLCipher, attempts to write in the database throw a DatabaseError
+    /// whose resultCode is `SQLITE_READONLY`.
+    ///
+    /// - parameter block: A block that accesses the database.
+    func asyncRead(_ block: @escaping (Result<Database, Error>) -> Void)
+    #endif
+    
     /// Synchronously executes a read-only block that takes a database
     /// connection, and returns its result.
     ///
@@ -62,9 +89,9 @@ public protocol DatabaseReader : class {
     ///
     ///     try reader.unsafeRead { db in
     ///         // Those two values may be different because some other thread
-    ///         // may have inserted or deleted a wine between the two requests:
-    ///         let count1 = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
-    ///         let count2 = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
+    ///         // may have inserted or deleted a player between the two requests:
+    ///         let count1 = try Player.fetchCount(db)
+    ///         let count2 = try Player.fetchCount(db)
     ///     }
     ///
     /// Cursor iterations are isolated, though:
@@ -93,9 +120,9 @@ public protocol DatabaseReader : class {
     ///
     ///     try reader.unsafeReentrantRead { db in
     ///         // Those two values may be different because some other thread
-    ///         // may have inserted or deleted a wine between the two requests:
-    ///         let count1 = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
-    ///         let count2 = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM wine")!
+    ///         // may have inserted or deleted a player between the two requests:
+    ///         let count1 = try Player.fetchCount(db)
+    ///         let count2 = try Player.fetchCount(db)
     ///     }
     ///
     /// Cursor iterations are isolated, though:
@@ -217,6 +244,13 @@ public final class AnyDatabaseReader : DatabaseReader {
     public func read<T>(_ block: (Database) throws -> T) throws -> T {
         return try base.read(block)
     }
+    
+    #if compiler(>=5.0)
+    /// :nodoc:
+    public func asyncRead(_ block: @escaping (Result<Database, Error>) -> Void) {
+        base.asyncRead(block)
+    }
+    #endif
     
     /// :nodoc:
     public func unsafeRead<T>(_ block: (Database) throws -> T) throws -> T {

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -62,6 +62,24 @@ extension DatabaseSnapshot {
         return try serializedDatabase.sync(block)
     }
     
+    #if compiler(>=5.0)
+    /// Asynchronously executes a read-only block in a protected dispatch queue.
+    ///
+    ///     let players = try snapshot.asyncRead { result in
+    ///         do {
+    ///             let db = try result.get()
+    ///             let count = try Player.fetchCount(db)
+    ///         } catch {
+    ///             // Handle error
+    ///         }
+    ///     }
+    ///
+    /// - parameter block: A block that accesses the database.
+    public func asyncRead(_ block: @escaping (Result<Database, Error>) -> Void) {
+        serializedDatabase.async { block(.success($0)) }
+    }
+    #endif
+    
     /// Alias for `read`. See `DatabaseReader.unsafeRead`.
     ///
     /// :nodoc:

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -388,7 +388,7 @@ public class DatabaseFuture<Value> {
         _wait = wait
     }
     
-    init(_ result: Result<Value>) {
+    init(_ result: DatabaseResult<Value>) {
         _wait = result.get
     }
     
@@ -428,6 +428,13 @@ public final class AnyDatabaseWriter : DatabaseWriter {
     public func read<T>(_ block: (Database) throws -> T) throws -> T {
         return try base.read(block)
     }
+    
+    #if compiler(>=5.0)
+    /// :nodoc:
+    public func asyncRead(_ block: @escaping (Result<Database, Error>) -> Void) {
+        base.asyncRead(block)
+    }
+    #endif
     
     /// :nodoc:
     public func unsafeRead<T>(_ block: (Database) throws -> T) throws -> T {

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -569,7 +569,7 @@ private func makeFetchFunction<Record, T>(
     controller: FetchedRecordsController<Record>,
     fetchAlongside: @escaping (Database) throws -> T,
     willProcessTransaction: @escaping () -> (),
-    completion: @escaping (Result<(fetchedItems: [Item<Record>], fetchedAlongside: T, observer: FetchedRecordsObserver<Record>)>) -> ()
+    completion: @escaping (DatabaseResult<(fetchedItems: [Item<Record>], fetchedAlongside: T, observer: FetchedRecordsObserver<Record>)>) -> ()
     ) -> (FetchedRecordsObserver<Record>) -> ()
 {
     // Make sure we keep a weak reference to the fetched records controller,

--- a/GRDB/Utils/DatabaseResult.swift
+++ b/GRDB/Utils/DatabaseResult.swift
@@ -1,7 +1,7 @@
 #if compiler(>=5.0)
-typealias Result<Success> = Swift.Result<Success, Error>
+typealias DatabaseResult<Success> = Swift.Result<Success, Error>
 #else
-enum Result<Success> {
+enum DatabaseResult<Success> {
     case success(Success)
     case failure(Error)
     
@@ -13,7 +13,7 @@ enum Result<Success> {
         }
     }
     
-    func map<T>(_ transform: (Success) -> T) -> Result<T> {
+    func map<T>(_ transform: (Success) -> T) -> DatabaseResult<T> {
         switch self {
         case .success(let success):
             return .success(transform(success))

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -40,7 +40,7 @@ extension ValueReducer {
     func fetchFuture(_ db: Database, writer: DatabaseWriter, requiringWriteAccess: Bool) -> DatabaseFuture<Fetched> {
         if requiringWriteAccess {
             // Synchronous fetch
-            return DatabaseFuture(Result {
+            return DatabaseFuture(DatabaseResult {
                 var fetchedValue: Fetched!
                 try db.inTransaction {
                     fetchedValue = try fetch(db)

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -249,8 +249,8 @@
 		5659F4951EA8D964004A4992 /* ReadWriteBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */; };
 		5659F49A1EA8D989004A4992 /* Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F4971EA8D989004A4992 /* Pool.swift */; };
 		5659F49D1EA8D989004A4992 /* Pool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F4971EA8D989004A4992 /* Pool.swift */; };
-		5659F4A21EA8D997004A4992 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* Result.swift */; };
-		5659F4A51EA8D997004A4992 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* Result.swift */; };
+		5659F4A21EA8D997004A4992 /* DatabaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* DatabaseResult.swift */; };
+		5659F4A51EA8D997004A4992 /* DatabaseResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659F49F1EA8D997004A4992 /* DatabaseResult.swift */; };
 		565EFAF11D0436CE00A8FA9D /* NumericOverflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565EFAED1D0436CE00A8FA9D /* NumericOverflowTests.swift */; };
 		565EFAF51D0436CE00A8FA9D /* NumericOverflowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565EFAED1D0436CE00A8FA9D /* NumericOverflowTests.swift */; };
 		5665F868203EF4640084C6C0 /* ColumnInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5665F865203EF4590084C6C0 /* ColumnInfoTests.swift */; };
@@ -850,7 +850,7 @@
 		5659F4871EA8D94E004A4992 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadWriteBox.swift; sourceTree = "<group>"; };
 		5659F4971EA8D989004A4992 /* Pool.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Pool.swift; sourceTree = "<group>"; };
-		5659F49F1EA8D997004A4992 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		5659F49F1EA8D997004A4992 /* DatabaseResult.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseResult.swift; sourceTree = "<group>"; };
 		565B0FEE1BBC7D980098DE03 /* FetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchableRecordTests.swift; sourceTree = "<group>"; };
 		565D5D701BBC694D00DC9BD4 /* Row+FoundationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Row+FoundationTests.swift"; sourceTree = "<group>"; };
 		565D5D731BBC70AE00DC9BD4 /* StatementArguments+FoundationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatementArguments+FoundationTests.swift"; sourceTree = "<group>"; };
@@ -1440,12 +1440,12 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				5659F49F1EA8D997004A4992 /* DatabaseResult.swift */,
 				563EF44C2161F196007DAACD /* Inflections.swift */,
 				569BBA4B229170B300478429 /* Inflections+English.swift */,
 				563EF41E215F8A76007DAACD /* OrderedDictionary.swift */,
 				5659F4971EA8D989004A4992 /* Pool.swift */,
 				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
-				5659F49F1EA8D997004A4992 /* Result.swift */,
 				5659F4871EA8D94E004A4992 /* Utils.swift */,
 			);
 			path = Utils;
@@ -2112,7 +2112,7 @@
 				566B91181FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				F3BA80181CFB2876003DC1BA /* SerializedDatabase.swift in Sources */,
 				5674A7051F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
-				5659F4A51EA8D997004A4992 /* Result.swift in Sources */,
+				5659F4A51EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				564CE52521B312AD00652B19 /* ValueObservation+MapReducer.swift in Sources */,
 				F3BA800D1CFB2871003DC1BA /* DatabasePool.swift in Sources */,
 				5656A87C2295BD56001FF3FF /* QueryInterfaceRequest+Association.swift in Sources */,
@@ -2443,7 +2443,7 @@
 				566B91151FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				F3BA80741CFB2E55003DC1BA /* SerializedDatabase.swift in Sources */,
 				5674A7041F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
-				5659F4A21EA8D997004A4992 /* Result.swift in Sources */,
+				5659F4A21EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				564CE52421B312AD00652B19 /* ValueObservation+MapReducer.swift in Sources */,
 				F3BA80691CFB2E55003DC1BA /* DatabasePool.swift in Sources */,
 				5656A87B2295BD56001FF3FF /* QueryInterfaceRequest+Association.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -8321,6 +8321,8 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     When you use a [database queue](#database-queues) or a [database snapshot](#database-snapshots), the read has to wait for any eventual concurrent database access performed by this queue or snapshot to complete.
     
     When you use a [database pool](#database-pools), reads are generally non-blocking, unless the maximum number of concurrent reads has been reached. In this case, a read has to wait for another read to complete. That maximum number can be [configured](#databasepool-configuration).
+    
+    > :point_up: **Note**: because it uses the standard `Result` type, `asyncRead` is only available with a Swift 5+ compiler, starting Xcode 10.2.
 
 - **`asyncWrite`**
     
@@ -8360,13 +8362,15 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     ```
     
     The scheduled asynchronous transaction has to wait for any eventual concurrent database write to complete before it can start.
+    
+    > :point_up: **Note**: because it uses the standard `Result` type, `asyncWrite` is only available with a Swift 5+ compiler, starting Xcode 10.2.
 
 - **`asyncWriteWithoutTransaction`**
 
     The `asyncWriteWithoutTransaction` method can be used from any thread. It submits your database statements for asynchronous execution on a protected dispatch queue, outside of any transaction:
 
     ```swift
-    reader.asyncWriteWithoutTransaction { db in
+    writer.asyncWriteWithoutTransaction { db in
         try {
             try Player(...).insert(db)
         } catch {

--- a/README.md
+++ b/README.md
@@ -8304,7 +8304,7 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     The `asyncRead` method can be used from any thread. It submits your database statements for asynchronous execution on a protected dispatch queue:
     
     ```swift
-    reader.asyncRead { result: Result<Database> in
+    reader.asyncRead { (result: Result<Database>) in
         try {
             let db = try result.get()
             let players = try Player.fetchAll(db)
@@ -8329,9 +8329,9 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     The `asyncWrite` method can be used from any thread. It submits your database statements for asynchronous execution on a protected dispatch queue, wrapped inside a [database transaction](#transactions-and-savepoints):
     
     ```swift
-    writer.asyncWrite({ db: Database in
+    writer.asyncWrite({ (db: Database) in
         try Player(...).insert(db)
-    }, completion: { result: Result<Void, Error> in
+    }, completion: { (db: Database, result: Result<Void, Error>) in
         switch result {
         case let .success:
             // handle transaction success
@@ -8341,20 +8341,20 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     })
     ```
     
-    `asyncWrite` accepts two function arguments. The first one executes your database updates. The second one is a completion function which accepts the result of the asynchronous transaction.
+    `asyncWrite` accepts two function arguments. The first one executes your database updates. The second one is a completion function which accepts a database connection and the result of the asynchronous transaction.
     
     On the first unhandled error during database updates, all changes are reverted, the whole transaction is rollbacked, and the error is passed to the completion function.
     
     When the transaction completes successfully, the result of the first function is contained in the standard `Result` passed to the completion function:
     
     ```swift
-    writer.asyncWrite({ db: Database in
+    writer.asyncWrite({ (db: Database) in
         try Player(...).insert(db)
         return try Player.fetchCount(db)
-    }, completion: { result: Result<Int, Error> in
+    }, completion: { (db: Database, result: Result<Int, Error>) in
         switch result {
         case let .success(newPlayerCount):
-            // handle value and transaction success
+            print("new player count: \(newPlayerCount)")
         case let .failure(error):
             // handle transaction error
         }
@@ -8370,7 +8370,7 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     The `asyncWriteWithoutTransaction` method can be used from any thread. It submits your database statements for asynchronous execution on a protected dispatch queue, outside of any transaction:
 
     ```swift
-    writer.asyncWriteWithoutTransaction { db in
+    writer.asyncWriteWithoutTransaction { (db: Database) in
         try {
             try Player(...).insert(db)
         } catch {

--- a/README.md
+++ b/README.md
@@ -8379,7 +8379,7 @@ let component = MyReadOnlyComponent(reader: dbQueue)
     }
     ```
     
-    **Writing outside of any transaction is dangerous.** Please see [Transactions and Savepoints](#transactions-and-savepoints) for more information.
+    **Writing outside of any transaction is dangerous.** You should almost always prefer the `asyncWrite` method described above. Please see [Transactions and Savepoints](#transactions-and-savepoints) for more information.
     
     The scheduled asynchronous updates have to wait for any eventual concurrent database write to complete before they can start.
 

--- a/Tests/GRDBTests/DatabaseReaderTests.swift
+++ b/Tests/GRDBTests/DatabaseReaderTests.swift
@@ -73,6 +73,7 @@ class DatabaseReaderTests : GRDBTestCase {
         let _: DatabaseReader = AnyDatabaseReader(reader)
     }
     
+    #if compiler(>=5.0)
     func testAsyncRead() throws {
         func test(_ dbReader: DatabaseReader) throws {
             let expectation = self.expectation(description: "updates")
@@ -98,7 +99,9 @@ class DatabaseReaderTests : GRDBTestCase {
         try test(makeDatabasePool())
         try test(makeDatabasePool().makeSnapshot())
     }
+    #endif
     
+    #if compiler(>=5.0)
     func testAsyncReadPreventsDatabaseModification() throws {
         func test(_ dbReader: DatabaseReader) throws {
             let expectation = self.expectation(description: "updates")
@@ -124,4 +127,5 @@ class DatabaseReaderTests : GRDBTestCase {
         try test(makeDatabasePool())
         try test(makeDatabasePool().makeSnapshot())
     }
+    #endif
 }

--- a/Tests/GRDBTests/DatabaseReaderTests.swift
+++ b/Tests/GRDBTests/DatabaseReaderTests.swift
@@ -72,4 +72,56 @@ class DatabaseReaderTests : GRDBTestCase {
         let reader: DatabaseReader = DatabaseQueue()
         let _: DatabaseReader = AnyDatabaseReader(reader)
     }
+    
+    func testAsyncRead() throws {
+        func test(_ dbReader: DatabaseReader) throws {
+            let expectation = self.expectation(description: "updates")
+            let semaphore = DispatchSemaphore(value: 0)
+            var count: Int?
+            dbReader.asyncRead { db in
+                // Make sure this block executes asynchronously
+                semaphore.wait()
+                do {
+                    count = try Int.fetchOne(db.get(), sql: "SELECT COUNT(*) FROM sqlite_master")
+                } catch {
+                    XCTFail("Unexpected error: \(error)")
+                }
+                expectation.fulfill()
+            }
+            semaphore.signal()
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertNotNil(count)
+        }
+        
+        try test(makeDatabaseQueue())
+        try test(makeDatabasePool())
+        try test(makeDatabasePool().makeSnapshot())
+    }
+    
+    func testAsyncReadPreventsDatabaseModification() throws {
+        func test(_ dbReader: DatabaseReader) throws {
+            let expectation = self.expectation(description: "updates")
+            let semaphore = DispatchSemaphore(value: 0)
+            dbReader.asyncRead { db in
+                // Make sure this block executes asynchronously
+                semaphore.wait()
+                do {
+                    try db.get().execute(sql: "CREATE TABLE testAsyncReadPreventsDatabaseModification (a)")
+                    XCTFail("Expected error")
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_READONLY)
+                } catch {
+                    XCTFail("Unexpected error: \(error)")
+                }
+                expectation.fulfill()
+            }
+            semaphore.signal()
+            waitForExpectations(timeout: 1, handler: nil)
+        }
+        
+        try test(makeDatabaseQueue())
+        try test(makeDatabasePool())
+        try test(makeDatabasePool().makeSnapshot())
+    }
 }

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -102,7 +102,8 @@ class DatabaseWriterTests : GRDBTestCase {
                 // Make sure this block executes asynchronously
                 semaphore.wait()
                 try db.execute(sql: "CREATE TABLE testAsyncWrite (a)")
-            }, completion: { result in
+            }, completion: { db, result in
+                XCTAssertFalse(db.isInsideTransaction)
                 switch result {
                 case .success:
                     break
@@ -132,7 +133,8 @@ class DatabaseWriterTests : GRDBTestCase {
                 // Make sure this block executes asynchronously
                 semaphore.wait()
                 try db.execute(sql: "This is not SQL")
-            }, completion: { result in
+            }, completion: { db, result in
+                XCTAssertFalse(db.isInsideTransaction)
                 switch result {
                 case .success:
                     XCTFail("Expected error")


### PR DESCRIPTION
This PR adds asynchronous database access methods on DatabaseQueue, Pool, and Snaphot:

```swift
protocol DatabaseReader {
    #if compiler(>=5.0)
    func asyncRead(_ block: @escaping (Result<Database, Error>) -> Void)
    #endif
}

protocol DatabaseWriter {
    #if compiler(>=5.0)
    func asyncWrite<T>(
        _ updates: @escaping (Database) throws -> T,
        completion: @escaping (Database, Result<T, Error>) -> Void)
    #endif

    func asyncWriteWithoutTransaction(_ updates: @escaping (Database) -> Void)
}
```

`asyncWrite` and `asyncRead` use the Result type from the Standard Library, and are only available with a Swift 5+ compiler (Xcode 10.2+).

I'm worried that `asyncWriteWithoutTransaction` is easier to use than the safer alternative `asyncWrite`. Let's hope the very long name sounds like a warning for the users.

Those methods will fuel RxGRDB and GRDBCombine.