### PR TITLE
Fix associations altered by another association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -61,9 +59,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**Fixed**
+
+- [#677](https://github.com/groue/GRDB.swift/pull/677): Fix associations altered by another association
 
 
 ## 4.8.0

--- a/GRDB/QueryInterface/SQL/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQL/SQLRelation.swift
@@ -376,7 +376,7 @@ extension SQLRelation {
     
     func filteringChildren(_ included: (Child) throws -> Bool) rethrows -> SQLRelation {
         var relation = self
-        try relation.children = relation.children.filter { try included($1) }
+        relation.children = try relation.children.filter { try included($1) }
         return relation
     }
 }

--- a/GRDB/QueryInterface/SQL/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQL/SQLRelation.swift
@@ -167,8 +167,14 @@ struct SQLRelation {
             case .allPrefetched:
                 return [child.makeAssociationForKey(key)]
             case .oneOptional, .oneRequired, .allNotPrefetched:
-                return child.relation.prefetchedAssociations.map {
-                    $0.through(child.makeAssociationForKey(key))
+                return child.relation.prefetchedAssociations.map { association in
+                    // Remove redundant pivot child
+                    let pivotKey = association.pivot.keyName
+                    let child = child.mapRelation { relation in
+                        assert(relation.children[pivotKey] != nil)
+                        return relation.removingChild(forKey: pivotKey)
+                    }
+                    return association.through(child.makeAssociationForKey(key))
                 }
             }
         }
@@ -193,6 +199,14 @@ extension SQLRelation {
     func select(_ selection: [SQLSelectable]) -> SQLRelation {
         var relation = self
         relation.selection = selection
+        return relation
+    }
+    
+    /// Removes all selections from chidren
+    func selectOnly(_ selection: [SQLSelectable]) -> SQLRelation {
+        var relation = self
+        relation.selection = selection
+        relation.children = relation.children.mapValues { $0.mapRelation { $0.selectOnly([]) } }
         return relation
     }
     
@@ -239,12 +253,6 @@ extension SQLRelation {
 }
 
 extension SQLRelation {
-    func deletingChildren() -> SQLRelation {
-        var relation = self
-        relation.children = [:]
-        return relation
-    }
-    
     /// Returns a relation extended with an association.
     ///
     /// This method provides support for public joining methods such
@@ -357,6 +365,18 @@ extension SQLRelation {
         } else {
             relation.children.appendValue(child, forKey: key)
         }
+        return relation
+    }
+    
+    func removingChild(forKey key: String) -> SQLRelation {
+        var relation = self
+        relation.children.removeValue(forKey: key)
+        return relation
+    }
+    
+    func filteringChildren(_ included: (Child) throws -> Bool) rethrows -> SQLRelation {
+        var relation = self
+        try relation.children = relation.children.filter { try included($1) }
         return relation
     }
 }
@@ -616,16 +636,16 @@ struct SQLAssociationCondition: Equatable {
             // Join on a multiple columns.
             // ((table.a = 1) AND (table.b = 2)) OR ((table.a = 3) AND (table.b = 4)) ...
             return leftRows
-                .map { leftRow in
+                .map({ leftRow in
                     // (table.a = 1) AND (table.b = 2)
                     columnMappings
-                        .map { columns -> SQLExpression in
+                        .map({ columns -> SQLExpression in
                             let rightColumn = QualifiedColumn(columns.right, alias: rightAlias)
                             let leftValue = leftRow[columns.left] as DatabaseValue
                             return rightColumn == leftValue
-                        }
+                        })
                         .joined(operator: .and)
-                }
+                })
                 .joined(operator: .or)
         }
     }

--- a/GRDB/Utils/OrderedDictionary.swift
+++ b/GRDB/Utils/OrderedDictionary.swift
@@ -17,6 +17,12 @@ struct OrderedDictionary<Key: Hashable, Value> {
         return keys.map { dictionary[$0]! }
     }
     
