### PR TITLE
DatabasePool write barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -56,9 +54,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**New**
+
+- [#603](https://github.com/groue/GRDB.swift/pull/603): DatabasePool write barrier
 
 
 ## 4.3.0

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -490,6 +490,9 @@
 		5690C33B1D23E7D200E59934 /* FoundationDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C3361D23E7D200E59934 /* FoundationDateTests.swift */; };
 		5690C3401D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
 		5690C3431D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
+		56915782231BF28B00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56915781231BF28B00E1D237 /* PoolTests.swift */; };
+		56915783231BF28B00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56915781231BF28B00E1D237 /* PoolTests.swift */; };
+		56915784231BF28B00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56915781231BF28B00E1D237 /* PoolTests.swift */; };
 		569178491CED9B6000E179EA /* DatabaseQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569178451CED9B6000E179EA /* DatabaseQueueTests.swift */; };
 		569531091C9067DC00CF1A2B /* DatabaseQueueCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569530FB1C9067CC00CF1A2B /* DatabaseQueueCrashTests.swift */; };
 		5695310A1C9067DC00CF1A2B /* DatabaseValueConvertibleCrashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569530FC1C9067CC00CF1A2B /* DatabaseValueConvertibleCrashTests.swift */; };
@@ -1477,6 +1480,7 @@
 		5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateComponentsTests.swift; sourceTree = "<group>"; };
 		5690C3361D23E7D200E59934 /* FoundationDateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateTests.swift; sourceTree = "<group>"; };
 		5690C33F1D23E82A00E59934 /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		56915781231BF28B00E1D237 /* PoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoolTests.swift; sourceTree = "<group>"; };
 		569178451CED9B6000E179EA /* DatabaseQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTests.swift; sourceTree = "<group>"; };
 		569530FB1C9067CC00CF1A2B /* DatabaseQueueCrashTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueCrashTests.swift; sourceTree = "<group>"; };
 		569530FC1C9067CC00CF1A2B /* DatabaseValueConvertibleCrashTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleCrashTests.swift; sourceTree = "<group>"; };
@@ -2177,6 +2181,7 @@
 				569BBA4522906A8200478429 /* InflectionsTests.json */,
 				569BBA3522905FFA00478429 /* InflectionsTests.swift */,
 				56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */,
+				56915781231BF28B00E1D237 /* PoolTests.swift */,
 				56FF45551D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift */,
 				56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */,
 			);
@@ -3494,6 +3499,7 @@
 				5653EAE520944B4F00F46237 /* AssociationParallelRowScopesTests.swift in Sources */,
 				56A4CDB41D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */,
 				56CC9247201E058100CB597E /* DropFirstCursorTests.swift in Sources */,
+				56915783231BF28B00E1D237 /* PoolTests.swift in Sources */,
 				56E8CE0E1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				5665FA342129EEA0004D8612 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
 				56A238581B9C74A90082EB20 /* RecordPrimaryKeyRowIDTests.swift in Sources */,
@@ -3694,6 +3700,7 @@
 				562393601DEE06D300A6B01F /* CursorTests.swift in Sources */,
 				5653EAE420944B4F00F46237 /* AssociationParallelRowScopesTests.swift in Sources */,
 				56D4968F1D81316E008276D7 /* RowFromDictionaryTests.swift in Sources */,
+				56915782231BF28B00E1D237 /* PoolTests.swift in Sources */,
 				56D4968E1D81316E008276D7 /* RowCopiedFromStatementTests.swift in Sources */,
 				5665FA332129EEA0004D8612 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
 				56CC9246201E058100CB597E /* DropFirstCursorTests.swift in Sources */,
@@ -4026,6 +4033,7 @@
 				AAA4DD85230F262000C74B15 /* AssociationParallelRowScopesTests.swift in Sources */,
 				AAA4DD86230F262000C74B15 /* SQLExpressionLiteralTests.swift in Sources */,
 				AAA4DD87230F262000C74B15 /* DropFirstCursorTests.swift in Sources */,
