### PR TITLE
Don't keep the sqlCipher passphrase in memory longer than necessary

### DIFF
--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -79,11 +79,29 @@ public struct Configuration {
     // MARK: - Encryption
     
     #if SQLITE_HAS_CODEC
-    /// The passphrase for the encrypted database.
+    /// A block which returns the passphrase for the encrypted database.
+    ///
+    /// If encrypting, you should use either this _or_ `passphrase`.
+    /// Using both is an error.
     ///
     /// Default: nil
-    public var passphrase: String?
-    
+    public var passphraseBlock: (() throws -> String)? {
+        didSet {
+            assert(passphraseBlock == nil || passphrase == nil, "cannot use both passphrase *and* passphraseBlock")
+        }
+    }
+
+    /// The passphrase for the encrypted database.
+    ///
+    /// If encrypting, you should use either this _or_ `passphraseBlock`.
+    /// Using both is an error.
+    ///
+    /// Default: nil
+    public var passphrase: String? {
+        didSet {
+            assert(passphraseBlock == nil || passphrase == nil, "cannot use both passphrase *and* passphraseBlock")
+        }
+    }
     #endif
     
     /// If set, allows custom configuration to be run every time

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -213,7 +213,7 @@ extension Database {
         
         #if SQLITE_HAS_CODEC
         try validateSQLCipher()
-        if let passphrase = configuration.passphrase {
+        if let passphrase = try configuration.passphraseBlock?() ?? configuration.passphrase {
             try setCipherPassphrase(passphrase)
         }
         #endif

--- a/Tests/GRDBTests/EncryptionTests.swift
+++ b/Tests/GRDBTests/EncryptionTests.swift
@@ -23,6 +23,27 @@ class EncryptionTests: GRDBTestCase {
         }
     }
 
+    func testDatabaseQueueWithPassphraseToDatabaseQueueWithPassphraseBlock() throws {
+        do {
+            dbConfiguration.passphrase = "secret"
+            dbConfiguration.passphraseBlock = nil
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "CREATE TABLE data (value INTEGER)")
+                try db.execute(sql: "INSERT INTO data (value) VALUES (1)")
+            }
+        }
+
+        do {
+            dbConfiguration.passphrase = nil
+            dbConfiguration.passphraseBlock = { return "secret" }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
+            try dbQueue.inDatabase { db in
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 1)
+            }
+        }
+    }
+
     func testDatabaseQueueWithPassphraseToDatabaseQueueWithoutPassphrase() throws {
         do {
             dbConfiguration.passphrase = "secret"


### PR DESCRIPTION
Pull Request Checklist
- [x] This pull request is submitted against the development branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.

Helps minimize the time the passphrase is stored in application memory