### PR TITLE
Configuration.onConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -57,9 +55,33 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+
+### New
+
+- [#604](https://github.com/groue/GRDB.swift/pull/604): Configuration.onConnect
+
+
+### API Diff
+
+**Deprecations**
+
+```diff
+ struct Configuration {
++    @available(*, deprecated)
+     var prepareDatabase: ((Database) throws -> Void)?
+ }
+```
+
+**New Methods**
+
+```diff
+ struct Configuration {
++    mutating func onConnect(execute function: @escaping (Database) throws -> Void)
+ }
+```
+
 
 ## 4.4.0
 

--- a/Documentation/GRDB3MigrationGuide.md
+++ b/Documentation/GRDB3MigrationGuide.md
@@ -141,12 +141,12 @@ The integration of GRDB with SQLCipher has changed.
 
 2. The default SQLCipher version which comes with GRDB 4 is now SQLCipher 4, which is incompatible with SQLCipher 3. SQLCipher 3 is still supported, though. See [Encryption] for more details.
 
-3. The `cipherPageSize` and `kdfIterations` configuration properties are discontinued. With GRDB 4, run sql pragmas in the `prepareDatabase` property of the configuration:
+3. The `cipherPageSize` and `kdfIterations` configuration properties are discontinued. With GRDB 4, run sql pragmas in the `onConnect` method of the configuration:
     
     ```swift
     var configuration = Configuration()
     configuration.passphrase = "secret"
-    configuration.prepareDatabase = { db in
+    configuration.onConnect { db in
         try db.execute(sql: "PRAGMA cipher_page_size = 4096")
         try db.execute(sql: "PRAGMA kdf_iter = 128000")
     }

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -93,6 +93,10 @@ public struct Configuration {
     
     // MARK: - Managing SQLite Connections
     
+    // TODO: remove when the deprecated prepareDatabase turns unavailable.
+    private var _prepareDatabase: ((Database) throws -> Void)?
+    private var _databaseDidConnect: ((Database) throws -> Void)?
+    
     /// A function that is run when an SQLite connection is opened, before the
     /// connection is made available for database access methods.
     ///
@@ -102,7 +106,39 @@ public struct Configuration {
     ///     config.prepareDatabase = { db in
     ///         try db.execute(sql: "PRAGMA kdf_iter = 10000")
     ///     }
-    public var prepareDatabase: ((Database) throws -> Void)?
+    @available(*, deprecated, message: "Register the database preparation function with Configuration.onConnect { db in ... } instead") // swiftlint:disable:this line_length
+    public var prepareDatabase: ((Database) throws -> Void)? {
+        get { return _prepareDatabase }
+        set { _prepareDatabase = newValue }
+    }
+    
+    /// Registers a function that is run when an SQLite connection is opened,
+    /// before the connection is made available for database access methods.
+    ///
+    /// For example:
+    ///
+    ///     var config = Configuration()
+    ///     config.onConnect { db in
+    ///         try db.execute(sql: "PRAGMA kdf_iter = 10000")
+    ///     }
+    ///
+    /// You can call this method multiple times. All registered functions are
+    /// run, in the same order as their registration.
+    public mutating func onConnect(execute function: @escaping (Database) throws -> Void) {
+        if let old = _databaseDidConnect {
+            _databaseDidConnect = { db in
+                try old(db)
+                try function(db)
+            }
+        } else {
+            _databaseDidConnect = function
+        }
+    }
+    
+    func databaseDidConnect(_ db: Database) throws {
+        try _prepareDatabase?(db)
+        try _databaseDidConnect?(db)
+    }
     
     // MARK: - Transactions
     

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -84,7 +84,7 @@ public struct Configuration {
     /// The passphrase for the encrypted database.
     ///
     /// Default: nil
-    @available(*, deprecated, message: "Use Database.usePassphrase(_:) in Configuration.prepareDatabase instead.")
+    @available(*, deprecated, message: "Use Database.usePassphrase(_:) in Configuration.onConnect instead.")
     public var passphrase: String? {
         get { return _passphrase }
         set { _passphrase = newValue }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -962,10 +962,10 @@ extension Database {
     
     /// Sets the passphrase used to crypt and decrypt an SQLCipher database.
     ///
-    /// Call this method from Configuration.prepareDatabase, as in the example below:
+    /// Call this method from Configuration.onConnect, as in the example below:
     ///
     ///     var config = Configuration()
-    ///     config.prepareDatabase = { db in
+    ///     config.onConnect { db in
     ///         try db.usePassphrase("secret")
     ///     }
     public func usePassphrase(_ passphrase: String) throws {

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -221,7 +221,7 @@ extension Database {
         #endif
         
         // Last step before we can start accessing the database.
-        try configuration.prepareDatabase?(self)
+        try configuration.databaseDidConnect(self)
         
         try validateFormat()
         configuration.SQLiteConnectionDidOpen?()

--- a/GRDB/Fixit/GRDB-4.0.swift
+++ b/GRDB/Fixit/GRDB-4.0.swift
@@ -257,13 +257,13 @@ extension ValueObservation {
 }
 
 extension Configuration {
-    @available(*, unavailable, message: "Run the PRAGMA cipher_page_size in Configuration.prepareDatabase instead.")
+    @available(*, unavailable, message: "Run the PRAGMA cipher_page_size in Configuration.onConnect instead.")
     public var cipherPageSize: Int {
         get { preconditionFailure() }
         set { preconditionFailure() }
     }
     
-    @available(*, unavailable, message: "Run the PRAGMA kdf_iter in Configuration.prepareDatabase instead.")
+    @available(*, unavailable, message: "Run the PRAGMA kdf_iter in Configuration.onConnect instead.")
     public var kdfIterations: Int {
         get { preconditionFailure() }
         set { preconditionFailure() }

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 ## Cleanup
 
-- [ ] Deprecate DatabaseQueue/Pool.addFunction, collation, tokenizer: those should be done in Configuration.prepareDatabase
+- [ ] Deprecate DatabaseQueue/Pool.addFunction, collation, tokenizer: those should be done in Configuration.onConnect
 - [ ] SQLCipher: sqlite3_rekey is discouraged (https://github.com/ccgus/fmdb/issues/547#issuecomment-259219320)
 - [ ] Write regression tests for #156 and #157
 - [ ] Fix matchingRowIds (todo: what is the problem, already?)

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -6,7 +6,90 @@ import XCTest
 #endif
 
 class DatabaseConfigurationTests: GRDBTestCase {
-    func testPrepareDatabase() throws {
+    func testOnConnect() throws {
+        // onConnect is called when connection opens
+        var connectionCount = 0
+        var configuration = Configuration()
+        configuration.onConnect { db in
+            connectionCount += 1
+        }
+        
+        _ = DatabaseQueue(configuration: configuration)
+        XCTAssertEqual(connectionCount, 1)
+        
+        _ = try makeDatabaseQueue(configuration: configuration)
+        XCTAssertEqual(connectionCount, 2)
+        
+        let pool = try makeDatabasePool(configuration: configuration)
+        XCTAssertEqual(connectionCount, 3)
+        
+        try pool.read { _ in }
+        XCTAssertEqual(connectionCount, 4)
+        
+        try pool.makeSnapshot().read { _ in }
+        XCTAssertEqual(connectionCount, 5)
+    }
+    
+    func testMultipleOnConnect() throws {
+        // onConnect can be called multiple times. Order is deterministic.
+        var events: [Int] = []
+        var configuration = Configuration()
+        configuration.onConnect { db in
+            events.append(1)
+        }
+        configuration.onConnect { db in
+            events.append(2)
+        }
+
+        _ = DatabaseQueue(configuration: configuration)
+        XCTAssertEqual(events, [1, 2])
+    }
+    
+    func testOnConnectError() throws {
+        struct TestError: Error { }
+        var error: TestError?
+        var configuration = Configuration()
+        configuration.onConnect { db in
+            if let error = error {
+                throw error
+            }
+        }
+        
+        // TODO: what about in-memory DatabaseQueue???
+        
+        do {
+            error = TestError()
+            _ = try makeDatabaseQueue(configuration: configuration)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        
+        do {
+            error = TestError()
+            _ = try makeDatabasePool(configuration: configuration)
+            XCTFail("Expected TestError")
+        } catch is TestError { }
+        
+        do {
+            error = nil
+            let pool = try makeDatabasePool(configuration: configuration)
+            
+            do {
+                error = TestError()
+                try pool.read { _ in }
+                XCTFail("Expected TestError")
+            } catch is TestError { }
+            
+            do {
+                error = TestError()
+                _ = try pool.makeSnapshot()
+                XCTFail("Expected TestError")
+            } catch is TestError { }
+        }
+    }
+    
+    // MARK: - Deprecated
+    
+    func testDeprecatedPrepareDatabase() throws {
         // prepareDatabase is called when connection opens
         var connectionCount = 0
         var configuration = Configuration()
@@ -30,7 +113,7 @@ class DatabaseConfigurationTests: GRDBTestCase {
         XCTAssertEqual(connectionCount, 5)
     }
     
-    func testPrepareDatabaseError() throws {
+    func testDeprecatedPrepareDatabaseError() throws {
         struct TestError: Error { }
         var error: TestError?
         
@@ -71,5 +154,23 @@ class DatabaseConfigurationTests: GRDBTestCase {
                 XCTFail("Expected TestError")
             } catch is TestError { }
         }
+    }
+    
+    func testDeprecatedPrepareDatabaseIsCalledBeforeOnConnect() throws {
+        // prepareDatabase is called before onConnect functions
+        var events: [Int] = []
+        var configuration = Configuration()
+        configuration.onConnect { db in
+            events.append(2)
+        }
+        configuration.prepareDatabase = { db in
+            events.append(1)
+        }
+        configuration.onConnect { db in
+            events.append(3)
+        }
+        
+        _ = DatabaseQueue(configuration: configuration)
+        XCTAssertEqual(events, [1, 2, 3])
     }
 }

--- a/Tests/GRDBTests/EncryptionTests.swift
+++ b/Tests/GRDBTests/EncryptionTests.swift
@@ -7,7 +7,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabaseQueueWithPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -19,7 +19,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -32,7 +32,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabaseQueueWithoutPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -56,7 +56,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabaseQueueWithWrongPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -68,7 +68,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("wrong")
             }
             do {
@@ -84,7 +84,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabaseQueueWithNewPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -96,7 +96,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -116,7 +116,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("newSecret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -129,7 +129,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabasePoolWithPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -141,7 +141,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -154,7 +154,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabasePoolWithoutPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -178,7 +178,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabasePoolWithWrongPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -190,7 +190,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("wrong")
             }
             do {
@@ -206,7 +206,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabaseQueueWithPassphraseToDatabasePoolWithNewPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -219,7 +219,7 @@ class EncryptionTests: GRDBTestCase {
         do {
             var passphrase = "secret"
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase(passphrase)
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -242,7 +242,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("newSecret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -255,7 +255,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabasePoolWithPassphraseToDatabasePoolWithPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -267,7 +267,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -280,7 +280,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabasePoolWithPassphraseToDatabasePoolWithoutPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -304,7 +304,7 @@ class EncryptionTests: GRDBTestCase {
     func testDatabasePoolWithPassphraseToDatabasePoolWithWrongPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -316,7 +316,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("wrong")
             }
             do {
@@ -333,7 +333,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -346,7 +346,7 @@ class EncryptionTests: GRDBTestCase {
         do {
             var passphrase = "secret"
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase(passphrase)
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -369,7 +369,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("newSecret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -391,7 +391,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -425,7 +425,7 @@ class EncryptionTests: GRDBTestCase {
     func testCipherPageSize() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA cipher_page_size = 8192")
             }
@@ -438,7 +438,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA cipher_page_size = 4096")
             }
@@ -460,7 +460,7 @@ class EncryptionTests: GRDBTestCase {
     func testCipherKDFIterations() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA kdf_iter = 128000")
             }
@@ -473,7 +473,7 @@ class EncryptionTests: GRDBTestCase {
 
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA kdf_iter = 128000")
             }
@@ -495,7 +495,7 @@ class EncryptionTests: GRDBTestCase {
     func testCipherWithMismatchedKDFIterations() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA kdf_iter = 128000")
             }
@@ -515,7 +515,7 @@ class EncryptionTests: GRDBTestCase {
 
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA kdf_iter = 64000")
             }
@@ -545,7 +545,7 @@ class EncryptionTests: GRDBTestCase {
             }
             
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             do {
@@ -567,7 +567,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "encrypted.sqlite", configuration: config)
@@ -588,7 +588,7 @@ class EncryptionTests: GRDBTestCase {
             let testBundle = Bundle(for: type(of: self))
             let path = testBundle.url(forResource: "db", withExtension: "SQLCipher3")!.path
             var configuration = Configuration()
-            configuration.prepareDatabase = { db in
+            configuration.onConnect { db in
                 try db.usePassphrase("secret")
                 try db.execute(sql: "PRAGMA cipher_compatibility = 3")
             }
@@ -645,7 +645,7 @@ class EncryptionTests: GRDBTestCase {
     func testDeprecatedDatabaseQueueWithPassphraseToDatabaseQueueWithNewPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -657,7 +657,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -672,7 +672,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("newSecret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -685,7 +685,7 @@ class EncryptionTests: GRDBTestCase {
     func testDeprecatedDatabaseQueueWithPassphraseToDatabasePoolWithNewPassphrase() throws {
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
@@ -697,7 +697,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -713,7 +713,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("newSecret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -727,7 +727,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -739,7 +739,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("secret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)
@@ -755,7 +755,7 @@ class EncryptionTests: GRDBTestCase {
         
         do {
             var config = Configuration()
-            config.prepareDatabase = { db in
+            config.onConnect { db in
                 try db.usePassphrase("newSecret")
             }
             let dbPool = try makeDatabasePool(filename: "test.sqlite", configuration: config)

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -118,7 +118,7 @@ class GRDBTestCase: XCTestCase {
         
         #if GRDBCIPHER_USE_ENCRYPTION
         // Encrypt all databases by default.
-        dbConfiguration.prepareDatabase = { db in
+        dbConfiguration.onConnect { db in
             try db.usePassphrase("secret")
         }
         #endif

--- a/Tests/GRDBTests/SQLInterpolationTests.swift
+++ b/Tests/GRDBTests/SQLInterpolationTests.swift
@@ -117,8 +117,8 @@ class SQLInterpolationTests: GRDBTestCase {
     func testQualifiedExpressionInterpolation() {
         var sql = SQLInterpolation(literalCapacity: 0, interpolationCount: 1)
         
-        sql.appendInterpolation(Column("name").aliased("foo")); sql.appendLiteral("\n")
-        sql.appendInterpolation(1.databaseValue.aliased("bar"))
+        sql.appendInterpolation(Column("name").forKey("foo")); sql.appendLiteral("\n")
+        sql.appendInterpolation(1.databaseValue.forKey("bar"))
         
         XCTAssertEqual(sql.sql, """
             "name" AS "foo"

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -245,7 +245,7 @@ extension SQLLiteralTests {
     
     func testQualifiedExpressionInterpolation() {
         let query: SQLLiteral = """
-            SELECT \(Column("name").aliased("foo"))
+            SELECT \(Column("name").forKey("foo"))
             FROM player
             """
         XCTAssertEqual(query.sql, """


### PR DESCRIPTION
The new `Configuration.onConnect` method replaces the deprecated `Configuration.prepareDatabase` property:

```diff
-config.prepareDatabase = { db in ... }
+config.onConnect { db in ... }
```

The new API improves on the deprecated one in two ways:

- It makes it possible to stage the database connection setup, because `onConnect` can be called several times.
- It profits from Xcode autocompletion.