### PR TITLE
Upgrade custom SQLite builds to version 3.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,18 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#659](https://github.com/groue/GRDB.swift/pull/659): Database interruption
 - [#660](https://github.com/groue/GRDB.swift/pull/660): Database Lock Prevention
 
+### Breaking Changes
+
+[Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) now disable by default the support for the [Double-quoted String Literals misfeature](https://sqlite.org/quirks.html#dblquote). You can restore the previous behavior if your application relies on it:
+
+```swift
+// Enable support for Double-quoted String Literals
+var configuration = Configuration()
+configuration.acceptsDoubleQuotedStringLiterals = true
+let dbQueue = try DatabaseQueue(path: ..., configuration: configuration)
+```
+
+
 ### Documentation Diff
 
 A new [Interrupt a Database](README.md#interrupt-a-database) chapter documents the new `interrupt()` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,13 +63,14 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - [#659](https://github.com/groue/GRDB.swift/pull/659): Database interruption
 - [#660](https://github.com/groue/GRDB.swift/pull/660): Database Lock Prevention
+- [#662](https://github.com/groue/GRDB.swift/pull/662): Upgrade custom SQLite builds to version 3.30.1 (thanks to [@swiftlyfalling](https://github.com/swiftlyfalling/SQLiteLib))
 
 ### Breaking Changes
 
 [Custom SQLite builds](Documentation/CustomSQLiteBuilds.md) now disable by default the support for the [Double-quoted String Literals misfeature](https://sqlite.org/quirks.html#dblquote). You can restore the previous behavior if your application relies on it:
 
 ```swift
-// Enable support for Double-quoted String Literals
+// Enable support for the Double-quoted String Literals misfeature
 var configuration = Configuration()
 configuration.acceptsDoubleQuotedStringLiterals = true
 let dbQueue = try DatabaseQueue(path: ..., configuration: configuration)

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -76,16 +76,26 @@ public struct Configuration {
     public var trace: TraceFunction?
     
     /// If false, SQLite from version 3.29.0 will not interpret a double-quoted
-    /// string as a string literal if it does not match any valid identifier:
+    /// string as a string literal if it does not match any valid identifier.
     ///
-    ///     // no such column: naame
+    /// For example:
+    ///
+    ///     // Error: no such column: foo
     ///     let name = try String.fetchOne(db, sql: """
-    ///         SELECT "naame" FROM "player"
+    ///         SELECT "foo" FROM "player"
     ///         """)
     ///
-    /// See https://sqlite.org/quirks.html#dblquote for more information.
+    /// When true, or before version 3.29.0, such strings are interpreted as
+    /// string literals, as in the example below. This is a well known SQLite
+    /// [misfeature](https://sqlite.org/quirks.html#dblquote).
     ///
-    /// Default: false
+    ///     // Success: "foo"
+    ///     let name = try String.fetchOne(db, sql: """
+    ///         SELECT "foo" FROM "player"
+    ///         """)
+    ///
+    /// - Recommended value: false
+    /// - Default value: false
     public var acceptsDoubleQuotedStringLiterals = false
     
     // MARK: - Encryption

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -75,6 +75,19 @@ public struct Configuration {
     /// Default: nil
     public var trace: TraceFunction?
     
+    /// If false, SQLite from version 3.29.0 will not interpret a double-quoted
+    /// string as a string literal if it does not match any valid identifier:
+    ///
+    ///     // no such column: naame
+    ///     let name = try String.fetchOne(db, sql: """
+    ///         SELECT "naame" FROM "player"
+    ///         """)
+    ///
+    /// See https://sqlite.org/quirks.html#dblquote for more information.
+    ///
+    /// Default: false
+    public var acceptsDoubleQuotedStringLiterals = false
+    
     // MARK: - Encryption
     
     #if SQLITE_HAS_CODEC

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -209,6 +209,7 @@ public final class Database {
     func setup() throws {
         // Setup trace first, so that setup queries are traced.
         setupTrace()
+        setupDoubleQuotedStringLiterals()
         try setupForeignKeys()
         setupBusyMode()
         setupDefaultFunctions()
@@ -292,6 +293,14 @@ public final class Database {
         let db = Unmanaged<Database>.fromOpaque(dbPointer!).takeUnretainedValue()
         db.configuration.trace!(sql)
         return SQLITE_OK
+    }
+    
+    private func setupDoubleQuotedStringLiterals() {
+        if configuration.acceptsDoubleQuotedStringLiterals {
+            enableDoubleQuotedStringLiterals(sqliteConnection)
+        } else {
+            disableDoubleQuotedStringLiterals(sqliteConnection)
+        }
     }
     
     private func setupForeignKeys() throws {

--- a/GRDB/QueryInterface/SQL/SQLCollatedExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollatedExpression.swift
@@ -40,6 +40,32 @@ public struct SQLCollatedExpression {
         return SQLOrdering.desc(sqlExpression)
     }
     
+    #if GRDBCUSTOMSQLITE
+    /// Returns an ordering suitable for QueryInterfaceRequest.order()
+    ///
+    ///     let email: SQLCollatedExpression = Column("email").collating(.nocase)
+    ///
+    ///     // SELECT * FROM player ORDER BY email COLLATE NOCASE ASC NULLS LAST
+    ///     Player.order(email.ascNullsLast)
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    public var ascNullsLast: SQLOrderingTerm {
+        return SQLOrdering.ascNullsLast(sqlExpression)
+    }
+    
+    /// Returns an ordering suitable for QueryInterfaceRequest.order()
+    ///
+    ///     let email: SQLCollatedExpression = Column("email").collating(.nocase)
+    ///
+    ///     // SELECT * FROM player ORDER BY email COLLATE NOCASE DESC NULLS FIRST
+    ///     Player.order(email.descNullsFirst)
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    public var descNullsFirst: SQLOrderingTerm {
+        return SQLOrdering.descNullsFirst(sqlExpression)
+    }
+    #endif
+    
     init(_ expression: SQLExpression, collationName: Database.CollationName) {
         self.expression = expression
         self.collationName = collationName

--- a/GRDB/QueryInterface/SQL/SQLOrdering.swift
+++ b/GRDB/QueryInterface/SQL/SQLOrdering.swift
@@ -26,6 +26,10 @@ public protocol SQLOrderingTerm {
 enum SQLOrdering: SQLOrderingTerm {
     case asc(SQLExpression)
     case desc(SQLExpression)
+    #if GRDBCUSTOMSQLITE
+    case ascNullsLast(SQLExpression)
+    case descNullsFirst(SQLExpression)
+    #endif
     
     var reversed: SQLOrderingTerm {
         switch self {
@@ -33,6 +37,12 @@ enum SQLOrdering: SQLOrderingTerm {
             return SQLOrdering.desc(expression)
         case .desc(let expression):
             return SQLOrdering.asc(expression)
+            #if GRDBCUSTOMSQLITE
+        case .ascNullsLast(let expression):
+            return SQLOrdering.descNullsFirst(expression)
+        case .descNullsFirst(let expression):
+            return SQLOrdering.ascNullsLast(expression)
+            #endif
         }
     }
     
@@ -42,6 +52,12 @@ enum SQLOrdering: SQLOrderingTerm {
             return expression.expressionSQL(&context, wrappedInParenthesis: false) + " ASC"
         case .desc(let expression):
             return expression.expressionSQL(&context, wrappedInParenthesis: false) + " DESC"
+            #if GRDBCUSTOMSQLITE
+        case .ascNullsLast(let expression):
+            return expression.expressionSQL(&context, wrappedInParenthesis: false) + " ASC NULLS LAST"
+        case .descNullsFirst(let expression):
+            return expression.expressionSQL(&context, wrappedInParenthesis: false) + " DESC NULLS FIRST"
+            #endif
         }
     }
     
@@ -51,6 +67,12 @@ enum SQLOrdering: SQLOrderingTerm {
             return SQLOrdering.asc(expression.qualifiedExpression(with: alias))
         case .desc(let expression):
             return SQLOrdering.desc(expression.qualifiedExpression(with: alias))
+            #if GRDBCUSTOMSQLITE
+        case .ascNullsLast(let expression):
+            return SQLOrdering.ascNullsLast(expression.qualifiedExpression(with: alias))
+        case .descNullsFirst(let expression):
+            return SQLOrdering.descNullsFirst(expression.qualifiedExpression(with: alias))
+            #endif
         }
     }
 }

--- a/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
@@ -16,6 +16,22 @@ extension SQLSpecificExpressible {
     public var desc: SQLOrderingTerm {
         return SQLOrdering.desc(sqlExpression)
     }
+    
+    #if GRDBCUSTOMSQLITE
+    /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    public var ascNullsLast: SQLOrderingTerm {
+        return SQLOrdering.ascNullsLast(sqlExpression)
+    }
+    
+    /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    public var descNullsFirst: SQLOrderingTerm {
+        return SQLOrdering.descNullsFirst(sqlExpression)
+    }
+    #endif
 }
 
 

--- a/README.md
+++ b/README.md
@@ -4083,6 +4083,13 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     Player.order(scoreColumn.desc, nameColumn)
     ```
     
+    SQLite considers NULL values to be smaller than any other values for sorting purposes. Hence, NULLs naturally appear at the beginning of an ascending ordering and at the end of a descending ordering. With a [custom SQLite build], this can be changed using `.ascNullsLast` and `.descNullsFirst`:
+    
+    ```swift
+    // SELECT * FROM player ORDER BY score ASC NULLS LAST
+    Player.order(nameColumn.ascNullsLast)
+    ```
+    
     Each `order` call clears any previous ordering:
     
     ```swift

--- a/Sources/sqlite3/shim.h
+++ b/Sources/sqlite3/shim.h
@@ -2,8 +2,27 @@
 
 typedef void(*errorLogCallback)(void *pArg, int iErrCode, const char *zMsg);
 
-// Wrapper around sqlite3_config(SQLITE_CONFIG_LOG, ...) which is a variadic
-// function that can't be used from Swift.
+/// Wrapper around sqlite3_config(SQLITE_CONFIG_LOG, ...) which is a variadic
+/// function that can't be used from Swift.
 static inline void registerErrorLogCallback(errorLogCallback callback) {
     sqlite3_config(SQLITE_CONFIG_LOG, callback, 0);
 }
+
+#if SQLITE_VERSION_NUMBER >= 3029000
+/// Wrapper around sqlite3_db_config() which is a variadic function that can't
+/// be used from Swift.
+static inline void disableDoubleQuotedStringLiterals(sqlite3 *db) {
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 0, (void *)0);
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 0, (void *)0);
+}
+
+/// Wrapper around sqlite3_db_config() which is a variadic function that can't
+/// be used from Swift.
+static inline void enableDoubleQuotedStringLiterals(sqlite3 *db) {
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 1, (void *)0);
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 1, (void *)0);
+}
+#else
+static inline void disableDoubleQuotedStringLiterals(sqlite3 *db) { }
+static inline void enableDoubleQuotedStringLiterals(sqlite3 *db) { }
+#endif

--- a/Support/grdb_config.h
+++ b/Support/grdb_config.h
@@ -15,11 +15,30 @@
 
 typedef void(*errorLogCallback)(void *pArg, int iErrCode, const char *zMsg);
 
-// Wrapper around sqlite3_config(SQLITE_CONFIG_LOG, ...) which is a variadic
-// function that can't be used from Swift.
+/// Wrapper around sqlite3_config(SQLITE_CONFIG_LOG, ...) which is a variadic
+/// function that can't be used from Swift.
 static inline void registerErrorLogCallback(errorLogCallback callback) {
     sqlite3_config(SQLITE_CONFIG_LOG, callback, 0);
 }
+
+#if SQLITE_VERSION_NUMBER >= 3029000
+/// Wrapper around sqlite3_db_config() which is a variadic function that can't
+/// be used from Swift.
+static inline void disableDoubleQuotedStringLiterals(sqlite3 *db) {
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 0, (void *)0);
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 0, (void *)0);
+}
+
+/// Wrapper around sqlite3_db_config() which is a variadic function that can't
+/// be used from Swift.
+static inline void enableDoubleQuotedStringLiterals(sqlite3 *db) {
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 1, (void *)0);
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 1, (void *)0);
+}
+#else
+static inline void disableDoubleQuotedStringLiterals(sqlite3 *db) { }
+static inline void enableDoubleQuotedStringLiterals(sqlite3 *db) { }
+#endif
 
 // Expose APIs that are missing from system <sqlite3.h>
 #ifdef GRDB_SQLITE_ENABLE_PREUPDATE_HOOK

--- a/TODO.md
+++ b/TODO.md
@@ -41,6 +41,7 @@
 
 ## Unsure if necessary
 
+- [ ] https://sqlite.org/pragma.html#pragma_index_xinfo
 - [ ] Deprecate DatabaseQueue/Pool.addFunction, collation, tokenizer: those should be done in Configuration.prepareDatabase
 - [ ] filter(rowid:), filter(rowids:)
 - [ ] https://github.com/apple/swift-evolution/blob/master/proposals/0075-import-test.md

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -1,8 +1,13 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-import GRDBCustomSQLite
+    import GRDBCustomSQLite
 #else
-import GRDB
+    #if SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
+    import GRDB
 #endif
 
 class DatabaseConfigurationTests: GRDBTestCase {

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -101,8 +101,10 @@ class DatabaseConfigurationTests: GRDBTestCase {
         XCTAssertEqual(foo, "foo")
         
         // Test SQLITE_DBCONFIG_DQS_DDL
-        try dbQueue.inDatabase { db in
-            try db.execute(sql: "CREATE INDEX i ON player(\"foo\")")
+        if sqlite3_libversion_number() > 3008010 {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "CREATE INDEX i ON player(\"foo\")")
+            }
         }
     }
     
@@ -143,7 +145,10 @@ class DatabaseConfigurationTests: GRDBTestCase {
             }
         } catch let error as DatabaseError {
             XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
-            XCTAssertEqual(error.message, "no such column: foo")
+            XCTAssert([
+                "no such column: foo",
+                "table player has no column named foo"]
+                .contains(error.message))
             XCTAssertEqual(error.sql, "CREATE INDEX i ON player(\"foo\")")
         }
     }

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+import GRDBCustomSQLite
 #else
-    import GRDB
+import GRDB
 #endif
 
 class DatabaseConfigurationTests: GRDBTestCase {
@@ -70,6 +70,76 @@ class DatabaseConfigurationTests: GRDBTestCase {
                 _ = try pool.makeSnapshot()
                 XCTFail("Expected TestError")
             } catch is TestError { }
+        }
+    }
+    
+    func testAcceptsDoubleQuotedStringLiteralsDefault() throws {
+        let configuration = Configuration()
+        XCTAssertFalse(configuration.acceptsDoubleQuotedStringLiterals)
+    }
+    
+    func testAcceptsDoubleQuotedStringLiteralsTrue() throws {
+        var configuration = Configuration()
+        configuration.acceptsDoubleQuotedStringLiterals = true
+        let dbQueue = try makeDatabaseQueue(configuration: configuration)
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player(name TEXT);
+                INSERT INTO player DEFAULT VALUES;
+                """)
+        }
+        
+        // Test SQLITE_DBCONFIG_DQS_DML
+        let foo = try dbQueue.inDatabase { db in
+            try String.fetchOne(db, sql: "SELECT \"foo\" FROM player")
+        }
+        XCTAssertEqual(foo, "foo")
+        
+        // Test SQLITE_DBCONFIG_DQS_DDL
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE INDEX i ON player(\"foo\")")
+        }
+    }
+    
+    func testAcceptsDoubleQuotedStringLiteralsFalse() throws {
+        var configuration = Configuration()
+        configuration.acceptsDoubleQuotedStringLiterals = false
+        let dbQueue = try makeDatabaseQueue(configuration: configuration)
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player(name TEXT);
+                INSERT INTO player DEFAULT VALUES;
+                """)
+        }
+        
+        // Test SQLITE_DBCONFIG_DQS_DML
+        do {
+            let foo = try dbQueue.inDatabase { db in
+                try String.fetchOne(db, sql: "SELECT \"foo\" FROM player")
+            }
+            if sqlite3_libversion_number() >= 3029000 {
+                XCTFail("Expected error")
+            } else {
+                XCTAssertEqual(foo, "foo")
+            }
+        } catch let error as DatabaseError {
+            XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+            XCTAssertEqual(error.message, "no such column: foo")
+            XCTAssertEqual(error.sql, "SELECT \"foo\" FROM player")
+        }
+        
+        // Test SQLITE_DBCONFIG_DQS_DDL
+        do {
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "CREATE INDEX i ON player(\"foo\")")
+            }
+            if sqlite3_libversion_number() >= 3029000 {
+                XCTFail("Expected error")
+            }
+        } catch let error as DatabaseError {
+            XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+            XCTAssertEqual(error.message, "no such column: foo")
+            XCTAssertEqual(error.sql, "CREATE INDEX i ON player(\"foo\")")
         }
     }
 }

--- a/Tests/GRDBTests/FTS5PatternTests.swift
+++ b/Tests/GRDBTests/FTS5PatternTests.swift
@@ -32,7 +32,7 @@ class FTS5PatternTests: GRDBTestCase {
                 ("écarlates", 1),
                 ("fooéı👨👨🏿🇫🇷🇨🇮", 0),
                 // Prefix queries
-                ("*", 1),   // weird
+                // ("*", 1),   // No longer valid on SQLite 3.30.1
                 ("Robin*", 1),
                 // Phrase queries
                 ("\"foulent muscles\"", 1),

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+import GRDBCustomSQLite
 #else
-    import GRDB
+import GRDB
 #endif
 
 private struct Col {
@@ -18,7 +18,7 @@ private struct Reader : TableRecord {
 private let tableRequest = Reader.all()
 
 class QueryInterfaceRequestTests: GRDBTestCase {
-
+    
     var collation: DatabaseCollation!
     
     override func setup(_ dbWriter: DatabaseWriter) throws {
@@ -88,10 +88,10 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             }
         }
     }
-
-
+    
+    
     // MARK: - Count
-
+    
     func testFetchCount() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -135,10 +135,10 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT MAX(\"age\") FROM \"readers\" GROUP BY \"name\")")
         }
     }
-
-
+    
+    
     // MARK: - Select
-
+    
     func testSelectLiteral() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -155,7 +155,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(rows[1][1] as Int64, 1)
         }
     }
-
+    
     func testSelectLiteralWithPositionalArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -172,7 +172,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(rows[1][1] as Int64, 1)
         }
     }
-
+    
     func testSelectLiteralWithNamedArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -228,7 +228,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             XCTAssertEqual(rows[1][1] as Int64, 1)
         }
     }
-
+    
     func testSelectionCustomKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -526,14 +526,14 @@ class QueryInterfaceRequestTests: GRDBTestCase {
                 .filter(sql: "name = :name", arguments: ["name": "arthur"])),
             "SELECT * FROM \"readers\" WHERE (age > 20) AND (name = 'arthur')")
     }
-
+    
     func testFilter() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(true)),
             "SELECT * FROM \"readers\" WHERE 1")
     }
-
+    
     func testMultipleFilter() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
@@ -617,7 +617,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
             sql(dbQueue, tableRequest.group(Col.name).having(min(Col.age) > 18).having(max(Col.age) < 50)),
-                "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (MIN(\"age\") > 18) AND (MAX(\"age\") < 50)")
+            "SELECT * FROM \"readers\" GROUP BY \"name\" HAVING (MIN(\"age\") > 18) AND (MAX(\"age\") < 50)")
     }
     
     
@@ -661,6 +661,14 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(abs(Col.age))),
             "SELECT * FROM \"readers\" ORDER BY ABS(\"age\")")
+        #if GRDBCUSTOMSQLITE
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.age.ascNullsLast)),
+            "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.age.descNullsFirst)),
+            "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        #endif
     }
     
     func testSortWithCollation() throws {
@@ -674,6 +682,14 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.name.collating(collation))),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE localized_case_insensitive")
+        #if GRDBCUSTOMSQLITE
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).ascNullsLast)),
+            "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst)),
+            "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")
+        #endif
     }
     
     func testMultipleSort() throws {
@@ -706,6 +722,14 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(abs(Col.age)).reversed()),
             "SELECT * FROM \"readers\" ORDER BY ABS(\"age\") DESC")
+        #if GRDBCUSTOMSQLITE
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.age.descNullsFirst).reversed()),
+            "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.age.ascNullsLast).reversed()),
+            "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        #endif
     }
     
     func testReverseWithCollation() throws {
@@ -719,6 +743,14 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.name.collating(collation)).reversed()),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE localized_case_insensitive DESC")
+        #if GRDBCUSTOMSQLITE
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).ascNullsLast).reversed()),
+            "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst).reversed()),
+            "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
+        #endif
     }
     
     func testMultipleReverse() throws {

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -258,6 +258,14 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, Reader.order(abs(Col.age))),
             "SELECT * FROM \"readers\" ORDER BY ABS(\"age\")")
+        #if GRDBCUSTOMSQLITE
+        XCTAssertEqual(
+            sql(dbQueue, Reader.order(Col.age.ascNullsLast)),
+            "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
+        XCTAssertEqual(
+            sql(dbQueue, Reader.order(Col.age.descNullsFirst)),
+            "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        #endif
     }
     
     func testMultipleSort() throws {


### PR DESCRIPTION
This pull request bumps the version of custom SQLite builds to 3.30.1.

With custom SQLite builds:

- You can use the `ascNullsLast` and `descNullsFirst` orderings:

    ```swift
    // SELECT * FROM player ORDER BY score ASC NULLS LAST
    let players = Player.order(Column("score").ascNullsLast).fetchAll(db)
    ```

- **Breaking Change**: the support for the [Double-quoted String Literals misfeature](https://sqlite.org/quirks.html#dblquote) is now disabled by default. You can restore the previous behavior if your application relies on it:

    ```swift
    // Enable support for the Double-quoted String Literals misfeature
    var configuration = Configuration()
    configuration.acceptsDoubleQuotedStringLiterals = true
    let dbQueue = try DatabaseQueue(path: ..., configuration: configuration)
    ```