+				56915784231BF28B00E1D237 /* PoolTests.swift in Sources */,
 				AAA4DD88230F262000C74B15 /* DatabaseValueConvertibleFetchTests.swift in Sources */,
 				AAA4DD89230F262000C74B15 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
 				AAA4DD8A230F262000C74B15 /* RecordPrimaryKeyRowIDTests.swift in Sources */,

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -171,12 +171,17 @@ extension DatabasePool {
     
     /// Free as much memory as possible.
     ///
-    /// This method blocks the current thread until all database accesses are completed.
+    /// This method blocks the current thread until all database accesses
+    /// are completed.
     ///
     /// See also setupMemoryManagement(application:)
     public func releaseMemory() {
-        forEachConnection { $0.releaseMemory() }
-        readerPool.clear()
+        // Release writer memory
+        writer.sync { $0.releaseMemory() }
+        // Release readers memory by closing all connections
+        readerPool.barrier {
+            readerPool.removeAll()
+        }
     }
     
     

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -243,10 +243,11 @@ extension DatabasePool {
     
     /// Changes the passphrase of an encrypted database
     public func change(passphrase: String) throws {
-        try readerPool.clear(andThen: {
+        try readerPool.barrier {
             try writer.sync { try $0.change(passphrase: passphrase) }
+            readerPool.removeAll()
             readerConfig.passphrase = passphrase
-        })
+        }
     }
 }
 #endif

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -636,6 +636,22 @@ extension DatabasePool: DatabaseReader {
         return try writer.sync(updates)
     }
     
+    /// A barrier write ensures that no database access is executed until all
+    /// previous accesses have completed, and the specified updates have been
+    /// executed.
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - important: Reads executed by concurrent *database snapshots* are not
+    ///   considered: they can run concurrently with the barrier updates.
+    /// - parameter updates: The updates to the database.
+    /// - throws: The error thrown by the updates.
+    public func barrierWriteWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T {
+        return try readerPool.barrier {
+            try writer.sync(updates)
+        }
+    }
+    
     /// Synchronously executes database updates in a protected dispatch queue,
     /// wrapped inside a transaction, and returns the result.
     ///

--- a/GRDB/Utils/ReadWriteBox.swift
+++ b/GRDB/Utils/ReadWriteBox.swift
@@ -8,8 +8,8 @@ final class ReadWriteBox<T> {
     }
     
     init(_ value: T) {
-        self._value = value
-        self.queue = DispatchQueue(label: "GRDB.ReadWriteBox", attributes: [.concurrent])
+        _value = value
+        queue = DispatchQueue(label: "GRDB.ReadWriteBox", attributes: [.concurrent])
     }
     
     func read<U>(_ block: (T) throws -> U) rethrows -> U {
@@ -29,6 +29,7 @@ final class ReadWriteBox<T> {
 }
 
 extension ReadWriteBox where T: Numeric {
+    @discardableResult
     func increment() -> T {
         return write { n in
             n += 1

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -323,6 +323,8 @@
 		5690C33E1D23E7D200E59934 /* FoundationDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C3361D23E7D200E59934 /* FoundationDateTests.swift */; };
 		5690C3421D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
 		5690C3451D23E82A00E59934 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C33F1D23E82A00E59934 /* Data.swift */; };
+		5691578D231BF2BE00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5691578B231BF2BE00E1D237 /* PoolTests.swift */; };
+		5691578E231BF2BE00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5691578B231BF2BE00E1D237 /* PoolTests.swift */; };
 		56959620222C458A002CB7C9 /* AssociationHasManyThroughSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695961E222C4589002CB7C9 /* AssociationHasManyThroughSQLTests.swift */; };
 		56959621222C458A002CB7C9 /* AssociationHasManyThroughSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5695961E222C4589002CB7C9 /* AssociationHasManyThroughSQLTests.swift */; };
 		56959636222D058B002CB7C9 /* AssociationHasManySQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56959635222D058B002CB7C9 /* AssociationHasManySQLTests.swift */; };
@@ -899,6 +901,7 @@
 		5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateComponentsTests.swift; sourceTree = "<group>"; };
 		5690C3361D23E7D200E59934 /* FoundationDateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateTests.swift; sourceTree = "<group>"; };
 		5690C33F1D23E82A00E59934 /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		5691578B231BF2BE00E1D237 /* PoolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PoolTests.swift; sourceTree = "<group>"; };
 		569178451CED9B6000E179EA /* DatabaseQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTests.swift; sourceTree = "<group>"; };
 		5695311E1C907A8C00CF1A2B /* DatabaseSchemaCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseSchemaCache.swift; sourceTree = "<group>"; };
 		569531231C90878D00CF1A2B /* DatabaseQueueSchemaCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueSchemaCacheTests.swift; sourceTree = "<group>"; };
@@ -1514,6 +1517,7 @@
 				569BBA42229066CB00478429 /* InflectionsTests.json */,
 				569BBA3E229065CF00478429 /* InflectionsTests.swift */,
 				56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */,