+    private init(keys: [Key], dictionary: [Key: Value]) {
+        assert(Set(keys) == Set(dictionary.keys))
+        self.keys = keys
+        self.dictionary = dictionary
+    }
+    
     /// Creates an empty ordered dictionary.
     init() {
         keys = []
@@ -107,6 +113,12 @@ struct OrderedDictionary<Key: Hashable, Value> {
                 dict.appendValue(value, forKey: pair.key)
             }
         }
+    }
+    
+    func filter(_ isIncluded: ((key: Key, value: Value)) throws -> Bool) rethrows -> OrderedDictionary<Key, Value> {
+        let dictionary = try self.dictionary.filter(isIncluded)
+        let keys = self.keys.filter(dictionary.keys.contains)
+        return OrderedDictionary(keys: keys, dictionary: dictionary)
     }
 }
 

--- a/Tests/GRDBTests/AssociationHasManySQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManySQLTests.swift
@@ -764,4 +764,75 @@ class AssociationHasManySQLTests: GRDBTestCase {
             }
         }
     }
+    
+    func testJoinedAssociation() throws {
+        struct Toy: TableRecord { }
+        struct Child: TableRecord {
+            static let toy = hasOne(Toy.self)
+            static let parent = belongsTo(Parent.self)
+        }
+        struct Parent: TableRecord, EncodableRecord {
+            static let children = hasMany(Child.self)
+            func encode(to container: inout PersistenceContainer) {
+                container["id"] = 1
+            }
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "child") { t in
+                t.column("parentId", .integer).references("parent")
+            }
+            try db.create(table: "toy") { t in
+                t.column("childId", .integer).references("child")
+            }
+        }
+        
+        try dbQueue.inDatabase { db in
+            do {
+                let association = Parent.children.joining(required: Child.toy)
+                try assertEqualSQL(db, Parent.all().including(required: association), """
+                    SELECT "parent".*, "child".* \
+                    FROM "parent" JOIN "child" ON "child"."parentId" = "parent"."id" \
+                    JOIN "toy" ON "toy"."childId" = "child"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent.all().joining(required: association), """
+                    SELECT "parent".* FROM "parent" \
+                    JOIN "child" ON "child"."parentId" = "parent"."id" \
+                    JOIN "toy" ON "toy"."childId" = "child"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent().request(for: association), """
+                    SELECT "child".* \
+                    FROM "child" \
+                    JOIN "toy" ON "toy"."childId" = "child"."rowid" \
+                    WHERE "child"."parentId" = 1
+                    """)
+            }
+            do {
+                // not a realistic use case, but testable anyway
+                let association = Parent.children.joining(required: Child.parent)
+                try assertEqualSQL(db, Parent.all().including(required: association), """
+                    SELECT "parent1".*, "child".* \
+                    FROM "parent" "parent1" \
+                    JOIN "child" ON "child"."parentId" = "parent1"."id" \
+                    JOIN "parent" "parent2" ON "parent2"."id" = "child"."parentId"
+                    """)
+                try assertEqualSQL(db, Parent.all().joining(required: association), """
+                    SELECT "parent1".* \
+                    FROM "parent" "parent1" \
+                    JOIN "child" ON "child"."parentId" = "parent1"."id" \
+                    JOIN "parent" "parent2" ON "parent2"."id" = "child"."parentId"
+                    """)
+                try assertEqualSQL(db, Parent().request(for: association), """
+                    SELECT "child".* \
+                    FROM "child" \
+                    JOIN "parent" ON "parent"."id" = "child"."parentId" \
+                    WHERE "child"."parentId" = 1
+                    """)
+            }
+        }
+    }
 }

--- a/Tests/GRDBTests/AssociationHasManySQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManySQLTests.swift
@@ -765,7 +765,7 @@ class AssociationHasManySQLTests: GRDBTestCase {
         }
     }
     
