### PR TITLE
Rename aliased(_:) methods to forKey(_:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,31 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#562](https://github.com/groue/GRDB.swift/pull/562): Fix crash when using more than one DatabaseCollation
 - [#563](https://github.com/groue/GRDB.swift/pull/563): More tests for eager loading of hasMany associations
 - [#574](https://github.com/groue/GRDB.swift/pull/574): SwiftLint
+- [#577](https://github.com/groue/GRDB.swift/pull/577): Rename aliased(_:) methods to forKey(_:)
+
+### API Diff
+
+```diff
+ extension AssociationAggregate {
++    @available(*, deprecated, renamed: "forKey(_:)")
+     func aliased(_ name: String) -> AssociationAggregate<RowDecoder>
++    func forKey(_ name: String) -> AssociationAggregate<RowDecoder>
+ 
++    @available(*, deprecated, renamed: "forKey(_:)")
+     func aliased(_ key: CodingKey) -> AssociationAggregate<RowDecoder>
++    func forKey(_ key: CodingKey) -> AssociationAggregate<RowDecoder>
+ }
+ 
+ extension SQLSpecificExpressible {
++    @available(*, deprecated, renamed: "forKey(_:)")
+     func aliased(_ name: String) -> SQLSelectable
++    func forKey(_ name: String) -> SQLSelectable
+ 
++    @available(*, deprecated, renamed: "forKey(_:)")
+     func aliased(_ key: CodingKey) -> SQLSelectable
++    func forKey(_ key: CodingKey) -> SQLSelectable
+ }
+```
 
 
 ## 4.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#562](https://github.com/groue/GRDB.swift/pull/562): Fix crash when using more than one DatabaseCollation
 - [#563](https://github.com/groue/GRDB.swift/pull/563): More tests for eager loading of hasMany associations
 - [#574](https://github.com/groue/GRDB.swift/pull/574): SwiftLint
-- [#577](https://github.com/groue/GRDB.swift/pull/577): Rename aliased(_:) methods to forKey(_:)
+- [#577](https://github.com/groue/GRDB.swift/pull/577): Rename `aliased(_:)` methods to `forKey(_:)`
 
 ### API Diff
 

--- a/GRDB/QueryInterface/Request/Association/Association.swift
+++ b/GRDB/QueryInterface/Request/Association/Association.swift
@@ -353,7 +353,7 @@ extension AssociationToMany where OriginRowDecoder: TableRecord {
     ///     let teams: [Team] = try Team.having(Team.players.count() > 10).fetchAll(db)
     public var count: AssociationAggregate<OriginRowDecoder> {
         return makeAggregate(SQLExpressionCountDistinct(Column.rowID))
-            .aliased("\(key.singularizedName)Count")
+            .forKey("\(key.singularizedName)Count")
     }
     
     /// Creates an aggregate that is true if there exists no associated records.
@@ -373,7 +373,7 @@ extension AssociationToMany where OriginRowDecoder: TableRecord {
     ///     let teams: [Team] = try Team.having(Team.players.isEmpty() == false)
     public var isEmpty: AssociationAggregate<OriginRowDecoder> {
         return makeAggregate(SQLExpressionIsEmpty(SQLExpressionCountDistinct(Column.rowID)))
-            .aliased("hasNo\(key.singularizedName.uppercasingFirstCharacter)")
+            .forKey("hasNo\(key.singularizedName.uppercasingFirstCharacter)")
     }
     
     /// Creates an aggregate which evaluate to the average value of the given
@@ -397,7 +397,7 @@ extension AssociationToMany where OriginRowDecoder: TableRecord {
         let aggregate = makeAggregate(SQLExpressionFunction(.avg, arguments: expression))
         if let column = expression as? ColumnExpression {
             let name = key.singularizedName
-            return aggregate.aliased("average\(name.uppercasingFirstCharacter)\(column.name.uppercasingFirstCharacter)")
+            return aggregate.forKey("average\(name.uppercasingFirstCharacter)\(column.name.uppercasingFirstCharacter)")
         } else {
             return aggregate
         }
@@ -424,7 +424,7 @@ extension AssociationToMany where OriginRowDecoder: TableRecord {
         let aggregate = makeAggregate(SQLExpressionFunction(.max, arguments: expression))
         if let column = expression as? ColumnExpression {
             let name = key.singularizedName
-            return aggregate.aliased("max\(name.uppercasingFirstCharacter)\(column.name.uppercasingFirstCharacter)")
+            return aggregate.forKey("max\(name.uppercasingFirstCharacter)\(column.name.uppercasingFirstCharacter)")
         } else {
             return aggregate
         }
@@ -451,7 +451,7 @@ extension AssociationToMany where OriginRowDecoder: TableRecord {
         let aggregate = makeAggregate(SQLExpressionFunction(.min, arguments: expression))
         if let column = expression as? ColumnExpression {
             let name = key.singularizedName
-            return aggregate.aliased("min\(name.uppercasingFirstCharacter)\(column.name.uppercasingFirstCharacter)")
+            return aggregate.forKey("min\(name.uppercasingFirstCharacter)\(column.name.uppercasingFirstCharacter)")
         } else {
             return aggregate
         }
@@ -478,7 +478,7 @@ extension AssociationToMany where OriginRowDecoder: TableRecord {
         let aggregate = makeAggregate(SQLExpressionFunction(.sum, arguments: expression))
         if let column = expression as? ColumnExpression {
             let name = key.singularizedName
-            return aggregate.aliased("\(name)\(column.name.uppercasingFirstCharacter)Sum")
+            return aggregate.forKey("\(name)\(column.name.uppercasingFirstCharacter)Sum")
         } else {
             return aggregate
         }

--- a/GRDB/QueryInterface/Request/Association/AssociationAggregate.swift
+++ b/GRDB/QueryInterface/Request/Association/AssociationAggregate.swift
@@ -78,7 +78,7 @@ extension AssociationAggregate {
     ///     let aggregate = Author.books.count.aliased("numberOfBooks")
     ///     let request = Author.annotated(with: aggregate)
     ///     if let row = try Row.fetchOne(db, request) {
-    ///         let bookCount: Int = row["numberOfBooks"]
+    ///         let numberOfBooks: Int = row["numberOfBooks"]
     ///     }
     @available(*, deprecated, renamed: "forKey(_:)")
     public func aliased(_ name: String) -> AssociationAggregate<RowDecoder> {
@@ -92,7 +92,7 @@ extension AssociationAggregate {
     ///     let aggregate = Author.books.count.forKey("numberOfBooks")
     ///     let request = Author.annotated(with: aggregate)
     ///     if let row = try Row.fetchOne(db, request) {
-    ///         let bookCount: Int = row["numberOfBooks"]
+    ///         let numberOfBooks: Int = row["numberOfBooks"]
     ///     }
     public func forKey(_ key: String) -> AssociationAggregate<RowDecoder> {
         var aggregate = self
@@ -107,10 +107,10 @@ extension AssociationAggregate {
     ///
     ///     struct AuthorInfo: Decodable, FetchableRecord {
     ///         var author: Author
-    ///         var bookCount: Int
+    ///         var numberOfBooks: Int
     ///
     ///         static func fetchAll(_ db: Database) throws -> [AuthorInfo] {
-    ///             let aggregate = Author.books.count.aliased(CodingKeys.bookCount)
+    ///             let aggregate = Author.books.count.aliased(CodingKeys.numberOfBooks)
     ///             let request = Author.annotated(with: aggregate)
     ///             return try AuthorInfo.fetchAll(db, request)
     ///         }
@@ -127,10 +127,10 @@ extension AssociationAggregate {
     ///
     ///     struct AuthorInfo: Decodable, FetchableRecord {
     ///         var author: Author
-    ///         var bookCount: Int
+    ///         var numberOfBooks: Int
     ///
     ///         static func fetchAll(_ db: Database) throws -> [AuthorInfo] {
-    ///             let aggregate = Author.books.count.forKey(CodingKeys.bookCount)
+    ///             let aggregate = Author.books.count.forKey(CodingKeys.numberOfBooks)
     ///             let request = Author.annotated(with: aggregate)
     ///             return try AuthorInfo.fetchAll(db, request)
     ///         }

--- a/GRDB/QueryInterface/Request/Association/AssociationAggregate.swift
+++ b/GRDB/QueryInterface/Request/Association/AssociationAggregate.swift
@@ -62,8 +62,8 @@ public struct AssociationAggregate<RowDecoder> {
     /// - It helps implementing aggregate operators such as `&&`, `+`, etc.
     let prepare: AssociationAggregatePreparation<RowDecoder>
     
-    /// The SQL alias for the value of this aggregate. See aliased(_:).
-    var alias: String?
+    /// The SQL name for the value of this aggregate. See forKey(_:).
+    var key: String?
     
     init(_ prepare: @escaping AssociationAggregatePreparation<RowDecoder>) {
         self.prepare = prepare
@@ -75,14 +75,28 @@ extension AssociationAggregate {
     ///
     /// For example:
     ///
-    ///     let aggregate = Author.books.count.aliased("foo")
+    ///     let aggregate = Author.books.count.aliased("numberOfBooks")
     ///     let request = Author.annotated(with: aggregate)
     ///     if let row = try Row.fetchOne(db, request) {
-    ///         let bookCount: Int = row["foo"]
+    ///         let bookCount: Int = row["numberOfBooks"]
     ///     }
+    @available(*, deprecated, renamed: "forKey(_:)")
     public func aliased(_ name: String) -> AssociationAggregate<RowDecoder> {
+        return forKey(name)
+    }
+    
+    /// Returns an aggregate that is selected in a column with the given name.
+    ///
+    /// For example:
+    ///
+    ///     let aggregate = Author.books.count.forKey("numberOfBooks")
+    ///     let request = Author.annotated(with: aggregate)
+    ///     if let row = try Row.fetchOne(db, request) {
+    ///         let bookCount: Int = row["numberOfBooks"]
+    ///     }
+    public func forKey(_ key: String) -> AssociationAggregate<RowDecoder> {
         var aggregate = self
-        aggregate.alias = name
+        aggregate.key = key
         return aggregate
     }
     
@@ -101,8 +115,28 @@ extension AssociationAggregate {
     ///             return try AuthorInfo.fetchAll(db, request)
     ///         }
     ///     }
+    @available(*, deprecated, renamed: "forKey(_:)")
     public func aliased(_ key: CodingKey) -> AssociationAggregate<RowDecoder> {
-        return aliased(key.stringValue)
+        return forKey(key)
+    }
+    
+    /// Returns an aggregate that is selected in a column named like the given
+    /// coding key.
+    ///
+    /// For example:
+    ///
+    ///     struct AuthorInfo: Decodable, FetchableRecord {
+    ///         var author: Author
+    ///         var bookCount: Int
+    ///
+    ///         static func fetchAll(_ db: Database) throws -> [AuthorInfo] {
+    ///             let aggregate = Author.books.count.forKey(CodingKeys.bookCount)
+    ///             let request = Author.annotated(with: aggregate)
+    ///             return try AuthorInfo.fetchAll(db, request)
+    ///         }
+    ///     }
+    public func forKey(_ key: CodingKey) -> AssociationAggregate<RowDecoder> {
+        return forKey(key.stringValue)
     }
 }
 
@@ -876,8 +910,8 @@ public func ?? <RowDecoder>(
         return (request: request, expression: expression ?? rhs)
     }
     
-    // Preserve alias
-    aggregate.alias = lhs.alias
+    // Preserve key
+    aggregate.key = lhs.key
     return aggregate
 }
 

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest+Association.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest+Association.swift
@@ -4,8 +4,8 @@ extension QueryInterfaceRequest where RowDecoder: TableRecord {
     
     private func annotated(with aggregate: AssociationAggregate<RowDecoder>) -> QueryInterfaceRequest {
         let (request, expression) = aggregate.prepare(self)
-        if let alias = aggregate.alias {
-            return request.annotated(with: [expression.aliased(alias)])
+        if let key = aggregate.key {
+            return request.annotated(with: [expression.forKey(key)])
         } else {
             return request.annotated(with: [expression])
         }

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -101,7 +101,7 @@ extension QueryInterfaceRequest: FetchRequest {
             let prefetchedRelation = association
                 .mapPivotRelation { $0.qualified(with: pivotAlias) }
                 .destinationRelation(fromOriginRows: { _ in [] /* no origin row */ })
-                .annotated(with: pivotColumns.map { pivotAlias[Column($0)].aliased("grdb_\($0)") })
+                .annotated(with: pivotColumns.map { pivotAlias[Column($0)].forKey("grdb_\($0)") })
             let prefetchedQuery = SQLQuery(relation: prefetchedRelation)
             
             // Union region
@@ -529,7 +529,7 @@ private func prefetch(_ db: Database, associations: [SQLAssociation], in rows: [
             let prefetchedRelation = association
                 .mapPivotRelation { $0.qualified(with: pivotAlias) }
                 .destinationRelation(fromOriginRows: { _ in rows })
-                .annotated(with: pivotColumns.map { pivotAlias[Column($0)].aliased("grdb_\($0)") })
+                .annotated(with: pivotColumns.map { pivotAlias[Column($0)].forKey("grdb_\($0)") })
             prefetchedRows = try QueryInterfaceRequest(relation: prefetchedRelation)
                 .fetchAll(db)
                 .grouped(byDatabaseValuesOnColumns: pivotColumns.map { "grdb_\($0)" })

--- a/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
@@ -24,18 +24,78 @@ extension SQLSpecificExpressible {
 /// :nodoc:
 extension SQLSpecificExpressible {
     
-    /// Returns a value that can be used as an argument to QueryInterfaceRequest.select()
+    /// Give the expression the given SQL name.
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// For example:
+    ///
+    ///     // SELECT (width * height) AS area FROM shape
+    ///     let area = (Column("width") * Column("height")).aliased("area")
+    ///     let request = Shape.select(area)
+    ///     if let row = try Row.fetchOne(db, request) {
+    ///         let area: Int = row["area"]
+    ///     }
+    @available(*, deprecated, renamed: "forKey(_:)")
     public func aliased(_ name: String) -> SQLSelectable {
-        return SQLAliasedExpression(sqlExpression, name: name)
+        return forKey(name)
     }
     
-    /// Returns a value that can be used as an argument to QueryInterfaceRequest.select()
+    /// Give the expression the given SQL name.
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// For example:
+    ///
+    ///     // SELECT (width * height) AS area FROM shape
+    ///     let area = (Column("width") * Column("height")).forKey("area")
+    ///     let request = Shape.select(area)
+    ///     if let row = try Row.fetchOne(db, request) {
+    ///         let area: Int = row["area"]
+    ///     }
+    public func forKey(_ key: String) -> SQLSelectable {
+        return SQLAliasedExpression(sqlExpression, name: key)
+    }
+    
+    /// Give the expression the same SQL name as the coding key.
+    ///
+    /// For example:
+    ///
+    ///     struct Shape: Decodable, FetchableRecord, TableRecord {
+    ///         let width: Int
+    ///         let height: Int
+    ///         let area: Int
+    ///
+    ///         static let databaseSelection: [SQLSelectable] = [
+    ///             Column(CodingKeys.width),
+    ///             Column(CodingKeys.height),
+    ///             (Column(CodingKeys.width) * Column(CodingKeys.height)).aliased(CodingKeys.area),
+    ///         ]
+    ///     }
+    ///
+    ///     // SELECT width, height, (width * height) AS area FROM shape
+    ///     let shapes: [Shape] = try Shape.fetchAll(db)
+    @available(*, deprecated, renamed: "forKey(_:)")
     public func aliased(_ key: CodingKey) -> SQLSelectable {
-        return aliased(key.stringValue)
+        return forKey(key)
+    }
+    
+    /// Give the expression the same SQL name as the coding key.
+    ///
+    /// For example:
+    ///
+    ///     struct Shape: Decodable, FetchableRecord, TableRecord {
+    ///         let width: Int
+    ///         let height: Int
+    ///         let area: Int
+    ///
+    ///         static let databaseSelection: [SQLSelectable] = [
+    ///             Column(CodingKeys.width),
+    ///             Column(CodingKeys.height),
+    ///             (Column(CodingKeys.width) * Column(CodingKeys.height)).forKey(CodingKeys.area),
+    ///         ]
+    ///     }
+    ///
+    ///     // SELECT width, height, (width * height) AS area FROM shape
+    ///     let shapes: [Shape] = try Shape.fetchAll(db)
+    public func forKey(_ key: CodingKey) -> SQLSelectable {
+        return forKey(key.stringValue)
     }
 }
 

--- a/GRDBCustom.xcodeproj/xcshareddata/xcschemes/GRDBCustomSQLiteOSX.xcscheme
+++ b/GRDBCustom.xcodeproj/xcshareddata/xcschemes/GRDBCustomSQLiteOSX.xcscheme
@@ -40,6 +40,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/TODO.md
+++ b/TODO.md
@@ -70,7 +70,6 @@
     Make it possible to build a single observation where some requests depend on the result of other requests. As long as we can't express this in a single observation, we fail the "guaranteed consistency is possible" contract.
 - [ ] matching (FTS3, 5) on associations and DerivableRequest
 - [ ] rename fetchOne to fetchFirst
-- [ ] Rename aliased() to forKey() when relevant
 - [ ] new.updateChanges(from: old) vs. old.updateChanges(with: { old.a = new.a }). This is confusing.
 
 Swift 4.2

--- a/Tests/GRDBTests/AssociationAggregateTests.swift
+++ b/Tests/GRDBTests/AssociationAggregateTests.swift
@@ -653,15 +653,15 @@ class AssociationAggregateTests: GRDBTestCase {
         }
     }
     
-    func testAnnotatedWithHasManyAggregateAlias() throws {
+    func testAnnotatedWithHasManyAggregateWithCustomKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             let request = Team
-                .annotated(with: Team.players.average(Column("score")).aliased("a1"))
-                .annotated(with: Team.players.count.aliased("a2"))
-                .annotated(with: Team.players.max(Column("score")).aliased("a3"))
-                .annotated(with: Team.players.min(Column("score")).aliased("a4"))
-                .annotated(with: Team.players.sum(Column("score")).aliased("a5"))
+                .annotated(with: Team.players.average(Column("score")).forKey("a1"))
+                .annotated(with: Team.players.count.forKey("a2"))
+                .annotated(with: Team.players.max(Column("score")).forKey("a3"))
+                .annotated(with: Team.players.min(Column("score")).forKey("a4"))
+                .annotated(with: Team.players.sum(Column("score")).forKey("a5"))
             
             try assertEqualSQL(db, request, """
                 SELECT "team".*, \
@@ -681,10 +681,10 @@ class AssociationAggregateTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
             let request = Team
-                .annotated(with: Team.players.average(Column("score") * Column("score")).aliased("a1"))
-                .annotated(with: Team.players.max(Column("score") * 10).aliased("a3"))
-                .annotated(with: Team.players.min(-Column("score")).aliased("a4"))
-                .annotated(with: Team.players.sum(Column("score") * Column("score")).aliased("a5"))
+                .annotated(with: Team.players.average(Column("score") * Column("score")).forKey("a1"))
+                .annotated(with: Team.players.max(Column("score") * 10).forKey("a3"))
+                .annotated(with: Team.players.min(-Column("score")).forKey("a4"))
+                .annotated(with: Team.players.sum(Column("score") * Column("score")).forKey("a5"))
             try assertEqualSQL(db, request, """
                 SELECT "team".*, \
                 AVG("player"."score" * "player"."score") AS "a1", \

--- a/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
@@ -95,7 +95,7 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
                     .including(required: A.b
                     .select(
                         Column("name"),
-                        (Column("id") + aAlias[Column("id")]).aliased("foo")))
+                        (Column("id") + aAlias[Column("id")]).forKey("foo")))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b"."name", "b"."id" + "a"."id" AS "foo" \
                     FROM "a" \

--- a/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
@@ -95,7 +95,7 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                     .including(required: A.b
                     .select(
                         Column("name"),
-                        (Column("id") + aAlias[Column("id")]).aliased("foo")))
+                        (Column("id") + aAlias[Column("id")]).forKey("foo")))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b"."name", "b"."id" + "a"."id" AS "foo" \
                     FROM "a" \

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
@@ -107,7 +107,7 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
                     .including(required: A.c
                         .select(
                             Column("name"),
-                            (Column("id") + aAlias[Column("id")]).aliased("foo")))
+                            (Column("id") + aAlias[Column("id")]).forKey("foo")))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c"."name", "c"."id" + "a"."id" AS "foo" \
                     FROM "a" \

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -122,7 +122,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(try tableRequest.select(Col.age * 2).distinct().fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
-            XCTAssertEqual(try tableRequest.select((Col.age * 2).aliased("ignored")).distinct().fetchCount(db), 0)
+            XCTAssertEqual(try tableRequest.select((Col.age * 2).forKey("ignored")).distinct().fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
             XCTAssertEqual(try tableRequest.select(Col.name, Col.age).fetchCount(db), 0)
@@ -229,12 +229,12 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         }
     }
 
-    func testSelectAliased() throws {
+    func testSelectionCustomKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.execute(sql: "INSERT INTO readers (name, age) VALUES (?, ?)", arguments: ["Arthur", 42])
             
-            let request = tableRequest.select(Col.name.aliased("nom"), (Col.age + 1).aliased("agePlusOne"))
+            let request = tableRequest.select(Col.name.forKey("nom"), (Col.age + 1).forKey("agePlusOne"))
             let row = try Row.fetchOne(db, request)!
             XCTAssertEqual(lastSQLQuery, "SELECT \"name\" AS \"nom\", \"age\" + 1 AS \"agePlusOne\" FROM \"readers\" LIMIT 1")
             XCTAssertEqual(row["nom"] as String, "Arthur")

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -65,7 +65,7 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(try Reader.select(Col.age * 2).distinct().fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
-            XCTAssertEqual(try Reader.select((Col.age * 2).aliased("ignored")).distinct().fetchCount(db), 0)
+            XCTAssertEqual(try Reader.select((Col.age * 2).forKey("ignored")).distinct().fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(DISTINCT \"age\" * 2) FROM \"readers\"")
             
             XCTAssertEqual(try Reader.select(Col.name, Col.age).fetchCount(db), 0)


### PR DESCRIPTION
This PR renames the method that gives an alias to an SQL column from `aliased(_:)` to `forKey(_:)`:

```swift
// SELECT (width * height) AS area FROM shape
let area = (Column("width") * Column("height")).forKey("area")
let request = Shape.select(area)
if let row = try Row.fetchOne(db, request) {
    let area: Int = row["area"]
}

// SELECT author.*,
//        COUNT(DISTINCT book.rowid) AS numberOfBooks,
// FROM author
// LEFT JOIN book ON book.authorId = author.id
// GROUP BY author.id
let aggregate = Author.books.count.forKey("numberOfBooks")
let request = Author.annotated(with: aggregate)
if let row = try Row.fetchOne(db, request) {
    let author = Author(row: row)
    let numberOfBooks: Int = row["numberOfBooks"]
}
```

The old `aliased(_:)` methods are still defined, but deprecated.

The goal of this PR is to increase API consistency:

- The `forKey(_:)` method is now the unique way to rename values, associated records, and association aggregates, when one wants to customize the decoding of codable records, or the keys used for raw Row subscript.
- The method `aliased(_:)` is now only used by [table aliases](https://github.com/groue/GRDB.swift/blob/master/Documentation/AssociationsBasics.md#table-aliases).