+				5691578B231BF2BE00E1D237 /* PoolTests.swift */,
 				56FF45551D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift */,
 				56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */,
 			);
@@ -1546,8 +1550,8 @@
 				56741EA71E66A8B3003E422D /* FetchRequestTests.swift */,
 				56A5EF0E1EF7F20B00F03071 /* ForeignKeyInfoTests.swift */,
 				567A80521D41350C00C7DCEC /* IndexInfoTests.swift */,
-				56D5075D1F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift */,
 				565EFAED1D0436CE00A8FA9D /* NumericOverflowTests.swift */,
+				56D5075D1F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift */,
 				56F3E7481E66F83A00BF0F01 /* ResultCodeTests.swift */,
 				56A2381D1B9C74A90082EB20 /* Row */,
 				569C1EB11CF07DDD0042627B /* SchedulingWatchdogTests.swift */,
@@ -2385,6 +2389,7 @@
 				F3BA80D61CFB2FFD003DC1BA /* DatabaseReaderTests.swift in Sources */,
 				5653EB7520961FB200F46237 /* AssociationRowScopeSearchTests.swift in Sources */,
 				563B06D22185E04600B38F35 /* ValueObservationExtentTests.swift in Sources */,
+				5691578D231BF2BE00E1D237 /* PoolTests.swift in Sources */,
 				5698AC9D1DA4B0430056AF8C /* FTS4RecordTests.swift in Sources */,
 				5665FA3E2129EED8004D8612 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
 				563B06DA2185E04600B38F35 /* ValueObservationSchedulingTests.swift in Sources */,
@@ -2717,6 +2722,7 @@
 				F3BA81321CFB3064003DC1BA /* RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
 				5653EB7420961FB200F46237 /* AssociationRowScopeSearchTests.swift in Sources */,
 				563B06D12185E04600B38F35 /* ValueObservationExtentTests.swift in Sources */,
+				5691578E231BF2BE00E1D237 /* PoolTests.swift in Sources */,
 				5623935A1DEE013C00A6B01F /* FilterCursorTests.swift in Sources */,
 				5665FA3D2129EED8004D8612 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
 				563B06D92185E04600B38F35 /* ValueObservationSchedulingTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -8016,6 +8016,12 @@ For more information about database pools, grab information about SQLite [WAL mo
 
 ### Advanced DatabasePool
 
+- [The `concurrenRead` Method](#the-concurrenread-method)
+- [The `barrierWriteWithoutTransaction` Method](#the-barrierwritewithouttransaction-method)
+
+
+#### The `concurrenRead` Method
+
 [Database pools](#database-pools) are very concurrent, since all reads can run in parallel, and can even run during write operations. But writes are still serialized: at any given point in time, there is no more than a single thread that is writing into the database.
 
 When your application modifies the database, and then reads some value that depends on those modifications, you may want to avoid locking the writer queue longer than necessary:
@@ -8086,6 +8092,20 @@ try dbPool.writeWithoutTransaction { db in
 ```
 
 [Transaction Observers](#transactionobserver-protocol) can also use `concurrentRead` in their `databaseDidCommit` method in order to process database changes without blocking other threads that want to write into the database.
+
+
+#### The `barrierWriteWithoutTransaction` Method
+
+```swift
+try dbPool.barrierWriteWithoutTransaction { db in
+    // Exclusive database access
+}
+```
+
+The barrier write guarantees exclusive access to the database: the method blocks until all concurrent database accesses are completed, reads and writes, and postpones all other accesses until it completes.
+
+There is a known limitation: reads performed by [database snapshots](#database-snapshots) are out of scope, and may run concurrently with the barrier.
+
 
 
 ### Database Snapshots

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -385,6 +385,8 @@
 		5656A803229474DD001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
 		5676FBB022F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */; };
 		5676FBB122F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */; };
+		56915793231C0D6A00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56915792231C0D6A00E1D237 /* PoolTests.swift */; };
+		56915794231C0D6A00E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56915792231C0D6A00E1D237 /* PoolTests.swift */; };
 		569BBA31228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA32228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		56DF0027228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
