### PR TITLE
Honor conflict resolution for batch updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -59,9 +57,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one expection: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**Fixed**
+
+- [#647](https://github.com/groue/GRDB.swift/pull/647): Honor conflict resolution for batch updates
 
 
 ## 4.6.0

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -503,11 +503,18 @@ extension QueryInterfaceRequest where T: MutablePersistableRecord {
     ///     }
     ///
     /// - parameter db: A database connection.
-    /// - returns: The number of updated rows
+    /// - parameter conflictResolution: A policy for conflict resolution,
+    ///   defaulting to the record's persistenceConflictPolicy.
+    /// - parameter assignments: An array of column assignments.
+    /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
-    public func updateAll(_ db: Database, _ assignments: [ColumnAssignment]) throws -> Int {
-        let conflictResolution = RowDecoder.persistenceConflictPolicy.conflictResolutionForUpdate
+    public func updateAll(
+        _ db: Database,
+        onConflict conflictResolution: Database.ConflictResolution? = nil,
+        _ assignments: [ColumnAssignment]) throws -> Int
+    {
+        let conflictResolution = conflictResolution ?? RowDecoder.persistenceConflictPolicy.conflictResolutionForUpdate
         guard let updateStatement = try SQLQueryGenerator(query).makeUpdateStatement(
             db,
             conflictResolution: conflictResolution,
@@ -530,16 +537,21 @@ extension QueryInterfaceRequest where T: MutablePersistableRecord {
     ///     }
     ///
     /// - parameter db: A database connection.
-    /// - returns: The number of updated rows
+    /// - parameter conflictResolution: A policy for conflict resolution,
+    ///   defaulting to the record's persistenceConflictPolicy.
+    /// - parameter assignment: A column assignment.
+    /// - parameter otherAssignments: Eventual other column assignments.
+    /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public func updateAll(
         _ db: Database,
+        onConflict conflictResolution: Database.ConflictResolution? = nil,
         _ assignment: ColumnAssignment,
         _ otherAssignments: ColumnAssignment...)
         throws -> Int
     {
-        return try updateAll(db, [assignment] + otherAssignments)
+        return try updateAll(db, onConflict: conflictResolution, [assignment] + otherAssignments)
     }
 }
 

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -507,7 +507,12 @@ extension QueryInterfaceRequest where T: MutablePersistableRecord {
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public func updateAll(_ db: Database, _ assignments: [ColumnAssignment]) throws -> Int {
-        guard let updateStatement = try SQLQueryGenerator(query).makeUpdateStatement(db, assignments) else {
+        let conflictResolution = RowDecoder.persistenceConflictPolicy.conflictResolutionForUpdate
+        guard let updateStatement = try SQLQueryGenerator(query).makeUpdateStatement(
+            db,
+            conflictResolution: conflictResolution,
+            assignments: assignments) else
+        {
             // database not hit
             return 0
         }

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -530,11 +530,19 @@ extension MutablePersistableRecord {
     ///     }
     ///
     /// - parameter db: A database connection.
-    /// - returns: The number of updated rows
+    /// - parameter conflictResolution: A policy for conflict resolution,
+    ///   defaulting to the record's persistenceConflictPolicy.
+    /// - parameter assignments: An array of column assignments.
+    /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
-    public static func updateAll(_ db: Database, _ assignments: [ColumnAssignment]) throws -> Int {
-        return try all().updateAll(db, assignments)
+    public static func updateAll(
+        _ db: Database,
+        onConflict conflictResolution: Database.ConflictResolution? = nil,
+        _ assignments: [ColumnAssignment])
+        throws -> Int
+    {
+        return try all().updateAll(db, onConflict: conflictResolution, assignments)
     }
     
     /// Updates all records; returns the number of updated records.
@@ -547,16 +555,21 @@ extension MutablePersistableRecord {
     ///     }
     ///
     /// - parameter db: A database connection.
-    /// - returns: The number of updated rows
+    /// - parameter conflictResolution: A policy for conflict resolution,
+    ///   defaulting to the record's persistenceConflictPolicy.
+    /// - parameter assignment: A column assignment.
+    /// - parameter otherAssignments: Eventual other column assignments.
+    /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public static func updateAll(
         _ db: Database,
+        onConflict conflictResolution: Database.ConflictResolution? = nil,
         _ assignment: ColumnAssignment,
         _ otherAssignments: ColumnAssignment...)
         throws -> Int
     {
-        return try updateAll(db, [assignment] + otherAssignments)
+        return try updateAll(db, onConflict: conflictResolution, [assignment] + otherAssignments)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -4659,6 +4659,13 @@ As a convenience, you can also use the `+=`, `-=`, `*=`, or `/=` operators:
 try Player.updateAll(db, scoreColumn += bonusColumn * 2)
 ```
 
+Default [Conflict Resolution] rules apply, and you may also provide a specific one:
+
+```swift
+// UPDATE OR IGNORE player SET ...
+try Player.updateAll(db, onConflict: .ignore, /* assignments... */)
+```
+
 > :point_up: **Note** The `updateAll` method is only available for records that adopts the [PersistableRecord] protocol.
 
 

--- a/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
@@ -35,8 +35,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     }
     
     func testRequestUpdateAll() throws {
-        let dbQueue = try makeDatabaseQueue()
-        try dbQueue.write { db in
+        try makeDatabaseQueue().write { db in
             let assignment = Columns.score <- 0
             
             try Player.updateAll(db, assignment)
@@ -280,6 +279,34 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             
             try Player.filter(key: 1).incrementScore(db)
             try XCTAssertEqual(Player.fetchOne(db, key: 1)!.score, 2)
+        }
+    }
+    
+    func testPersistenceConflictPolicyAbort() throws {
+        struct AbortPlayer: PersistableRecord {
+            static let databaseTableName = "player"
+            static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .abort, update: .abort)
+            func encode(to container: inout PersistenceContainer) { }
+        }
+        try makeDatabaseQueue().write { db in
+            try AbortPlayer.updateAll(db, Column("score") <- 0)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = 0
+                """)
+        }
+    }
+    
+    func testPersistenceConflictPolicyIgnore() throws {
+        struct IgnorePlayer: PersistableRecord {
+            static let databaseTableName = "player"
+            static let persistenceConflictPolicy = PersistenceConflictPolicy(insert: .abort, update: .ignore)
+            func encode(to container: inout PersistenceContainer) { }
+        }
+        try makeDatabaseQueue().write { db in
+            try IgnorePlayer.updateAll(db, Column("score") <- 0)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE OR IGNORE "player" SET "score" = 0
+                """)
         }
     }
 }


### PR DESCRIPTION
During the development of batch updates (#646), conflict resolution has been forgotten. This pull request fixes this omission!

```swift
// UPDATE OR IGNORE player SET ...
try Player.updateAll(db, onConflict: .ignore, /* assignments... */)

// Uses Player.persistenceConflictPolicy.conflictResolutionForUpdate
try Player.updateAll(db, /* assignments... */)
```
