### PR TITLE
Complete Reactive Support

### DIFF
--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -127,7 +127,7 @@ extension DatabaseSnapshot {
             // Deal with initial value
             switch observation.scheduling {
             case .mainQueue:
-                if let value = try unsafeReentrantRead(observation.fetchFirst) {
+                if let value = try unsafeReentrantRead(observation.fetch) {
                     if DispatchQueue.isMain {
                         onChange(value)
                     } else {
@@ -138,7 +138,7 @@ extension DatabaseSnapshot {
                 }
             case let .async(onQueue: queue, startImmediately: startImmediately):
                 if startImmediately {
-                    if let value = try unsafeReentrantRead(observation.fetchFirst) {
+                    if let value = try unsafeReentrantRead(observation.fetch) {
                         queue.async {
                             onChange(value)
                         }
@@ -146,7 +146,7 @@ extension DatabaseSnapshot {
                 }
             case let .unsafe(startImmediately: startImmediately):
                 if startImmediately {
-                    if let value = try unsafeReentrantRead(observation.fetchFirst) {
+                    if let value = try unsafeReentrantRead(observation.fetch) {
                         onChange(value)
                     }
                 }

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -203,8 +203,8 @@ extension DatabaseValueConvertible {
     
     /// Returns a single value fetched from a prepared statement.
     ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
+    /// The result is nil if the query returns no row, or if the fetched
+    /// database value is null.
     ///
     ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
     ///     let name = try String.fetchOne(statement)   // String?
@@ -266,8 +266,8 @@ extension DatabaseValueConvertible {
     
     /// Returns a single value fetched from an SQL query.
     ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
+    /// The result is nil if the query returns no row, or if the fetched
+    /// database value is null.
     ///
     ///     let name = try String.fetchOne(db, sql: "SELECT name FROM ...") // String?
     ///
@@ -327,8 +327,8 @@ extension DatabaseValueConvertible {
     
     /// Returns a single value fetched from a fetch request.
     ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
+    /// The result is nil if the query returns no row, or if the fetched
+    /// database value is null.
     ///
     ///     let request = Player.filter(key: 1).select(Column("name"))
     ///     let name = try String.fetchOne(db, request) // String?
@@ -451,8 +451,8 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     
     /// Returns a single value fetched from a prepared statement.
     ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
+    /// The result is nil if the query returns no row, or if the fetched
+    /// database value is null.
     ///
     ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
     ///     let name = try Optional<String>.fetchOne(statement)   // String?
@@ -514,8 +514,8 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     
     /// Returns a single value fetched from an SQL query.
     ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
+    /// The result is nil if the query returns no row, or if the fetched
+    /// database value is null.
     ///
     ///     let name = try Optional<String>.fetchOne(db, sql: "SELECT name FROM ...") // String?
     ///
@@ -575,8 +575,8 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     
     /// Returns a single value fetched from a fetch request.
     ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
+    /// The result is nil if the query returns no row, or if the fetched
+    /// database value is null.
     ///
     ///     let request = Player.filter(key: 1).select(Column("name"))
     ///     let name = try Optional<String>.fetchOne(db, request) // String?

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -448,26 +448,6 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     public static func fetchAll(_ statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> [Wrapped?] {
         return try Array(fetchCursor(statement, arguments: arguments, adapter: adapter))
     }
-    
-    /// Returns a single value fetched from a prepared statement.
-    ///
-    /// The result is nil if the query returns no row, or if the fetched
-    /// database value is null.
-    ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
-    ///     let name = try Optional<String>.fetchOne(statement)   // String?
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: An optional value.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchOne(_ statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> Wrapped? {
-        // fetchOne returns nil if there is no row, or if there is a row with a null value
-        let cursor = try NullableDatabaseValueCursor<Wrapped>(statement: statement, arguments: arguments, adapter: adapter)
-        return try cursor.next() ?? nil
-    }
 }
 
 extension Optional where Wrapped: DatabaseValueConvertible {
@@ -511,24 +491,6 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     public static func fetchAll(_ db: Database, sql: String, arguments: StatementArguments = StatementArguments(), adapter: RowAdapter? = nil) throws -> [Wrapped?] {
         return try fetchAll(db, SQLRequest<Void>(sql: sql, arguments: arguments, adapter: adapter))
     }
-    
-    /// Returns a single value fetched from an SQL query.
-    ///
-    /// The result is nil if the query returns no row, or if the fetched
-    /// database value is null.
-    ///
-    ///     let name = try Optional<String>.fetchOne(db, sql: "SELECT name FROM ...") // String?
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: An optional value.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchOne(_ db: Database, sql: String, arguments: StatementArguments = StatementArguments(), adapter: RowAdapter? = nil) throws -> Wrapped? {
-        return try fetchOne(db, SQLRequest<Void>(sql: sql, arguments: arguments, adapter: adapter))
-    }
 }
 
 extension Optional where Wrapped: DatabaseValueConvertible {
@@ -571,24 +533,6 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     public static func fetchAll<R: FetchRequest>(_ db: Database, _ request: R) throws -> [Wrapped?] {
         let request = try request.makePreparedRequest(db, forSingleResult: false)
         return try fetchAll(request.statement, adapter: request.adapter)
-    }
-    
-    /// Returns a single value fetched from a fetch request.
-    ///
-    /// The result is nil if the query returns no row, or if the fetched
-    /// database value is null.
-    ///
-    ///     let request = Player.filter(key: 1).select(Column("name"))
-    ///     let name = try Optional<String>.fetchOne(db, request) // String?
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: An optional value.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchOne<R: FetchRequest>(_ db: Database, _ request: R) throws -> Wrapped? {
-        let request = try request.makePreparedRequest(db, forSingleResult: true)
-        return try fetchOne(request.statement, adapter: request.adapter)
     }
 }
 
@@ -640,6 +584,6 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     /// - returns: An optional value.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public func fetchOne(_ db: Database) throws -> RowDecoder._Wrapped? {
-        return try Optional<RowDecoder._Wrapped>.fetchOne(db, self)
+        return try RowDecoder._Wrapped.fetchOne(db, self)
     }
 }

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -232,7 +232,7 @@ extension ValueReducers {
     /// identical database values.
     ///
     /// :nodoc:
-    public struct AllValues<RowDecoder>: ValueReducer
+    public struct AllValues<RowDecoder>: ImmediateValueReducer
         where RowDecoder: DatabaseValueConvertible
     {
         private let _fetch: (Database) throws -> [DatabaseValue]
@@ -264,7 +264,7 @@ extension ValueReducers {
     /// identical database values.
     ///
     /// :nodoc:
-    public struct OneValue<RowDecoder>: ValueReducer
+    public struct OneValue<RowDecoder>: ImmediateValueReducer
         where RowDecoder: DatabaseValueConvertible
     {
         private let _fetch: (Database) throws -> DatabaseValue?
@@ -306,7 +306,7 @@ extension ValueReducers {
     /// identical database values.
     ///
     /// :nodoc:
-    public struct AllOptionalValues<RowDecoder>: ValueReducer
+    public struct AllOptionalValues<RowDecoder>: ImmediateValueReducer
         where RowDecoder: DatabaseValueConvertible
     {
         private let _fetch: (Database) throws -> [DatabaseValue]

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -193,7 +193,7 @@ extension ValueReducers {
     /// identical database rows.
     ///
     /// :nodoc:
-    public struct AllRecords<RowDecoder>: ValueReducer
+    public struct AllRecords<RowDecoder>: ImmediateValueReducer
         where RowDecoder: FetchableRecord
     {
         private let _fetch: (Database) throws -> [Row]
@@ -223,7 +223,7 @@ extension ValueReducers {
     /// identical database rows.
     ///
     /// :nodoc:
-    public struct OneRecord<RowDecoder>: ValueReducer
+    public struct OneRecord<RowDecoder>: ImmediateValueReducer
         where RowDecoder: FetchableRecord
     {
         private let _fetch: (Database) throws -> Row?

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -133,7 +133,7 @@ extension ValueReducers {
     /// consecutive identical arrays.
     ///
     /// :nodoc:
-    public struct AllRows: ValueReducer {
+    public struct AllRows: ImmediateValueReducer {
         private let _fetch: (Database) throws -> [Row]
         private var previousRows: [Row]?
         
@@ -161,7 +161,7 @@ extension ValueReducers {
     /// identical database rows.
     ///
     /// :nodoc:
-    public struct OneRow: ValueReducer {
+    public struct OneRow: ImmediateValueReducer {
         private let _fetch: (Database) throws -> Row?
         private var previousRow: Row??
         

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -214,23 +214,10 @@ extension ValueObservation where Reducer: ValueReducer {
     // Exposed for RxGRDB and GRDBCombine
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
-    /// Returns the observed value.
+    /// Fetches and returns the observed value.
     ///
-    /// This method returns nil if observation would not notify any
-    /// initial value.
-    ///
-    /// For example, the observation below notifies changes to a player if and
-    /// only if it exists:
-    ///
-    ///     let observation = Player.filter(key: 42)
-    ///         .observationForFirst()
-    ///         .compactMap { $0 } // filters out missing player
-    ///
-    /// The `fetchFirst` method thus returns nil if player does not exist:
-    ///
-    ///     let player: Player? = try dbQueue.read { db in
-    ///         try observation.fetch(db)
-    ///     }
+    /// This method is guaranteed to return a non-nil value if the reducer
+    /// conforms to the ImmediateValueReducer protocol. Otherwise, it may nil.
     ///
     /// :nodoc:
     public func fetch(_ db: Database) throws -> Reducer.Value? {

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -211,6 +211,9 @@ extension ValueObservation where Reducer: ValueReducer {
 
     // MARK: - Fetching Values
     
+    // Exposed for RxGRDB and GRDBCombine
+    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+    ///
     /// Returns the observed value.
     ///
     /// This method returns nil if observation would not notify any
@@ -226,9 +229,11 @@ extension ValueObservation where Reducer: ValueReducer {
     /// The `fetchFirst` method thus returns nil if player does not exist:
     ///
     ///     let player: Player? = try dbQueue.read { db in
-    ///         try observation.fetchFirst(db)
+    ///         try observation.fetch(db)
     ///     }
-    func fetchFirst(_ db: Database) throws -> Reducer.Value? {
+    ///
+    /// :nodoc:
+    public func fetch(_ db: Database) throws -> Reducer.Value? {
         var reducer = try makeReducer(db)
         return try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess))
     }

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -42,6 +42,11 @@ extension ValueReducers {
     }
 }
 
+extension ValueReducers.Combine2: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer
+{ }
+
 extension ValueObservation where Reducer == Void {
     public static func combine<
         R1: ValueReducer,
@@ -123,6 +128,12 @@ extension ValueReducers {
         }
     }
 }
+
+extension ValueReducers.Combine3: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer,
+    R3: ImmediateValueReducer
+{ }
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
@@ -224,6 +235,13 @@ extension ValueReducers {
         }
     }
 }
+
+extension ValueReducers.Combine4: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer,
+    R3: ImmediateValueReducer,
+    R4: ImmediateValueReducer
+{ }
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
@@ -340,6 +358,14 @@ extension ValueReducers {
         }
     }
 }
+
+extension ValueReducers.Combine5: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer,
+    R3: ImmediateValueReducer,
+    R4: ImmediateValueReducer,
+    R5: ImmediateValueReducer
+{ }
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
@@ -472,6 +498,15 @@ extension ValueReducers {
     }
 }
 
+extension ValueReducers.Combine6: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer,
+    R3: ImmediateValueReducer,
+    R4: ImmediateValueReducer,
+    R5: ImmediateValueReducer,
+    R6: ImmediateValueReducer
+{ }
+
 extension ValueObservation where Reducer == Void {
     public static func combine<
         R1: ValueReducer,
@@ -589,6 +624,16 @@ extension ValueReducers {
         }
     }
 }
+
+extension ValueReducers.Combine7: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer,
+    R3: ImmediateValueReducer,
+    R4: ImmediateValueReducer,
+    R5: ImmediateValueReducer,
+    R6: ImmediateValueReducer,
+    R7: ImmediateValueReducer
+{ }
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
@@ -719,6 +764,17 @@ extension ValueReducers {
         }
     }
 }
+
+extension ValueReducers.Combine8: ImmediateValueReducer where
+    R1: ImmediateValueReducer,
+    R2: ImmediateValueReducer,
+    R3: ImmediateValueReducer,
+    R4: ImmediateValueReducer,
+    R5: ImmediateValueReducer,
+    R6: ImmediateValueReducer,
+    R7: ImmediateValueReducer,
+    R8: ImmediateValueReducer
+{ }
 
 extension ValueObservation where Reducer == Void {
     public static func combine<

--- a/GRDB/ValueObservation/ValueReducer/Fetch.swift
+++ b/GRDB/ValueObservation/ValueReducer/Fetch.swift
@@ -4,7 +4,7 @@ extension ValueReducers {
     /// A reducer which pass raw fetched values through.
     ///
     /// :nodoc:
-    public struct Fetch<Value>: ValueReducer {
+    public struct Fetch<Value>: ImmediateValueReducer {
         private let _fetch: (Database) throws -> Value
         
         public init(_ fetch: @escaping (Database) throws -> Value) {

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -48,6 +48,8 @@ extension ValueReducers {
     }
 }
 
+extension ValueReducers.Map: ImmediateValueReducer where Base: ImmediateValueReducer { }
+
 /// :nodoc:
 @available(*, deprecated, renamed: "ValueReducers.Map")
 public typealias MapValueReducer<Base, Value> = ValueReducers.Map<Base, Value> where Base: ValueReducer

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -64,6 +64,8 @@ extension ValueReducers {
     }
 }
 
+extension ValueReducers.RemoveDuplicates: ImmediateValueReducer where Base: ImmediateValueReducer { }
+
 /// :nodoc:
 @available(*, deprecated, renamed: "ValueReducers.RemoveDuplicates")
 public typealias DistinctUntilChangedValueReducer<Base> = ValueReducers.RemoveDuplicates<Base> where Base: ValueReducer, Base.Value: Equatable

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -18,6 +18,26 @@ public protocol ValueReducer {
     mutating func value(_ fetched: Fetched) -> Value?
 }
 
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+///
+/// ImmediateValueReducer is a ValueReducer which guarantees a non-nil
+/// initial value.
+///
+/// The following assert must always pass:
+///
+///     // 1st fetch and reduce
+///     var reducer = /* some newly initialized ImmediateValueReducer */
+///     let fetched = try reducer.fetch(db)
+///     let value = reducer.value(fetched)
+///     assert(value != nil)
+///
+/// Subsequent values may be nil:
+///
+///     // subsequent fetches and reduce
+///     let fetched = try reducer.fetch(db)
+///     let value = reducer.value(fetched) // can be nil
+public protocol ImmediateValueReducer: ValueReducer { }
+
 extension ValueReducer {
     /// Synchronous fetch
     func fetch(_ db: Database, requiringWriteAccess: Bool) throws -> Fetched {

--- a/README.md
+++ b/README.md
@@ -1137,9 +1137,9 @@ try dbQueue.read { db in
     try Int.fetchAll(db, sql: "SELECT ...", arguments: ...)    // [Int]
     try Int.fetchOne(db, sql: "SELECT ...", arguments: ...)    // Int?
     
+    // When database may contain NULL:
     try Optional<Int>.fetchCursor(db, sql: "SELECT ...", arguments: ...) // A Cursor of Int?
     try Optional<Int>.fetchAll(db, sql: "SELECT ...", arguments: ...)    // [Int?]
-    try Optional<Int>.fetchOne(db, sql: "SELECT ...", arguments: ...)    // Int?
 }
 
 let playerCount = try dbQueue.read { db in

--- a/README.md
+++ b/README.md
@@ -1137,9 +1137,9 @@ try dbQueue.read { db in
     try Int.fetchAll(db, sql: "SELECT ...", arguments: ...)    // [Int]
     try Int.fetchOne(db, sql: "SELECT ...", arguments: ...)    // Int?
     
-    // When database may contain NULL:
     try Optional<Int>.fetchCursor(db, sql: "SELECT ...", arguments: ...) // A Cursor of Int?
     try Optional<Int>.fetchAll(db, sql: "SELECT ...", arguments: ...)    // [Int?]
+    try Optional<Int>.fetchOne(db, sql: "SELECT ...", arguments: ...)    // Int?
 }
 
 let playerCount = try dbQueue.read { db in

--- a/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
@@ -623,18 +623,12 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 do {
                     let sql = "SELECT 1 WHERE 0"
                     let statement = try db.makeSelectStatement(sql: sql)
-                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
-                    try test(Optional<Fetched>.fetchOne(statement))
-                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)))
                     try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
                 }
                 do {
                     let sql = "SELECT 0, 1 WHERE 0"
                     let statement = try db.makeSelectStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
-                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
-                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
-                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)))
                     try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
                 }
             }
@@ -645,18 +639,12 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 do {
                     let sql = "SELECT NULL"
                     let statement = try db.makeSelectStatement(sql: sql)
-                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
-                    try test(Optional<Fetched>.fetchOne(statement))
-                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)))
                     try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
                 }
                 do {
                     let sql = "SELECT 0, NULL"
                     let statement = try db.makeSelectStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
-                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
-                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
-                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)))
                     try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
                 }
             }
@@ -667,18 +655,12 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 do {
                     let sql = "SELECT 1"
                     let statement = try db.makeSelectStatement(sql: sql)
-                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
-                    try test(Optional<Fetched>.fetchOne(statement))
-                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)))
                     try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
                 }
                 do {
                     let sql = "SELECT 0, 1"
                     let statement = try db.makeSelectStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
-                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
-                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
-                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)))
                     try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
                 }
             }
@@ -714,17 +696,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT throw()"
-                try test(Optional<Fetched>.fetchOne(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db), sql: sql)
             }
             do {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
-                try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
         }
@@ -746,17 +722,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT * FROM nonExistingTable"
-                try test(Optional<Fetched>.fetchOne(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db), sql: sql)
             }
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
-                try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
         }


### PR DESCRIPTION
This PR adds missing pieces for the companion libraries RxGRDB and GRDBCombine:

- The [experimental](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features) `ImmediateValueReducer` protocol guarantees an Observable/Publisher that a ValueObservation emits an initial value. It makes it possible to define a Single/Future. All value observations have this quality, but the ones that are filtered with `compactMap`.

- Optional values were lacking the fetchOne method: `Optional<String>.fetchOne(...)` was not available because `String.fetchOne(...)` was just enough. This lack of uniformity was a hindrance for companion libraries that are highly generic and don't really care about such detail. So now optional values have the fetchOne method, with the exact same behavior as the non-optional one: all return nil if there was no row to fetch, or if the row contains a NULL value.