@@ -592,6 +594,7 @@
 		564A2156226B8E18001F64F1 /* GRDBTestsEncrypted.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBTestsEncrypted.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5656A801229474DC001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationQueryInterfaceRequestTests.swift; sourceTree = "<group>"; };
 		5676FBAF22F5CF04004717D9 /* ValueObservationRegionRecordingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationRegionRecordingTests.swift; sourceTree = "<group>"; };
+		56915792231C0D6A00E1D237 /* PoolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoolTests.swift; sourceTree = "<group>"; };
 		569BBA30228DF91000478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0025228DE00900D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0026228DE00900D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
@@ -774,6 +777,7 @@
 				564A1FCE226B89DF001F64F1 /* MutablePersistableRecordTests.swift */,
 				564A1F2E226B89CF001F64F1 /* NumericOverflowTests.swift */,
 				564A1FCB226B89DF001F64F1 /* PersistableRecordTests.swift */,
+				56915792231C0D6A00E1D237 /* PoolTests.swift */,
 				564A1F49226B89D1001F64F1 /* PrefixCursorTests.swift */,
 				564A1F46226B89D1001F64F1 /* PrefixWhileCursorTests.swift */,
 				564A1F97226B89DA001F64F1 /* PrimaryKeyInfoTests.swift */,
@@ -1129,6 +1133,7 @@
 				564A2064226B89E1001F64F1 /* AssociationHasOneThroughFetchableRecordTests.swift in Sources */,
 				564A1FFA226B89E1001F64F1 /* FTS5WrapperTokenizerTests.swift in Sources */,
 				564A2056226B89E1001F64F1 /* TableRecordTests.swift in Sources */,
+				56915793231C0D6A00E1D237 /* PoolTests.swift in Sources */,
 				564A2042226B89E1001F64F1 /* FTS5TableBuilderTests.swift in Sources */,
 				564A2089226B89E1001F64F1 /* DatabaseValueConversionErrorTests.swift in Sources */,
 				564A2081226B89E1001F64F1 /* TransactionObserverTests.swift in Sources */,
@@ -1327,6 +1332,7 @@
 				564A20E8226B8E18001F64F1 /* AssociationHasOneThroughFetchableRecordTests.swift in Sources */,
 				564A20E9226B8E18001F64F1 /* FTS5WrapperTokenizerTests.swift in Sources */,
 				564A20EA226B8E18001F64F1 /* TableRecordTests.swift in Sources */,
+				56915794231C0D6A00E1D237 /* PoolTests.swift in Sources */,
 				564A20EB226B8E18001F64F1 /* FTS5TableBuilderTests.swift in Sources */,
 				564A20EC226B8E18001F64F1 /* DatabaseValueConversionErrorTests.swift in Sources */,
 				564A20ED226B8E18001F64F1 /* TransactionObserverTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -387,6 +387,8 @@
 		5656A806229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */; };
 		5676FBAD22F5CEF6004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */; };
 		5676FBAE22F5CEF6004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */; };
+		56915790231C0D5100E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5691578F231C0D5100E1D237 /* PoolTests.swift */; };
+		56915791231C0D5100E1D237 /* PoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5691578F231C0D5100E1D237 /* PoolTests.swift */; };
 		569BBA2E228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		569BBA2F228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */; };
 		56DF0021228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */; };
@@ -595,6 +597,7 @@
 		564A2158226C8F24001F64F1 /* db.SQLCipher3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = db.SQLCipher3; sourceTree = SOURCE_ROOT; };
 		5656A804229474F4001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationQueryInterfaceRequestTests.swift; sourceTree = "<group>"; };
 		5676FBAC22F5CEF5004717D9 /* ValueObservationRegionRecordingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueObservationRegionRecordingTests.swift; sourceTree = "<group>"; };
+		5691578F231C0D5100E1D237 /* PoolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PoolTests.swift; sourceTree = "<group>"; };
 		569BBA2D228DF90200478429 /* AssociationPrefetchingFetchableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingFetchableRecordTests.swift; sourceTree = "<group>"; };
 		56DF001F228DDFF000D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
 		56DF0020228DDFF000D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
@@ -778,6 +781,7 @@
 				564A1FCE226B89DF001F64F1 /* MutablePersistableRecordTests.swift */,
 				564A1F2E226B89CF001F64F1 /* NumericOverflowTests.swift */,
 				564A1FCB226B89DF001F64F1 /* PersistableRecordTests.swift */,
+				5691578F231C0D5100E1D237 /* PoolTests.swift */,
 				564A1F49226B89D1001F64F1 /* PrefixCursorTests.swift */,
 				564A1F46226B89D1001F64F1 /* PrefixWhileCursorTests.swift */,
 				564A1F97226B89DA001F64F1 /* PrimaryKeyInfoTests.swift */,
