### PR TITLE
More batch delete and update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -60,9 +58,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**New**
+
+- [#676](https://github.com/groue/GRDB.swift/pull/676): More batch delete and update
 
 
 ## 4.7.0

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -360,8 +360,14 @@ extension Database {
         where T.Iterator.Element == String
     {
         // Check primaryKey first, so that we fail early if the table does not exist
-        let primaryKey = try self.primaryKey(tableName)
         let lowercasedColumns = Set(columns.map { $0.lowercased() })
+        
+        // Assume "rowid" is a primary key
+        if lowercasedColumns == ["rowid"] {
+            return ["rowid"]
+        }
+        
+        let primaryKey = try self.primaryKey(tableName)
         if Set(primaryKey.columns.map { $0.lowercased() }) == lowercasedColumns {
             return primaryKey.columns
         }

--- a/GRDB/QueryInterface/SQL/Column.swift
+++ b/GRDB/QueryInterface/SQL/Column.swift
@@ -65,7 +65,7 @@ public struct Column: ColumnExpression {
 /// A qualified column in the database, as in `SELECT t.a FROM t`
 struct QualifiedColumn: ColumnExpression {
     var name: String
-    private let alias: TableAlias
+    let alias: TableAlias
     
     /// Creates a column given its name.
     init(_ name: String, alias: TableAlias) {

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -1,6 +1,6 @@
 /// SQLQueryGenerator is able to generate an SQL SELECT query.
 struct SQLQueryGenerator {
-    fileprivate var relation: SQLQualifiedRelation
+    fileprivate private(set) var relation: SQLQualifiedRelation
     private let isDistinct: Bool
     private let groupPromise: DatabasePromise<[SQLExpression]>?
     private let havingExpressions: [SQLExpression]
@@ -485,7 +485,7 @@ private struct SQLQualifiedRelation {
     ///     SELECT ... FROM ... AS ... JOIN ... WHERE ... ORDER BY ...
     ///                                     |
     ///                                     • joins
-    var joins: OrderedDictionary<String, SQLQualifiedJoin>
+    private(set) var joins: OrderedDictionary<String, SQLQualifiedJoin>
     
     init(_ relation: SQLRelation) {
         // Qualify the source, so that it be disambiguated with an SQL alias

--- a/README.md
+++ b/README.md
@@ -2630,6 +2630,7 @@ try place.delete(db)                   // DELETE
 try place.exists(db)
 
 // Type methods
+try Place.updateAll(db, ...)               // UPDATE
 try Place.deleteAll(db)                    // DELETE
 try Place.deleteAll(db, keys:...)          // DELETE
 try Place.deleteOne(db, key:...)           // DELETE
@@ -2640,6 +2641,8 @@ try Place.deleteOne(db, key:...)           // DELETE
 - `update` and `updateChanges` can also throw a [PersistenceError](#persistenceerror), should the update fail because there is no matching row in the database.
     
     When saving an object that may or may not already exist in the database, prefer the `save` method:
+
+- `updateAll` performs a batch update. See [Update Requests](#update-requests).
 
 - `save` makes sure your values are stored in the database.
 

--- a/Tests/GRDBTests/IndexInfoTests.swift
+++ b/Tests/GRDBTests/IndexInfoTests.swift
@@ -56,14 +56,16 @@ class IndexInfoTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (id INTEGER PRIMARY KEY, name TEXT, email TEXT UNIQUE)")
+            try XCTAssertTrue(db.table("persons", hasUniqueKey: ["rowid"]))
             try XCTAssertTrue(db.table("persons", hasUniqueKey: ["id"]))
             try XCTAssertTrue(db.table("persons", hasUniqueKey: ["email"]))
             try XCTAssertFalse(db.table("persons", hasUniqueKey: []))
             try XCTAssertFalse(db.table("persons", hasUniqueKey: ["name"]))
-            try XCTAssertFalse(db.table("persons", hasUniqueKey: ["id", "email"]))
+            try XCTAssertFalse(db.table("persons", hasUniqueKey: ["id", "email"])) // TODO: is it expected?
             
             try db.execute(sql: "CREATE TABLE citizenships (year INTEGER, personId INTEGER NOT NULL, countryIsoCode TEXT NOT NULL, PRIMARY KEY (personId, countryIsoCode))")
             try db.execute(sql: "CREATE INDEX citizenshipsOnYear ON citizenships(year)")
+            try XCTAssertTrue(db.table("citizenships", hasUniqueKey: ["rowid"]))
             try XCTAssertTrue(db.table("citizenships", hasUniqueKey: ["personId", "countryIsoCode"]))
             try XCTAssertTrue(db.table("citizenships", hasUniqueKey: ["countryIsoCode", "personId"]))
             try XCTAssertFalse(db.table("citizenships", hasUniqueKey: []))

--- a/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
@@ -184,4 +184,114 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
             }
         }
     }
+    
+    func testJoinedRequestDelete() throws {
+        try makeDatabaseQueue().inDatabase { db in
+            struct Player: MutablePersistableRecord {
+                static let team = belongsTo(Team.self)
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            
+            struct Team: MutablePersistableRecord {
+                static let players = hasMany(Player.self)
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            
+            try db.create(table: "team") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("teamId", .integer).references("team")
+            }
+            
+            do {
+                try Player.including(required: Player.team).deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "player" WHERE rowid IN (\
+                    SELECT "player"."rowid" \
+                    FROM "player" \
+                    JOIN "team" ON "team"."id" = "player"."teamId")
+                    """)
+            }
+            do {
+                let alias = TableAlias(name: "p")
+                try Player.aliased(alias).including(required: Player.team).deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "player" WHERE rowid IN (\
+                    SELECT "p"."rowid" \
+                    FROM "player" "p" \
+                    JOIN "team" ON "team"."id" = "p"."teamId")
+                    """)
+            }
+            do {
+                try Team.having(Team.players.isEmpty).deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "team" WHERE rowid IN (\
+                    SELECT "team"."rowid" \
+                    FROM "team" \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    GROUP BY "team"."id" \
+                    HAVING COUNT(DISTINCT "player"."rowid") = 0)
+                    """)
+            }
+        }
+    }
+    
+    func testGroupedRequestDelete() throws {
+        try makeDatabaseQueue().inDatabase { db in
+            struct Player: MutablePersistableRecord {
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            struct Passport: MutablePersistableRecord {
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("score", .integer)
+            }
+            try db.create(table: "passport") { t in
+                t.column("countryCode", .text).notNull()
+                t.column("citizenId", .integer).notNull()
+                t.primaryKey(["countryCode", "citizenId"])
+            }
+            do {
+                try Player.all().groupByPrimaryKey().deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "player" WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "player" \
+                    GROUP BY "id")
+                    """)
+            }
+            do {
+                try Player.all().group(Column.rowID).deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "player" WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "player" \
+                    GROUP BY "rowid")
+                    """)
+            }
+            do {
+                try Passport.all().groupByPrimaryKey().deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "passport" WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "passport" \
+                    GROUP BY "countryCode", "citizenId")
+                    """)
+            }
+            do {
+                try Passport.all().group(Column.rowID).deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "passport" WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "passport" \
+                    GROUP BY "rowid")
+                    """)
+            }
+        }
+    }
 }

--- a/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordDeleteTests.swift
@@ -236,6 +236,12 @@ class MutablePersistableRecordDeleteTests: GRDBTestCase {
                     HAVING COUNT(DISTINCT "player"."rowid") = 0)
                     """)
             }
+            do {
+                try Team.including(all: Team.players).deleteAll(db)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    DELETE FROM "team"
+                    """)
+            }
         }
     }
     

--- a/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
@@ -442,6 +442,12 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     HAVING COUNT(DISTINCT "player"."rowid") = 0)
                     """)
             }
+            do {
+                try Team.including(all: Team.players).updateAll(db, Column("active") <- false)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "team" SET "active" = 0
+                    """)
+            }
         }
     }
     

--- a/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+import GRDBCustomSQLite
 #else
-    import GRDB
+import GRDB
 #endif
 
 private struct Player: Codable, PersistableRecord, FetchableRecord {
@@ -10,6 +10,15 @@ private struct Player: Codable, PersistableRecord, FetchableRecord {
     var name: String
     var score: Int
     var bonus: Int
+    
+    static func createTable(_ db: Database) throws {
+        try db.create(table: "player") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("name", .text)
+            t.column("score", .integer)
+            t.column("bonus", .integer)
+        }
+    }
 }
 
 private enum Columns: String, ColumnExpression {
@@ -23,19 +32,9 @@ private extension QueryInterfaceRequest where RowDecoder == Player {
 }
 
 class MutablePersistableRecordUpdateTests: GRDBTestCase {
-    override func setup(_ dbWriter: DatabaseWriter) throws {
-        try dbWriter.write { db in
-            try db.create(table: "player") { t in
-                t.autoIncrementedPrimaryKey("id")
-                t.column("name", .text)
-                t.column("score", .integer)
-                t.column("bonus", .integer)
-            }
-        }
-    }
-    
     func testRequestUpdateAll() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
             let assignment = Columns.score <- 0
             
             try Player.updateAll(db, assignment)
@@ -57,7 +56,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0 WHERE "id" IN (1, 2)
                 """)
-
+            
             try Player.filter(sql: "id = 1").updateAll(db, assignment)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0 WHERE id = 1
@@ -67,7 +66,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0 WHERE (id = 1) AND (\"name\" = 'Arthur')
                 """)
-
+            
             try Player.select(Columns.name).updateAll(db, assignment)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
@@ -88,7 +87,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0
                     """)
-
+                
                 try Player.order(Columns.name).limit(1).updateAll(db, assignment)
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 ORDER BY \"name\" LIMIT 1
@@ -109,6 +108,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testComplexAssignment() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Columns.score <- Columns.score * (Columns.bonus + 1))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" * ("bonus" + 1)
@@ -118,6 +119,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testAssignmentSubtractAndAssign() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Columns.score -= 1)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" - 1
@@ -132,7 +135,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" - (-"bonus")
                 """)
-
+            
             try Player.updateAll(db, Columns.score -= Columns.bonus * 2)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" - ("bonus" * 2)
@@ -142,6 +145,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testAssignmentAddAndAssign() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Columns.score += 1)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" + 1
@@ -156,7 +161,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" + (-"bonus")
                 """)
-
+            
             try Player.updateAll(db, Columns.score += Columns.bonus * 2)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" + ("bonus" * 2)
@@ -166,6 +171,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testAssignmentMultiplyAndAssign() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Columns.score *= 1)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" * 1
@@ -180,7 +187,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" * (-"bonus")
                 """)
-
+            
             try Player.updateAll(db, Columns.score *= Columns.bonus * 2)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" * ("bonus" * 2)
@@ -190,6 +197,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testAssignmentDivideAndAssign() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Columns.score /= 1)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" / 1
@@ -204,16 +213,18 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" / (-"bonus")
                 """)
