### PR TITLE
Automatic region tracking for ValueObservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#576](https://github.com/groue/GRDB.swift/pull/576): Expose table name and full-text filtering methods to DerivableRequest
 - [#577](https://github.com/groue/GRDB.swift/pull/577): Rename `aliased(_:)` methods to `forKey(_:)`
 - [#585](https://github.com/groue/GRDB.swift/pull/585): Fix use of SQLite authorizers
+- [#586](https://github.com/groue/GRDB.swift/pull/586): Automatic region tracking for ValueObservation
 
 ### API Diff
 
@@ -121,6 +122,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 +    @available(*, deprecated, renamed: "forKey(_:)")
      func aliased(_ key: CodingKey) -> SQLSelectable
 +    func forKey(_ key: CodingKey) -> SQLSelectable
+ }
+ 
+ extension ValueObservation where Reducer == Void {
++    static func tracking<Value>(fetch: @escaping (Database) throws -> Value) -> ValueObservation<ValueReducers.Fetch<Value>>
  }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,15 +54,29 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 
 ## Next Release
 
+**New**
+
+- [#570](https://github.com/groue/GRDB.swift/pull/570) by [@chrisballinger](https://github.com/chrisballinger): Allow Swift static library integration via CocoaPods
+- [#576](https://github.com/groue/GRDB.swift/pull/576): Expose table name and full-text filtering methods to DerivableRequest
+- [#586](https://github.com/groue/GRDB.swift/pull/586): Automatic region tracking for ValueObservation
+
+**Fixed**
+
 - [#560](https://github.com/groue/GRDB.swift/pull/560) by [@bellebethcooper](https://github.com/bellebethcooper): Minor typo fix
 - [#562](https://github.com/groue/GRDB.swift/pull/562): Fix crash when using more than one DatabaseCollation
-- [#563](https://github.com/groue/GRDB.swift/pull/563): More tests for eager loading of hasMany associations
-- [#570](https://github.com/groue/GRDB.swift/pull/570) by [@chrisballinger](https://github.com/chrisballinger): Allow Swift static library integration via CocoaPods
-- [#574](https://github.com/groue/GRDB.swift/pull/574): SwiftLint
-- [#576](https://github.com/groue/GRDB.swift/pull/576): Expose table name and full-text filtering methods to DerivableRequest
 - [#577](https://github.com/groue/GRDB.swift/pull/577): Rename `aliased(_:)` methods to `forKey(_:)`
 - [#585](https://github.com/groue/GRDB.swift/pull/585): Fix use of SQLite authorizers
-- [#586](https://github.com/groue/GRDB.swift/pull/586): Automatic region tracking for ValueObservation
+
+**Other**
+
+- [#563](https://github.com/groue/GRDB.swift/pull/563): More tests for eager loading of hasMany associations
+- [#574](https://github.com/groue/GRDB.swift/pull/574): SwiftLint
+
+
+### Documentation Diff
+
+The [ValueObservation](README.md#valueobservation) chapter has been updated so that it fosters the new `ValueObservation.tracking(value:)` method. Other ways to define observations are now described as optimizations.
+
 
 ### API Diff
 

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -822,19 +822,6 @@ let novels = try author
     .fetchAll(db) // [Book]
 ```
 
-Those requests can also turn out useful when you want to track their changes with [database observation tools] like [ValueObservation]:
-
-```swift
-// Track changes in the author's books:
-let author: Author = ...
-author.books.observationForAll().start(
-    in: dbQueue,
-    onError: { error in ... },
-    onChange: { (books: [Book]) in
-        print("Author's book have changed")
-    })
-```
-
 
 ## Joining And Prefetching Associated Records
 

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -461,6 +461,8 @@
 		5674A7231F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A71C1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift */; };
 		5674A72A1F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A7261F30A9090095F066 /* FetchableRecordDecodableTests.swift */; };
 		5674A72D1F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A7261F30A9090095F066 /* FetchableRecordDecodableTests.swift */; };
+		5676FBA622F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FB9F22F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift */; };
+		5676FBA722F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FB9F22F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift */; };
 		567A80571D41350C00C7DCEC /* IndexInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567A80521D41350C00C7DCEC /* IndexInfoTests.swift */; };
 		567DAF1C1EAB61ED00FC0928 /* grdb_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 567DAF141EAB61ED00FC0928 /* grdb_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		567DAF1F1EAB61ED00FC0928 /* grdb_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 567DAF141EAB61ED00FC0928 /* grdb_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1129,6 +1131,7 @@
 		5674A70B1F3087700095F066 /* DatabaseValueConvertibleEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEncodableTests.swift; sourceTree = "<group>"; };
 		5674A71C1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordEncodableTests.swift; sourceTree = "<group>"; };
 		5674A7261F30A9090095F066 /* FetchableRecordDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchableRecordDecodableTests.swift; sourceTree = "<group>"; };
+		5676FB9F22F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationRegionRecordingTests.swift; sourceTree = "<group>"; };
 		567A80521D41350C00C7DCEC /* IndexInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexInfoTests.swift; sourceTree = "<group>"; };
 		567DAF141EAB61ED00FC0928 /* grdb_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grdb_config.h; sourceTree = "<group>"; };
 		567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLogErrorTests.swift; sourceTree = "<group>"; };
@@ -1628,6 +1631,7 @@
 				563B06C22185D29F00B38F35 /* ValueObservationReadonlyTests.swift */,
 				563B071421862C4600B38F35 /* ValueObservationRecordTests.swift */,
 				563B06BC2185CCD300B38F35 /* ValueObservationReducerTests.swift */,
+				5676FB9F22F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift */,
 				563B0704218627F700B38F35 /* ValueObservationRowTests.swift */,
 				563B06C12185D29F00B38F35 /* ValueObservationSchedulingTests.swift */,
 			);
@@ -3092,6 +3096,7 @@
 				568068351EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */,
 				565D5D751BBC70AE00DC9BD4 /* StatementArguments+FoundationTests.swift in Sources */,
 				56703298212B5450007D270F /* DatabaseUUIDEncodingStrategyTests.swift in Sources */,
+				5676FBA722F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				5623931C1DECC02000A6B01F /* RowFetchTests.swift in Sources */,
 				5653EAD720944B4F00F46237 /* AssociationChainRowScopesTests.swift in Sources */,
 				569BBA28228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */,
@@ -3291,6 +3296,7 @@
 				5623934E1DEDFEFB00A6B01F /* EnumeratedCursorTests.swift in Sources */,
 				568068311EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */,
 				56703297212B5450007D270F /* DatabaseUUIDEncodingStrategyTests.swift in Sources */,
+				5676FBA622F5CAD9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				56D496B41D8133F8008276D7 /* DatabaseTests.swift in Sources */,
 				56D496951D81317B008276D7 /* MutablePersistableRecordTests.swift in Sources */,
 				569BBA27228DE51800478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */,

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -288,6 +288,13 @@ extension Database {
         try observationBroker.updateStatementDidFail(statement)
     }
     
+    @inline(__always)
+    func selectStatementWillExecute(_ statement: SelectStatement) {
+        if _isRecordingSelectedRegion {
+            _selectedRegion.formUnion(statement.databaseRegion)
+        }
+    }
+    
     func selectStatementDidFail(_ statement: SelectStatement) {
         // Failed statements can not be reused, because sqlite3_reset won't
         // be able to restore the statement to its initial state:

--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -154,6 +154,13 @@ public struct DatabaseRegion: CustomStringConvertible, Equatable {
         let filteredRegions = tableRegions.filter { viewNames.contains($0.key) == false }
         return DatabaseRegion(tableRegions: filteredRegions)
     }
+    
+    /// Returns a region which doesn't contain any SQLite internal table.
+    func ignoringInternalSQLiteTables() -> DatabaseRegion {
+        guard let tableRegions = tableRegions else { return .fullDatabase }
+        let filteredRegions = tableRegions.filter { !$0.key.starts(with: "sqlite_") }
+        return DatabaseRegion(tableRegions: filteredRegions)
+    }
 }
 
 extension DatabaseRegion {

--- a/GRDB/Core/DatabaseRegionObservation.swift
+++ b/GRDB/Core/DatabaseRegionObservation.swift
@@ -13,25 +13,14 @@ public struct DatabaseRegionObservation {
     /// `.observerLifetime`: the observation lasts until the
     /// observer returned by the `start(in:onChange:)` method
     /// is deallocated.
-    public var extent = Database.TransactionObservationExtent.observerLifetime
+    public var extent: Database.TransactionObservationExtent
     
     /// A closure that is evaluated when the observation starts, and returns
     /// the observed database region.
     var observedRegion: (Database) throws -> DatabaseRegion
-    
-    // Not public because we foster DatabaseRegionConvertible.
-    init(tracking region: @escaping (Database) throws -> DatabaseRegion) {
-        self.observedRegion = { db in
-            // Remove views from the observed region.
-            //
-            // We can do it because we are only interested in modifications in
-            // actual tables. And we want to do it because we have a fast path
-            // for simple regions that span a single table.
-            let views = try db.schema().names(ofType: .view)
-            return try region(db).ignoring(views)
-        }
-    }
-    
+}
+
+extension DatabaseRegionObservation {
     /// Creates a DatabaseRegionObservation which observes *regions*, and
     /// notifies whenever one of the observed regions is modified by a
     /// database transaction.
@@ -75,7 +64,9 @@ public struct DatabaseRegionObservation {
     ///
     /// - parameter regions: A list of observed regions.
     public init(tracking regions: [DatabaseRegionConvertible]) {
-        self.init(tracking: DatabaseRegion.union(regions))
+        self.init(
+            extent: .observerLifetime,
+            observedRegion: DatabaseRegion.union(regions))
     }
 }
 
@@ -95,7 +86,7 @@ extension DatabaseRegionObservation {
         // Use unsafeReentrantWrite so that observation can start from any
         // dispatch queue.
         return try dbWriter.unsafeReentrantWrite { db -> TransactionObserver in
-            let region = try observedRegion(db)
+            let region = try observedRegion(db).ignoringViews(db)
             let observer = DatabaseRegionObserver(region: region, onChange: onChange)
             db.add(transactionObserver: observer, extent: extent)
             return observer

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -65,6 +65,9 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor 
             _columnIndex = 0
         }
         _statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {
@@ -118,6 +121,9 @@ public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>:
             _columnIndex = 0
         }
         _statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -343,6 +343,7 @@ extension DatabaseWriter {
         let requiresWriteAccess = observation.requiresWriteAccess
         let observer = ValueObserver<Reducer>(
             requiresWriteAccess: requiresWriteAccess,
+            observesSelectedRegion: observation.observesSelectedRegion,
             writer: self,
             reduceQueue: configuration.makeDispatchQueue(defaultLabel: "GRDB", purpose: "ValueObservation.reducer"),
             onError: onError,
@@ -363,18 +364,23 @@ extension DatabaseWriter {
                 
                 do {
                     try unsafeReentrantWrite { db in
-                        let region = try observation.observedRegion(db).ignoringViews(db)
-                        var reducer = try observation.makeReducer(db)
+                        observer.notificationQueue = DispatchQueue.main
+                        observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
+                        observer.reducer = try observation.makeReducer(db)
                         
-                        // Fetch initial value
-                        if let value = try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)) {
+                        // Initial value & selected region
+                        let fetchedValue: Reducer.Fetched
+                        if observation.observesSelectedRegion {
+                            (fetchedValue, observer.selectedRegion) = try db.recordingSelectedRegion {
+                                try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                            }
+                        } else {
+                            fetchedValue = try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                        }
+                        if let value = observer.reducer.value(fetchedValue) {
                             startValue = value
                         }
-                        
-                        // Start observing the database
-                        observer.region = region
-                        observer.reducer = reducer
-                        observer.notificationQueue = DispatchQueue.main
+
                         db.add(transactionObserver: observer, extent: .observerLifetime)
                     }
                 } catch {
@@ -385,20 +391,25 @@ extension DatabaseWriter {
                 // has the default scheduling .mainQueue
                 asyncWriteWithoutTransaction { db in
                     do {
-                        let region = try observation.observedRegion(db).ignoringViews(db)
-                        var reducer = try observation.makeReducer(db)
+                        observer.notificationQueue = DispatchQueue.main
+                        observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
+                        observer.reducer = try observation.makeReducer(db)
                         
-                        // Fetch initial value
-                        if let value = try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)) {
+                        // Initial value & selected region
+                        let fetchedValue: Reducer.Fetched
+                        if observation.observesSelectedRegion {
+                            (fetchedValue, observer.selectedRegion) = try db.recordingSelectedRegion {
+                                try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                            }
+                        } else {
+                            fetchedValue = try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                        }
+                        if let value = observer.reducer.value(fetchedValue) {
                             DispatchQueue.main.async {
                                 onChange(value)
                             }
                         }
                         
-                        // Start observing the database
-                        observer.region = region
-                        observer.reducer = reducer
-                        observer.notificationQueue = DispatchQueue.main
                         db.add(transactionObserver: observer, extent: .observerLifetime)
                     } catch {
                         DispatchQueue.main.async {
@@ -412,22 +423,31 @@ extension DatabaseWriter {
             // Use case: observation must not block the target queue
             asyncWriteWithoutTransaction { db in
                 do {
-                    let region = try observation.observedRegion(db).ignoringViews(db)
-                    var reducer = try observation.makeReducer(db)
+                    observer.notificationQueue = queue
+                    observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
+                    observer.reducer = try observation.makeReducer(db)
                     
-                    // Fetch initial value
-                    if startImmediately,
-                        let value = try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess))
-                    {
-                        queue.async {
-                            onChange(value)
+                    // Initial value & selected region
+                    if startImmediately {
+                        let fetchedValue: Reducer.Fetched
+                        if observation.observesSelectedRegion {
+                            (fetchedValue, observer.selectedRegion) = try db.recordingSelectedRegion {
+                                try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                            }
+                        } else {
+                            fetchedValue = try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                        }
+                        if let value = observer.reducer.value(fetchedValue) {
+                            queue.async {
+                                onChange(value)
+                            }
+                        }
+                    } else if observation.observesSelectedRegion {
+                        (_, observer.selectedRegion) = try db.recordingSelectedRegion {
+                            try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
                         }
                     }
                     
-                    // Start observing the database
-                    observer.region = region
-                    observer.reducer = reducer
-                    observer.notificationQueue = queue
                     db.add(transactionObserver: observer, extent: .observerLifetime)
                 } catch {
                     queue.async {
@@ -458,20 +478,29 @@ extension DatabaseWriter {
                 
                 do {
                     try unsafeReentrantWrite { db in
-                        let region = try observation.observedRegion(db).ignoringViews(db)
-                        var reducer = try observation.makeReducer(db)
+                        observer.notificationQueue = nil
+                        observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
+                        observer.reducer = try observation.makeReducer(db)
                         
-                        // Fetch initial value
-                        if startImmediately,
-                            let value = try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess))
-                        {
-                            startValue = value
+                        // Initial value & selected region
+                        if startImmediately {
+                            let fetchedValue: Reducer.Fetched
+                            if observation.observesSelectedRegion {
+                                (fetchedValue, observer.selectedRegion) = try db.recordingSelectedRegion {
+                                    try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                                }
+                            } else {
+                                fetchedValue = try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                            }
+                            if let value = observer.reducer.value(fetchedValue) {
+                                startValue = value
+                            }
+                        } else if observation.observesSelectedRegion {
+                            (_, observer.selectedRegion) = try db.recordingSelectedRegion {
+                                try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                            }
                         }
                         
-                        // Start observing the database
-                        observer.region = region
-                        observer.reducer = reducer
-                        observer.notificationQueue = nil
                         db.add(transactionObserver: observer, extent: .observerLifetime)
                     }
                 } catch {
@@ -484,13 +513,17 @@ extension DatabaseWriter {
                 // queue on which the onChange and onError callbacks are called.
                 asyncWriteWithoutTransaction { db in
                     do {
-                        let region = try observation.observedRegion(db).ignoringViews(db)
-                        let reducer = try observation.makeReducer(db)
-                        
-                        // Start observing the database
-                        observer.region = region
-                        observer.reducer = reducer
                         observer.notificationQueue = nil
+                        observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
+                        observer.reducer = try observation.makeReducer(db)
+                        
+                        // Selected region
+                        if observation.observesSelectedRegion {
+                            (_, observer.selectedRegion) = try db.recordingSelectedRegion {
+                                try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+                            }
+                        }
+                        
                         db.add(transactionObserver: observer, extent: .observerLifetime)
                     } catch {
                         onError(error)

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -363,7 +363,7 @@ extension DatabaseWriter {
                 
                 do {
                     try unsafeReentrantWrite { db in
-                        let region = try observation.observedRegion(db)
+                        let region = try observation.observedRegion(db).ignoringViews(db)
                         var reducer = try observation.makeReducer(db)
                         
                         // Fetch initial value
@@ -385,7 +385,7 @@ extension DatabaseWriter {
                 // has the default scheduling .mainQueue
                 asyncWriteWithoutTransaction { db in
                     do {
-                        let region = try observation.observedRegion(db)
+                        let region = try observation.observedRegion(db).ignoringViews(db)
                         var reducer = try observation.makeReducer(db)
                         
                         // Fetch initial value
@@ -412,7 +412,7 @@ extension DatabaseWriter {
             // Use case: observation must not block the target queue
             asyncWriteWithoutTransaction { db in
                 do {
-                    let region = try observation.observedRegion(db)
+                    let region = try observation.observedRegion(db).ignoringViews(db)
                     var reducer = try observation.makeReducer(db)
                     
                     // Fetch initial value
@@ -458,7 +458,7 @@ extension DatabaseWriter {
                 
                 do {
                     try unsafeReentrantWrite { db in
-                        let region = try observation.observedRegion(db)
+                        let region = try observation.observedRegion(db).ignoringViews(db)
                         var reducer = try observation.makeReducer(db)
                         
                         // Fetch initial value
@@ -484,7 +484,7 @@ extension DatabaseWriter {
                 // queue on which the onChange and onError callbacks are called.
                 asyncWriteWithoutTransaction { db in
                     do {
-                        let region = try observation.observedRegion(db)
+                        let region = try observation.observedRegion(db).ignoringViews(db)
                         let reducer = try observation.makeReducer(db)
                         
                         // Start observing the database

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -790,6 +790,9 @@ public final class RowCursor: Cursor {
         self._row = try Row(statement: statement).adapted(with: adapter, layout: statement)
         self._sqliteStatement = statement.sqliteStatement
         statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -384,6 +384,9 @@ final class StatementCursor: Cursor {
         _statement = statement
         _sqliteStatement = statement.sqliteStatement
         _statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -277,7 +277,7 @@ extension Statement {
 ///     }
 public final class SelectStatement: Statement {
     /// The database region that the statement looks into.
-    public private(set) var databaseRegion = DatabaseRegion()
+    public internal(set) var databaseRegion = DatabaseRegion()
     
     /// Creates a prepared statement. Returns nil if the compiled string is
     /// blank or empty.

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -276,6 +276,10 @@ extension Statement {
 ///         let moreThanThirtyCount = try Int.fetchOne(statement, arguments: [30])!
 ///     }
 public final class SelectStatement: Statement {
+    // Database region is computed during statement compilation, and maybe
+    // optimized when statement is compiled for a QueryInterfaceRequest, in
+    // order to perform focused database observation. See
+    // SQLQueryGenerator.optimizedDatabaseRegion(_:_:)
     /// The database region that the statement looks into.
     public internal(set) var databaseRegion = DatabaseRegion()
     

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -77,6 +77,9 @@ public final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & Sta
             _columnIndex = 0
         }
         _statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {
@@ -133,6 +136,9 @@ public final class FastNullableDatabaseValueCursor<Value>: Cursor
             _columnIndex = 0
         }
         _statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -86,7 +86,7 @@ extension QueryInterfaceRequest: FetchRequest {
     /// - parameter db: A database connection.
     /// :nodoc:
     public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
-        var region = try SQLQueryGenerator(query).databaseRegion(db)
+        var region = try SQLQueryGenerator(query).makeSelectStatement(db).databaseRegion
         
         // Iterate all prefetched associations
         var fifo = query.relation.prefetchedAssociations
@@ -105,7 +105,7 @@ extension QueryInterfaceRequest: FetchRequest {
             let prefetchedQuery = SQLQuery(relation: prefetchedRelation)
             
             // Union region
-            try region.formUnion(SQLQueryGenerator(prefetchedQuery).databaseRegion(db))
+            try region.formUnion(SQLQueryGenerator(prefetchedQuery).makeSelectStatement(db).databaseRegion)
             
             // Append nested prefetched associations (support for
             // A.including(all: A.bs.including(all: B.cs))

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -429,6 +429,9 @@ public final class RecordCursor<Record: FetchableRecord>: Cursor {
         _row = try Row(statement: statement).adapted(with: adapter, layout: statement)
         _sqliteStatement = statement.sqliteStatement
         _statement.reset(withArguments: arguments)
+        
+        // Assume cursor is created for iteration
+        statement.database.selectStatementWillExecute(statement)
     }
     
     deinit {

--- a/GRDB/ValueObservation/ValueObservation+MapReducer.swift
+++ b/GRDB/ValueObservation/ValueObservation+MapReducer.swift
@@ -4,11 +4,10 @@ extension ValueObservation {
     /// Returns a ValueObservation with a transformed reducer.
     public func mapReducer<R>(_ transform: @escaping (Database, Reducer) throws -> R) -> ValueObservation<R> {
         let makeReducer = self.makeReducer
-        var observation = ValueObservation<R>(
-            tracking: observedRegion,
-            reducer: { db in try transform(db, makeReducer(db)) })
-        observation.scheduling = scheduling
-        observation.requiresWriteAccess = requiresWriteAccess
-        return observation
+        return ValueObservation<R>(
+            observedRegion: observedRegion,
+            makeReducer: { db in try transform(db, makeReducer(db)) },
+            requiresWriteAccess: requiresWriteAccess,
+            scheduling: scheduling)
     }
 }

--- a/GRDB/ValueObservation/ValueObservation+MapReducer.swift
+++ b/GRDB/ValueObservation/ValueObservation+MapReducer.swift
@@ -5,7 +5,8 @@ extension ValueObservation {
     public func mapReducer<R>(_ transform: @escaping (Database, Reducer) throws -> R) -> ValueObservation<R> {
         let makeReducer = self.makeReducer
         return ValueObservation<R>(
-            observedRegion: observedRegion,
+            baseRegion: baseRegion,
+            observesSelectedRegion: observesSelectedRegion,
             makeReducer: { db in try transform(db, makeReducer(db)) },
             requiresWriteAccess: requiresWriteAccess,
             scheduling: scheduling)

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -345,16 +345,15 @@ extension ValueObservation where Reducer == Void {
     /// - The observation lasts until the observer returned by
     /// `start` is deallocated.
     ///
-    /// - parameter regions: A list of observed regions.
-    /// - parameter fetch: A closure that fetches a value.
+    /// - parameter value: A closure that fetches a value.
     public static func tracking<Value>(
-        fetch: @escaping (Database) throws -> Value)
+        value: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     {
         return ValueObservation<ValueReducers.Fetch<Value>>(
             baseRegion: { _ in DatabaseRegion() },
             observesSelectedRegion: true,
-            makeReducer: { _ in ValueReducers.Fetch(fetch) },
+            makeReducer: { _ in ValueReducers.Fetch(value) },
             requiresWriteAccess: false,
             scheduling: .mainQueue)
     }

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -3,13 +3,20 @@ import Foundation
 /// Support for ValueObservation.
 /// See DatabaseWriter.add(observation:onError:onChange:)
 class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
-    // Region, reducer, and notificationQueue must be set before observer is
+    // Reducer and notificationQueue must be set before observer is
     // added to a database.
-    var region: DatabaseRegion!
     var reducer: Reducer!
     var notificationQueue: DispatchQueue?
     
+    var baseRegion = DatabaseRegion() {
+        didSet { observedRegion = baseRegion.union(selectedRegion) }
+    }
+    var selectedRegion = DatabaseRegion() {
+        didSet { observedRegion = baseRegion.union(selectedRegion) }
+    }
+    var observedRegion: DatabaseRegion! // internal for testability
     private var requiresWriteAccess: Bool
+    private var observesSelectedRegion: Bool
     private unowned var writer: DatabaseWriter
     private let reduceQueue: DispatchQueue
     private let onError: (Error) -> Void
@@ -19,6 +26,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
     
     init(
         requiresWriteAccess: Bool,
+        observesSelectedRegion: Bool,
         writer: DatabaseWriter,
         reduceQueue: DispatchQueue,
         onError: @escaping (Error) -> Void,
@@ -26,6 +34,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
     {
         self.writer = writer
         self.requiresWriteAccess = requiresWriteAccess
+        self.observesSelectedRegion = observesSelectedRegion
         self.reduceQueue = reduceQueue
         self.onError = onError
         self.onChange = onChange
@@ -37,12 +46,12 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
     
     func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool {
         if isCancelled { return false }
-        return region.isModified(byEventsOfKind: eventKind)
+        return observedRegion.isModified(byEventsOfKind: eventKind)
     }
     
     func databaseDidChange(with event: DatabaseEvent) {
         if isCancelled { return }
-        if region.isModified(by: event) {
+        if observedRegion.isModified(by: event) {
             isChanged = true
             stopObservingDatabaseChangesUntilNextTransaction()
         }
@@ -54,7 +63,56 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
         isChanged = false
         
         // Grab future fetched value
-        let future = reducer.fetchFuture(db, writer: writer, requiringWriteAccess: requiresWriteAccess)
+        let future: DatabaseFuture<Reducer.Fetched>
+        if requiresWriteAccess {
+            // Synchronous read/write fetch
+            if observesSelectedRegion {
+                do {
+                    var fetchedValue: Reducer.Fetched!
+                    var selectedRegion: DatabaseRegion!
+                    try db.inTransaction {
+                        let (_fetchedValue, _selectedRegion) = try db.recordingSelectedRegion {
+                            try reducer.fetch(db)
+                        }
+                        fetchedValue = _fetchedValue
+                        selectedRegion = _selectedRegion
+                        return .commit
+                    }
+                    self.selectedRegion = selectedRegion
+                    future = DatabaseFuture(Result.success(fetchedValue))
+                } catch {
+                    future = DatabaseFuture(Result.failure(error))
+                }
+            } else {
+                // Synchronous read/write fetch
+                future = DatabaseFuture(DatabaseResult {
+                    var fetchedValue: Reducer.Fetched!
+                    try db.inTransaction {
+                        fetchedValue = try reducer.fetch(db)
+                        return .commit
+                    }
+                    return fetchedValue
+                })
+            }
+        } else {
+            if observesSelectedRegion {
+                // Synchronous read-only fetch
+                do {
+                    let (fetchedValue, selectedRegion) = try db.readOnly {
+                        try db.recordingSelectedRegion {
+                            try reducer.fetch(db)
+                        }
+                    }
+                    self.selectedRegion = selectedRegion
+                    future = DatabaseFuture(Result.success(fetchedValue))
+                } catch {
+                    future = DatabaseFuture(Result.failure(error))
+                }
+            } else {
+                // Concurrent fetch
+                future = writer.concurrentRead(reducer.fetch)
+            }
+        }
         
         // Wait for future fetched value in reduceQueue. This guarantees:
         // - that notifications have the same ordering as transactions.

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -79,9 +79,9 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
                         return .commit
                     }
                     self.selectedRegion = selectedRegion
-                    future = DatabaseFuture(Result.success(fetchedValue))
+                    future = DatabaseFuture(DatabaseResult.success(fetchedValue))
                 } catch {
-                    future = DatabaseFuture(Result.failure(error))
+                    future = DatabaseFuture(DatabaseResult.failure(error))
                 }
             } else {
                 // Synchronous read/write fetch
@@ -104,9 +104,9 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
                         }
                     }
                     self.selectedRegion = selectedRegion
-                    future = DatabaseFuture(Result.success(fetchedValue))
+                    future = DatabaseFuture(DatabaseResult.success(fetchedValue))
                 } catch {
-                    future = DatabaseFuture(Result.failure(error))
+                    future = DatabaseFuture(DatabaseResult.failure(error))
                 }
             } else {
                 // Concurrent fetch

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -51,12 +51,15 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine2<R1, R2>>
     {
         return ValueObservation<ValueReducers.Combine2>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine2(
+            makeReducer: { try ValueReducers.Combine2(
                 o1.makeReducer($0),
-                o2.makeReducer($0)) })
+                o2.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }
 
@@ -135,14 +138,18 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine3<R1, R2, R3>>
     {
         return ValueObservation<ValueReducers.Combine3>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0),
                 o3.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine3(
+            makeReducer: { try ValueReducers.Combine3(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
-                o3.makeReducer($0)) })
+                o3.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess
+                || o3.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }
 
@@ -238,16 +245,21 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine4<R1, R2, R3, R4>>
     {
         return ValueObservation<ValueReducers.Combine4>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0),
                 o3.observedRegion($0),
                 o4.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine4(
+            makeReducer: { try ValueReducers.Combine4(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
                 o3.makeReducer($0),
-                o4.makeReducer($0)) })
+                o4.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess
+                || o3.requiresWriteAccess
+                || o4.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }
 
@@ -356,18 +368,24 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine5<R1, R2, R3, R4, R5>>
     {
         return ValueObservation<ValueReducers.Combine5>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0),
                 o3.observedRegion($0),
                 o4.observedRegion($0),
                 o5.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine5(
+            makeReducer: { try ValueReducers.Combine5(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
                 o3.makeReducer($0),
                 o4.makeReducer($0),
-                o5.makeReducer($0)) })
+                o5.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess
+                || o3.requiresWriteAccess
+                || o4.requiresWriteAccess
+                || o5.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }
 
@@ -489,20 +507,27 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine6<R1, R2, R3, R4, R5, R6>>
     {
         return ValueObservation<ValueReducers.Combine6>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0),
                 o3.observedRegion($0),
                 o4.observedRegion($0),
                 o5.observedRegion($0),
                 o6.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine6(
+            makeReducer: { try ValueReducers.Combine6(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
                 o3.makeReducer($0),
                 o4.makeReducer($0),
                 o5.makeReducer($0),
-                o6.makeReducer($0)) })
+                o6.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess
+                || o3.requiresWriteAccess
+                || o4.requiresWriteAccess
+                || o5.requiresWriteAccess
+                || o6.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }
 
@@ -609,7 +634,7 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine7<R1, R2, R3, R4, R5, R6, R7>>
     {
         return ValueObservation<ValueReducers.Combine7>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0),
                 o3.observedRegion($0),
@@ -617,14 +642,22 @@ extension ValueObservation where Reducer == Void {
                 o5.observedRegion($0),
                 o6.observedRegion($0),
                 o7.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine7(
+            makeReducer: { try ValueReducers.Combine7(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
                 o3.makeReducer($0),
                 o4.makeReducer($0),
                 o5.makeReducer($0),
                 o6.makeReducer($0),
-                o7.makeReducer($0)) })
+                o7.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess
+                || o3.requiresWriteAccess
+                || o4.requiresWriteAccess
+                || o5.requiresWriteAccess
+                || o6.requiresWriteAccess
+                || o7.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }
 
@@ -742,7 +775,7 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine8<R1, R2, R3, R4, R5, R6, R7, R8>>
     {
         return ValueObservation<ValueReducers.Combine8>(
-            tracking: { try DatabaseRegion.union(
+            observedRegion: { try DatabaseRegion.union(
                 o1.observedRegion($0),
                 o2.observedRegion($0),
                 o3.observedRegion($0),
@@ -751,7 +784,7 @@ extension ValueObservation where Reducer == Void {
                 o6.observedRegion($0),
                 o7.observedRegion($0),
                 o8.observedRegion($0)) },
-            reducer: { try ValueReducers.Combine8(
+            makeReducer: { try ValueReducers.Combine8(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
                 o3.makeReducer($0),
@@ -759,6 +792,15 @@ extension ValueObservation where Reducer == Void {
                 o5.makeReducer($0),
                 o6.makeReducer($0),
                 o7.makeReducer($0),
-                o8.makeReducer($0)) })
+                o8.makeReducer($0)) },
+            requiresWriteAccess: o1.requiresWriteAccess
+                || o2.requiresWriteAccess
+                || o3.requiresWriteAccess
+                || o4.requiresWriteAccess
+                || o5.requiresWriteAccess
+                || o6.requiresWriteAccess
+                || o7.requiresWriteAccess
+                || o8.requiresWriteAccess,
+            scheduling: .mainQueue)
     }
 }

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -51,9 +51,11 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine2<R1, R2>>
     {
         return ValueObservation<ValueReducers.Combine2>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine2(
                 o1.makeReducer($0),
                 o2.makeReducer($0)) },
@@ -138,10 +140,13 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine3<R1, R2, R3>>
     {
         return ValueObservation<ValueReducers.Combine3>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0),
-                o3.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0),
+                o3.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion
+                || o3.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine3(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
@@ -245,11 +250,15 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine4<R1, R2, R3, R4>>
     {
         return ValueObservation<ValueReducers.Combine4>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0),
-                o3.observedRegion($0),
-                o4.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0),
+                o3.baseRegion($0),
+                o4.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion
+                || o3.observesSelectedRegion
+                || o4.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine4(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
@@ -368,12 +377,17 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine5<R1, R2, R3, R4, R5>>
     {
         return ValueObservation<ValueReducers.Combine5>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0),
-                o3.observedRegion($0),
-                o4.observedRegion($0),
-                o5.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0),
+                o3.baseRegion($0),
+                o4.baseRegion($0),
+                o5.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion
+                || o3.observesSelectedRegion
+                || o4.observesSelectedRegion
+                || o5.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine5(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
@@ -507,13 +521,19 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine6<R1, R2, R3, R4, R5, R6>>
     {
         return ValueObservation<ValueReducers.Combine6>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0),
-                o3.observedRegion($0),
-                o4.observedRegion($0),
-                o5.observedRegion($0),
-                o6.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0),
+                o3.baseRegion($0),
+                o4.baseRegion($0),
+                o5.baseRegion($0),
+                o6.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion
+                || o3.observesSelectedRegion
+                || o4.observesSelectedRegion
+                || o5.observesSelectedRegion
+                || o6.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine6(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
@@ -634,14 +654,21 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine7<R1, R2, R3, R4, R5, R6, R7>>
     {
         return ValueObservation<ValueReducers.Combine7>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0),
-                o3.observedRegion($0),
-                o4.observedRegion($0),
-                o5.observedRegion($0),
-                o6.observedRegion($0),
-                o7.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0),
+                o3.baseRegion($0),
+                o4.baseRegion($0),
+                o5.baseRegion($0),
+                o6.baseRegion($0),
+                o7.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion
+                || o3.observesSelectedRegion
+                || o4.observesSelectedRegion
+                || o5.observesSelectedRegion
+                || o6.observesSelectedRegion
+                || o7.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine7(
                 o1.makeReducer($0),
                 o2.makeReducer($0),
@@ -775,15 +802,23 @@ extension ValueObservation where Reducer == Void {
         -> ValueObservation<ValueReducers.Combine8<R1, R2, R3, R4, R5, R6, R7, R8>>
     {
         return ValueObservation<ValueReducers.Combine8>(
-            observedRegion: { try DatabaseRegion.union(
-                o1.observedRegion($0),
-                o2.observedRegion($0),
-                o3.observedRegion($0),
-                o4.observedRegion($0),
-                o5.observedRegion($0),
-                o6.observedRegion($0),
-                o7.observedRegion($0),
-                o8.observedRegion($0)) },
+            baseRegion: { try DatabaseRegion.union(
+                o1.baseRegion($0),
+                o2.baseRegion($0),
+                o3.baseRegion($0),
+                o4.baseRegion($0),
+                o5.baseRegion($0),
+                o6.baseRegion($0),
+                o7.baseRegion($0),
+                o8.baseRegion($0)) },
+            observesSelectedRegion: o1.observesSelectedRegion
+                || o2.observesSelectedRegion
+                || o3.observesSelectedRegion
+                || o4.observesSelectedRegion
+                || o5.observesSelectedRegion
+                || o6.observesSelectedRegion
+                || o7.observesSelectedRegion
+                || o8.observesSelectedRegion,
             makeReducer: { try ValueReducers.Combine8(
                 o1.makeReducer($0),
                 o2.makeReducer($0),

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -34,25 +34,6 @@ extension ValueReducer {
             }
         }
     }
-    
-    /// Synchronous or asynchronous fetch
-    /// Support for ValueObserver
-    func fetchFuture(_ db: Database, writer: DatabaseWriter, requiringWriteAccess: Bool) -> DatabaseFuture<Fetched> {
-        if requiringWriteAccess {
-            // Synchronous fetch
-            return DatabaseFuture(DatabaseResult {
-                var fetchedValue: Fetched!
-                try db.inTransaction {
-                    fetchedValue = try fetch(db)
-                    return .commit
-                }
-                return fetchedValue
-            })
-        } else {
-            // Concurrent fetch
-            return writer.concurrentRead(fetch)
-        }
-    }
 }
 
 /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -303,6 +303,8 @@
 		5674A71F1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A71C1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift */; };
 		5674A7271F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A7261F30A9090095F066 /* FetchableRecordDecodableTests.swift */; };
 		5674A7291F30A9090095F066 /* FetchableRecordDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5674A7261F30A9090095F066 /* FetchableRecordDecodableTests.swift */; };
+		5676FBAA22F5CEB9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBA822F5CEB8004717D9 /* ValueObservationRegionRecordingTests.swift */; };
+		5676FBAB22F5CEB9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBA822F5CEB8004717D9 /* ValueObservationRegionRecordingTests.swift */; };
 		567A80561D41350C00C7DCEC /* IndexInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567A80521D41350C00C7DCEC /* IndexInfoTests.swift */; };
 		567A805A1D41350C00C7DCEC /* IndexInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567A80521D41350C00C7DCEC /* IndexInfoTests.swift */; };
 		567DAF1E1EAB61ED00FC0928 /* grdb_config.h in Headers */ = {isa = PBXBuildFile; fileRef = 567DAF141EAB61ED00FC0928 /* grdb_config.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -886,6 +888,7 @@
 		5674A70B1F3087700095F066 /* DatabaseValueConvertibleEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEncodableTests.swift; sourceTree = "<group>"; };
 		5674A71C1F30A8DF0095F066 /* MutablePersistableRecordEncodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordEncodableTests.swift; sourceTree = "<group>"; };
 		5674A7261F30A9090095F066 /* FetchableRecordDecodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchableRecordDecodableTests.swift; sourceTree = "<group>"; };
+		5676FBA822F5CEB8004717D9 /* ValueObservationRegionRecordingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationRegionRecordingTests.swift; sourceTree = "<group>"; };
 		567A80521D41350C00C7DCEC /* IndexInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexInfoTests.swift; sourceTree = "<group>"; };
 		567DAF141EAB61ED00FC0928 /* grdb_config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = grdb_config.h; sourceTree = "<group>"; };
 		567DAF341EAB789800FC0928 /* DatabaseLogErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseLogErrorTests.swift; sourceTree = "<group>"; };
@@ -1312,6 +1315,7 @@
 				563B06CD2185E04600B38F35 /* ValueObservationReadonlyTests.swift */,
 				563B071121862C3E00B38F35 /* ValueObservationRecordTests.swift */,
 				563B06CF2185E04600B38F35 /* ValueObservationReducerTests.swift */,
+				5676FBA822F5CEB8004717D9 /* ValueObservationRegionRecordingTests.swift */,
 				563B0701218627DE00B38F35 /* ValueObservationRowTests.swift */,
 				563B06D02185E04600B38F35 /* ValueObservationSchedulingTests.swift */,
 			);
@@ -2416,6 +2420,7 @@
 				56DF0018228DDB8300D611F3 /* AssociationPrefetchingRowTests.swift in Sources */,
 				F3BA80541CFB2B59003DC1BA /* DatabaseRegionTests.swift in Sources */,
 				567DAF3C1EAB789800FC0928 /* DatabaseLogErrorTests.swift in Sources */,
+				5676FBAB22F5CEB9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				566A84442041AB2D00E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,
 				F3BA81171CFB305E003DC1BA /* QueryInterfaceExpressionsTests.swift in Sources */,
 				569BBA2C228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */,
@@ -2747,6 +2752,7 @@
 				56DF0017228DDB8300D611F3 /* AssociationPrefetchingRowTests.swift in Sources */,
 				F3BA812E1CFB3064003DC1BA /* RecordPrimaryKeyMultipleTests.swift in Sources */,
 				F3BA81021CFB3032003DC1BA /* CGFloatTests.swift in Sources */,
+				5676FBAA22F5CEB9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				566A84432041AB2D00E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,
 				567DAF381EAB789800FC0928 /* DatabaseLogErrorTests.swift in Sources */,
 				569BBA2B228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */,

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,12 @@ endif
 TEST_ACTIONS = clean build build-for-testing test-without-building
 
 # When adding support for an Xcode version, look for available devices with `instruments -s devices`
-ifeq ($(XCODEVERSION),10.2)
+ifeq ($(XCODEVERSION),10.3)
+  MAX_SWIFT_VERSION = 5
+  MIN_SWIFT_VERSION = 4.2
+  MAX_IOS_DESTINATION = "platform=iOS Simulator,name=iPhone X,OS=12.4"
+  MIN_IOS_DESTINATION = "platform=iOS Simulator,name=iPhone 4s,OS=9.0"
+else ifeq ($(XCODEVERSION),10.2)
   MAX_SWIFT_VERSION = 5
   MIN_SWIFT_VERSION = 4.2
   MAX_IOS_DESTINATION = "platform=iOS Simulator,name=iPhone X,OS=12.2"
@@ -320,10 +325,10 @@ test_performance: Realm FMDB SQLite.swift
 	  -scheme GRDBOSXPerformanceComparisonTests \
 	  build-for-testing test-without-building
 
-Realm: Tests/Performance/Realm/build/osx/swift-10.2.1/RealmSwift.framework
+Realm: Tests/Performance/Realm/build/osx/swift-10.3/RealmSwift.framework
 
 # Makes sure the Tests/Performance/Realm submodule has been downloaded, and Realm framework has been built.
-Tests/Performance/Realm/build/osx/swift-10.2.1/RealmSwift.framework:
+Tests/Performance/Realm/build/osx/swift-10.3/RealmSwift.framework:
 	$(GIT) submodule update --init --recursive Tests/Performance/Realm
 	cd Tests/Performance/Realm && sh build.sh osx-swift
 

--- a/README.md
+++ b/README.md
@@ -6100,7 +6100,7 @@ Changes are only notified after they have been committed in the database. No ins
 
 - **[ValueObservation Usage](#valueobservation-usage)**
 - [observationForCount, observationForAll, observationForFirst](#observationforcount-observationforall-observationforfirst)
-- [ValueObservation.tracking(fetch:)](#valueobservationtrackingfetch)
+- [ValueObservation.tracking(value:)](#valueobservationtrackingvalue)
 - [ValueObservation.tracking(_:fetch:)](#valueobservationtracking_fetch)
 - [ValueObservation Transformations](#valueobservation-transformations): [map](#valueobservationmap), [compactMap](#valueobservationcompactmap), ...
 - [ValueObservation Error Handling](#valueobservation-error-handling)
@@ -6258,7 +6258,7 @@ They perform a filtering of consecutive identical values, based on raw database 
     ```
 
 
-### ValueObservation.tracking(fetch:)
+### ValueObservation.tracking(value:)
 
 Observing the database is not always a matter of tracking a single request, as above.
 
@@ -6298,7 +6298,7 @@ print("""
     """)
 ```
 
-Now, in order to track changes in the Hall of Fame, we'll use the `ValueObservation.tracking(fetch:)` method. Just make it fetch the observed values:
+Now, in order to track changes in the Hall of Fame, we'll use the `ValueObservation.tracking(value:)` method. Just make it fetch the observed value:
 
 ```swift
 let observation = ValueObservation.tracking { db in
@@ -6316,7 +6316,7 @@ let observer = observation.start(
     })
 ```
 
-- Observation built from `ValueObservation.tracking(fetch:)` can observe several tables:
+- Observation built from `ValueObservation.tracking(value:)` can observe several tables:
 
     ```swift
     // Observe several tables
@@ -6330,7 +6330,7 @@ let observer = observation.start(
     }
     ```
 
-- Unlike [observationForCount, observationForAll, observationForFirst](#observationforcount-observationforall-observationforfirst), `ValueObservation.tracking(fetch:)` does not filter out consecutive identical values. For example, database changes that happen to the worst players trigger the observation of the Hall of Fame, just in case the best players would be modified.
+- Unlike [observationForCount, observationForAll, observationForFirst](#observationforcount-observationforall-observationforfirst), `ValueObservation.tracking(value:)` does not filter out consecutive identical values. For example, database changes that happen to the worst players trigger the observation of the Hall of Fame, just in case the best players would be modified.
     
     You can filter out those duplicates with the [ValueObservation.removeDuplicates](#valueobservationremoveduplicates) method. It requires the observed value to adopt the Equatable protocol:
     
@@ -6347,7 +6347,7 @@ let observer = observation.start(
 
 ### ValueObservation.tracking(_:fetch:)
 
-The `ValueObservation.tracking(_:fetch:)` method is an **optimized** version of the [`ValueObservation.tracking(fetch:)`](#valueobservationtrackingfetch) method seen above. 
+The `ValueObservation.tracking(_:fetch:)` method is an **optimized** version of the [`ValueObservation.tracking(value:)`](#valueobservationtrackingvalue) method seen above. 
 
 It ouputs exactly the same results, but it can perform better when you use a [database pool](#database-pools), and the fetch is slow. It reduces write contention by fetching fresh values without blocking write accesses. When you use a [database queue](#database-queues), no optimization is applied.
 

--- a/README.md
+++ b/README.md
@@ -6284,7 +6284,10 @@ extension {
     }
 }
 
-let hallOfFame = try dbQueue.read { db in try HallOfFame.fetch(db) }
+let hallOfFame = try dbQueue.read { db in 
+    try HallOfFame.fetch(db)
+}
+
 print("""
     Best players out of \(hallOfFame.totalPlayerCount):
     \(hallOfFame.bestPlayers)

--- a/README.md
+++ b/README.md
@@ -6369,7 +6369,7 @@ let observation = ValueObservation.tracking { db in
 let observer = observation.start(
     in: dbQueue,
     onError: { error in ... },
-    onChange:{ (hallOfFame: HallOfFame) in
+    onChange: { (hallOfFame: HallOfFame) in
         print("""
             Best players out of \(hallOfFame.totalPlayerCount):
             \(hallOfFame.bestPlayers)
@@ -6419,7 +6419,7 @@ let observation = ValueObservation.tracking(Player.all(), fetch: { db in
 let observer = observation.start(
     in: dbQueue,
     onError: { error in ... },
-    onChange:{ (hallOfFame: HallOfFame) in
+    onChange: { (hallOfFame: HallOfFame) in
         print("""
             Best players out of \(hallOfFame.totalPlayerCount):
             \(hallOfFame.bestPlayers)

--- a/README.md
+++ b/README.md
@@ -6396,18 +6396,16 @@ When you use a [database pool](#database-pools), and the fetch is slow, you may 
 
 ### ValueObservation.tracking(_:fetch:)
 
-The `ValueObservation.tracking(_:fetch:)` method is an optimized version of the [`ValueObservation.tracking(fetch:)`](#valueobservationtrackingfetch) method seen above. 
+The `ValueObservation.tracking(_:fetch:)` method is an **optimized** version of the [`ValueObservation.tracking(fetch:)`](#valueobservationtrackingfetch) method seen above. 
 
-It only performs better when you use a [database pool](#database-pools), and the fetch is slow, because it reduces write contention by fetching fresh values without blocking write accesses.
-
-When you use a [database queue](#database-queues), the results are the same, but no optimization is applied.
+It ouputs exactly the same results, but it can perform better when you use a [database pool](#database-pools), and the fetch is slow. It reduces write contention by fetching fresh values without blocking write accesses. When you use a [database queue](#database-queues), no optimization is applied.
 
 It accepts two arguments:
 
 1. A list of observed requests.
 2. A closure that fetches a fresh value whenever one of the observed requests are modified.
 
-Changes that happen outside of the observed requests are ignored, so make sure you cover the database region you want to observe.
+Changes that happen outside of the observed requests are ignored, so make sure you fully cover the database region you want to observe. This is the price you pay for the optimization.
 
 In the Hall Of Fame example seen above, any change to the `player` table can impact the Hall of Fame. We thus track the request for all players, `Player.all()`, and fetch a new Hall of Fame whenever players change:
 

--- a/README.md
+++ b/README.md
@@ -6257,7 +6257,6 @@ struct HallOfFame {
     var totalPlayerCount: Int
     var bestPlayers: [Player]
 }
-```
 
 extension HallOfFame {
     /// Fetch the HallOfFame

--- a/README.md
+++ b/README.md
@@ -6338,7 +6338,7 @@ let observer = observation.start(
     extension HallOfFame: Equatable { ... }
     
     let observation = ValueObservation
-        .tracking(fetch: HallOfFame.fetch)
+        .tracking(value: HallOfFame.fetch)
         .removeDuplicates()
     ```
 

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -383,13 +383,15 @@
 		564A2151226B8E18001F64F1 /* Betty.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 564A1F6F226B89D6001F64F1 /* Betty.jpeg */; };
 		5656A802229474DD001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
 		5656A803229474DD001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
+		5676FBB022F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */; };
+		5676FBB122F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */; };
 		569BBA31228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA32228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		56DF0027228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF0028228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF0029228DE00900D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF002A228DE00900D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */; };
-		5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5B33E6E34F941B4C839A714F /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		98AB0B01EB11B33719AE412E /* Pods_GRDBTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE2436BF42B9FCD6552E7076 /* Pods_GRDBTests.framework */; };
 		F2B3C4250D67969FF3948955 /* Pods_GRDBTestsEncrypted.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D5C7999E7D9CE7145687F5D /* Pods_GRDBTestsEncrypted.framework */; };
 /* End PBXBuildFile section */
@@ -589,6 +591,7 @@
 		564A1FDD226B89E1001F64F1 /* FTS5RecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FTS5RecordTests.swift; sourceTree = "<group>"; };
 		564A2156226B8E18001F64F1 /* GRDBTestsEncrypted.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTestsEncrypted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationQueryInterfaceRequestTests.swift; sourceTree = "<group>"; };
+		5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationRegionRecordingTests.swift; sourceTree = "<group>"; };
 		569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
@@ -603,7 +606,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */,
+				5B33E6E34F941B4C839A714F /* (null) in Frameworks */,
 				98AB0B01EB11B33719AE412E /* Pods_GRDBTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -831,6 +834,7 @@
 				564A1F85226B89D8001F64F1 /* ValueObservationReadonlyTests.swift */,
 				564A1F44226B89D0001F64F1 /* ValueObservationRecordTests.swift */,
 				564A1F87226B89D8001F64F1 /* ValueObservationReducerTests.swift */,
+				5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */,
 				564A1F9C226B89DA001F64F1 /* ValueObservationRowTests.swift */,
 				564A1F48226B89D1001F64F1 /* ValueObservationSchedulingTests.swift */,
 				564A1FBA226B89DD001F64F1 /* VirtualTableModuleTests.swift */,
@@ -1097,6 +1101,7 @@
 				564A2078226B89E1001F64F1 /* ForeignKeyInfoTests.swift in Sources */,
 				564A2050226B89E1001F64F1 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				564A2091226B89E1001F64F1 /* FetchableRecord+QueryInterfaceRequestTests.swift in Sources */,
+				5676FBB022F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				564A208F226B89E1001F64F1 /* AssociationParallelRowScopesTests.swift in Sources */,
 				564A2047226B89E1001F64F1 /* AnyCursorTests.swift in Sources */,
 				564A1FFC226B89E1001F64F1 /* DatabaseValueTests.swift in Sources */,
@@ -1294,6 +1299,7 @@
 				564A20CE226B8E18001F64F1 /* ForeignKeyInfoTests.swift in Sources */,
 				564A20CF226B8E18001F64F1 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				564A20D0226B8E18001F64F1 /* FetchableRecord+QueryInterfaceRequestTests.swift in Sources */,
+				5676FBB122F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				564A20D1226B8E18001F64F1 /* AssociationParallelRowScopesTests.swift in Sources */,
 				564A20D2226B8E18001F64F1 /* AnyCursorTests.swift in Sources */,
 				564A20D3226B8E18001F64F1 /* DatabaseValueTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -385,13 +385,15 @@
 		564A215A226C8F25001F64F1 /* db.SQLCipher3 in Resources */ = {isa = PBXBuildFile; fileRef = 564A2158226C8F24001F64F1 /* db.SQLCipher3 */; };
 		5656A805229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
 		5656A806229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
+		5676FBAD22F5CEF6004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */; };
+		5676FBAE22F5CEF6004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */; };
 		569BBA2E228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA2F228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		56DF0021228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF0022228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF0023228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF0024228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
-		5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		5B33E6E34F941B4C839A714F /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		E158370AAEED49ECD53CE24A /* Pods_GRDBTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67377FE4CDAD675809F93AD4 /* Pods_GRDBTests.framework */; };
 		F2B3C4250D67969FF3948955 /* Pods_GRDBTestsEncrypted.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D5C7999E7D9CE7145687F5D /* Pods_GRDBTestsEncrypted.framework */; };
 /* End PBXBuildFile section */
@@ -592,6 +594,7 @@
 		564A2156226B8E18001F64F1 /* GRDBTestsEncrypted.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTestsEncrypted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		564A2158226C8F24001F64F1 /* db.SQLCipher3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = db.SQLCipher3; sourceTree = SOURCE_ROOT; };
 		5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationQueryInterfaceRequestTests.swift; sourceTree = "<group>"; };
+		5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationRegionRecordingTests.swift; sourceTree = "<group>"; };
 		569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
 		56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
@@ -606,7 +609,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B33E6E34F941B4C839A714F /* BuildFile in Frameworks */,
+				5B33E6E34F941B4C839A714F /* (null) in Frameworks */,
 				E158370AAEED49ECD53CE24A /* Pods_GRDBTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -835,6 +838,7 @@
 				564A1F85226B89D8001F64F1 /* ValueObservationReadonlyTests.swift */,
 				564A1F44226B89D0001F64F1 /* ValueObservationRecordTests.swift */,
 				564A1F87226B89D8001F64F1 /* ValueObservationReducerTests.swift */,
+				5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */,
 				564A1F9C226B89DA001F64F1 /* ValueObservationRowTests.swift */,
 				564A1F48226B89D1001F64F1 /* ValueObservationSchedulingTests.swift */,
 				564A1FBA226B89DD001F64F1 /* VirtualTableModuleTests.swift */,
@@ -1103,6 +1107,7 @@
 				564A2078226B89E1001F64F1 /* ForeignKeyInfoTests.swift in Sources */,
 				564A2050226B89E1001F64F1 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				564A2091226B89E1001F64F1 /* FetchableRecord+QueryInterfaceRequestTests.swift in Sources */,
+				5676FBAD22F5CEF6004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				564A208F226B89E1001F64F1 /* AssociationParallelRowScopesTests.swift in Sources */,
 				564A2047226B89E1001F64F1 /* AnyCursorTests.swift in Sources */,
 				564A1FFC226B89E1001F64F1 /* DatabaseValueTests.swift in Sources */,
@@ -1300,6 +1305,7 @@
 				564A20CE226B8E18001F64F1 /* ForeignKeyInfoTests.swift in Sources */,
 				564A20CF226B8E18001F64F1 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				564A20D0226B8E18001F64F1 /* FetchableRecord+QueryInterfaceRequestTests.swift in Sources */,
+				5676FBAE22F5CEF6004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
 				564A20D1226B8E18001F64F1 /* AssociationParallelRowScopesTests.swift in Sources */,
 				564A20D2226B8E18001F64F1 /* AnyCursorTests.swift in Sources */,
 				564A20D3226B8E18001F64F1 /* DatabaseValueTests.swift in Sources */,

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -87,7 +87,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -112,7 +112,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM \"a\" WHERE 0 ORDER BY \"cola1\"
@@ -138,7 +138,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" \
@@ -196,7 +196,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "parent" ORDER BY "parentA", "parentB"
@@ -219,7 +219,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "parent" WHERE 0 ORDER BY "parentA", "parentB"
@@ -238,7 +238,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "parent" WHERE "parentA" = 'foo' ORDER BY "parentA", "parentB"
@@ -268,7 +268,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -302,7 +302,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -354,7 +354,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * \
@@ -419,7 +419,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -448,7 +448,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -501,7 +501,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * \
@@ -543,7 +543,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -579,7 +579,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" \
@@ -623,7 +623,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "b" ORDER BY "colb1"
@@ -658,7 +658,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "b" ORDER BY "colb1"
@@ -696,7 +696,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "b" ORDER BY "colb1"
@@ -738,7 +738,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "b" ORDER BY "colb1"
@@ -772,7 +772,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -812,7 +812,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -854,7 +854,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -900,7 +900,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT * FROM "a" ORDER BY "cola1"
@@ -941,7 +941,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "b".*, "a".* \
@@ -993,7 +993,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "b".*, "a1".*, "a2".* \
@@ -1051,7 +1051,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "a".*, "c".* \
@@ -1103,7 +1103,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "a".*, "c1".*, "c2".* \
@@ -1163,7 +1163,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "d".*, "c".*, "a".* \
@@ -1201,7 +1201,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 XCTAssertEqual(selectQueries, [
                     """
                     SELECT "d".*, "a".* \
@@ -1239,7 +1239,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 // LEFT JOIN in the first query are useless but harmless.
                 // And SQLite may well optimize them out.
                 // So don't bother removing them.
@@ -1294,7 +1294,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 // LEFT JOIN in the first query are useless but harmless.
                 // And SQLite may well optimize them out.
                 // So don't bother removing them.
@@ -1355,7 +1355,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 // LEFT JOIN in the first query are useless but harmless.
                 // And SQLite may well optimize them out.
                 // So don't bother removing them.
@@ -1410,7 +1410,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 // LEFT JOIN in the first query are useless but harmless.
                 // And SQLite may well optimize them out.
                 // So don't bother removing them.
@@ -1473,7 +1473,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 // LEFT JOIN in the first query are useless but harmless.
                 // And SQLite may well optimize them out.
                 // So don't bother removing them.
@@ -1514,7 +1514,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 sqlQueries.removeAll()
                 _ = try Row.fetchAll(db, request)
                 
-                let selectQueries = sqlQueries.filter { $0.contains("SELECT") }
+                let selectQueries = sqlQueries.filter { $0.contains("SELECT") && !$0.contains("sqlite_") }
                 // LEFT JOIN in the first query are useless but harmless.
                 // And SQLite may well optimize them out.
                 // So don't bother removing them.

--- a/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
+++ b/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
@@ -334,7 +334,7 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
             notificationExpectation.fulfill()
         }
         let token = observer as! ValueObserverToken<ValueReducers.AllValues<Name>> // Non-public implementation detail
-        XCTAssertEqual(token.observer.region.description, "t(id,name)") // view is not tracked
+        XCTAssertEqual(token.observer.observedRegion.description, "t(id,name)") // view is not tracked
         try withExtendedLifetime(observer) {
             // Test view observation
             try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -24,7 +24,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         
         let observation = ValueObservation.tracking { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
         
         let observer = try observation.start(in: dbQueue) { count in
@@ -33,7 +33,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
         
         let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-        XCTAssertEqual(token.observer.observedRegion.description, "a(*),source(name)")
+        XCTAssertEqual(token.observer.observedRegion.description, "a(value),source(name)")
         
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
@@ -49,7 +49,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [0, 1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
         }
     }
     
@@ -71,7 +71,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         
         var observation = ValueObservation.tracking { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
         observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: false)
         
@@ -96,7 +96,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
         }
     }
     
@@ -118,7 +118,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         
         var observation = ValueObservation.tracking { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
         observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: true)
         
@@ -143,7 +143,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [0, 1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
         }
     }
     
@@ -165,7 +165,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         
         var observation = ValueObservation.tracking { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
         observation.scheduling = .unsafe(startImmediately: false)
         
@@ -190,7 +190,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
         }
     }
     
@@ -212,7 +212,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         
         var observation = ValueObservation.tracking { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
         observation.scheduling = .unsafe(startImmediately: true)
         
@@ -222,7 +222,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
         
         let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-        XCTAssertEqual(token.observer.observedRegion.description, "a(*),source(name)")
+        XCTAssertEqual(token.observer.observedRegion.description, "a(value),source(name)")
         
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
@@ -238,7 +238,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [0, 1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
         }
     }
 }

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -34,6 +34,15 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             }
             
             do {
+                // Test for rowID optimization
+                struct Player: TableRecord, FetchableRecord, Decodable { }
+                let (_, region) = try db.recordingSelectedRegion {
+                    _ = try Player.fetchOne(db, key: 123)
+                }
+                XCTAssertEqual(region.description, "player(id,name)[123]")
+            }
+
+            do {
                 let (_, region) = try db.recordingSelectedRegion {
                     _ = try Row.fetchAll(db, sql: "SELECT * FROM team")
                     _ = try Row.fetchAll(db, sql: "SELECT * FROM player")

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -1,12 +1,12 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+    @testable import GRDBCustomSQLite
 #else
-    import GRDB
+    @testable import GRDB
 #endif
 
 class ValueObservationRegionRecordingTests: GRDBTestCase {
-    func testRegionRecording() throws {
+    func testMainQueueScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -32,6 +32,9 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             notificationExpectation.fulfill()
         }
         
+        let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+        XCTAssertEqual(token.observer.observedRegion.description, "a(*),source(name)")
+        
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
@@ -44,10 +47,13 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             
             waitForExpectations(timeout: 1, handler: nil)
             XCTAssertEqual(results, [0, 1, 2, 3])
+            
+            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
         }
     }
     
-    func testRegionRecordingWithoutInitialFetch() throws {
+    func testAsyncSchedulingWithoutInitialFetch() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -74,6 +80,8 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             notificationExpectation.fulfill()
         }
         
+        // Can't test observedRegion because it is defined asynchronously
+        
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
@@ -86,6 +94,151 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             
             waitForExpectations(timeout: 1, handler: nil)
             XCTAssertEqual(results, [1, 2, 3])
+            
+            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+        }
+    }
+    
+    func testAsyncSchedulingWithInitialFetch() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute(sql: """
+                CREATE TABLE source(name TEXT);
+                INSERT INTO source VALUES ('a');
+                CREATE TABLE a(value INTEGER);
+                CREATE TABLE b(value INTEGER);
+                """)
+        }
+        
+        var results: [Int] = []
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 4
+        
+        var observation = ValueObservation.tracking { db -> Int in
+            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
+            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+        }
+        observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: true)
+        
+        let observer = try observation.start(in: dbQueue) { count in
+            results.append(count)
+            notificationExpectation.fulfill()
+        }
+        
+        // Can't test observedRegion because it is defined asynchronously
+        
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results, [0, 1, 2, 3])
+            
+            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+        }
+    }
+    
+    func testUnsafeSchedulingWithoutInitialFetch() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute(sql: """
+                CREATE TABLE source(name TEXT);
+                INSERT INTO source VALUES ('a');
+                CREATE TABLE a(value INTEGER);
+                CREATE TABLE b(value INTEGER);
+                """)
+        }
+        
+        var results: [Int] = []
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 3
+        
+        var observation = ValueObservation.tracking { db -> Int in
+            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
+            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+        }
+        observation.scheduling = .unsafe(startImmediately: false)
+        
+        let observer = try observation.start(in: dbQueue) { count in
+            results.append(count)
+            notificationExpectation.fulfill()
+        }
+        
+        // Can't test observedRegion because it is defined asynchronously
+        
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results, [1, 2, 3])
+            
+            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
+        }
+    }
+    
+    func testUnsafeSchedulingWithInitialFetch() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute(sql: """
+                CREATE TABLE source(name TEXT);
+                INSERT INTO source VALUES ('a');
+                CREATE TABLE a(value INTEGER);
+                CREATE TABLE b(value INTEGER);
+                """)
+        }
+        
+        var results: [Int] = []
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 4
+        
+        var observation = ValueObservation.tracking { db -> Int in
+            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
+            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+        }
+        observation.scheduling = .unsafe(startImmediately: true)
+        
+        let observer = try observation.start(in: dbQueue) { count in
+            results.append(count)
+            notificationExpectation.fulfill()
+        }
+        
+        let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+        XCTAssertEqual(token.observer.observedRegion.description, "a(*),source(name)")
+        
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results, [0, 1, 2, 3])
+            
+            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
+            XCTAssertEqual(token.observer.observedRegion.description, "b(*),source(name)")
         }
     }
 }

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+    import GRDBCustomSQLite
+#else
+    import GRDB
+#endif
+
+class ValueObservationRegionRecordingTests: GRDBTestCase {
+    func testRegionRecording() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute(sql: """
+                CREATE TABLE source(name TEXT);
+                INSERT INTO source VALUES ('a');
+                CREATE TABLE a(value INTEGER);
+                CREATE TABLE b(value INTEGER);
+                """)
+        }
+        
+        var results: [Int] = []
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 4
+        
+        let observation = ValueObservation.tracking { db -> Int in
+            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
+            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+        }
+        
+        let observer = try observation.start(in: dbQueue) { count in
+            results.append(count)
+            notificationExpectation.fulfill()
+        }
+        
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results, [0, 1, 2, 3])
+        }
+    }
+    
+    func testRegionRecordingWithoutInitialFetch() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write {
+            try $0.execute(sql: """
+                CREATE TABLE source(name TEXT);
+                INSERT INTO source VALUES ('a');
+                CREATE TABLE a(value INTEGER);
+                CREATE TABLE b(value INTEGER);
+                """)
+        }
+        
+        var results: [Int] = []
+        let notificationExpectation = expectation(description: "notification")
+        notificationExpectation.assertForOverFulfill = true
+        notificationExpectation.expectedFulfillmentCount = 3
+        
+        var observation = ValueObservation.tracking { db -> Int in
+            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
+            return try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+        }
+        observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: false)
+        
+        let observer = try observation.start(in: dbQueue) { count in
+            results.append(count)
+            notificationExpectation.fulfill()
+        }
+        
+        try withExtendedLifetime(observer) {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
+                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
+                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
+                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
+            }
+            
+            waitForExpectations(timeout: 1, handler: nil)
+            XCTAssertEqual(results, [1, 2, 3])
+        }
+    }
+}

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -73,6 +73,20 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
+    func testTupleObservation() throws {
+        // Here we just test that user can destructure an observed tuple.
+        // I'm completely paranoid about tuple destructuring - I can't wrap my
+        // head about the rules that allow or disallow it.
+        let dbQueue = try makeDatabaseQueue()
+        let observation = ValueObservation.tracking { db -> (Int, String) in
+            (0, "")
+        }
+        _ = observation.start(
+            in: dbQueue,
+            onError: { _ in },
+            onChange: { (int: Int, string: String) in }) // <- destructure
+    }
+    
     func testMainQueueScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {


### PR DESCRIPTION
This pull request introduces a new **very** simple way to define a ValueObservation 😍

```swift
// NEW!
let observation = ValueObservation.tracking { db in
    // Just fetch and return the values you want to track
}
```

For example:

```swift
// Observe all players
let observation = ValueObservation.tracking { db in
    try Player.fetchAll(db)
}

observation.start(
    in: dbQueue,
    onError: { error in ... }
    onChange: { (players: [Player]) in
        print("Fresh players: \(players).")
    })
```


The old method `tracking(_:fetch:)` is still present, but is now presented as an optimized version which can help reduce write contention when you use a DatabasePool and the fetch is slow:

```swift
// Optimized for DatabasePool and slow fetches
let observation = ValueObservation.tracking(region, ...) { db in
    // Fetch and return values
}
```

---

There are two new internal features behind this pull request:

- Observations are now able to automatically infer their tracked region from the executed fetch request(s):

    ```swift
    // Observes the row of id 1 in the player table
    let observation = ValueObservation.tracking { db in
        try Player.fetchOne(db, key: 1)
    }
    ```

- The database region tracked by an observation is able to change as time passes and observed values are refreshed.

    This allows to perform conditionals (if, guard, switch) during the fetch. 

    For example, the observation below tracks only the team database table, or both the team and player tables, depending on the presence or absence of the tracked team as time passes and database gets modified:

    ```swift
    let teamId = 123
    let observation = ValueObservation.tracking { db -> (Team, [Player])? in
        guard let team = try Team.fetchOne(db, key: teamId) else {
            return nil
        }
        let players = Player.filter(teamId: teamId).fetchAll(db)
        return (team, players)
    }
    ```