@@ -1135,6 +1139,7 @@
 				564A2064226B89E1001F64F1 /* AssociationHasOneThroughFetchableRecordTests.swift in Sources */,
 				564A1FFA226B89E1001F64F1 /* FTS5WrapperTokenizerTests.swift in Sources */,
 				564A2056226B89E1001F64F1 /* TableRecordTests.swift in Sources */,
+				56915790231C0D5100E1D237 /* PoolTests.swift in Sources */,
 				564A2042226B89E1001F64F1 /* FTS5TableBuilderTests.swift in Sources */,
 				564A2089226B89E1001F64F1 /* DatabaseValueConversionErrorTests.swift in Sources */,
 				564A2081226B89E1001F64F1 /* TransactionObserverTests.swift in Sources */,
@@ -1333,6 +1338,7 @@
 				564A20E8226B8E18001F64F1 /* AssociationHasOneThroughFetchableRecordTests.swift in Sources */,
 				564A20E9226B8E18001F64F1 /* FTS5WrapperTokenizerTests.swift in Sources */,
 				564A20EA226B8E18001F64F1 /* TableRecordTests.swift in Sources */,
+				56915791231C0D5100E1D237 /* PoolTests.swift in Sources */,
 				564A20EB226B8E18001F64F1 /* FTS5TableBuilderTests.swift in Sources */,
 				564A20EC226B8E18001F64F1 /* DatabaseValueConversionErrorTests.swift in Sources */,
 				564A20ED226B8E18001F64F1 /* TransactionObserverTests.swift in Sources */,

