### PR TITLE
Fix Data interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -55,9 +53,12 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**Fixed**
+
+- [#592](https://github.com/groue/GRDB.swift/pull/592): Fix Data interpolation
+
 
 ## 4.2.0
 

--- a/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
@@ -75,6 +75,15 @@ extension SQLInterpolation {
         appendInterpolation(Column(codingKey.stringValue))
     }
     
+    // When a value is both an expression and a sequence of expression,
+    // favor the expression side. Use case: Foundation.Data interpolation.
+    /// :nodoc:
+    public mutating func appendInterpolation<T>(_ expressible: T)
+        where T: Sequence, T.Element: SQLExpressible, T: SQLExpressible
+    {
+        sql += expressible.sqlExpression.expressionSQL(&context, wrappedInParenthesis: false)
+    }
+
     /// Appends a sequence of expressions, wrapped in parentheses.
     ///
     ///     // SELECT * FROM player WHERE id IN (?,?,?)

--- a/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
@@ -75,7 +75,7 @@ extension SQLInterpolation {
         appendInterpolation(Column(codingKey.stringValue))
     }
     
-    // When a value is both an expression and a sequence of expression,
+    // When a value is both an expression and a sequence of expressions,
     // favor the expression side. Use case: Foundation.Data interpolation.
     /// :nodoc:
     public mutating func appendInterpolation<T>(_ expressible: T)

--- a/Tests/GRDBTests/SQLInterpolationTests.swift
+++ b/Tests/GRDBTests/SQLInterpolationTests.swift
@@ -104,6 +104,16 @@ class SQLInterpolationTests: GRDBTestCase {
         test(value: V(), isInterpolatedAs: "V".databaseValue)
     }
     
+    func testDataInterpolation() {
+        // This test makes sure the Sequence conformance of Data does not
+        // kick in.
+        let data = "SQLite".data(using: .utf8)!
+        var sql = SQLInterpolation(literalCapacity: 0, interpolationCount: 1)
+        sql.appendInterpolation(data)
+        XCTAssertEqual(sql.sql, "?")
+        XCTAssertEqual(sql.arguments, [data])
+    }
+    
     func testQualifiedExpressionInterpolation() {
         var sql = SQLInterpolation(literalCapacity: 0, interpolationCount: 1)
         

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -234,6 +234,15 @@ extension SQLLiteralTests {
         test(value: V(), isInterpolatedAs: "V".databaseValue)
     }
     
+    func testDataInterpolation() {
+        // This test makes sure the Sequence conformance of Data does not
+        // kick in.
+        let data = "SQLite".data(using: .utf8)!
+        let query: SQLLiteral = "SELECT \(data)"
+        XCTAssertEqual(query.sql, "SELECT ?")
+        XCTAssertEqual(query.arguments, [data])
+    }
+    
     func testQualifiedExpressionInterpolation() {
         let query: SQLLiteral = """
             SELECT \(Column("name").aliased("foo"))


### PR DESCRIPTION
This pull request fixes #591, which has revealed that SQL interpolation would interpret Foundation Data as a sequence of bytes instead of a whole blob. Thanks @bikram990 for raising the issue!