-
+            
             try Player.updateAll(db, Columns.score /= Columns.bonus * 2)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" / ("bonus" * 2)
                 """)
         }
     }
-
+    
     func testMultipleAssignments() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Columns.score <- 0, Columns.bonus <- 1)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
@@ -238,15 +249,17 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testUpdateAllWithoutAssignmentDoesNotAccessTheDatabase() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
             sqlQueries.removeAll()
             try XCTAssertEqual(Player.updateAll(db, []), 0)
             try XCTAssertEqual(Player.all().updateAll(db, []), 0)
             XCTAssert(sqlQueries.isEmpty)
         }
     }
-
+    
     func testUpdateAllReturnsNumberOfUpdatedRows() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
             try Player(id: 1, name: "Arthur", score: 0, bonus: 2).insert(db)
             try Player(id: 2, name: "Barbara", score: 0, bonus: 1).insert(db)
             try Player(id: 3, name: "Craig", score: 0, bonus: 0).insert(db)
@@ -269,6 +282,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testQueryInterfaceExtension() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
             try Player(id: 1, name: "Arthur", score: 0, bonus: 0).insert(db)
             try Player(id: 2, name: "Barbara", score: 0, bonus: 0).insert(db)
             try Player(id: 3, name: "Craig", score: 0, bonus: 0).insert(db)
@@ -289,6 +303,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             func encode(to container: inout PersistenceContainer) { }
         }
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try AbortPlayer.updateAll(db, Column("score") <- 0)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
@@ -303,7 +319,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
-
+            
             try AbortPlayer.all().updateAll(db, [Column("score") <- 0])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
@@ -318,6 +334,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             func encode(to container: inout PersistenceContainer) { }
         }
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try IgnorePlayer.updateAll(db, Column("score") <- 0)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
@@ -342,6 +360,8 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     
     func testConflictPolicyCustom() throws {
         try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
             try Player.updateAll(db, Column("score") <- 0)
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
@@ -366,6 +386,119 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
+        }
+    }
+    
+    func testJoinedRequestUpdate() throws {
+        try makeDatabaseQueue().inDatabase { db in
+            struct Player: MutablePersistableRecord {
+                static let team = belongsTo(Team.self)
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            
+            struct Team: MutablePersistableRecord {
+                static let players = hasMany(Player.self)
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            
+            try db.create(table: "team") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("active", .boolean)
+            }
+            
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("teamId", .integer).references("team")
+                t.column("score", .integer)
+            }
+            
+            do {
+                try Player.including(required: Player.team).updateAll(db, Column("score") <- 0)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "player" SET "score" = 0 WHERE rowid IN (\
+                    SELECT "player"."rowid" \
+                    FROM "player" \
+                    JOIN "team" ON "team"."id" = "player"."teamId")
+                    """)
+            }
+            do {
+                let alias = TableAlias(name: "p")
+                try Player.aliased(alias).including(required: Player.team).updateAll(db, Column("score") <- 0)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "player" SET "score" = 0 WHERE rowid IN (\
+                    SELECT "p"."rowid" \
+                    FROM "player" "p" \
+                    JOIN "team" ON "team"."id" = "p"."teamId")
+                    """)
+            }
+            do {
+                try Team.having(Team.players.isEmpty).updateAll(db, Column("active") <- false)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "team" SET "active" = 0 WHERE rowid IN (\
+                    SELECT "team"."rowid" \
+                    FROM "team" \
+                    LEFT JOIN "player" ON "player"."teamId" = "team"."id" \
+                    GROUP BY "team"."id" \
+                    HAVING COUNT(DISTINCT "player"."rowid") = 0)
+                    """)
+            }
+        }
+    }
+    
+    func testGroupedRequestUpdate() throws {
+        try makeDatabaseQueue().inDatabase { db in
+            struct Player: MutablePersistableRecord {
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            struct Passport: MutablePersistableRecord {
+                func encode(to container: inout PersistenceContainer) { preconditionFailure("should not be called") }
+            }
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("score", .integer)
+            }
+            try db.create(table: "passport") { t in
+                t.column("countryCode", .text).notNull()
+                t.column("citizenId", .integer).notNull()
+                t.column("active", .boolean)
+                t.primaryKey(["countryCode", "citizenId"])
+            }
+            do {
+                try Player.all().groupByPrimaryKey().updateAll(db, Column("score") <- 0)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "player" SET "score" = 0 WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "player" \
+                    GROUP BY "id")
+                    """)
+            }
+            do {
+                try Player.all().group(Column.rowID).updateAll(db, Column("score") <- 0)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "player" SET "score" = 0 WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "player" \
+                    GROUP BY "rowid")
+                    """)
+            }
+            do {
+                try Passport.all().groupByPrimaryKey().updateAll(db, Column("active") <- true)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "passport" SET "active" = 1 WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "passport" \
+                    GROUP BY "countryCode", "citizenId")
+                    """)
+            }
+            do {
+                try Passport.all().group(Column.rowID).updateAll(db, Column("active") <- true)
+                XCTAssertEqual(self.lastSQLQuery, """
+                    UPDATE "passport" SET "active" = 1 WHERE rowid IN (\
+                    SELECT "rowid" \
+                    FROM "passport" \
+                    GROUP BY "rowid")
+                    """)
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request makes it possible to use the `deleteAll` and `updateAll` methods with more query interface requests. Generally speaking, requests that are joined, or grouped on a unique key, can now be batch deleted or updated, when previous versions of GRDB would raise a fatal error.

For example:

```swift
try dbQueue.write { db in
    // All teams without players
    let request = Team.having(Team.players.isEmpty)
    try request.deleteAll(db)
    try request.updateAll(db, Column("active") <- false)
    
    // All players whose team is inactive
    let request = Player.joining(required: Player.team.filter(Column("active") == false))
    try request.deleteAll(db)
    try request.updateAll(db, Column("score") <- 0)
}
```