-    func testJoinedAssociation() throws {
+    func testAssociationFilteredByOtherAssociation() throws {
         struct Toy: TableRecord { }
         struct Child: TableRecord {
             static let toy = hasOne(Toy.self)

--- a/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
@@ -313,4 +313,125 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
                 """)
         }
     }
+    
+    func testJoinedAssociation() throws {
+        struct Pet: TableRecord {
+            static let child = belongsTo(Child.self)
+        }
+        struct Toy: TableRecord { }
+        struct Child: TableRecord {
+            static let toy = hasOne(Toy.self)
+            static let pets = hasMany(Pet.self)
+        }
+        struct Parent: TableRecord, EncodableRecord {
+            static let children = hasMany(Child.self)
+            func encode(to container: inout PersistenceContainer) {
+                container["id"] = 1
+            }
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "parent") { t in
+                t.autoIncrementedPrimaryKey("id")
+            }
+            try db.create(table: "child") { t in
+                t.column("parentId", .integer).references("parent")
+            }
+            try db.create(table: "toy") { t in
+                t.column("childId", .integer).references("child")
+            }
+            try db.create(table: "pet") { t in
+                t.column("childId", .integer).references("child")
+            }
+        }
+        
+        try dbQueue.inDatabase { db in
+            do {
+                let association = Parent.hasMany(
+                    Pet.self,
+                    through: Parent.children.joining(required: Child.toy),
+                    using: Child.pets)
+                try assertEqualSQL(db, Parent.all().including(required: association), """
+                    SELECT "parent".*, "pet".* \
+                    FROM "parent" \
+                    JOIN "child" ON "child"."parentId" = "parent"."id" \
+                    JOIN "toy" ON "toy"."childId" = "child"."rowid" \
+                    JOIN "pet" ON "pet"."childId" = "child"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent.all().joining(required: association), """
+                    SELECT "parent".* \
+                    FROM "parent" \
+                    JOIN "child" ON "child"."parentId" = "parent"."id" \
+                    JOIN "toy" ON "toy"."childId" = "child"."rowid" \
+                    JOIN "pet" ON "pet"."childId" = "child"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent().request(for: association), """
+                    SELECT "pet".* \
+                    FROM "pet" \
+                    JOIN "child" ON ("child"."rowid" = "pet"."childId") AND ("child"."parentId" = 1) \
+                    JOIN "toy" ON "toy"."childId" = "child"."rowid"
+                    """)
+            }
+            do {
+                let association = Parent.hasMany(
+                    Pet.self,
+                    through: Parent.children.filter(sql: "1 + 1"),
+                    using: Child.pets.joining(required: Pet.child.filter(sql: "1").joining(required: Child.toy)))
+                try assertEqualSQL(db, Parent.all().including(required: association), """
+                    SELECT "parent".*, "pet".* \
+                    FROM "parent" \
+                    JOIN "child" "child1" ON ("child1"."parentId" = "parent"."id") AND (1 + 1) \
+                    JOIN "pet" ON "pet"."childId" = "child1"."rowid" \
+                    JOIN "child" "child2" ON ("child2"."rowid" = "pet"."childId") AND (1) \
+                    JOIN "toy" ON "toy"."childId" = "child2"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent.all().joining(required: association), """
+                    SELECT "parent".* \
+                    FROM "parent" \
+                    JOIN "child" "child1" ON ("child1"."parentId" = "parent"."id") AND (1 + 1) \
+                    JOIN "pet" ON "pet"."childId" = "child1"."rowid" \
+                    JOIN "child" "child2" ON ("child2"."rowid" = "pet"."childId") AND (1) \
+                    JOIN "toy" ON "toy"."childId" = "child2"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent().request(for: association), """
+                    SELECT "pet".* \
+                    FROM "pet" \
+                    JOIN "child" "child1" ON ("child1"."rowid" = "pet"."childId") AND (1) \
+                    JOIN "toy" ON "toy"."childId" = "child1"."rowid" \
+                    JOIN "child" "child2" ON ("child2"."rowid" = "pet"."childId") AND (1 + 1) AND ("child2"."parentId" = 1)
+                    """)
+            }
+            do {
+                let association = Parent.hasMany(
+                    Pet.self,
+                    through: Parent.children.filter(sql: "1 + 1"),
+                    using: Child.pets)
+                    .joining(required: Pet.child.filter(sql: "1").joining(required: Child.toy))
+                try assertEqualSQL(db, Parent.all().including(required: association), """
+                    SELECT "parent".*, "pet".* \
+                    FROM "parent" \
+                    JOIN "child" "child1" ON ("child1"."parentId" = "parent"."id") AND (1 + 1) \
+                    JOIN "pet" ON "pet"."childId" = "child1"."rowid" \
+                    JOIN "child" "child2" ON ("child2"."rowid" = "pet"."childId") AND (1) \
+                    JOIN "toy" ON "toy"."childId" = "child2"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent.all().joining(required: association), """
+                    SELECT "parent".* \
+                    FROM "parent" \
+                    JOIN "child" "child1" ON ("child1"."parentId" = "parent"."id") AND (1 + 1) \
+                    JOIN "pet" ON "pet"."childId" = "child1"."rowid" \
+                    JOIN "child" "child2" ON ("child2"."rowid" = "pet"."childId") AND (1) \
+                    JOIN "toy" ON "toy"."childId" = "child2"."rowid"
+                    """)
+                try assertEqualSQL(db, Parent().request(for: association), """
+                    SELECT "pet".* \
+                    FROM "pet" \
+                    JOIN "child" "child1" ON ("child1"."rowid" = "pet"."childId") AND (1) \
+                    JOIN "toy" ON "toy"."childId" = "child1"."rowid" \
+                    JOIN "child" "child2" ON ("child2"."rowid" = "pet"."childId") AND (1 + 1) AND ("child2"."parentId" = 1)
+                    """)
+            }
+        }
+    }
 }