--- a/Tests/GRDBTests/PoolTests.swift
+++ b/Tests/GRDBTests/PoolTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+#if GRDBCUSTOMSQLITE
+@testable import GRDBCustomSQLite
+#else
+@testable import GRDB
+#endif
+
+class PoolTests: XCTestCase {
+    /// Returns a Pool whose elements are incremented integers: 1, 2, 3...
+    private func makeCounterPool(maximumCount: Int) -> Pool<Int> {
+        let count = ReadWriteBox(0)
+        return Pool(maximumCount: maximumCount, makeElement: count.increment)
+    }
+    
+    func testElementsAreReused() throws {
+        let pool = makeCounterPool(maximumCount: 2)
+        
+        // Get and release element
+        let first = try pool.get()
+        XCTAssertEqual(first.element, 1)
+        first.release()
+        
+        // Get recycled element
+        let second = try pool.get()
+        XCTAssertEqual(second.element, 1)
+        
+        // Get new element
+        let third = try pool.get()
+        XCTAssertEqual(third.element, 2)
+        
+        // Release elements
+        second.release()
+        third.release()
+        
+        // Get and release recycled elements
+        let fourth = try pool.get()
+        XCTAssertEqual(fourth.element, 1)
+        let fifth = try pool.get()
+        XCTAssertEqual(fifth.element, 2)
+        fourth.release()
+        fifth.release()
+    }
+    
+    func testRemoveAll() throws {
+        let pool = makeCounterPool(maximumCount: 2)
+        
+        // Get elements
+        let first = try pool.get()
+        XCTAssertEqual(first.element, 1)
+        let second = try pool.get()
+        XCTAssertEqual(second.element, 2)
+        
+        // removeAll is not locked by used elements
+        pool.removeAll()
+        
+        // Release elements
+        first.release()
+        second.release()
+        
+        // Get and release new elements
+        let third = try pool.get()
+        XCTAssertEqual(third.element, 3)
+        let fourth = try pool.get()
+        XCTAssertEqual(fourth.element, 4)
+        third.release()
+        fourth.release()
+    }
+    
+    func testBarrierLocksElements() throws {
+        if #available(OSX 10.10, *) {
+            let expectation = self.expectation(description: "lock")
+            expectation.isInverted = true
+            
+            let pool = makeCounterPool(maximumCount: 1)
+            var element: Int?
+            let s1 = DispatchSemaphore(value: 0)
+            let s2 = DispatchSemaphore(value: 0)
+            let s3 = DispatchSemaphore(value: 0)
+            
+            DispatchQueue.global().async {
+                pool.barrier {
+                    s1.signal()
+                    s2.wait()
+                }
+            }
+            
+            DispatchQueue.global().async {
+                // Wait for barrier to start
+                s1.wait()
+                
+                let first = try! pool.get()
+                element = first.element
+                first.release()
+                expectation.fulfill()
+                s3.signal()
+            }
+            
+            // Assert that get() is blocked
+            waitForExpectations(timeout: 1)
+            
+            // Release barrier
+            s2.signal()
+            
+            // Wait for get() to complete
+            s3.wait()
+            XCTAssertEqual(element, 1)
+        }
+    }
+    
+    func testBarrierIsLockedByOneUsedElementOutOfOne() throws {
+        if #available(OSX 10.10, *) {
+            let expectation = self.expectation(description: "lock")
+            expectation.isInverted = true
+            
+            let pool = makeCounterPool(maximumCount: 1)
+            
+            // Get element
+            let first = try pool.get()
+            XCTAssertEqual(first.element, 1)
+            
+            let s = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                pool.barrier { }
+                expectation.fulfill()
+                s.signal()
+            }
+            
+            // Assert that barrier is blocked
+            waitForExpectations(timeout: 1)
+            
+            // Release element
+            first.release()
+            
+            // Wait for barrier to complete
+            s.wait()
+            
+            // Get and release recycled element
+            let second = try pool.get()
+            XCTAssertEqual(second.element, 1)
+            second.release()
+        }
+    }
+    
+    func testBarrierIsLockedByOneUsedElementOutOfTwo() throws {
+        if #available(OSX 10.10, *) {
+            let expectation = self.expectation(description: "lock")
+            expectation.isInverted = true
+            
+            let pool = makeCounterPool(maximumCount: 2)
+            
+            // Get elements
+            let first = try pool.get()
+            XCTAssertEqual(first.element, 1)
+            let second = try pool.get()
+            XCTAssertEqual(second.element, 2)
+            
+            // Release first element
+            first.release()
+            
+            let s = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                pool.barrier { }
+                expectation.fulfill()
+                s.signal()
+            }
+            
+            // Assert that barrier is blocked
+            waitForExpectations(timeout: 1)
+            
+            // Release second element
+            second.release()
+            
+            // Wait for barrier to complete
+            s.wait()
+            
+            // Get and release recycled element
+            let third = try pool.get()
+            XCTAssertEqual(third.element, 1)
+            third.release()
+        }
+    }
+    
+    func testBarrierIsLockedByTwoUsedElementsOutOfTwo() throws {
+        if #available(OSX 10.10, *) {
+            let expectation = self.expectation(description: "lock")
+            expectation.isInverted = true
+            
+            let pool = makeCounterPool(maximumCount: 2)
+            
+            // Get elements
+            let first = try pool.get()
+            XCTAssertEqual(first.element, 1)
+            let second = try pool.get()
+            XCTAssertEqual(second.element, 2)
+            
+            let s = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                pool.barrier { }
+                expectation.fulfill()
+                s.signal()
+            }
+            
+            // Assert that barrier is blocked
+            waitForExpectations(timeout: 1)
+            
+            // Release elements
+            first.release()
+            second.release()
+            
+            // Wait for barrier to complete
+            s.wait()
+            
+            // Get and release recycled element
+            let third = try pool.get()
+            XCTAssertEqual(third.element, 1)
+            third.release()
+        }
+    }
+
+    func testBarrierRemoveAll() throws {
+        if #available(OSX 10.10, *) {
+            let expectation = self.expectation(description: "lock")
+            expectation.isInverted = true
+            
+            let pool = makeCounterPool(maximumCount: 1)
+            
+            // Get element
+            let first = try pool.get()
+            XCTAssertEqual(first.element, 1)
+            
+            let s = DispatchSemaphore(value: 0)
+            DispatchQueue.global().async {
+                // No deadlock
+                pool.barrier { pool.removeAll() }
+                expectation.fulfill()
+                s.signal()
+            }
+            
+            // Assert that barrier is blocked
+            waitForExpectations(timeout: 1)
+            
+            // Release element
+            first.release()
+            
+            // Wait for barrier to complete
+            s.wait()
+            
+            // Get and release new element
+            let second = try pool.get()
+            XCTAssertEqual(second.element, 2)
+            second.release()
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new DatabasePool database access method:

```swift
try dbPool.barrierWriteWithoutTransaction { db in
    ...
}
```

The barrier guarantees exclusive access to the database: the method blocks until all concurrent database accesses are completed, reads and writes, and postpones all other accesses until it completes.

There is a known limitation: reads performed by database snapshots are out of scope, and may run concurrently with the barrier.

The goal of the pull request is to provide support for users who need to change the passphrase of an SQLCipher database: we need a way to wait until all reads and writes are completed, rekey the database, and only then allow further database accesses. See #602.