### PR TITLE
Register functions, collations, and FTS5 tokenizers in the `onConnect` configuration function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,18 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 ### New
 
 - [#605](https://github.com/groue/GRDB.swift/pull/605): Configuration.onConnect
+- [#606](https://github.com/groue/GRDB.swift/pull/606): Register functions, collations, and FTS5 tokenizers in the `onConnect` configuration function
 
 
 ### API Diff
+
+**New Method**
+
+```diff
+ struct Configuration {
++    mutating func onConnect(execute function: @escaping (Database) throws -> Void)
+ }
+```
 
 **Deprecations**
 
@@ -72,13 +81,26 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 +    @available(*, deprecated)
      var prepareDatabase: ((Database) throws -> Void)?
  }
-```
-
-**New Methods**
-
-```diff
- struct Configuration {
-+    mutating func onConnect(execute function: @escaping (Database) throws -> Void)
+ 
+ protocol DatabaseReader {
++    @available(*, deprecated)
+     func add(function: DatabaseFunction)
++    @available(*, deprecated)
+     func remove(function: DatabaseFunction)
++    @available(*, deprecated)
+     func add(collation: DatabaseCollation)
++    @available(*, deprecated)
+     func remove(collation: DatabaseCollation)
+ }
+ 
+ class DatabaseQueue {
++    @available(*, deprecated)
+     func add<Tokenizer: FTS5CustomTokenizer>(tokenizer: Tokenizer.Type)
+ }
+ 
+ class DatabasePool {
++    @available(*, deprecated)
+     func add<Tokenizer: FTS5CustomTokenizer>(tokenizer: Tokenizer.Type)
  }
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 
 The [Custom SQL Functions and Aggregates](README.md#custom-sql-functions-and-aggregates), [String Comparison](README.md#string-comparison) and [FTS5 Tokenizers](Documentation/FTS5Tokenizers.md) chapters show how to use the `onConnect` configuration function in order to register SQL functions, collations, and custom FTS5 tokenizers.
 
+The [Encryption](README.md#encryption) chapter has been updated with the new `onConnect` configuration function.
+
 
 ### API Diff
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [#606](https://github.com/groue/GRDB.swift/pull/606): Register functions, collations, and FTS5 tokenizers in the `onConnect` configuration function
 
 
+### Documentation Diff
+
+The [Custom SQL Functions and Aggregates](README.md#custom-sql-functions-and-aggregates), [String Comparison](README.md#string-comparison) and [FTS5 Tokenizers](Documentation/FTS5Tokenizers.md) chapters show how to use the `onConnect` configuration function in order to register SQL functions, collations, and custom FTS5 tokenizers.
+
+
 ### API Diff
 
 **New Method**

--- a/Documentation/FTS5Tokenizers.md
+++ b/Documentation/FTS5Tokenizers.md
@@ -61,12 +61,16 @@ GRDB lets you use and define FTS5 tokenizers through three protocols:
 
 Once you have a custom tokenizer type that adopts [FTS5CustomTokenizer](#fts5customtokenizer) or [FTS5WrapperTokenizer](#fts5wrappertokenizer), it can fuel the FTS5 engine.
 
-**Register the custom tokenizer into the database:**
+**Register the custom tokenizer** inside the `onConnect` configuration function:
 
 ```swift
 class MyTokenizer : FTS5CustomTokenizer { ... }
 
-dbQueue.add(tokenizer: MyTokenizer.self) // or dbPool.add
+var config = Configuration()
+config.onConnect { db in
+    db.add(tokenizer: MyTokenizer.self)
+}
+let dbQueue = try DatabaseQueue(path: "...", configuration: config)
 ```
 
 **Create [full-text tables](../../../#create-fts5-virtual-tables) that use the custom tokenizer:**
@@ -376,9 +380,13 @@ final class LatinAsciiTokenizer : FTS5WrapperTokenizer {
 Remember to register LatinAsciiTokenizer before using it:
 
 ```swift
-dbQueue.add(tokenizer: LatinAsciiTokenizer.self) // or dbPool.add
+var config = Configuration()
+config.onConnect { db in
+    db.add(tokenizer: LatinAsciiTokenizer.self) // or dbPool.add
+}
+let dbQueue = try DatabaseQueue(path: "...", configuration: config)
 
-dbQueue.inDatabase { db in
+dbQueue.write { db in
     try db.create(virtualTable: "documents", using: FTS5()) { t in
         t.tokenizer = LatinAsciiTokenizer.tokenizerDescriptor()
         t.column("authors")

--- a/Documentation/GRDB3MigrationGuide.md
+++ b/Documentation/GRDB3MigrationGuide.md
@@ -141,7 +141,7 @@ The integration of GRDB with SQLCipher has changed.
 
 2. The default SQLCipher version which comes with GRDB 4 is now SQLCipher 4, which is incompatible with SQLCipher 3. SQLCipher 3 is still supported, though. See [Encryption] for more details.
 
-3. The `cipherPageSize` and `kdfIterations` configuration properties are discontinued. With GRDB 4, run sql pragmas in the `onConnect` method of the configuration:
+3. The `cipherPageSize` and `kdfIterations` configuration properties are discontinued. With GRDB 4, run sql pragmas in the `onConnect` configuration function:
     
     ```swift
     var configuration = Configuration()

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -122,6 +122,9 @@ public struct Configuration {
     ///         try db.execute(sql: "PRAGMA kdf_iter = 10000")
     ///     }
     ///
+    /// The argument connection has been setup by GRDB: foreign keys, busy mode,
+    /// trace, database observation, etc. are configured.
+    ///
     /// You can call this method multiple times. All registered functions are
     /// run, in the same order as their registration.
     public mutating func onConnect(execute function: @escaping (Database) throws -> Void) {

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -162,6 +162,7 @@ public final class Database {
         self.sqliteConnection = try Database.openConnection(path: path, flags: configuration.SQLiteOpenFlags)
         self.configuration = configuration
         self.schemaCache = schemaCache
+        configuration.SQLiteConnectionDidOpen?()
     }
     
     deinit {
@@ -224,7 +225,6 @@ extension Database {
         try configuration.databaseDidConnect(self)
         
         try validateFormat()
-        configuration.SQLiteConnectionDidOpen?()
     }
     
     private func setupTrace() {

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -114,7 +114,7 @@ public final class Database {
         // > connection while this routine is running, then the return value
         // > is undefined.
         SchedulingWatchdog.preconditionValidQueue(self)
-        if isClosed { return false } // Support for SerializedDatabasae.deinit
+        if isClosed { return false } // Support for SerializedDatabase.deinit
         return sqlite3_get_autocommit(sqliteConnection) == 0
     }
     

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -76,15 +76,12 @@ public final class DatabaseFunction: Hashable {
     ///         }
     ///     }
     ///
-    ///     let dbQueue = DatabaseQueue()
     ///     let fn = DatabaseFunction("mysum", argumentCount: 1, aggregate: MySum.self)
-    ///     dbQueue.add(function: fn)
-    ///     try dbQueue.write { db in
-    ///         try db.execute(sql: "CREATE TABLE test(i)")
-    ///         try db.execute(sql: "INSERT INTO test(i) VALUES (1)")
-    ///         try db.execute(sql: "INSERT INTO test(i) VALUES (2)")
-    ///         try Int.fetchOne(db, sql: "SELECT mysum(i) FROM test")! // 3
-    ///     }
+    ///     db.add(function: fn)
+    ///     try db.execute(sql: "CREATE TABLE test(i)")
+    ///     try db.execute(sql: "INSERT INTO test(i) VALUES (1)")
+    ///     try db.execute(sql: "INSERT INTO test(i) VALUES (2)")
+    ///     try Int.fetchOne(db, sql: "SELECT mysum(i) FROM test")! // 3
     ///
     /// - parameters:
     ///     - name: The function name.
@@ -367,15 +364,12 @@ extension DatabaseFunction {
 ///         }
 ///     }
 ///
-///     let dbQueue = DatabaseQueue()
 ///     let fn = DatabaseFunction("mysum", argumentCount: 1, aggregate: MySum.self)
-///     dbQueue.add(function: fn)
-///     try dbQueue.write { db in
-///         try db.execute(sql: "CREATE TABLE test(i)")
-///         try db.execute(sql: "INSERT INTO test(i) VALUES (1)")
-///         try db.execute(sql: "INSERT INTO test(i) VALUES (2)")
-///         try Int.fetchOne(db, sql: "SELECT mysum(i) FROM test")! // 3
-///     }
+///     db.add(function: fn)
+///     try db.execute(sql: "CREATE TABLE test(i)")
+///     try db.execute(sql: "INSERT INTO test(i) VALUES (1)")
+///     try db.execute(sql: "INSERT INTO test(i) VALUES (2)")
+///     try Int.fetchOne(db, sql: "SELECT mysum(i) FROM test")! // 3
 public protocol DatabaseAggregate {
     /// Creates an aggregate.
     init()

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -17,6 +17,7 @@ public final class DatabasePool: DatabaseWriter {
     private var readerConfig: Configuration
     private var readerPool: Pool<SerializedDatabase>!
     
+    // TODO: remove when add(function/collation/tokenizer:) are removed
     private var functions = Set<DatabaseFunction>()
     private var collations = Set<DatabaseCollation>()
     var tokenizerRegistrations: [(Database) -> Void] = []
@@ -121,6 +122,7 @@ public final class DatabasePool: DatabaseWriter {
     }
     #endif
     
+    // TODO: remove when add(function/collation/tokenizer:) are removed
     private func setupDatabase(_ db: Database) {
         for function in functions {
             db.add(function: function)

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -381,11 +381,13 @@ extension DatabaseQueue {
     ///     try dbQueue.read { db in
     ///         try Int.fetchOne(db, sql: "SELECT succ(1)") // 2
     ///     }
+    @available(*, deprecated, message: "Use Database.add(function:) instead")
     public func add(function: DatabaseFunction) {
         writer.sync { $0.add(function: function) }
     }
     
     /// Remove an SQL function.
+    @available(*, deprecated, message: "Use Database.remove(function:) instead")
     public func remove(function: DatabaseFunction) {
         writer.sync { $0.remove(function: function) }
     }
@@ -401,11 +403,13 @@ extension DatabaseQueue {
     ///     try dbQueue.write { db in
     ///         try db.execute(sql: "CREATE TABLE file (name TEXT COLLATE LOCALIZED_STANDARD")
     ///     }
+    @available(*, deprecated, message: "Use Database.add(collation:) instead")
     public func add(collation: DatabaseCollation) {
         writer.sync { $0.add(collation: collation) }
     }
     
     /// Remove a collation.
+    @available(*, deprecated, message: "Use Database.remove(collation:) instead")
     public func remove(collation: DatabaseCollation) {
         writer.sync { $0.remove(collation: collation) }
     }

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -162,9 +162,11 @@ public protocol DatabaseReader: AnyObject {
     ///     try reader.read { db in
     ///         try Int.fetchOne(db, sql: "SELECT succ(1)")! // 2
     ///     }
+    @available(*, deprecated, message: "Use Database.add(function:) instead")
     func add(function: DatabaseFunction)
     
     /// Remove an SQL function.
+    @available(*, deprecated, message: "Use Database.remove(function:) instead")
     func remove(function: DatabaseFunction)
     
     
@@ -177,9 +179,11 @@ public protocol DatabaseReader: AnyObject {
     ///     }
     ///     reader.add(collation: collation)
     ///     try reader.execute(sql: "SELECT * FROM file ORDER BY name COLLATE localized_standard")
+    @available(*, deprecated, message: "Use Database.add(collation:) instead")
     func add(collation: DatabaseCollation)
     
     /// Remove a collation.
+    @available(*, deprecated, message: "Use Database.remove(collation:) instead")
     func remove(collation: DatabaseCollation)
     
     // MARK: - Value Observation
@@ -277,11 +281,13 @@ public final class AnyDatabaseReader: DatabaseReader {
     // MARK: - Functions
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.add(function:) instead")
     public func add(function: DatabaseFunction) {
         base.add(function: function)
     }
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.remove(function:) instead")
     public func remove(function: DatabaseFunction) {
         base.remove(function: function)
     }
@@ -289,11 +295,13 @@ public final class AnyDatabaseReader: DatabaseReader {
     // MARK: - Collations
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.add(collation:) instead")
     public func add(collation: DatabaseCollation) {
         base.add(collation: collation)
     }
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.remove(collation:) instead")
     public func remove(collation: DatabaseCollation) {
         base.remove(collation: collation)
     }

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -96,20 +96,24 @@ extension DatabaseSnapshot {
     
     // MARK: - Functions
     
+    @available(*, deprecated, message: "Use Database.add(function:) instead")
     public func add(function: DatabaseFunction) {
         serializedDatabase.sync { $0.add(function: function) }
     }
     
+    @available(*, deprecated, message: "Use Database.remove(function:) instead")
     public func remove(function: DatabaseFunction) {
         serializedDatabase.sync { $0.remove(function: function) }
     }
     
     // MARK: - Collations
     
+    @available(*, deprecated, message: "Use Database.add(collation:) instead")
     public func add(collation: DatabaseCollation) {
         serializedDatabase.sync { $0.add(collation: collation) }
     }
     
+    @available(*, deprecated, message: "Use Database.remove(collation:) instead")
     public func remove(collation: DatabaseCollation) {
         serializedDatabase.sync { $0.remove(collation: collation) }
     }

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -96,11 +96,13 @@ extension DatabaseSnapshot {
     
     // MARK: - Functions
     
+    /// :nodoc:
     @available(*, deprecated, message: "Use Database.add(function:) instead")
     public func add(function: DatabaseFunction) {
         serializedDatabase.sync { $0.add(function: function) }
     }
     
+    /// :nodoc:
     @available(*, deprecated, message: "Use Database.remove(function:) instead")
     public func remove(function: DatabaseFunction) {
         serializedDatabase.sync { $0.remove(function: function) }
@@ -108,11 +110,13 @@ extension DatabaseSnapshot {
     
     // MARK: - Collations
     
+    /// :nodoc:
     @available(*, deprecated, message: "Use Database.add(collation:) instead")
     public func add(collation: DatabaseCollation) {
         serializedDatabase.sync { $0.add(collation: collation) }
     }
     
+    /// :nodoc:
     @available(*, deprecated, message: "Use Database.remove(collation:) instead")
     public func remove(collation: DatabaseCollation) {
         serializedDatabase.sync { $0.remove(collation: collation) }
@@ -120,6 +124,7 @@ extension DatabaseSnapshot {
     
     // MARK: - Value Observation
     
+    /// :nodoc:
     public func add<Reducer: ValueReducer>(
         observation: ValueObservation<Reducer>,
         onError: @escaping (Error) -> Void,
@@ -163,6 +168,7 @@ extension DatabaseSnapshot {
         return SnapshotValueObserver()
     }
     
+    /// :nodoc:
     public func remove(transactionObserver: TransactionObserver) {
         // Can't remove an observer which could not be added :-)
     }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -672,11 +672,13 @@ public final class AnyDatabaseWriter: DatabaseWriter {
     // MARK: - Functions
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.add(function:) instead")
     public func add(function: DatabaseFunction) {
         base.add(function: function)
     }
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.remove(function:) instead")
     public func remove(function: DatabaseFunction) {
         base.remove(function: function)
     }
@@ -684,11 +686,13 @@ public final class AnyDatabaseWriter: DatabaseWriter {
     // MARK: - Collations
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.add(collation:) instead")
     public func add(collation: DatabaseCollation) {
         base.add(collation: collation)
     }
     
     /// :nodoc:
+    @available(*, deprecated, message: "Use Database.remove(collation:) instead")
     public func remove(collation: DatabaseCollation) {
         base.remove(collation: collation)
     }

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -181,10 +181,29 @@ extension DatabaseQueue {
     ///
     ///     class MyTokenizer : FTS5CustomTokenizer { ... }
     ///     dbQueue.add(tokenizer: MyTokenizer.self)
+    @available(*, deprecated, message: "Use Database.add(tokenizer:) instead")
     public func add<Tokenizer: FTS5CustomTokenizer>(tokenizer: Tokenizer.Type) {
         inDatabase { db in
             db.add(tokenizer: Tokenizer.self)
         }
+    }
+}
+
+extension DatabasePool {
+    
+    // MARK: - Custom FTS5 Tokenizers
+    
+    /// Add a custom FTS5 tokenizer.
+    ///
+    ///     class MyTokenizer : FTS5CustomTokenizer { ... }
+    ///     dbPool.add(tokenizer: MyTokenizer.self)
+    @available(*, deprecated, message: "Use Database.add(tokenizer:) instead")
+    public func add<Tokenizer: FTS5CustomTokenizer>(tokenizer: Tokenizer.Type) {
+        func registerTokenizer(db: Database) {
+            db.add(tokenizer: Tokenizer.self)
+        }
+        tokenizerRegistrations.append(registerTokenizer)
+        forEachConnection(registerTokenizer)
     }
 }
 #endif

--- a/README.md
+++ b/README.md
@@ -7373,7 +7373,7 @@ config.onConnect { db in
 let dbQueue = try DatabaseQueue(path: dbPath, configuration: config)
 ```
 
-It is also in `onConnect` that you perform other [SQLCipher configuration steps](https://www.zetetic.net/sqlcipher/sqlcipher-api/) that must happen early in the lifetime of a SQLCipher connection. For example:
+It is also in the `onConnect` configuration function that you perform other [SQLCipher configuration steps](https://www.zetetic.net/sqlcipher/sqlcipher-api/) that must happen early in the lifetime of a SQLCipher connection. For example:
 
 ```swift
 var config = Configuration()
@@ -7421,7 +7421,7 @@ try dbPool.barrierWriteWithoutTransaction { db in
 }
 ```
 
-> :point_up: **Note**: When an application wants to keep on using a database queue or pool after the passphrase has changed, it is responsible for providing the correct passphrase to the `usePassphrase` method called in the database preparation function. Consider:
+> :point_up: **Note**: When an application wants to keep on using a database queue or pool after the passphrase has changed, it is responsible for providing the correct passphrase to the `usePassphrase` method called in the `onConnect` configuration function. Consider:
 >
 > ```swift
 > // WRONG: this won't work across a passphrase change
@@ -7483,7 +7483,7 @@ try existingDBQueue.inDatabase { db in
 
 #### Managing the lifetime of the passphrase string
 
-It is recommended to avoid keeping the passphrase in memory longer than necessary. To do this, make sure you load the passphrase from inside the `onConnect` function:
+It is recommended to avoid keeping the passphrase in memory longer than necessary. To do this, make sure you load the passphrase from inside the `onConnect` configuration function:
 
 ```swift
 // NOT RECOMMENDED: this keeps the passphrase in memory longer than necessary

--- a/Tests/GRDBTests/DatabaseAggregateTests.swift
+++ b/Tests/GRDBTests/DatabaseAggregateTests.swift
@@ -30,8 +30,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try DatabaseValue.fetchOne(db, sql: "SELECT f()")!.isNull)
         }
     }
@@ -45,8 +45,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int64.fetchOne(db, sql: "SELECT f()")!, Int64(1))
         }
     }
@@ -60,8 +60,8 @@ class DatabaseAggregateTests: GRDBTestCase {
             }
         }
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT f()")!, 1e100)
         }
     }
@@ -75,8 +75,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f()")!, "foo")
         }
     }
@@ -90,8 +90,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Data.fetchOne(db, sql: "SELECT f()")!, "foo".data(using: .utf8))
         }
     }
@@ -105,8 +105,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try CustomValueType.fetchOne(db, sql: "SELECT f()") != nil)
         }
     }
@@ -125,8 +125,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Bool.fetchOne(db, sql: "SELECT f(NULL)")!)
             XCTAssertFalse(try Bool.fetchOne(db, sql: "SELECT f(1)")!)
             XCTAssertFalse(try Bool.fetchOne(db, sql: "SELECT f(1.1)")!)
@@ -148,8 +148,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Int64.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try Int64.fetchOne(db, sql: "SELECT f(1)")!, 1)
             XCTAssertEqual(try Int64.fetchOne(db, sql: "SELECT f(1.1)")!, 1)
@@ -168,8 +168,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Double.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT f(1)")!, 1.0)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT f(1.1)")!, 1.1)
@@ -188,8 +188,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try String.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f('foo')")!, "foo")
         }
@@ -207,8 +207,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Data.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try Data.fetchOne(db, sql: "SELECT f(?)", arguments: ["foo".data(using: .utf8)])!, "foo".data(using: .utf8))
             XCTAssertEqual(try Data.fetchOne(db, sql: "SELECT f(?)", arguments: [Data()])!, Data())
@@ -227,8 +227,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try CustomValueType.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertTrue(try CustomValueType.fetchOne(db, sql: "SELECT f('CustomValueType')") != nil)
         }
@@ -245,8 +245,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f()")!, "foo")
             do {
                 try db.execute(sql: "SELECT f(1)")
@@ -272,8 +272,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT upper(?)", arguments: ["Roué"])!, "ROUé")
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f(?)", arguments: ["Roué"])!, "ROUÉ")
             XCTAssertTrue(try String.fetchOne(db, sql: "SELECT f(NULL)") == nil)
@@ -302,8 +302,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 2, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(1, 2)")!, 3)
             do {
                 try db.execute(sql: "SELECT f()")
@@ -329,8 +329,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f()")!, 0)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(1)")!, 1)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(1, 1)")!, 2)
@@ -350,8 +350,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -373,8 +373,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -396,8 +396,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -419,8 +419,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -444,8 +444,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -465,8 +465,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -486,8 +486,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -507,8 +507,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -537,8 +537,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(a) FROM (SELECT 1 AS a UNION ALL SELECT 2 UNION ALL SELECT 3)")!, 6)
         }
     }
@@ -557,8 +557,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         }
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 1, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             let row = try Row.fetchOne(db, sql: "SELECT f(a), f(b) FROM (SELECT 1 AS a, 2 AS b UNION ALL SELECT 2, 4 UNION ALL SELECT 3, 6)")!
             XCTAssertEqual(row[0], 6)
             XCTAssertEqual(row[1], 12)
@@ -590,8 +590,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(allocationCount, 0)
             XCTAssertEqual(aliveCount, 0)
             try db.execute(sql: "SELECT f()")
@@ -625,8 +625,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(allocationCount, 0)
             XCTAssertEqual(aliveCount, 0)
             _ = try? db.execute(sql: "SELECT f()")
@@ -659,8 +659,8 @@ class DatabaseAggregateTests: GRDBTestCase {
         
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("f", argumentCount: 0, aggregate: Aggregate.self)
-        dbQueue.add(function: fn)
         dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(allocationCount, 0)
             XCTAssertEqual(aliveCount, 0)
             _ = try? db.execute(sql: "SELECT f()")

--- a/Tests/GRDBTests/DatabaseCollationTests.swift
+++ b/Tests/GRDBTests/DatabaseCollationTests.swift
@@ -58,9 +58,9 @@ class DatabaseCollationTests: GRDBTestCase {
                 return .orderedDescending
             }
         }
-        dbQueue.add(collation: collation)
         
         try dbQueue.inDatabase { db in
+            db.add(collation: collation)
             try db.execute(sql: "CREATE TABLE strings (id INTEGER PRIMARY KEY, name TEXT COLLATE LOCALIZED_STANDARD)")
             try db.execute(sql: "INSERT INTO strings VALUES (1, 'a')")
             try db.execute(sql: "INSERT INTO strings VALUES (2, 'aa')")

--- a/Tests/GRDBTests/DatabaseCursorTests.swift
+++ b/Tests/GRDBTests/DatabaseCursorTests.swift
@@ -34,9 +34,11 @@ class DatabaseCursorTests: GRDBTestCase {
 
     // TODO: this test should be duplicated for all cursor types
     func testStepError() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let cursor = try Int.fetchCursor(db, sql: "SELECT throw()")
             do {
@@ -53,9 +55,11 @@ class DatabaseCursorTests: GRDBTestCase {
 
     // TODO: this test should be duplicated for all cursor types
     func testStepDatabaseError() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = DatabaseError(resultCode: ResultCode(rawValue: 0xDEAD), message: "custom error")
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let cursor = try Int.fetchCursor(db, sql: "SELECT throw()")
             do {

--- a/Tests/GRDBTests/DatabaseFunctionTests.swift
+++ b/Tests/GRDBTests/DatabaseFunctionTests.swift
@@ -59,8 +59,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return nil
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try DatabaseValue.fetchOne(db, sql: "SELECT f()")!.isNull)
         }
     }
@@ -70,8 +70,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return Int64(1)
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int64.fetchOne(db, sql: "SELECT f()")!, Int64(1))
         }
     }
@@ -81,8 +81,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return 1e100
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT f()")!, 1e100)
         }
     }
@@ -92,8 +92,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return "foo"
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f()")!, "foo")
         }
     }
@@ -103,8 +103,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return "foo".data(using: .utf8)
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Data.fetchOne(db, sql: "SELECT f()")!, "foo".data(using: .utf8))
         }
     }
@@ -114,8 +114,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return CustomValueType()
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try CustomValueType.fetchOne(db, sql: "SELECT f()") != nil)
         }
     }
@@ -127,8 +127,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             return dbValues[0].isNull
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Bool.fetchOne(db, sql: "SELECT f(NULL)")!)
             XCTAssertFalse(try Bool.fetchOne(db, sql: "SELECT f(1)")!)
             XCTAssertFalse(try Bool.fetchOne(db, sql: "SELECT f(1.1)")!)
@@ -143,8 +143,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             return Int64.fromDatabaseValue(dbValues[0])
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Int64.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try Int64.fetchOne(db, sql: "SELECT f(1)")!, 1)
             XCTAssertEqual(try Int64.fetchOne(db, sql: "SELECT f(1.1)")!, 1)
@@ -156,8 +156,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             return Double.fromDatabaseValue(dbValues[0])
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Double.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT f(1)")!, 1.0)
             XCTAssertEqual(try Double.fetchOne(db, sql: "SELECT f(1.1)")!, 1.1)
@@ -169,8 +169,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             return String.fromDatabaseValue(dbValues[0])
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try String.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f('foo')")!, "foo")
         }
@@ -181,8 +181,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             return Data.fromDatabaseValue(dbValues[0])
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try Data.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertEqual(try Data.fetchOne(db, sql: "SELECT f(?)", arguments: ["foo".data(using: .utf8)])!, "foo".data(using: .utf8))
             XCTAssertEqual(try Data.fetchOne(db, sql: "SELECT f(?)", arguments: [Data()])!, Data())
@@ -194,8 +194,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             return CustomValueType.fromDatabaseValue(dbValues[0])
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertTrue(try CustomValueType.fetchOne(db, sql: "SELECT f(NULL)") == nil)
             XCTAssertTrue(try CustomValueType.fetchOne(db, sql: "SELECT f('CustomValueType')") != nil)
         }
@@ -208,8 +208,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return "foo"
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f()")!, "foo")
             do {
                 try db.execute(sql: "SELECT f(1)")
@@ -228,8 +228,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 1) { (dbValues: [DatabaseValue]) in
             String.fromDatabaseValue(dbValues[0]).map { $0.uppercased() }
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT upper(?)", arguments: ["Roué"])!, "ROUé")
             XCTAssertEqual(try String.fetchOne(db, sql: "SELECT f(?)", arguments: ["Roué"])!, "ROUÉ")
             XCTAssertTrue(try String.fetchOne(db, sql: "SELECT f(NULL)") == nil)
@@ -251,8 +251,8 @@ class DatabaseFunctionTests: GRDBTestCase {
             let ints = dbValues.compactMap { Int.fromDatabaseValue($0) }
             return ints.reduce(0, +)
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(1, 2)")!, 3)
             do {
                 try db.execute(sql: "SELECT f()")
@@ -271,8 +271,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f") { dbValues in
             return dbValues.count
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f()")!, 0)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(1)")!, 1)
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f(1, 1)")!, 2)
@@ -286,8 +286,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f") { dbValues in
             throw DatabaseError(message: "custom error message")
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -303,8 +303,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f") { dbValues in
             throw DatabaseError(resultCode: ResultCode(rawValue: 123))
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -320,8 +320,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f") { dbValues in
             throw DatabaseError(resultCode: ResultCode(rawValue: 123), message: "custom error message")
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -337,8 +337,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f") { dbValues in
             throw NSError(domain: "CustomErrorDomain", code: 123, userInfo: [NSLocalizedDescriptionKey: "custom error message"])
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             do {
                 try db.execute(sql: "SELECT f()")
                 XCTFail("Expected DatabaseError")
@@ -359,8 +359,8 @@ class DatabaseFunctionTests: GRDBTestCase {
         let fn = DatabaseFunction("f", argumentCount: 0) { dbValues in
             return x
         }
-        dbQueue.add(function: fn)
         try dbQueue.inDatabase { db in
+            db.add(function: fn)
             x = 321
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT f()")!, 321)
         }

--- a/Tests/GRDBTests/DatabasePoolCollationTests.swift
+++ b/Tests/GRDBTests/DatabasePoolCollationTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class DatabasePoolCollationTests: GRDBTestCase {
     
-    func testCollationIsSharedBetweenWriterAndReaders() throws {
+    func testDeprecatedCollationIsSharedBetweenWriterAndReaders() throws {
         let dbPool = try makeDatabasePool()
         
         let collation1 = DatabaseCollation("collation1") { (string1, string2) in

--- a/Tests/GRDBTests/DatabasePoolFunctionTests.swift
+++ b/Tests/GRDBTests/DatabasePoolFunctionTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 class DatabasePoolFunctionTests: GRDBTestCase {
     
-    func testFunctionIsSharedBetweenWriterAndReaders() throws {
+    func testDeprecatedFunctionIsSharedBetweenWriterAndReaders() throws {
         let dbPool = try makeDatabasePool()
         
         let function1 = DatabaseFunction("function1", argumentCount: 1, pure: true) { (dbValues: [DatabaseValue]) in

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -29,7 +29,7 @@ class DatabaseQueueTests: GRDBTestCase {
     }
     #endif
     
-    func testAddRemoveFunction() throws {
+    func testDeprecatedAddRemoveFunction() throws {
         // Adding a function and then removing it should succeed
         let dbQueue = try makeDatabaseQueue()
         let fn = DatabaseFunction("succ", argumentCount: 1) { dbValues in
@@ -59,7 +59,7 @@ class DatabaseQueueTests: GRDBTestCase {
         }
     }
 
-    func testAddRemoveCollation() throws {
+    func testDeprecatedAddRemoveCollation() throws {
         // Adding a collation and then removing it should succeed
         let dbQueue = try makeDatabaseQueue()
         let collation = DatabaseCollation("test_collation_foo") { (string1, string2) in

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -58,7 +58,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         }
     }
     
-    func testSnapshotInheritPoolFunctions() throws {
+    func testDeprecatedSnapshotInheritPoolFunctions() throws {
         let dbPool = try makeDatabasePool()
         let function = DatabaseFunction("foo", argumentCount: 0, pure: true) { _ in return "foo" }
         dbPool.add(function: function)
@@ -69,7 +69,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         }
     }
     
-    func testSnapshotFunctions() throws {
+    func testDeprecatedSnapshotFunctions() throws {
         let dbPool = try makeDatabasePool()
         let snapshot = try dbPool.makeSnapshot()
         let function = DatabaseFunction("foo", argumentCount: 0, pure: true) { _ in return "foo" }
@@ -79,7 +79,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         }
     }
 
-    func testSnapshotInheritPoolCollations() throws {
+    func testDeprecatedSnapshotInheritPoolCollations() throws {
         let dbPool = try makeDatabasePool()
         let collation = DatabaseCollation("reverse") { (string1, string2) in
             return (string1 == string2) ? .orderedSame : ((string1 < string2) ? .orderedDescending : .orderedAscending)
@@ -99,7 +99,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         }
     }
 
-    func testSnapshotCollations() throws {
+    func testDeprecatedSnapshotCollations() throws {
         let dbPool = try makeDatabasePool()
         try dbPool.write { db in
             try db.execute(sql: "CREATE TABLE items (text TEXT)")

--- a/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
@@ -68,9 +68,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     #endif
 
     func testFetchCursorStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ cursor: DatabaseValueCursor<Fetched>, sql: String) throws {
                 do {
@@ -178,9 +180,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testFetchAllStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ array: @autoclosure () throws -> [Fetched], sql: String) throws {
                 do {
@@ -327,9 +331,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testFetchOneStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ value: @autoclosure () throws -> Fetched?, sql: String) throws {
                 do {
@@ -436,9 +442,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testOptionalFetchCursorStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ cursor: NullableDatabaseValueCursor<Fetched>, sql: String) throws {
                 do {
@@ -548,9 +556,11 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testOptionalFetchAllStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ array: @autoclosure () throws -> [Fetched?], sql: String) throws {
                 do {

--- a/Tests/GRDBTests/FTS4TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS4TableBuilderTests.swift
@@ -302,17 +302,18 @@ class FTS4TableBuilderTests: GRDBTestCase {
         // Based on https://github.com/groue/GRDB.swift/issues/369
         var compressCalled = false
         var uncompressCalled = false
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("zipit", argumentCount: 1, pure: true, function: { dbValues in
+                compressCalled = true
+                return dbValues[0]
+            }))
+            db.add(function: DatabaseFunction("unzipit", argumentCount: 1, pure: true, function: { dbValues in
+                uncompressCalled = true
+                return dbValues[0]
+            }))
+        }
         
         let dbPool = try makeDatabasePool()
-        dbPool.add(function: DatabaseFunction("zipit", argumentCount: 1, pure: true, function: { dbValues in
-            compressCalled = true
-            return dbValues[0]
-        }))
-        dbPool.add(function: DatabaseFunction("unzipit", argumentCount: 1, pure: true, function: { dbValues in
-            uncompressCalled = true
-            return dbValues[0]
-        }))
-        
         try dbPool.write { db in
             try db.create(virtualTable: "documents", using: FTS4()) { t in
                 t.compress = "zipit"

--- a/Tests/GRDBTests/FTS5WrapperTokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5WrapperTokenizerTests.swift
@@ -101,8 +101,10 @@ private final class SynonymsTokenizer : FTS5WrapperTokenizer {
 class FTS5WrapperTokenizerTests: GRDBTestCase {
     
     func testStopWordsTokenizerDatabaseQueue() throws {
+        dbConfiguration.onConnect { db in
+            db.add(tokenizer: StopWordsTokenizer.self)
+        }
         let dbQueue = try makeDatabaseQueue()
-        dbQueue.add(tokenizer: StopWordsTokenizer.self)
         
         try dbQueue.inDatabase { db in
             try db.create(virtualTable: "documents", using: FTS5()) { t in
@@ -123,8 +125,10 @@ class FTS5WrapperTokenizerTests: GRDBTestCase {
     }
 
     func testStopWordsTokenizerDatabasePool() throws {
+        dbConfiguration.onConnect { db in
+            db.add(tokenizer: StopWordsTokenizer.self)
+        }
         let dbPool = try makeDatabaseQueue()
-        dbPool.add(tokenizer: StopWordsTokenizer.self)
         
         try dbPool.write { db in
             try db.create(virtualTable: "documents", using: FTS5()) { t in
@@ -154,8 +158,10 @@ class FTS5WrapperTokenizerTests: GRDBTestCase {
     }
 
     func testLatinAsciiTokenizer() throws {
+        dbConfiguration.onConnect { db in
+            db.add(tokenizer: LatinAsciiTokenizer.self)
+        }
         let dbQueue = try makeDatabaseQueue()
-        dbQueue.add(tokenizer: LatinAsciiTokenizer.self)
         
         // Without Latin ASCII conversion
         try dbQueue.inDatabase { db in
@@ -191,8 +197,10 @@ class FTS5WrapperTokenizerTests: GRDBTestCase {
     }
 
     func testSynonymsTokenizer() throws {
+        dbConfiguration.onConnect { db in
+            db.add(tokenizer: SynonymsTokenizer.self)
+        }
         let dbQueue = try makeDatabaseQueue()
-        dbQueue.add(tokenizer: SynonymsTokenizer.self)
         
         try dbQueue.inDatabase { db in
             try db.create(virtualTable: "documents", using: FTS5()) { t in

--- a/Tests/GRDBTests/FetchableRecordTests.swift
+++ b/Tests/GRDBTests/FetchableRecordTests.swift
@@ -74,9 +74,11 @@ class FetchableRecordTests: GRDBTestCase {
     #endif
     
     func testFetchCursorStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ cursor: RecordCursor<Fetched>, sql: String) throws {
                 do {
@@ -188,9 +190,11 @@ class FetchableRecordTests: GRDBTestCase {
     #endif
     
     func testFetchAllStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ array: @autoclosure () throws -> [Fetched], sql: String) throws {
                 do {
@@ -319,9 +323,11 @@ class FetchableRecordTests: GRDBTestCase {
     #endif
     
     func testFetchOneStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ value: @autoclosure () throws -> Fetched?, sql: String) throws {
                 do {

--- a/Tests/GRDBTests/InflectionsTests.swift
+++ b/Tests/GRDBTests/InflectionsTests.swift
@@ -10,6 +10,8 @@ class InflectionsTests: GRDBTestCase {
     private var originalInflections: Inflections?
     
     override func setUp() {
+        super.setUp()
+        
         // Dups the singleton before each test, restoring the original inflections later.
         originalInflections = Inflections.default
     }

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -24,6 +24,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     
     override func setUp() {
         super.setUp()
+        
         collation = DatabaseCollation("localized_case_insensitive") { (lhs, rhs) in
             return (lhs as NSString).localizedCaseInsensitiveCompare(rhs)
         }

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -22,6 +22,8 @@ class QueryInterfaceRequestTests: GRDBTestCase {
     var collation: DatabaseCollation!
     
     override func setUp() {
+        super.setUp()
+        
         collation = DatabaseCollation("localized_case_insensitive") { (lhs, rhs) in
             return (lhs as NSString).localizedCaseInsensitiveCompare(rhs)
         }

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -21,12 +21,15 @@ class QueryInterfaceRequestTests: GRDBTestCase {
 
     var collation: DatabaseCollation!
     
-    override func setup(_ dbWriter: DatabaseWriter) throws {
+    override func setUp() {
         collation = DatabaseCollation("localized_case_insensitive") { (lhs, rhs) in
             return (lhs as NSString).localizedCaseInsensitiveCompare(rhs)
         }
-        dbWriter.add(collation: collation)
-        
+        dbConfiguration.onConnect { [unowned self] db in
+            db.add(collation: self.collation)
+        }
+    }
+    override func setup(_ dbWriter: DatabaseWriter) throws {
         var migrator = DatabaseMigrator()
         migrator.registerMigration("createReaders") { db in
             try db.execute(sql: """

--- a/Tests/GRDBTests/RowFetchTests.swift
+++ b/Tests/GRDBTests/RowFetchTests.swift
@@ -63,9 +63,11 @@ class RowFetchTests: GRDBTestCase {
     #endif
     
     func testFetchCursorStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ cursor: RowCursor, sql: String) throws {
                 do {
@@ -174,9 +176,11 @@ class RowFetchTests: GRDBTestCase {
     #endif
 
     func testFetchAllStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ array: @autoclosure () throws -> [Row], sql: String) throws {
                 do {
@@ -302,9 +306,11 @@ class RowFetchTests: GRDBTestCase {
     #endif
 
     func testFetchOneStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ value: @autoclosure () throws -> Row?, sql: String) throws {
                 do {

--- a/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
@@ -130,9 +130,11 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testFetchCursorStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ cursor: FastDatabaseValueCursor<Fetched>, sql: String) throws {
                 do {
@@ -242,9 +244,11 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testFetchAllStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ array: @autoclosure () throws -> [Fetched], sql: String) throws {
                 do {
@@ -392,9 +396,11 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testFetchOneStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ value: @autoclosure () throws -> Fetched?, sql: String) throws {
                 do {
@@ -577,9 +583,11 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
     #endif
     
     func testOptionalFetchAllStepFailure() throws {
-        let dbQueue = try makeDatabaseQueue()
         let customError = NSError(domain: "Custom", code: 0xDEAD)
-        dbQueue.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             func test(_ array: @autoclosure () throws -> [Fetched?], sql: String) throws {
                 do {

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -231,6 +231,11 @@ class TableDefinitionTests: GRDBTestCase {
     }
 
     func testColumnCollation() throws {
+        let collation = DatabaseCollation("foo") { (lhs, rhs) in .orderedSame }
+        dbConfiguration.onConnect { db in
+            db.add(collation: collation)
+        }
+        
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inTransaction { db in
             try db.create(table: "test") { t in
@@ -244,8 +249,6 @@ class TableDefinitionTests: GRDBTestCase {
             return .rollback
         }
         
-        let collation = DatabaseCollation("foo") { (lhs, rhs) in .orderedSame }
-        dbQueue.add(collation: collation)
         try dbQueue.inTransaction { db in
             try db.create(table: "test") { t in
                 t.column("name", .text).collate(collation)

--- a/Tests/GRDBTests/UpdateStatementTests.swift
+++ b/Tests/GRDBTests/UpdateStatementTests.swift
@@ -166,12 +166,14 @@ class UpdateStatementTests : GRDBTestCase {
     }
     
     func testUpdateStatementAcceptsSelectQueriesAndConsumeAllRows() throws {
-        let dbQueue = try makeDatabaseQueue()
         var index = 0
-        dbQueue.add(function: DatabaseFunction("seq", argumentCount: 0, pure: false) { _ in
-            defer { index += 1 }
-            return index
-        })
+        dbConfiguration.onConnect { db in
+            db.add(function: DatabaseFunction("seq", argumentCount: 0, pure: false) { _ in
+                defer { index += 1 }
+                return index
+            })
+        }
+        let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.execute(sql: "SELECT seq() UNION ALL SELECT seq() UNION ALL SELECT seq()")
             let statement = try db.makeUpdateStatement(sql: "SELECT seq() UNION ALL SELECT seq() UNION ALL SELECT seq()")


### PR DESCRIPTION
This pull request deprecates DatabaseQueue and DatabasePool methods that can, and should, be handled with the `onConnect` configuration function:

```diff
 var config = Configuration()
+config.onConnect { db in
+    db.add(function: ...)
+    db.add(collation: ...)
+    db.add(tokenizer: ...)
+}
 let dbQueue = try DatabaseQueue(path: "...", configuration: config)
-dbQueue.add(function: ...)
-dbQueue.add(collation: ...)
-dbQueue.add(tokenizer: ...)
```
