### PR TITLE
Type inference of selected columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 **New**
 
+- [#656](https://github.com/groue/GRDB.swift/pull/656): Type inference of selected columns
 - [#659](https://github.com/groue/GRDB.swift/pull/659): Database interruption
 - [#660](https://github.com/groue/GRDB.swift/pull/660): Database Lock Prevention
 

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -143,7 +143,7 @@ extension QueryInterfaceRequest: SelectionRequest {
     ///         let request = Player.all().select([max(Column("score"))], as: Int.self)
     ///         let maxScore: Int? = try request.fetchOne(db)
     ///     }
-    public func select<RowDecoder>(_ selection: [SQLSelectable], as type: RowDecoder.Type)
+    public func select<RowDecoder>(_ selection: [SQLSelectable], as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return mapQuery { $0.select(selection) }.asRequest(of: RowDecoder.self)
@@ -157,7 +157,7 @@ extension QueryInterfaceRequest: SelectionRequest {
     ///         let request = Player.all().select(max(Column("score")), as: Int.self)
     ///         let maxScore: Int? = try request.fetchOne(db)
     ///     }
-    public func select<RowDecoder>(_ selection: SQLSelectable..., as type: RowDecoder.Type)
+    public func select<RowDecoder>(_ selection: SQLSelectable..., as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return select(selection, as: type)
@@ -174,7 +174,7 @@ extension QueryInterfaceRequest: SelectionRequest {
     public func select<RowDecoder>(
         sql: String,
         arguments: StatementArguments = StatementArguments(),
-        as type: RowDecoder.Type)
+        as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return select(literal: SQLLiteral(sql: sql, arguments: arguments), as: type)
@@ -209,7 +209,7 @@ extension QueryInterfaceRequest: SelectionRequest {
     ///     }
     public func select<RowDecoder>(
         literal sqlLiteral: SQLLiteral,
-        as type: RowDecoder.Type)
+        as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return select(SQLSelectionLiteral(literal: sqlLiteral), as: type)

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -78,7 +78,7 @@ extension TableRecord {
     ///     }
     public static func select<RowDecoder>(
         _ selection: [SQLSelectable],
-        as type: RowDecoder.Type)
+        as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return all().select(selection, as: type)
@@ -94,7 +94,7 @@ extension TableRecord {
     ///     }
     public static func select<RowDecoder>(
         _ selection: SQLSelectable...,
-        as type: RowDecoder.Type)
+        as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return all().select(selection, as: type)
@@ -111,7 +111,7 @@ extension TableRecord {
     public static func select<RowDecoder>(
         sql: String,
         arguments: StatementArguments = StatementArguments(),
-        as type: RowDecoder.Type)
+        as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return all().select(literal: SQLLiteral(sql: sql, arguments: arguments), as: type)
@@ -127,7 +127,7 @@ extension TableRecord {
     ///     }
     public static func select<RowDecoder>(
         literal sqlLiteral: SQLLiteral,
-        as type: RowDecoder.Type)
+        as type: RowDecoder.Type = RowDecoder.self)
         -> QueryInterfaceRequest<RowDecoder>
     {
         return all().select(literal: sqlLiteral, as: type)

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -470,8 +470,8 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         }
     }
     
+    // This test passes if this method compiles
     func testSelectAsTypeInference() {
-        // This test passes if it compiles
         _ = Reader.select(Col.name) as QueryInterfaceRequest<String>
         _ = Reader.select([Col.name]) as QueryInterfaceRequest<String>
         _ = Reader.select(sql: "name") as QueryInterfaceRequest<String>
@@ -481,15 +481,43 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         _ = Reader.all().select(sql: "name") as QueryInterfaceRequest<String>
         _ = Reader.all().select(literal: SQLLiteral(sql: "name")) as QueryInterfaceRequest<String>
         
-        // No ambiguity: those are requests of Reader. TODO: how to assert this statically?
-        _ = Reader.select(Col.name)
-        _ = Reader.select([Col.name])
-        _ = Reader.select(sql: "name")
-        _ = Reader.select(literal: SQLLiteral(sql: "name"))
-        _ = Reader.all().select(Col.name)
-        _ = Reader.all().select([Col.name])
-        _ = Reader.all().select(sql: "name")
-        _ = Reader.all().select(literal: SQLLiteral(sql: "name"))
+        func makeRequest() -> QueryInterfaceRequest<String> {
+            return Reader.select(Col.name)
+        }
+        
+        // Those should be, without any ambiguuity, requests of Reader.
+        do {
+            let request = Reader.select(Col.name)
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.select([Col.name])
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.select(sql: "name")
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.select(literal: SQLLiteral(sql: "name"))
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.all().select(Col.name)
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.all().select([Col.name])
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.all().select(sql: "name")
+            _ = request as QueryInterfaceRequest<Reader>
+        }
+        do {
+            let request = Reader.all().select(literal: SQLLiteral(sql: "name"))
+            _ = request as QueryInterfaceRequest<Reader>
+        }
     }
     
     

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -470,6 +470,28 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         }
     }
     
+    func testSelectAsTypeInference() {
+        // This test passes if it compiles
+        _ = Reader.select(Col.name) as QueryInterfaceRequest<String>
+        _ = Reader.select([Col.name]) as QueryInterfaceRequest<String>
+        _ = Reader.select(sql: "name") as QueryInterfaceRequest<String>
+        _ = Reader.select(literal: SQLLiteral(sql: "name")) as QueryInterfaceRequest<String>
+        _ = Reader.all().select(Col.name) as QueryInterfaceRequest<String>
+        _ = Reader.all().select([Col.name]) as QueryInterfaceRequest<String>
+        _ = Reader.all().select(sql: "name") as QueryInterfaceRequest<String>
+        _ = Reader.all().select(literal: SQLLiteral(sql: "name")) as QueryInterfaceRequest<String>
+        
+        // No ambiguity: those are requests of Reader. TODO: how to assert this statically?
+        _ = Reader.select(Col.name)
+        _ = Reader.select([Col.name])
+        _ = Reader.select(sql: "name")
+        _ = Reader.select(literal: SQLLiteral(sql: "name"))
+        _ = Reader.all().select(Col.name)
+        _ = Reader.all().select([Col.name])
+        _ = Reader.all().select(sql: "name")
+        _ = Reader.all().select(literal: SQLLiteral(sql: "name"))
+    }
+    
     
     // MARK: - Distinct
     


### PR DESCRIPTION
This pull request allows to omit the `as:` parameter of the `select(_:as:)` request derivation method. It can be convenient.

For example:

```swift
extension QueryInterfaceRequest where RowDecoder == Player {
    static func maximumScore(): QueryInterfaceRequest<Int?> {
        select(max(Column("score"))) // previously we needed `, as: Int.self`
    }
}

let maxScore: Int? = try dbQueue.read { db in
    try Player.all().maximumScore().fetchOne(db)
}
```

This also applies to RxGRDB and GRDBCombine:

```swift
extension PlayerDatabase {
    func maximumScorePublisher() -> AnyPublisher<Int?, Error> {
        ValueObservation
            .tracking(value: Player.select(max(Column("score"))).fetchOne) // previously we needed `, as: Int.self`
            .publisher(in: dbReader)
            .eraseToAnyPublisher()
    }
}
```
