### PR TITLE
More tests for eager loading of hasMany associations

### DIFF
--- a/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
@@ -20,7 +20,7 @@ private struct C: TableRecord, FetchableRecord, Decodable, Equatable {
 }
 private struct D: TableRecord, FetchableRecord, Decodable, Equatable {
     var cold1: Int64
-    var cold2: Int64
+    var cold2: Int64?
     var cold3: String
 }
 
@@ -61,6 +61,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                     INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
                     INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
                     INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
+                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
                     """,
                 arguments: [
                     1, "a1",
@@ -77,6 +78,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                     11, 8, "d2",
                     12, 8, "d3",
                     13, 9, "d4",
+                    14, nil, "d5",
                 ])
         }
     }
@@ -791,7 +793,6 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
         }
     }
     
-    // TODO: make a variant with joining(optional:)
     func testIncludingOptionalBelongsToIncludingAllHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write { db in
@@ -1009,6 +1010,72 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                                 C(row: ["colc1": 7, "colc2": 1]),
                             ]),
                         a2: nil))
+                }
+            }
+        }
+    }
+    
+    func testJoiningOptionalHasOneThroughIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = D
+                    .joining(optional: D
+                        .hasOne(A.self, through: D.belongsTo(C.self), using: C.belongsTo(A.self))
+                        .including(all: A
+                            .hasMany(B.self)
+                            .orderByPrimaryKey()))
+                    .orderByPrimaryKey()
+                
+                // Record (flat)
+                do {
+                    struct Record: FetchableRecord, Decodable, Equatable {
+                        var d: D
+                        var bs: [B] // not optional
+                    }
+                    
+                    // Record.fetchAll
+                    do {
+                        let records = try Record.fetchAll(db, request)
+                        XCTAssertEqual(records, [
+                            Record(
+                                d: D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
+                                bs: [
+                                    B(row: ["colb1": 4, "colb2": 1, "colb3": "b1"]),
+                                    B(row: ["colb1": 5, "colb2": 1, "colb3": "b2"]),
+                                ]),
+                            Record(
+                                d: D(row: ["cold1": 11, "cold2": 8, "cold3": "d2"]),
+                                bs: [
+                                    B(row: ["colb1": 6, "colb2": 2, "colb3": "b3"]),
+                                ]),
+                            Record(
+                                d: D(row: ["cold1": 12, "cold2": 8, "cold3": "d3"]),
+                                bs: [
+                                    B(row: ["colb1": 6, "colb2": 2, "colb3": "b3"]),
+                                ]),
+                            Record(
+                                d: D(row: ["cold1": 13, "cold2": 9, "cold3": "d4"]),
+                                bs: [
+                                    B(row: ["colb1": 6, "colb2": 2, "colb3": "b3"]),
+                                ]),
+                            Record(
+                                d: D(row: ["cold1": 14, "cold2": nil, "cold3": "d5"]),
+                                bs: []),
+                            ])
+                    }
+                    
+                    // Record.fetchOne
+                    do {
+                        let record = try Record.fetchOne(db, request)!
+                        XCTAssertEqual(record, Record(
+                            d: D(row: ["cold1": 10, "cold2": 7, "cold3": "d1"]),
+                            bs: [
+                                B(row: ["colb1": 4, "colb2": 1, "colb3": "b1"]),
+                                B(row: ["colb1": 5, "colb2": 1, "colb3": "b2"]),
+                            ]))
+                    }
                 }
             }
         }

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -236,7 +236,6 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
         }
     }
     
-    // TODO: make a variant with joining(optional:)
     func testIncludingOptionalBelongsToIncludingAllHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write { db in
@@ -284,6 +283,27 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                         .forKey("a2"))
                 
                 try XCTAssertEqual(request.databaseRegion(db).description, "a(cola1,cola2),b(colb1,colb2,colb3),c(colc1,colc2)")
+            }
+        }
+    }
+    
+    func testJoiningOptionalHasOneThroughIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = D
+                    .joining(optional: D
+                        .hasOne(A.self, through: D.belongsTo(C.self), using: C.belongsTo(A.self))
+                        .including(all: A
+                            .hasMany(B.self)
+                            .orderByPrimaryKey()))
+                    .orderByPrimaryKey()
+                
+                try XCTAssert([
+                    "a(*),b(colb1,colb2,colb3),c(colc1,colc2),d(cold1,cold2,cold3)",     // iOS 12
+                    "a(cola1),b(colb1,colb2,colb3),c(colc1,colc2),d(cold1,cold2,cold3)", // iOS 9
+                    ].contains(request.databaseRegion(db).description))
             }
         }
     }

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -12,6 +12,12 @@ private struct D: TableRecord { }
 
 class AssociationPrefetchingSQLTests: GRDBTestCase {
     override func setup(_ dbWriter: DatabaseWriter) throws {
+        // A.hasMany(B)
+        // A.hasMany(C)
+        // B.belongsTo(A)
+        // C.belongsTo(A)
+        // C.hasMany(D)
+        // D.belongsTo(C)
         try dbWriter.write { db in
             try db.create(table: "a") { t in
                 t.autoIncrementedPrimaryKey("cola1")
@@ -918,7 +924,6 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
         }
     }
 
-    // TODO: make a variant with joining(optional:)
     func testIncludingOptionalBelongsToIncludingAllHasMany() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write { db in
@@ -1134,6 +1139,388 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" <> 9) AND ("c"."colc2" IN (1, 2, 3)) \
                     WHERE "d"."cold1" <> 11 \
                     ORDER BY "d"."cold1"
+                    """])
+            }
+        }
+    }
+    
+    func testIncludingOptionalBelongsToIncludingOptionalBelongsToIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = D
+                    .including(optional: D
+                        .belongsTo(C.self)
+                        .including(optional: C
+                            .belongsTo(A.self)
+                            .including(all: A
+                                .hasMany(B.self)
+                                .orderByPrimaryKey())))
+                    .orderByPrimaryKey()
+                    .filter(Column("cold2") != 8)
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "d".*, "c".*, "a".* \
+                    FROM "d" \
+                    LEFT JOIN "c" ON "c"."colc1" = "d"."cold2" \
+                    LEFT JOIN "a" ON "a"."cola1" = "c"."colc2" \
+                    WHERE "d"."cold2" <> 8 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "b".*, "c"."colc1" AS "grdb_colc1" \
+                    FROM "b" \
+                    JOIN "a" ON "a"."cola1" = "b"."colb2" \
+                    JOIN "c" ON ("c"."colc2" = "a"."cola1") AND ("c"."colc1" IN (7, 9)) \
+                    ORDER BY "b"."colb1"
+                    """])
+            }
+        }
+    }
+    
+    func testIncludingOptionalHasOneThroughIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = D
+                    .including(optional: D
+                        .hasOne(A.self, through: D.belongsTo(C.self), using: C.belongsTo(A.self))
+                        .including(all: A
+                            .hasMany(B.self)
+                            .orderByPrimaryKey()))
+                    .orderByPrimaryKey()
+                    .filter(Column("cold2") != 8)
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "d".*, "a".* \
+                    FROM "d" \
+                    LEFT JOIN "c" ON "c"."colc1" = "d"."cold2" \
+                    LEFT JOIN "a" ON "a"."cola1" = "c"."colc2" \
+                    WHERE "d"."cold2" <> 8 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "b".*, "c"."colc1" AS "grdb_colc1" \
+                    FROM "b" \
+                    JOIN "a" ON "a"."cola1" = "b"."colb2" \
+                    JOIN "c" ON ("c"."colc2" = "a"."cola1") AND ("c"."colc1" IN (7, 9)) \
+                    ORDER BY "b"."colb1"
+                    """])
+            }
+        }
+    }
+
+    func testJoiningOptionalBelongsToIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = B
+                    .joining(optional: B
+                        .belongsTo(A.self)
+                        .including(all: A
+                            .hasMany(C.self)
+                            .orderByPrimaryKey())
+                    )
+                    .orderByPrimaryKey()
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "b".* \
+                    FROM "b" \
+                    LEFT JOIN "a" ON "a"."cola1" = "b"."colb2" \
+                    ORDER BY "b"."colb1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola1" IN (1, 2)) \
+                    ORDER BY "c"."colc1"
+                    """])
+            }
+            
+            // Request with filters
+            do {
+                let request = B
+                    .joining(optional: B
+                        .belongsTo(A.self)
+                        .filter(Column("cola2") == "a1")
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") == 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs1"))
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") != 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs2"))
+                        .forKey("a1"))
+                    .joining(optional: B
+                        .belongsTo(A.self)
+                        .filter(Column("cola2") == "a2")
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") == 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs1"))
+                        .including(all: A
+                            .hasMany(C.self)
+                            .filter(Column("colc1") != 9)
+                            .orderByPrimaryKey()
+                            .forKey("cs2"))
+                        .forKey("a2"))
+                    .orderByPrimaryKey()
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "b".* \
+                    FROM "b" \
+                    LEFT JOIN "a" "a1" ON ("a1"."cola1" = "b"."colb2") AND ("a1"."cola2" = 'a1') \
+                    LEFT JOIN "a" "a2" ON ("a2"."cola1" = "b"."colb2") AND ("a2"."cola2" = 'a2') \
+                    ORDER BY "b"."colb1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
+                    WHERE "c"."colc1" = 9 \
+                    ORDER BY "c"."colc1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a1') AND ("a"."cola1" IN (1, 2)) \
+                    WHERE "c"."colc1" <> 9 \
+                    ORDER BY "c"."colc1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)) \
+                    WHERE "c"."colc1" = 9 \
+                    ORDER BY "c"."colc1"
+                    """,
+                    """
+                    SELECT "c".*, "a"."cola1" AS "grdb_cola1" \
+                    FROM "c" \
+                    JOIN "a" ON ("a"."cola1" = "c"."colc2") AND ("a"."cola2" = 'a2') AND ("a"."cola1" IN (1, 2)) \
+                    WHERE "c"."colc1" <> 9 \
+                    ORDER BY "c"."colc1"
+                    """])
+            }
+        }
+    }
+    
+    func testJoiningOptionalHasOneIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = A
+                    .joining(optional: A
+                        .hasOne(C.self)
+                        .including(all: C
+                            .hasMany(D.self)
+                            .orderByPrimaryKey())
+                    )
+                    .orderByPrimaryKey()
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "a".* \
+                    FROM "a" \
+                    LEFT JOIN "c" ON "c"."colc2" = "a"."cola1" \
+                    ORDER BY "a"."cola1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc2" IN (1, 2, 3)) \
+                    ORDER BY "d"."cold1"
+                    """])
+            }
+            
+            // Request with filters
+            do {
+                let request = A
+                    .joining(optional: A
+                        .hasOne(C.self)
+                        .filter(Column("colc1") == 9)
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") == 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds1"))
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") != 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds2"))
+                        .forKey("c1"))
+                    .joining(optional: A
+                        .hasOne(C.self)
+                        .filter(Column("colc1") != 9)
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") == 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds1"))
+                        .including(all: C
+                            .hasMany(D.self)
+                            .filter(Column("cold1") != 11)
+                            .orderByPrimaryKey()
+                            .forKey("ds2"))
+                        .forKey("c2"))
+                    .orderByPrimaryKey()
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "a".* \
+                    FROM "a" \
+                    LEFT JOIN "c" "c1" ON ("c1"."colc2" = "a"."cola1") AND ("c1"."colc1" = 9) \
+                    LEFT JOIN "c" "c2" ON ("c2"."colc2" = "a"."cola1") AND ("c2"."colc1" <> 9) \
+                    ORDER BY "a"."cola1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 9) AND ("c"."colc2" IN (1, 2, 3)) \
+                    WHERE "d"."cold1" = 11 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" = 9) AND ("c"."colc2" IN (1, 2, 3)) \
+                    WHERE "d"."cold1" <> 11 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" <> 9) AND ("c"."colc2" IN (1, 2, 3)) \
+                    WHERE "d"."cold1" = 11 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "d".*, "c"."colc2" AS "grdb_colc2" \
+                    FROM "d" \
+                    JOIN "c" ON ("c"."colc1" = "d"."cold2") AND ("c"."colc1" <> 9) AND ("c"."colc2" IN (1, 2, 3)) \
+                    WHERE "d"."cold1" <> 11 \
+                    ORDER BY "d"."cold1"
+                    """])
+            }
+        }
+    }
+    
+    func testJoiningOptionalBelongsToJoiningOptionalBelongsToIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = D
+                    .joining(optional: D
+                        .belongsTo(C.self)
+                        .joining(optional: C
+                            .belongsTo(A.self)
+                            .including(all: A
+                                .hasMany(B.self)
+                                .orderByPrimaryKey())))
+                    .orderByPrimaryKey()
+                    .filter(Column("cold2") != 8)
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "d".* \
+                    FROM "d" \
+                    LEFT JOIN "c" ON "c"."colc1" = "d"."cold2" \
+                    LEFT JOIN "a" ON "a"."cola1" = "c"."colc2" \
+                    WHERE "d"."cold2" <> 8 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "b".*, "c"."colc1" AS "grdb_colc1" \
+                    FROM "b" \
+                    JOIN "a" ON "a"."cola1" = "b"."colb2" \
+                    JOIN "c" ON ("c"."colc2" = "a"."cola1") AND ("c"."colc1" IN (7, 9)) \
+                    ORDER BY "b"."colb1"
+                    """])
+            }
+        }
+    }
+    
+    func testJoiningOptionalHasOneThroughIncludingAllHasMany() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            // Plain request
+            do {
+                let request = D
+                    .joining(optional: D
+                        .hasOne(A.self, through: D.belongsTo(C.self), using: C.belongsTo(A.self))
+                        .including(all: A
+                            .hasMany(B.self)
+                            .orderByPrimaryKey()))
+                    .orderByPrimaryKey()
+                    .filter(Column("cold2") != 8)
+                
+                sqlQueries.removeAll()
+                _ = try Row.fetchAll(db, request)
+                
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                XCTAssertEqual(selectQueries, [
+                    """
+                    SELECT "d".* \
+                    FROM "d" \
+                    LEFT JOIN "c" ON "c"."colc1" = "d"."cold2" \
+                    LEFT JOIN "a" ON "a"."cola1" = "c"."colc2" \
+                    WHERE "d"."cold2" <> 8 \
+                    ORDER BY "d"."cold1"
+                    """,
+                    """
+                    SELECT "b".*, "c"."colc1" AS "grdb_colc1" \
+                    FROM "b" \
+                    JOIN "a" ON "a"."cola1" = "b"."colb2" \
+                    JOIN "c" ON ("c"."colc2" = "a"."cola1") AND ("c"."colc1" IN (7, 9)) \
+                    ORDER BY "b"."colb1"
                     """])
             }
         }

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -1240,7 +1240,9 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 _ = try Row.fetchAll(db, request)
                 
                 let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
-                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                // LEFT JOIN in the first query are useless but harmless.
+                // And SQLite may well optimize them out.
+                // So don't bother removing them.
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "b".* \
@@ -1293,7 +1295,9 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 _ = try Row.fetchAll(db, request)
                 
                 let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
-                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                // LEFT JOIN in the first query are useless but harmless.
+                // And SQLite may well optimize them out.
+                // So don't bother removing them.
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "b".* \
@@ -1352,7 +1356,9 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 _ = try Row.fetchAll(db, request)
                 
                 let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
-                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                // LEFT JOIN in the first query are useless but harmless.
+                // And SQLite may well optimize them out.
+                // So don't bother removing them.
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "a".* \
@@ -1405,7 +1411,9 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 _ = try Row.fetchAll(db, request)
                 
                 let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
-                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                // LEFT JOIN in the first query are useless but harmless.
+                // And SQLite may well optimize them out.
+                // So don't bother removing them.
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "a".* \
@@ -1466,7 +1474,9 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 _ = try Row.fetchAll(db, request)
                 
                 let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
-                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                // LEFT JOIN in the first query are useless but harmless.
+                // And SQLite may well optimize them out.
+                // So don't bother removing them.
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "d".* \
@@ -1505,7 +1515,9 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 _ = try Row.fetchAll(db, request)
                 
                 let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
-                #warning("TODO: remove the harmless but useless LEFT JOIN in the first query")
+                // LEFT JOIN in the first query are useless but harmless.
+                // And SQLite may well optimize them out.
+                // So don't bother removing them.
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "d".* \


### PR DESCRIPTION
This PR adds nothing but new tests for eager loading of hasMany associations. It happened that a few days ago I wrote a request and was just not quite sure it would work. It was working (GRDB associations are really neat), but it wasn't explicitly tested yet!

The newly tested requests have the following shape:

```swift
struct Source {
    static let middle = /* hasOne or belongsTo or hasOneThrough to Middle */
}
struct Middle {
    static let destinations = /* hasMany or hasManyThrough to Destination */
}

// Fetch Source and its destinations through an eventual middle record
struct SourceInfo: Decodable, FetchableRecord {
    var source: Source
    var destinations: [Destination]
}
let infos: [SourceInfo] = try Source
    .joining(optional: Source.middle.including(all: Pivot.destinations))
    .asRequest(of: SourceInfo.self)
    .fetchAll(db)
```