--- a/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasManyThroughSQLTests.swift
@@ -314,7 +314,7 @@ class AssociationHasManyThroughSQLTests: GRDBTestCase {
         }
     }
     
-    func testJoinedAssociation() throws {
+    func testAssociationFilteredByOtherAssociation() throws {
         struct Pet: TableRecord {
             static let child = belongsTo(Child.self)
         }


### PR DESCRIPTION
This pull request fixes some requests that involve an association altered by another association.

For example, the `Author.translatedBooks` association below is such an altered association:

```swift
extension Book {
    static let translator = belongsTo(Translator.self)
}
extension Author {
    static let books = hasMany(Book.self)
    
    // A book is translated if it is associated to a translator
    static let translatedBooks = books.joining(required: Book.translator)
}
```

Some requests that involve those altered associations used to erroneously drop the alteration.

- Requests which use the altered association with the `request(for:)` method:

    ```swift
    // Fixed
    extension Author {
        var translatedBooks: QueryInterfaceRequest<Book> {
            request(for: Author.translatedBooks) // !
        }
    }
    let author: Author = ...
    let translatedBooks: [Book] = try author.translatedBooks.fetchAll(db)
    ```

- Requests that eager load an hasManyThrough association based on the altered association:

    ```swift
    // Fixed
    extension Book {
        static let awards = hasMany(Award.self)
    }
    extension Author {
        static let awardsForTranslatedBooks = hasMany(
            Award.self,
            through: translatedBooks,            // !
            using: Book.awards)
    }
    struct AuthorInfo: Decodable, FetchableRecord {
        var author: Author
        var awardsForTranslatedBooks: [Award]
    }
    let authorInfos: [AuthorInfo] = try Author
        .including(all: Author.awardsForTranslatedBooks)
        .asRequest(of: AuthorInfo.self)
        .fetchAll(db)
    ```
