### PR TITLE
Expose table name and full-text filtering methods to DerivableRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,9 +97,9 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 +struct HasOneThroughAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne { }
 
 -struct QueryInterfaceRequest<T>: DerivableRequest { }
-+struct QueryInterfaceRequest<T>: FilteredRequest, JoinableRequest, OrderedRequest, SelectionRequest { }
-+extension QueryInterfaceRequest: TableRequest where RowDecoder: TableRecord { }
-+extension QueryInterfaceRequest: DerivableRequest where RowDecoder: TableRecord { }
++struct QueryInterfaceRequest<T>: FilteredRequest, OrderedRequest, SelectionRequest, TableRequuest { }
++extension QueryInterfaceRequest: JoinableRequest where T: TableRecord { }
++extension QueryInterfaceRequest: DerivableRequest where T: TableRecord { }
 
  extension AssociationAggregate {
 +    @available(*, deprecated, renamed: "forKey(_:)")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 ### API Diff
 
 ```diff
+-protocol DerivableRequest: FilteredRequest, JoinableRequest, OrderedRequest, SelectionRequest { }
++protocol DerivableRequest: FilteredRequest, JoinableRequest, OrderedRequest, SelectionRequest, TableRequest { }
+
 -extension QueryInterfaceRequest {
 -    func matching(_ pattern: FTS3Pattern?) -> QueryInterfaceRequest<T>
 -}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#562](https://github.com/groue/GRDB.swift/pull/562): Fix crash when using more than one DatabaseCollation
 - [#563](https://github.com/groue/GRDB.swift/pull/563): More tests for eager loading of hasMany associations
 - [#574](https://github.com/groue/GRDB.swift/pull/574): SwiftLint
+- [#576](https://github.com/groue/GRDB.swift/pull/576): Expose table name and full-text filtering methods to DerivableRequest
 
 
 ## 4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,44 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#574](https://github.com/groue/GRDB.swift/pull/574): SwiftLint
 - [#576](https://github.com/groue/GRDB.swift/pull/576): Expose table name and full-text filtering methods to DerivableRequest
 
+### API Diff
+
+```diff
+-extension QueryInterfaceRequest {
+-    func matching(_ pattern: FTS3Pattern?) -> QueryInterfaceRequest<T>
+-}
+-extension QueryInterfaceRequest {
+-    func matching(_ pattern: FTS5Pattern?) -> QueryInterfaceRequest<T>
+-}
++extension TableRequest where Self: FilteredRequest {
++    func matching(_ pattern: FTS3Pattern?) -> Self
++}
++extension TableRequest where Self: FilteredRequest {
++    func matching(_ pattern: FTS5Pattern?) -> Self
++}
+ 
+ protocol Association: DerivableRequest {
+-    associatedtype OriginRowDecoder
++    associatedtype OriginRowDecoder: TableRecord
+ }
+
+-struct BelongsToAssociation<Origin, Destination>: AssociationToOne { }
+-struct HasManyAssociation<Origin, Destination>: AssociationToMany { }
+-struct HasManyThroughAssociation<Origin, Destination>: AssociationToMany { }
+-struct HasOneAssociation<Origin, Destination>: AssociationToOne { }
+-struct HasOneThroughAssociation<Origin, Destination>: AssociationToOne { }
++struct BelongsToAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne { }
++struct HasManyAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToMany { }
++struct HasManyThroughAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToMany { }
++struct HasOneAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne { }
++struct HasOneThroughAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne { }
+
+-struct QueryInterfaceRequest<T>: DerivableRequest { }
++struct QueryInterfaceRequest<T>: FilteredRequest, JoinableRequest, OrderedRequest, SelectionRequest { }
++extension QueryInterfaceRequest: TableRequest where RowDecoder: TableRecord { }
++extension QueryInterfaceRequest: DerivableRequest where RowDecoder: TableRecord { }
+```
+
 
 ## 4.1.1
 

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -1,4 +1,5 @@
 #if SQLITE_ENABLE_FTS5
+import Foundation
 #if SWIFT_PACKAGE
 import CSQLite
 #elseif GRDBCIPHER

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -1,4 +1,5 @@
 #if SQLITE_ENABLE_FTS5
+import Foundation
 #if SWIFT_PACKAGE
 import CSQLite
 #elseif GRDBCIPHER

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -1,4 +1,5 @@
 #if SQLITE_ENABLE_FTS5
+import Foundation
 #if SWIFT_PACKAGE
 import CSQLite
 #elseif GRDBCIPHER

--- a/GRDB/QueryInterface/FTS3+QueryInterface.swift
+++ b/GRDB/QueryInterface/FTS3+QueryInterface.swift
@@ -1,4 +1,4 @@
-extension QueryInterfaceRequest {
+extension TableRequest where Self: FilteredRequest {
     
     // MARK: Full Text Search
     
@@ -11,7 +11,7 @@ extension QueryInterfaceRequest {
     ///
     /// If the search pattern is nil, the request does not match any
     /// database row.
-    public func matching(_ pattern: FTS3Pattern?) -> QueryInterfaceRequest<T> {
+    public func matching(_ pattern: FTS3Pattern?) -> Self {
         guard let pattern = pattern else {
             return none()
         }

--- a/GRDB/QueryInterface/FTS5+QueryInterface.swift
+++ b/GRDB/QueryInterface/FTS5+QueryInterface.swift
@@ -1,5 +1,5 @@
 #if SQLITE_ENABLE_FTS5
-extension QueryInterfaceRequest {
+extension TableRequest where Self: FilteredRequest {
     
     // MARK: Full Text Search
     
@@ -16,7 +16,7 @@ extension QueryInterfaceRequest {
     /// The selection defaults to all columns. This default can be changed for
     /// all requests by the `TableRecord.databaseSelection` property, or
     /// for individual requests with the `TableRecord.select` method.
-    public func matching(_ pattern: FTS5Pattern?) -> QueryInterfaceRequest<T> {
+    public func matching(_ pattern: FTS5Pattern?) -> Self {
         guard let pattern = pattern else {
             return none()
         }

--- a/GRDB/QueryInterface/Request/Association/Association.swift
+++ b/GRDB/QueryInterface/Request/Association/Association.swift
@@ -18,7 +18,7 @@ public protocol Association: DerivableRequest {
     ///         // BelongsToAssociation<Book, Author>
     ///         static let author = belongsTo(Author.self)
     ///     }
-    associatedtype OriginRowDecoder
+    associatedtype OriginRowDecoder: TableRecord
     
     /// :nodoc:
     var sqlAssociation: SQLAssociation { get }
@@ -290,8 +290,8 @@ extension Association {
     }
 }
 
-// Allow association.filter(key: ...)
-extension Association where Self: TableRequest, RowDecoder: TableRecord {
+// TableRequest
+extension Association {
     /// :nodoc:
     public var databaseTableName: String { return RowDecoder.databaseTableName }
 }
@@ -324,7 +324,7 @@ extension AssociationToMany {
     }
 }
 
-extension AssociationToMany where OriginRowDecoder: TableRecord {
+extension AssociationToMany {
     private func makeAggregate(_ expression: SQLExpression) -> AssociationAggregate<OriginRowDecoder> {
         return AssociationAggregate { request in
             let tableAlias = TableAlias()

--- a/GRDB/QueryInterface/Request/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/BelongsToAssociation.swift
@@ -58,7 +58,7 @@
 ///     }
 ///
 /// See ForeignKey for more information.
-public struct BelongsToAssociation<Origin, Destination>: AssociationToOne {
+public struct BelongsToAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne {
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -73,6 +73,3 @@ public struct BelongsToAssociation<Origin, Destination>: AssociationToOne {
         self.sqlAssociation = sqlAssociation
     }
 }
-
-// Allow BelongsToAssociation(...).filter(key: ...)
-extension BelongsToAssociation: TableRequest where Destination: TableRecord { }

--- a/GRDB/QueryInterface/Request/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/HasManyAssociation.swift
@@ -58,7 +58,7 @@
 ///     }
 ///
 /// See ForeignKey for more information.
-public struct HasManyAssociation<Origin, Destination>: AssociationToMany {
+public struct HasManyAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToMany {
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -73,6 +73,3 @@ public struct HasManyAssociation<Origin, Destination>: AssociationToMany {
         self.sqlAssociation = sqlAssociation
     }
 }
-
-// Allow HasManyAssociation(...).filter(key: ...)
-extension HasManyAssociation: TableRequest where Destination: TableRecord { }

--- a/GRDB/QueryInterface/Request/Association/HasManyThroughAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/HasManyThroughAssociation.swift
@@ -41,7 +41,7 @@
 /// two other associations: the `through:` and `using:` arguments. Those
 /// associations can be any other association (BelongsTo, HasMany,
 /// HasManyThrough, etc).
-public struct HasManyThroughAssociation<Origin, Destination>: AssociationToMany {
+public struct HasManyThroughAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToMany {
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -56,6 +56,3 @@ public struct HasManyThroughAssociation<Origin, Destination>: AssociationToMany 
         self.sqlAssociation = sqlAssociation
     }
 }
-
-// Allow HasManyThroughAssociation(...).filter(key: ...)
-extension HasManyThroughAssociation: TableRequest where Destination: TableRecord { }

--- a/GRDB/QueryInterface/Request/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/HasOneAssociation.swift
@@ -60,7 +60,7 @@
 ///     }
 ///
 /// See ForeignKey for more information.
-public struct HasOneAssociation<Origin, Destination>: AssociationToOne {
+public struct HasOneAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne {
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -75,6 +75,3 @@ public struct HasOneAssociation<Origin, Destination>: AssociationToOne {
         self.sqlAssociation = sqlAssociation
     }
 }
-
-// Allow HasOneAssociation(...).filter(key: ...)
-extension HasOneAssociation: TableRequest where Destination: TableRecord { }

--- a/GRDB/QueryInterface/Request/Association/HasOneThroughAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/HasOneThroughAssociation.swift
@@ -21,7 +21,7 @@
 /// two other associations: the `through:` and `using:` arguments. Those
 /// associations can be any other association to one (BelongsTo, HasOne,
 /// HasOneThrough).
-public struct HasOneThroughAssociation<Origin, Destination>: AssociationToOne {
+public struct HasOneThroughAssociation<Origin: TableRecord, Destination: TableRecord>: AssociationToOne {
     /// :nodoc:
     public typealias OriginRowDecoder = Origin
     
@@ -36,6 +36,3 @@ public struct HasOneThroughAssociation<Origin, Destination>: AssociationToOne {
         self.sqlAssociation = sqlAssociation
     }
 }
-
-// Allow HasOneThroughAssociation(...).filter(key: ...)
-extension HasOneThroughAssociation: TableRequest where Destination: TableRecord { }

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -28,7 +28,7 @@
 ///     }
 ///
 /// See https://github.com/groue/GRDB.swift#the-query-interface
-public struct QueryInterfaceRequest<T>: DerivableRequest {
+public struct QueryInterfaceRequest<T> {
     var query: SQLQuery
     
     init(query: SQLQuery) {
@@ -310,7 +310,7 @@ extension QueryInterfaceRequest: AggregatingRequest {
     }
 }
 
-extension QueryInterfaceRequest: JoinableRequest {
+extension QueryInterfaceRequest: _JoinableRequest {
     /// :nodoc:
     public func _including(all association: SQLAssociation) -> QueryInterfaceRequest {
         return mapQuery { $0._including(all: association) }
@@ -336,6 +336,8 @@ extension QueryInterfaceRequest: JoinableRequest {
         return mapQuery { $0._joining(required: association) }
     }
 }
+
+extension QueryInterfaceRequest: JoinableRequest where RowDecoder: TableRecord { }
 
 extension QueryInterfaceRequest {
     
@@ -471,6 +473,9 @@ extension QueryInterfaceRequest: TableRequest {
         }
     }
 }
+
+// TODO: remove this explicit conformance when Swift is able to infer it.
+extension QueryInterfaceRequest: DerivableRequest where RowDecoder: TableRecord { }
 
 extension QueryInterfaceRequest where T: MutablePersistableRecord {
     

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -337,7 +337,7 @@ extension QueryInterfaceRequest: _JoinableRequest {
     }
 }
 
-extension QueryInterfaceRequest: JoinableRequest where RowDecoder: TableRecord { }
+extension QueryInterfaceRequest: JoinableRequest where T: TableRecord { }
 
 extension QueryInterfaceRequest {
     
@@ -474,8 +474,7 @@ extension QueryInterfaceRequest: TableRequest {
     }
 }
 
-// TODO: remove this explicit conformance when Swift is able to infer it.
-extension QueryInterfaceRequest: DerivableRequest where RowDecoder: TableRecord { }
+extension QueryInterfaceRequest: DerivableRequest where T: TableRecord { }
 
 extension QueryInterfaceRequest where T: MutablePersistableRecord {
     

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -500,6 +500,8 @@ extension OrderedRequest {
     }
 }
 
+// MARK: - JoinableRequest
+
 /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
 ///
 /// Type-unsafe support for the JoinableRequest protocol.
@@ -548,7 +550,7 @@ public protocol JoinableRequest: _JoinableRequest {
     ///         // BelongsToAssociation<Book, Author>
     ///         static let author = belongsTo(Author.self)
     ///     }
-    associatedtype RowDecoder
+    associatedtype RowDecoder: TableRecord
 }
 
 extension JoinableRequest {
@@ -593,4 +595,4 @@ extension JoinableRequest {
 /// The base protocol for all requests that can be refined.
 ///
 /// :nodoc:
-public protocol DerivableRequest: SelectionRequest, FilteredRequest, OrderedRequest, JoinableRequest { }
+public protocol DerivableRequest: FilteredRequest, JoinableRequest, OrderedRequest, SelectionRequest, TableRequest { }

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -471,6 +471,10 @@ private struct SQLQualifiedJoin {
         case .innerJoin:
             guard allowsInnerJoin else {
                 // TODO: chainOptionalRequired
+                //
+                // When we eventually implement this, make sure we both support:
+                // - joining(optional: assoc.joining(required: ...))
+                // - having(assoc.joining(required: ...).isEmpty)
                 fatalError("Not implemented: chaining a required association behind an optional association")
             }
         case .leftJoin:

--- a/GRDB/QueryInterface/TableRecord+Association.swift
+++ b/GRDB/QueryInterface/TableRecord+Association.swift
@@ -60,7 +60,6 @@ extension TableRecord {
         key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> BelongsToAssociation<Self, Destination>
-        where Destination: TableRecord
     {
         let foreignKeyRequest = SQLForeignKeyRequest(
             originTable: databaseTableName,
@@ -146,7 +145,6 @@ extension TableRecord {
         key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> HasManyAssociation<Self, Destination>
-        where Destination: TableRecord
     {
         let foreignKeyRequest = SQLForeignKeyRequest(
             originTable: Destination.databaseTableName,
@@ -314,7 +312,6 @@ extension TableRecord {
         key: String? = nil,
         using foreignKey: ForeignKey? = nil)
         -> HasOneAssociation<Self, Destination>
-        where Destination: TableRecord
     {
         let foreignKeyRequest = SQLForeignKeyRequest(
             originTable: Destination.databaseTableName,

--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,6 @@
 - [ ] ValueObservation.flatMap:
 
     Make it possible to build a single observation where some requests depend on the result of other requests. As long as we can't express this in a single observation, we fail the "guaranteed consistency is possible" contract.
-- [ ] matching (FTS3, 5) on associations and DerivableRequest
 - [ ] rename fetchOne to fetchFirst
 - [ ] Rename aliased() to forKey() when relevant
 - [ ] new.updateChanges(from: old) vs. old.updateChanges(with: { old.a = new.a }). This is confusing.

--- a/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
@@ -175,10 +175,10 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
         ac: CAssociation,
         bCondition: String,
         cCondition: String) throws
-        where BAssociation: Association,
+        where
+        BAssociation: Association,
         CAssociation: Association,
-        BAssociation.OriginRowDecoder == CAssociation.OriginRowDecoder,
-        BAssociation.OriginRowDecoder: TableRecord
+        BAssociation.OriginRowDecoder == CAssociation.OriginRowDecoder
     {
         let A = BAssociation.OriginRowDecoder.self
         

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
@@ -177,10 +177,10 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
         ac: CAssociation,
         bCondition: String,
         cCondition: String) throws
-        where BAssociation: AssociationToOne,
+        where
+        BAssociation: AssociationToOne,
         CAssociation: AssociationToOne,
-        BAssociation.OriginRowDecoder == CAssociation.OriginRowDecoder,
-        BAssociation.OriginRowDecoder: TableRecord
+        BAssociation.OriginRowDecoder == CAssociation.OriginRowDecoder
     {
         let A = BAssociation.OriginRowDecoder.self
         
@@ -783,14 +783,14 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
         bCondition: String,
         cCondition: String,
         dCondition: String) throws
-        where BAssociation: AssociationToOne,
+        where
+        BAssociation: AssociationToOne,
         CAssociation: AssociationToOne,
         DCAssociation: AssociationToOne,
         DBAssociation: AssociationToOne,
         BAssociation.OriginRowDecoder == CAssociation.OriginRowDecoder,
         BAssociation.OriginRowDecoder == DCAssociation.OriginRowDecoder,
-        BAssociation.OriginRowDecoder == DBAssociation.OriginRowDecoder,
-        BAssociation.OriginRowDecoder: TableRecord
+        BAssociation.OriginRowDecoder == DBAssociation.OriginRowDecoder
     {
         let A = CAssociation.OriginRowDecoder.self
         

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+import GRDBCustomSQLite
 #else
-    import GRDB
+import GRDB
 #endif
 
 private struct Author: FetchableRecord, PersistableRecord, Codable {
@@ -18,10 +18,12 @@ private struct Author: FetchableRecord, PersistableRecord, Codable {
     
     static let databaseTableName = "author"
     static let books = hasMany(Book.self)
+    
     var books: QueryInterfaceRequest<Book> {
         return request(for: Author.books)
     }
 }
+
 private struct Book: FetchableRecord, PersistableRecord, Codable {
     var id: Int64
     var authorId: Int64
@@ -29,10 +31,21 @@ private struct Book: FetchableRecord, PersistableRecord, Codable {
     
     static let databaseTableName = "book"
     static let author = belongsTo(Author.self)
+    static let bookFts4 = hasOne(BookFts4.self, using: ForeignKey([Column.rowID]))
+    #if SQLITE_ENABLE_FTS5
+    static let bookFts5 = hasOne(BookFts5.self, using: ForeignKey([Column.rowID]))
+    #endif
+    
     var author: QueryInterfaceRequest<Author> {
         return request(for: Book.author)
     }
 }
+
+private struct BookFts4: FetchableRecord, TableRecord, Decodable { }
+
+#if SQLITE_ENABLE_FTS5
+private struct BookFts5: FetchableRecord, TableRecord, Decodable { }
+#endif
 
 private var libraryMigrator: DatabaseMigrator = {
     var migrator = DatabaseMigrator()
@@ -48,6 +61,16 @@ private var libraryMigrator: DatabaseMigrator = {
             t.column("authorId", .integer).notNull().references("author")
             t.column("title", .text).notNull()
         }
+        try db.create(virtualTable: "bookFts4", using: FTS4()) { t in
+            t.synchronize(withTable: "book")
+            t.column("title")
+        }
+        #if SQLITE_ENABLE_FTS5
+        try db.create(virtualTable: "bookFts5", using: FTS5()) { t in
+            t.synchronize(withTable: "book")
+            t.column("title")
+        }
+        #endif
     }
     migrator.registerMigration("fixture") { db in
         try Author(id: 1, firstName: "Herman", lastName: "Melville", country: "US").insert(db)
@@ -87,6 +110,28 @@ extension DerivableRequest where RowDecoder == Book {
     // JoinableRequest
     func filter(authorCountry: String) -> Self {
         return joining(required: Book.author.filter(country: authorCountry))
+    }
+    
+    // TableRequest & FilteredRequest
+    func filter(id: Int) -> Self {
+        return filter(key: id)
+    }
+    
+    // TableRequest & FilteredRequest
+    func matchingFts4(_ pattern: FTS3Pattern?) -> Self {
+        return joining(required: Book.bookFts4.matching(pattern))
+    }
+    
+    #if SQLITE_ENABLE_FTS5
+    // TableRequest & FilteredRequest
+    func matchingFts5(_ pattern: FTS3Pattern?) -> Self {
+        return joining(required: Book.bookFts5.matching(pattern))
+    }
+    #endif
+    
+    // TableRequest & OrderedRequest
+    func orderById() -> Self {
+        return orderByPrimaryKey()
     }
 }
 
@@ -259,6 +304,115 @@ class DerivableRequestTests: GRDBTestCase {
                     JOIN "book" ON "book"."authorId" = "author1"."id" \
                     JOIN "author" "author2" ON ("author2"."id" = "book"."authorId") AND ("author2"."country" = 'FR') \
                     ORDER BY "author1"."firstName"
+                    """)
+            }
+        }
+    }
+    
+    func testTableRequestFilteredRequest() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try libraryMigrator.migrate(dbQueue)
+        try dbQueue.inDatabase { db in
+            // filter(id:)
+            do {
+                let title = try Book.all()
+                    .filter(id: 2)
+                    .fetchOne(db)
+                    .map { $0.title }
+                XCTAssertEqual(title, "Du côté de chez Swann")
+                XCTAssertEqual(lastSQLQuery, """
+                    SELECT * FROM "book" WHERE "id" = 2
+                    """)
+                
+                let fullName = try Author
+                    .joining(required: Author.books.filter(id: 2))
+                    .fetchOne(db)
+                    .map { $0.fullName }
+                XCTAssertEqual(fullName, "Marcel Proust")
+                XCTAssertEqual(lastSQLQuery, """
+                    SELECT "author".* FROM "author" \
+                    JOIN "book" ON ("book"."authorId" = "author"."id") AND ("book"."id" = 2) \
+                    LIMIT 1
+                    """)
+            }
+            
+            // matchingFts4
+            do {
+                sqlQueries.removeAll()
+                let title = try Book.all()
+                    .matchingFts4(FTS3Pattern(matchingAllTokensIn: "moby dick"))
+                    .fetchOne(db)
+                    .map { $0.title }
+                XCTAssertEqual(title, "Moby-Dick")
+                XCTAssert(sqlQueries.contains("""
+                    SELECT "book".* FROM "book" \
+                    JOIN "bookFts4" ON ("bookFts4"."rowid" = "book"."id") AND ("bookFts4" MATCH 'moby dick') \
+                    LIMIT 1
+                    """))
+                
+                sqlQueries.removeAll()
+                let fullName = try Author
+                    .joining(required: Author.books.matchingFts4(FTS3Pattern(matchingAllTokensIn: "moby dick")))
+                    .fetchOne(db)
+                    .map { $0.fullName }
+                XCTAssertEqual(fullName, "Herman Melville")
+                XCTAssert(sqlQueries.contains("""
+                    SELECT "author".* FROM "author" \
+                    JOIN "book" ON "book"."authorId" = "author"."id" \
+                    JOIN "bookFts4" ON ("bookFts4"."rowid" = "book"."id") AND ("bookFts4" MATCH 'moby dick') \
+                    LIMIT 1
+                    """))
+            }
+            
+            #if SQLITE_ENABLE_FTS5
+            // matchingFts5
+            do {
+                sqlQueries.removeAll()
+                let title = try Book.all()
+                    .matchingFts5(FTS3Pattern(matchingAllTokensIn: "cote swann"))
+                    .fetchOne(db)
+                    .map { $0.title }
+                XCTAssertEqual(title, "Du côté de chez Swann")
+                XCTAssert(sqlQueries.contains("""
+                    SELECT "book".* FROM "book" \
+                    JOIN "bookFts5" ON ("bookFts5"."rowid" = "book"."id") AND ("bookFts5" MATCH 'cote swann') \
+                    LIMIT 1
+                    """))
+                
+                sqlQueries.removeAll()
+                let fullName = try Author
+                    .joining(required: Author.books.matchingFts5(FTS3Pattern(matchingAllTokensIn: "cote swann")))
+                    .fetchOne(db)
+                    .map { $0.fullName }
+                XCTAssertEqual(fullName, "Marcel Proust")
+                XCTAssert(sqlQueries.contains("""
+                    SELECT "author".* FROM "author" \
+                    JOIN "book" ON "book"."authorId" = "author"."id" \
+                    JOIN "bookFts5" ON ("bookFts5"."rowid" = "book"."id") AND ("bookFts5" MATCH 'cote swann') \
+                    LIMIT 1
+                    """))
+            }
+            #endif
+            
+            // orderById
+            do {
+                let titles = try Book.all()
+                    .orderById()
+                    .fetchAll(db)
+                    .map { $0.title }
+                XCTAssertEqual(titles, ["Moby-Dick", "Du côté de chez Swann"])
+                XCTAssertEqual(lastSQLQuery, """
+                    SELECT * FROM "book" ORDER BY "id"
+                    """)
+                
+                let fullNames = try Author
+                    .joining(required: Author.books.orderById())
+                    .fetchAll(db)
+                    .map { $0.fullName }
+                XCTAssertEqual(fullNames, ["Herman Melville", "Marcel Proust"])
+                XCTAssertEqual(lastSQLQuery, """
+                    SELECT "author".* FROM "author" \
+                    JOIN "book" ON "book"."authorId" = "author"."id" ORDER BY "book"."id"
                     """)
             }
         }

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -340,7 +340,7 @@ class DerivableRequestTests: GRDBTestCase {
             do {
                 sqlQueries.removeAll()
                 let title = try Book.all()
-                    .matchingFts4(FTS3Pattern(matchingAllTokensIn: "moby dick"))
+                    .matchingFts4(FTS3Pattern(rawPattern: "moby dick"))
                     .fetchOne(db)
                     .map { $0.title }
                 XCTAssertEqual(title, "Moby-Dick")
@@ -352,7 +352,7 @@ class DerivableRequestTests: GRDBTestCase {
                 
                 sqlQueries.removeAll()
                 let fullName = try Author
-                    .joining(required: Author.books.matchingFts4(FTS3Pattern(matchingAllTokensIn: "moby dick")))
+                    .joining(required: Author.books.matchingFts4(FTS3Pattern(rawPattern: "moby dick")))
                     .fetchOne(db)
                     .map { $0.fullName }
                 XCTAssertEqual(fullName, "Herman Melville")
@@ -369,7 +369,7 @@ class DerivableRequestTests: GRDBTestCase {
             do {
                 sqlQueries.removeAll()
                 let title = try Book.all()
-                    .matchingFts5(FTS3Pattern(matchingAllTokensIn: "cote swann"))
+                    .matchingFts5(FTS3Pattern(rawPattern: "cote swann"))
                     .fetchOne(db)
                     .map { $0.title }
                 XCTAssertEqual(title, "Du côté de chez Swann")
@@ -381,7 +381,7 @@ class DerivableRequestTests: GRDBTestCase {
                 
                 sqlQueries.removeAll()
                 let fullName = try Author
-                    .joining(required: Author.books.matchingFts5(FTS3Pattern(matchingAllTokensIn: "cote swann")))
+                    .joining(required: Author.books.matchingFts5(FTS3Pattern(rawPattern: "cote swann")))
                     .fetchOne(db)
                     .map { $0.fullName }
                 XCTAssertEqual(fullName, "Marcel Proust")

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -41,10 +41,10 @@ private struct Book: FetchableRecord, PersistableRecord, Codable {
     }
 }
 
-private struct BookFts4: FetchableRecord, TableRecord, Decodable { }
+private struct BookFts4: TableRecord { }
 
 #if SQLITE_ENABLE_FTS5
-private struct BookFts5: FetchableRecord, TableRecord, Decodable { }
+private struct BookFts5: TableRecord { }
 #endif
 
 private var libraryMigrator: DatabaseMigrator = {


### PR DESCRIPTION
This PR appends the TableRequest protocol to the requirements of the [DerivableRequest](https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md#define-record-requests) protocol.

This enhances the expressivity of DerivableRequest and [associations](https://github.com/groue/GRDB.swift/blob/master/Documentation/AssociationsBasics.md):

- Constrained extensions to DerivableRequest can now use `filter(key:)`, `filter(keys:)`, `orderByPrimaryKey()`, etc

- Associations and constrained extensions to DerivableRequest can now use the full-text methods `matching(_:)`.

The inspiration for this change comes from https://github.com/openbitapp/GRDB.swift. Thank you @robcas3!

---

Strictly speaking, this PR introduces breaking changes to both the [experimental](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features) protocols Association and DerivableRequest:

- Association now requires that its origin and destination associated types conform to the TableRecord protocol.

- DerivableRequest now requires TableRequest conformance.

Those breaking changes should be harmess: it is highly unlikely any GRDB user defines custom types based on those protocols.