### PR TITLE
Adding Multiple Section Support to FetchedRecordsController

### DIFF
--- a/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS/Player.swift
+++ b/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS/Player.swift
@@ -17,7 +17,7 @@ extension Player: Hashable { }
 // See https://github.com/groue/GRDB.swift/blob/master/README.md#records
 extension Player: Codable, FetchableRecord, MutablePersistableRecord {
     // Define database columns from CodingKeys
-    private enum Columns {
+    enum Columns {
         static let id = Column(CodingKeys.id)
         static let name = Column(CodingKeys.name)
         static let score = Column(CodingKeys.score)

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0489816B23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
+		0489816C23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
+		0489816D23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
+		0489816E23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
 		31A778841C6A4E0600F507F6 /* FetchedRecordsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */; };
 		560432A0228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
 		560432A1228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
@@ -1180,6 +1184,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0489816A23CD8EEE0012BC8A /* Diff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diff.swift; sourceTree = "<group>"; };
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
@@ -1956,6 +1961,7 @@
 				5659F4971EA8D989004A4992 /* Pool.swift */,
 				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
 				5659F4871EA8D94E004A4992 /* Utils.swift */,
+				0489816A23CD8EEE0012BC8A /* Diff.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2732,6 +2738,7 @@
 				56B964BF1DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
 				56D51D061EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				565490CE1D5AE252005622CB /* NSNull.swift in Sources */,
+				0489816D23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				5656A8202295B12F001FF3FF /* SQLAssociation.swift in Sources */,
 				565490E41D5AE252005622CB /* TableRecord.swift in Sources */,
 				564CE5AE21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
@@ -2890,6 +2897,7 @@
 				5674A6F91F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				5605F18E1C6B1A8700235C62 /* SQLCollatedExpression.swift in Sources */,
 				566475D61D981D5E00FF74B8 /* SQLOperators.swift in Sources */,
+				0489816C23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				5698AD381DABAF4A0056AF8C /* FTS5CustomTokenizer.swift in Sources */,
 				5653EB0A20944C7C00F46237 /* Association.swift in Sources */,
 				56A2387E1B9C75030082EB20 /* Database.swift in Sources */,
@@ -3437,6 +3445,7 @@
 				AAA4DC7D230F1E0600C74B15 /* EncodableRecord+Encodable.swift in Sources */,
 				AAA4DC7E230F1E0600C74B15 /* SQLCollatedExpression.swift in Sources */,
 				AAA4DC7F230F1E0600C74B15 /* SQLOperators.swift in Sources */,
+				0489816E23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				AAA4DC80230F1E0600C74B15 /* FTS5CustomTokenizer.swift in Sources */,
 				AAA4DC81230F1E0600C74B15 /* Association.swift in Sources */,
 				AAA4DC82230F1E0600C74B15 /* Database.swift in Sources */,
@@ -3777,6 +3786,7 @@
 				5636E9BC1D22574100B9B05F /* FetchRequest.swift in Sources */,
 				56BB6EA91D3009B100A1CA52 /* SchedulingWatchdog.swift in Sources */,
 				563EF44A2161F179007DAACD /* Inflections.swift in Sources */,
+				0489816B23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				566B91091FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
 				566B91231FA4CF810012D5B0 /* Database+Schema.swift in Sources */,
 				5613ED3F21A95A8B00DC7A68 /* Combine.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -7,10 +7,54 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0489816B23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
-		0489816C23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
-		0489816D23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
-		0489816E23CD8EEE0012BC8A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0489816A23CD8EEE0012BC8A /* Diff.swift */; };
+		048981C623CE6F380012BC8A /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981B923CE6F370012BC8A /* ContentEquatable.swift */; };
+		048981C723CE6F380012BC8A /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981B923CE6F370012BC8A /* ContentEquatable.swift */; };
+		048981C823CE6F380012BC8A /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981B923CE6F370012BC8A /* ContentEquatable.swift */; };
+		048981C923CE6F380012BC8A /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981B923CE6F370012BC8A /* ContentEquatable.swift */; };
+		048981CA23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BA23CE6F370012BC8A /* AnyDifferentiable.swift */; };
+		048981CB23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BA23CE6F370012BC8A /* AnyDifferentiable.swift */; };
+		048981CC23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BA23CE6F370012BC8A /* AnyDifferentiable.swift */; };
+		048981CD23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BA23CE6F370012BC8A /* AnyDifferentiable.swift */; };
+		048981CE23CE6F380012BC8A /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BB23CE6F370012BC8A /* DifferentiableSection.swift */; };
+		048981CF23CE6F380012BC8A /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BB23CE6F370012BC8A /* DifferentiableSection.swift */; };
+		048981D023CE6F380012BC8A /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BB23CE6F370012BC8A /* DifferentiableSection.swift */; };
+		048981D123CE6F380012BC8A /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BB23CE6F370012BC8A /* DifferentiableSection.swift */; };
+		048981D223CE6F380012BC8A /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BC23CE6F370012BC8A /* ElementPath.swift */; };
+		048981D323CE6F380012BC8A /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BC23CE6F370012BC8A /* ElementPath.swift */; };
+		048981D423CE6F380012BC8A /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BC23CE6F370012BC8A /* ElementPath.swift */; };
+		048981D523CE6F380012BC8A /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BC23CE6F370012BC8A /* ElementPath.swift */; };
+		048981D623CE6F380012BC8A /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BE23CE6F380012BC8A /* AppKitExtension.swift */; };
+		048981D723CE6F380012BC8A /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BE23CE6F380012BC8A /* AppKitExtension.swift */; };
+		048981D823CE6F380012BC8A /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BE23CE6F380012BC8A /* AppKitExtension.swift */; };
+		048981D923CE6F380012BC8A /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BE23CE6F380012BC8A /* AppKitExtension.swift */; };
+		048981DA23CE6F380012BC8A /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BF23CE6F380012BC8A /* UIKitExtension.swift */; };
+		048981DB23CE6F380012BC8A /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BF23CE6F380012BC8A /* UIKitExtension.swift */; };
+		048981DC23CE6F380012BC8A /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BF23CE6F380012BC8A /* UIKitExtension.swift */; };
+		048981DD23CE6F380012BC8A /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981BF23CE6F380012BC8A /* UIKitExtension.swift */; };
+		048981DE23CE6F380012BC8A /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C023CE6F380012BC8A /* StagedChangeset.swift */; };
+		048981DF23CE6F380012BC8A /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C023CE6F380012BC8A /* StagedChangeset.swift */; };
+		048981E023CE6F380012BC8A /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C023CE6F380012BC8A /* StagedChangeset.swift */; };
+		048981E123CE6F380012BC8A /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C023CE6F380012BC8A /* StagedChangeset.swift */; };
+		048981E223CE6F380012BC8A /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C123CE6F380012BC8A /* Changeset.swift */; };
+		048981E323CE6F380012BC8A /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C123CE6F380012BC8A /* Changeset.swift */; };
+		048981E423CE6F380012BC8A /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C123CE6F380012BC8A /* Changeset.swift */; };
+		048981E523CE6F380012BC8A /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C123CE6F380012BC8A /* Changeset.swift */; };
+		048981E623CE6F380012BC8A /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C223CE6F380012BC8A /* ContentIdentifiable.swift */; };
+		048981E723CE6F380012BC8A /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C223CE6F380012BC8A /* ContentIdentifiable.swift */; };
+		048981E823CE6F380012BC8A /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C223CE6F380012BC8A /* ContentIdentifiable.swift */; };
+		048981E923CE6F380012BC8A /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C223CE6F380012BC8A /* ContentIdentifiable.swift */; };
+		048981EA23CE6F380012BC8A /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C323CE6F380012BC8A /* Differentiable.swift */; };
+		048981EB23CE6F380012BC8A /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C323CE6F380012BC8A /* Differentiable.swift */; };
+		048981EC23CE6F380012BC8A /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C323CE6F380012BC8A /* Differentiable.swift */; };
+		048981ED23CE6F380012BC8A /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C323CE6F380012BC8A /* Differentiable.swift */; };
+		048981EE23CE6F380012BC8A /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C423CE6F380012BC8A /* ArraySection.swift */; };
+		048981EF23CE6F380012BC8A /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C423CE6F380012BC8A /* ArraySection.swift */; };
+		048981F023CE6F380012BC8A /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C423CE6F380012BC8A /* ArraySection.swift */; };
+		048981F123CE6F380012BC8A /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C423CE6F380012BC8A /* ArraySection.swift */; };
+		048981F223CE6F380012BC8A /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C523CE6F380012BC8A /* Algorithm.swift */; };
+		048981F323CE6F380012BC8A /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C523CE6F380012BC8A /* Algorithm.swift */; };
+		048981F423CE6F380012BC8A /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C523CE6F380012BC8A /* Algorithm.swift */; };
+		048981F523CE6F380012BC8A /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048981C523CE6F380012BC8A /* Algorithm.swift */; };
 		31A778841C6A4E0600F507F6 /* FetchedRecordsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */; };
 		560432A0228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
 		560432A1228F00C2009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */; };
@@ -1184,7 +1228,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0489816A23CD8EEE0012BC8A /* Diff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diff.swift; sourceTree = "<group>"; };
+		048981B923CE6F370012BC8A /* ContentEquatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentEquatable.swift; sourceTree = "<group>"; };
+		048981BA23CE6F370012BC8A /* AnyDifferentiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDifferentiable.swift; sourceTree = "<group>"; };
+		048981BB23CE6F370012BC8A /* DifferentiableSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DifferentiableSection.swift; sourceTree = "<group>"; };
+		048981BC23CE6F370012BC8A /* ElementPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementPath.swift; sourceTree = "<group>"; };
+		048981BE23CE6F380012BC8A /* AppKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitExtension.swift; sourceTree = "<group>"; };
+		048981BF23CE6F380012BC8A /* UIKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitExtension.swift; sourceTree = "<group>"; };
+		048981C023CE6F380012BC8A /* StagedChangeset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagedChangeset.swift; sourceTree = "<group>"; };
+		048981C123CE6F380012BC8A /* Changeset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Changeset.swift; sourceTree = "<group>"; };
+		048981C223CE6F380012BC8A /* ContentIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentIdentifiable.swift; sourceTree = "<group>"; };
+		048981C323CE6F380012BC8A /* Differentiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Differentiable.swift; sourceTree = "<group>"; };
+		048981C423CE6F380012BC8A /* ArraySection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySection.swift; sourceTree = "<group>"; };
+		048981C523CE6F380012BC8A /* Algorithm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Algorithm.swift; sourceTree = "<group>"; };
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A2228F1667009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
@@ -1603,6 +1658,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		048981B823CE6F100012BC8A /* DifferenceKit-1.1.5 */ = {
+			isa = PBXGroup;
+			children = (
+				048981C523CE6F380012BC8A /* Algorithm.swift */,
+				048981BA23CE6F370012BC8A /* AnyDifferentiable.swift */,
+				048981C423CE6F380012BC8A /* ArraySection.swift */,
+				048981C123CE6F380012BC8A /* Changeset.swift */,
+				048981B923CE6F370012BC8A /* ContentEquatable.swift */,
+				048981C223CE6F380012BC8A /* ContentIdentifiable.swift */,
+				048981C323CE6F380012BC8A /* Differentiable.swift */,
+				048981BB23CE6F370012BC8A /* DifferentiableSection.swift */,
+				048981BC23CE6F370012BC8A /* ElementPath.swift */,
+				048981BD23CE6F380012BC8A /* Extensions */,
+				048981C023CE6F380012BC8A /* StagedChangeset.swift */,
+			);
+			path = "DifferenceKit-1.1.5";
+			sourceTree = "<group>";
+		};
+		048981BD23CE6F380012BC8A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				048981BE23CE6F380012BC8A /* AppKitExtension.swift */,
+				048981BF23CE6F380012BC8A /* UIKitExtension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		5605F1471C672E4000235C62 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -1953,6 +2035,7 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				048981B823CE6F100012BC8A /* DifferenceKit-1.1.5 */,
 				5659F49F1EA8D997004A4992 /* DatabaseResult.swift */,
 				563EF4492161F179007DAACD /* Inflections.swift */,
 				569BBA482291707D00478429 /* Inflections+English.swift */,
@@ -1961,7 +2044,6 @@
 				5659F4971EA8D989004A4992 /* Pool.swift */,
 				5659F48F1EA8D964004A4992 /* ReadWriteBox.swift */,
 				5659F4871EA8D94E004A4992 /* Utils.swift */,
-				0489816A23CD8EEE0012BC8A /* Diff.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -2736,9 +2818,9 @@
 			files = (
 				5616AAF3207CD45E00AC3664 /* RequestProtocols.swift in Sources */,
 				56B964BF1DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
+				048981DC23CE6F380012BC8A /* UIKitExtension.swift in Sources */,
 				56D51D061EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				565490CE1D5AE252005622CB /* NSNull.swift in Sources */,
-				0489816D23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				5656A8202295B12F001FF3FF /* SQLAssociation.swift in Sources */,
 				565490E41D5AE252005622CB /* TableRecord.swift in Sources */,
 				564CE5AE21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
@@ -2752,6 +2834,7 @@
 				5698AD1C1DAAD17F0056AF8C /* FTS5Tokenizer.swift in Sources */,
 				56CEB5171EAA324B00BFAF62 /* FTS3+QueryInterface.swift in Sources */,
 				5656A8B22295BFD7001FF3FF /* TableRecord+QueryInterfaceRequest.swift in Sources */,
+				048981D823CE6F380012BC8A /* AppKitExtension.swift in Sources */,
 				56D91AB22205F8AC00770D8D /* SQLQuery.swift in Sources */,
 				56B964B71DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				5613ED5221A95C6D00DC7A68 /* ValueObservation+DatabaseValueConvertible.swift in Sources */,
@@ -2768,10 +2851,12 @@
 				564CE43321AA901800652B19 /* ValueObserver.swift in Sources */,
 				56CEB5671EAA359A00BFAF62 /* SQLSelectable.swift in Sources */,
 				5653EB272094A14400F46237 /* QueryInterfaceRequest+Association.swift in Sources */,
+				048981F023CE6F380012BC8A /* ArraySection.swift in Sources */,
 				565490B91D5AE236005622CB /* DatabasePool.swift in Sources */,
 				563B06AD217EF0CC00B38F35 /* ValueObservation.swift in Sources */,
 				5674A6EF1F307F0E0095F066 /* DatabaseValueConvertible+Encodable.swift in Sources */,
 				565490D81D5AE252005622CB /* DatabaseMigrator.swift in Sources */,
+				048981EC23CE6F380012BC8A /* Differentiable.swift in Sources */,
 				5656A8AF2295BFD7001FF3FF /* TableRecord+Association.swift in Sources */,
 				56CEB5601EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
 				565490C21D5AE236005622CB /* Row.swift in Sources */,
@@ -2784,10 +2869,12 @@
 				566A841C2041146100E50BFD /* DatabaseSnapshot.swift in Sources */,
 				5613ED4A21A95C1200DC7A68 /* ValueObservation+Row.swift in Sources */,
 				565490D51D5AE252005622CB /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
+				048981E023CE6F380012BC8A /* StagedChangeset.swift in Sources */,
 				565490C51D5AE236005622CB /* SerializedDatabase.swift in Sources */,
 				5698AC7E1DA37DCB0056AF8C /* VirtualTableModule.swift in Sources */,
 				564CE52221B3129A00652B19 /* ValueObservation+MapReducer.swift in Sources */,
 				5698AC3D1D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
+				048981E423CE6F380012BC8A /* Changeset.swift in Sources */,
 				563EF45D2163309F007DAACD /* Inflections.swift in Sources */,
 				569D6DE0220EF9E100A058A9 /* SQLInterpolation.swift in Sources */,
 				567ECE512222E431009245CA /* GRDB-4.0.swift in Sources */,
@@ -2797,11 +2884,13 @@
 				5613ED5621A95DD000DC7A68 /* ValueObservation+Count.swift in Sources */,
 				56CEB5591EAA359A00BFAF62 /* SQLExpression.swift in Sources */,
 				5674A6FF1F307F600095F066 /* FetchableRecord+Decodable.swift in Sources */,
+				048981D023CE6F380012BC8A /* DifferentiableSection.swift in Sources */,
 				56E9FAD9221053DD00C703A8 /* SQLLiteral.swift in Sources */,
 				56B964A31DA51B4C0002DA19 /* FTS5.swift in Sources */,
 				56D91AAB2205F2F100770D8D /* DatabasePromise.swift in Sources */,
 				566475A01D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
 				565490BB1D5AE236005622CB /* DatabaseReader.swift in Sources */,
+				048981C823CE6F380012BC8A /* ContentEquatable.swift in Sources */,
 				5659F4A61EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				5674A6F81F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				565490C31D5AE236005622CB /* RowAdapter.swift in Sources */,
@@ -2814,6 +2903,7 @@
 				565490DF1D5AE252005622CB /* TableDefinition.swift in Sources */,
 				565490B71D5AE236005622CB /* Database.swift in Sources */,
 				5674A6E81F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
+				048981F423CE6F380012BC8A /* Algorithm.swift in Sources */,
 				56E9FACD221046FD00C703A8 /* SQLInterpolation+QueryInterface.swift in Sources */,
 				5653EB2320944C7C00F46237 /* HasOneAssociation.swift in Sources */,
 				565490C01D5AE236005622CB /* DatabaseWriter.swift in Sources */,
@@ -2824,6 +2914,7 @@
 				566B91291FA4CF810012D5B0 /* Database+Schema.swift in Sources */,
 				5671FC261DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				5653EC142098738B00F46237 /* SQLGenerationContext.swift in Sources */,
+				048981CC23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */,
 				56CEB5521EAA359A00BFAF62 /* SQLExpressible.swift in Sources */,
 				568D13212207213F00674B58 /* SQLQueryGenerator.swift in Sources */,
 				565490DB1D5AE252005622CB /* SQLCollatedExpression.swift in Sources */,
@@ -2834,6 +2925,7 @@
 				56FBFEDB2210731A00945324 /* SQLRequest.swift in Sources */,
 				56F5ABD91D814330001F60CB /* Data.swift in Sources */,
 				565490D41D5AE252005622CB /* (null) in Sources */,
+				048981E823CE6F380012BC8A /* ContentIdentifiable.swift in Sources */,
 				566475D21D981D5E00FF74B8 /* SQLFunctions.swift in Sources */,
 				565490B61D5AE236005622CB /* Configuration.swift in Sources */,
 				565490E11D5AE252005622CB /* PersistableRecord.swift in Sources */,
@@ -2865,6 +2957,7 @@
 				565490CD1D5AE252005622CB /* Date.swift in Sources */,
 				5653EB0820944C7C00F46237 /* SQLForeignKeyRequest.swift in Sources */,
 				565490BE1D5AE236005622CB /* DatabaseValue.swift in Sources */,
+				048981D423CE6F380012BC8A /* ElementPath.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2897,7 +2990,6 @@
 				5674A6F91F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				5605F18E1C6B1A8700235C62 /* SQLCollatedExpression.swift in Sources */,
 				566475D61D981D5E00FF74B8 /* SQLOperators.swift in Sources */,
-				0489816C23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				5698AD381DABAF4A0056AF8C /* FTS5CustomTokenizer.swift in Sources */,
 				5653EB0A20944C7C00F46237 /* Association.swift in Sources */,
 				56A2387E1B9C75030082EB20 /* Database.swift in Sources */,
@@ -2909,6 +3001,7 @@
 				5613ED4921A95C1200DC7A68 /* ValueObservation+Row.swift in Sources */,
 				566B91361FA4D3810012D5B0 /* TransactionObserver.swift in Sources */,
 				564CE43221AA901800652B19 /* ValueObserver.swift in Sources */,
+				048981EF23CE6F380012BC8A /* ArraySection.swift in Sources */,
 				56AACAA922ACED7100A40F2A /* Fetch.swift in Sources */,
 				5605F1721C672E4000235C62 /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
 				56CEB5141EAA324B00BFAF62 /* FTS3+QueryInterface.swift in Sources */,
@@ -2929,12 +3022,15 @@
 				566A841B2041146100E50BFD /* DatabaseSnapshot.swift in Sources */,
 				56CEB54F1EAA359A00BFAF62 /* SQLExpressible.swift in Sources */,
 				56A238941B9C750B0082EB20 /* DatabaseMigrator.swift in Sources */,
+				048981E323CE6F380012BC8A /* Changeset.swift in Sources */,
 				5605F16A1C672E4000235C62 /* NSString.swift in Sources */,
 				566B910C1FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
+				048981DB23CE6F380012BC8A /* UIKitExtension.swift in Sources */,
 				56A8C2331D1914540096E9D4 /* UUID.swift in Sources */,
 				560D92411C672C3E00F4F92B /* DatabaseValueConvertible.swift in Sources */,
 				566475BD1D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				56A238A51B9C753B0082EB20 /* Record.swift in Sources */,
+				048981CB23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */,
 				5671FC231DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56D51D031EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				560D924C1C672C4B00F4F92B /* TableRecord.swift in Sources */,
@@ -2953,13 +3049,16 @@
 				56AE64132229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */,
 				56A2388C1B9C75030082EB20 /* Statement.swift in Sources */,
 				5659F4931EA8D964004A4992 /* ReadWriteBox.swift in Sources */,
+				048981EB23CE6F380012BC8A /* Differentiable.swift in Sources */,
 				56D91AB12205F8AC00770D8D /* SQLQuery.swift in Sources */,
 				56B7F43B1BEB42D500E39BBF /* Migration.swift in Sources */,
 				5690C3431D23E82A00E59934 /* Data.swift in Sources */,
 				5674A7001F307F600095F066 /* FetchableRecord+Decodable.swift in Sources */,
 				5674A6E91F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
 				566B91161FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
+				048981C723CE6F380012BC8A /* ContentEquatable.swift in Sources */,
 				56FC987B1D969DEF00E3C842 /* SQLExpression+QueryInterface.swift in Sources */,
+				048981DF23CE6F380012BC8A /* StagedChangeset.swift in Sources */,
 				56A238881B9C75030082EB20 /* Row.swift in Sources */,
 				5613ED4D21A95C4300DC7A68 /* ValueObservation+FetchableRecord.swift in Sources */,
 				564CE4D721B2DEB600652B19 /* CompactMap.swift in Sources */,
@@ -2970,6 +3069,7 @@
 				5695962A222C462D002CB7C9 /* HasManyThroughAssociation.swift in Sources */,
 				563363C11C942C04000BE133 /* DatabaseReader.swift in Sources */,
 				5659F4A31EA8D997004A4992 /* DatabaseResult.swift in Sources */,
+				048981D723CE6F380012BC8A /* AppKitExtension.swift in Sources */,
 				56B964BC1DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
 				5605F1661C672E4000235C62 /* NSNull.swift in Sources */,
 				5656A8AE2295BFD7001FF3FF /* TableRecord+Association.swift in Sources */,
@@ -2988,6 +3088,7 @@
 				56FBFED92210731A00945324 /* SQLRequest.swift in Sources */,
 				5644DE6E20F8C32E001FFDDE /* DatabaseValueConversion.swift in Sources */,
 				C96C0F2C2084A459006B2981 /* SQLiteDateParser.swift in Sources */,
+				048981CF23CE6F380012BC8A /* DifferentiableSection.swift in Sources */,
 				5605F1681C672E4000235C62 /* NSNumber.swift in Sources */,
 				5613ED5521A95DD000DC7A68 /* ValueObservation+Count.swift in Sources */,
 				564CE5AD21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
@@ -3009,9 +3110,12 @@
 				56CEB55D1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
 				566B91261FA4CF810012D5B0 /* Database+Schema.swift in Sources */,
 				566B912E1FA4D0CC0012D5B0 /* StatementAuthorizer.swift in Sources */,
+				048981D323CE6F380012BC8A /* ElementPath.swift in Sources */,
 				56CEB5641EAA359A00BFAF62 /* SQLSelectable.swift in Sources */,
 				56D91AA32205E03700770D8D /* SQLRelation.swift in Sources */,
 				564F9C311F07611600877A00 /* DatabaseFunction.swift in Sources */,
+				048981F323CE6F380012BC8A /* Algorithm.swift in Sources */,
+				048981E723CE6F380012BC8A /* ContentIdentifiable.swift in Sources */,
 				564CE59E21B7A8B500652B19 /* RemoveDuplicates.swift in Sources */,
 				56B964A01DA51B4C0002DA19 /* FTS5.swift in Sources */,
 				5674A6F01F307F0E0095F066 /* DatabaseValueConvertible+Encodable.swift in Sources */,
@@ -3445,7 +3549,6 @@
 				AAA4DC7D230F1E0600C74B15 /* EncodableRecord+Encodable.swift in Sources */,
 				AAA4DC7E230F1E0600C74B15 /* SQLCollatedExpression.swift in Sources */,
 				AAA4DC7F230F1E0600C74B15 /* SQLOperators.swift in Sources */,
-				0489816E23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				AAA4DC80230F1E0600C74B15 /* FTS5CustomTokenizer.swift in Sources */,
 				AAA4DC81230F1E0600C74B15 /* Association.swift in Sources */,
 				AAA4DC82230F1E0600C74B15 /* Database.swift in Sources */,
@@ -3457,6 +3560,7 @@
 				AAA4DC88230F1E0600C74B15 /* ValueObservation+Row.swift in Sources */,
 				AAA4DC89230F1E0600C74B15 /* TransactionObserver.swift in Sources */,
 				AAA4DC8A230F1E0600C74B15 /* ValueObserver.swift in Sources */,
+				048981F123CE6F380012BC8A /* ArraySection.swift in Sources */,
 				AAA4DC8B230F1E0600C74B15 /* Fetch.swift in Sources */,
 				AAA4DC8C230F1E0600C74B15 /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
 				AAA4DC8D230F1E0600C74B15 /* FTS3+QueryInterface.swift in Sources */,
@@ -3477,12 +3581,15 @@
 				AAA4DC9C230F1E0600C74B15 /* DatabaseSnapshot.swift in Sources */,
 				AAA4DC9D230F1E0600C74B15 /* SQLExpressible.swift in Sources */,
 				AAA4DC9E230F1E0600C74B15 /* DatabaseMigrator.swift in Sources */,
+				048981E523CE6F380012BC8A /* Changeset.swift in Sources */,
 				AAA4DC9F230F1E0600C74B15 /* NSString.swift in Sources */,
 				AAA4DCA0230F1E0600C74B15 /* Database+Statements.swift in Sources */,
+				048981DD23CE6F380012BC8A /* UIKitExtension.swift in Sources */,
 				AAA4DCA1230F1E0600C74B15 /* UUID.swift in Sources */,
 				AAA4DCA2230F1E0600C74B15 /* DatabaseValueConvertible.swift in Sources */,
 				AAA4DCA3230F1E0600C74B15 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				AAA4DCA4230F1E0600C74B15 /* Record.swift in Sources */,
+				048981CD23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */,
 				AAA4DCA5230F1E0600C74B15 /* FTS3TokenizerDescriptor.swift in Sources */,
 				AAA4DCA6230F1E0600C74B15 /* FetchableRecord+TableRecord.swift in Sources */,
 				AAA4DCA7230F1E0600C74B15 /* TableRecord.swift in Sources */,
@@ -3501,13 +3608,16 @@
 				AAA4DCB4230F1E0600C74B15 /* HasOneThroughAssociation.swift in Sources */,
 				AAA4DCB5230F1E0600C74B15 /* Statement.swift in Sources */,
 				AAA4DCB6230F1E0600C74B15 /* ReadWriteBox.swift in Sources */,
+				048981ED23CE6F380012BC8A /* Differentiable.swift in Sources */,
 				AAA4DCB7230F1E0600C74B15 /* SQLQuery.swift in Sources */,
 				AAA4DCB8230F1E0600C74B15 /* Migration.swift in Sources */,
 				AAA4DCB9230F1E0600C74B15 /* Data.swift in Sources */,
 				AAA4DCBA230F1E0600C74B15 /* FetchableRecord+Decodable.swift in Sources */,
 				AAA4DCBB230F1E0600C74B15 /* DatabaseValueConvertible+Decodable.swift in Sources */,
 				AAA4DCBC230F1E0600C74B15 /* DatabaseCollation.swift in Sources */,
+				048981C923CE6F380012BC8A /* ContentEquatable.swift in Sources */,
 				AAA4DCBD230F1E0600C74B15 /* SQLExpression+QueryInterface.swift in Sources */,
+				048981E123CE6F380012BC8A /* StagedChangeset.swift in Sources */,
 				AAA4DCBE230F1E0600C74B15 /* Row.swift in Sources */,
 				AAA4DCBF230F1E0600C74B15 /* ValueObservation+FetchableRecord.swift in Sources */,
 				AAA4DCC0230F1E0600C74B15 /* CompactMap.swift in Sources */,
@@ -3518,6 +3628,7 @@
 				AAA4DCC5230F1E0600C74B15 /* HasManyThroughAssociation.swift in Sources */,
 				AAA4DCC6230F1E0600C74B15 /* DatabaseReader.swift in Sources */,
 				AAA4DCC7230F1E0600C74B15 /* DatabaseResult.swift in Sources */,
+				048981D923CE6F380012BC8A /* AppKitExtension.swift in Sources */,
 				AAA4DCC8230F1E0600C74B15 /* FTS5Pattern.swift in Sources */,
 				AAA4DCC9230F1E0600C74B15 /* NSNull.swift in Sources */,
 				AAA4DCCA230F1E0600C74B15 /* TableRecord+Association.swift in Sources */,
@@ -3536,6 +3647,7 @@
 				AAA4DCD6230F1E0600C74B15 /* SQLRequest.swift in Sources */,
 				AAA4DCD7230F1E0600C74B15 /* DatabaseValueConversion.swift in Sources */,
 				AAA4DCD8230F1E0600C74B15 /* SQLiteDateParser.swift in Sources */,
+				048981D123CE6F380012BC8A /* DifferentiableSection.swift in Sources */,
 				AAA4DCD9230F1E0600C74B15 /* NSNumber.swift in Sources */,
 				AAA4DCDA230F1E0600C74B15 /* ValueObservation+Count.swift in Sources */,
 				AAA4DCDB230F1E0600C74B15 /* DatabaseRegionObservation.swift in Sources */,
@@ -3557,9 +3669,12 @@
 				AAA4DCEB230F1E0600C74B15 /* SQLOrdering.swift in Sources */,
 				AAA4DCEC230F1E0600C74B15 /* Database+Schema.swift in Sources */,
 				AAA4DCED230F1E0600C74B15 /* StatementAuthorizer.swift in Sources */,
+				048981D523CE6F380012BC8A /* ElementPath.swift in Sources */,
 				AAA4DCEE230F1E0600C74B15 /* SQLSelectable.swift in Sources */,
 				AAA4DCEF230F1E0600C74B15 /* SQLRelation.swift in Sources */,
 				AAA4DCF0230F1E0600C74B15 /* DatabaseFunction.swift in Sources */,
+				048981F523CE6F380012BC8A /* Algorithm.swift in Sources */,
+				048981E923CE6F380012BC8A /* ContentIdentifiable.swift in Sources */,
 				AAA4DCF1230F1E0600C74B15 /* RemoveDuplicates.swift in Sources */,
 				AAA4DCF2230F1E0600C74B15 /* FTS5.swift in Sources */,
 				AAA4DCF3230F1E0600C74B15 /* DatabaseValueConvertible+Encodable.swift in Sources */,
@@ -3786,7 +3901,6 @@
 				5636E9BC1D22574100B9B05F /* FetchRequest.swift in Sources */,
 				56BB6EA91D3009B100A1CA52 /* SchedulingWatchdog.swift in Sources */,
 				563EF44A2161F179007DAACD /* Inflections.swift in Sources */,
-				0489816B23CD8EEE0012BC8A /* Diff.swift in Sources */,
 				566B91091FA4C3970012D5B0 /* Database+Statements.swift in Sources */,
 				566B91231FA4CF810012D5B0 /* Database+Schema.swift in Sources */,
 				5613ED3F21A95A8B00DC7A68 /* Combine.swift in Sources */,
@@ -3798,6 +3912,7 @@
 				56CEB4F11EAA2EFA00BFAF62 /* FetchableRecord.swift in Sources */,
 				56D91AA22205E03700770D8D /* SQLRelation.swift in Sources */,
 				56300B781C53F592005A543B /* QueryInterfaceRequest.swift in Sources */,
+				048981EE23CE6F380012BC8A /* ArraySection.swift in Sources */,
 				56AACAA822ACED7100A40F2A /* Fetch.swift in Sources */,
 				5605F18D1C6B1A8700235C62 /* SQLCollatedExpression.swift in Sources */,
 				5613ED5421A95DD000DC7A68 /* ValueObservation+Count.swift in Sources */,
@@ -3818,12 +3933,15 @@
 				566475CC1D981D5E00FF74B8 /* SQLFunctions.swift in Sources */,
 				5698AC371D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
 				563EF415215F87EB007DAACD /* OrderedDictionary.swift in Sources */,
+				048981E223CE6F380012BC8A /* Changeset.swift in Sources */,
 				564F9C2D1F075DD200877A00 /* DatabaseFunction.swift in Sources */,
 				564CE5AC21B8FAB400652B19 /* DatabaseRegionObservation.swift in Sources */,
+				048981DA23CE6F380012BC8A /* UIKitExtension.swift in Sources */,
 				5659F4981EA8D989004A4992 /* Pool.swift in Sources */,
 				5674A6F41F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				56CEB54C1EAA359A00BFAF62 /* SQLExpressible.swift in Sources */,
 				5664759A1D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
+				048981CA23CE6F380012BC8A /* AnyDifferentiable.swift in Sources */,
 				567404881CEF84C8003ED5CC /* RowAdapter.swift in Sources */,
 				5653EB0320944C7C00F46237 /* BelongsToAssociation.swift in Sources */,
 				563363C41C942C37000BE133 /* DatabaseWriter.swift in Sources */,
@@ -3842,13 +3960,16 @@
 				56AE64122229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */,
 				56CEB55A1EAA359A00BFAF62 /* SQLOrdering.swift in Sources */,
 				56A238811B9C75030082EB20 /* DatabaseError.swift in Sources */,
+				048981EA23CE6F380012BC8A /* Differentiable.swift in Sources */,
 				56D51D001EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				566475BA1D981AD200FF74B8 /* SQLSpecificExpressible+QueryInterface.swift in Sources */,
 				5653EB0920944C7C00F46237 /* Association.swift in Sources */,
 				56A238851B9C75030082EB20 /* DatabaseValue.swift in Sources */,
 				5671FC201DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56A238A41B9C753B0082EB20 /* Record.swift in Sources */,
+				048981C623CE6F380012BC8A /* ContentEquatable.swift in Sources */,
 				56CEB5451EAA359A00BFAF62 /* Column.swift in Sources */,
+				048981DE23CE6F380012BC8A /* StagedChangeset.swift in Sources */,
 				5613ED5021A95C6D00DC7A68 /* ValueObservation+DatabaseValueConvertible.swift in Sources */,
 				5657AB0F1D10899D006283EF /* URL.swift in Sources */,
 				560D924B1C672C4B00F4F92B /* TableRecord.swift in Sources */,
@@ -3859,6 +3980,7 @@
 				56959629222C462D002CB7C9 /* HasManyThroughAssociation.swift in Sources */,
 				560A37A41C8F625000949E71 /* DatabasePool.swift in Sources */,
 				56B7F43A1BEB42D500E39BBF /* Migration.swift in Sources */,
+				048981D623CE6F380012BC8A /* AppKitExtension.swift in Sources */,
 				5613ED3521A95A5C00DC7A68 /* Map.swift in Sources */,
 				566B912B1FA4D0CC0012D5B0 /* StatementAuthorizer.swift in Sources */,
 				56A2388B1B9C75030082EB20 /* Statement.swift in Sources */,
@@ -3877,6 +3999,7 @@
 				56B964B91DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
 				56FBFEDA2210731A00945324 /* SQLRequest.swift in Sources */,
 				563363C01C942C04000BE133 /* DatabaseReader.swift in Sources */,
+				048981CE23CE6F380012BC8A /* DifferentiableSection.swift in Sources */,
 				564CE43121AA901800652B19 /* ValueObserver.swift in Sources */,
 				5605F1651C672E4000235C62 /* NSNull.swift in Sources */,
 				56CEB5191EAA328900BFAF62 /* FTS5+QueryInterface.swift in Sources */,
@@ -3898,9 +4021,12 @@
 				560D92471C672C4B00F4F92B /* PersistableRecord.swift in Sources */,
 				566475A21D9810A400FF74B8 /* SQLSelectable+QueryInterface.swift in Sources */,
 				5674A6E41F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
+				048981D223CE6F380012BC8A /* ElementPath.swift in Sources */,
 				5653EB0C20944C7C00F46237 /* HasManyAssociation.swift in Sources */,
 				5644DE6D20F8C32E001FFDDE /* DatabaseValueConversion.swift in Sources */,
 				5657AAB91D107001006283EF /* NSData.swift in Sources */,
+				048981F223CE6F380012BC8A /* Algorithm.swift in Sources */,
+				048981E623CE6F380012BC8A /* ContentIdentifiable.swift in Sources */,
 				560D92421C672C3E00F4F92B /* StatementColumnConvertible.swift in Sources */,
 				56CEB5531EAA359A00BFAF62 /* SQLExpression.swift in Sources */,
 				56B9649D1DA51B4C0002DA19 /* FTS5.swift in Sources */,

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -10,7 +10,7 @@ import SQLite3
 /// A database row.
 public final class Row: Equatable, Hashable, RandomAccessCollection,
     ExpressibleByDictionaryLiteral, CustomStringConvertible,
-    CustomDebugStringConvertible
+    CustomDebugStringConvertible, Differentiable
 {
     // It is not a violation of the Demeter law when another type uses this
     // property, which is exposed for optimizations.

--- a/GRDB/Record/FetchedRecordsController.swift
+++ b/GRDB/Record/FetchedRecordsController.swift
@@ -1,7 +1,9 @@
 import Foundation
 
-#if os(iOS)
+#if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
+#elseif os(macOS)
+import AppKit
 #endif
 
 /// You use FetchedRecordsController to track changes in the results of an
@@ -10,7 +12,9 @@ import UIKit
 /// See https://github.com/groue/GRDB.swift#fetchedrecordscontroller for
 /// more information.
 public final class FetchedRecordsController<Record: FetchableRecord> {
-    
+
+    public typealias Section = ArraySection<FetchedRecordsSectionInfo<Record>, Item<Record>>
+
     // MARK: - Initialization
     
     /// Creates a fetched records controller initialized from a SQL query and
@@ -43,15 +47,13 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
         arguments: StatementArguments = StatementArguments(),
         adapter: RowAdapter? = nil,
         queue: DispatchQueue = .main,
-        sectionColumn: ColumnExpression? = nil,
-        isSameRecord: ((Record, Record) -> Bool)? = nil) throws
+        sectionColumn: ColumnExpression? = nil) throws
     {
         try self.init(
             databaseWriter,
             request: SQLRequest<Record>(sql: sql, arguments: arguments, adapter: adapter),
             queue: queue,
-            sectionColumn: sectionColumn,
-            isSameRecord: isSameRecord)
+            sectionColumn: sectionColumn)
     }
     
     /// Creates a fetched records controller initialized from a fetch request
@@ -76,44 +78,14 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
     ///
     ///         This function should return true if the two records have the
     ///         same identity. For example, they have the same id.
-    public convenience init<Request>(
+    public init<Request>(
         _ databaseWriter: DatabaseWriter,
         request: Request,
         queue: DispatchQueue = .main,
-        sectionColumn: ColumnExpression? = nil,
-        isSameRecord: ((Record, Record) -> Bool)? = nil) throws
+        sectionColumn: ColumnExpression? = nil) throws
         where Request: FetchRequest, Request.RowDecoder == Record
     {
-        let itemsAreIdenticalFactory: ItemComparatorFactory<Record>
-        if let isSameRecord = isSameRecord {
-            itemsAreIdenticalFactory = { _ in { isSameRecord($0.record, $1.record) } }
-        } else {
-            itemsAreIdenticalFactory = { _ in { _, _ in false } }
-        }
-        
-        try self.init(
-            databaseWriter,
-            request: request,
-            queue: queue,
-            sectionColumn: sectionColumn,
-            itemsAreIdenticalFactory: itemsAreIdenticalFactory)
-    }
-    
-    private init<Request>(
-        _ databaseWriter: DatabaseWriter,
-        request: Request,
-        queue: DispatchQueue,
-        sectionColumn: ColumnExpression? = nil,
-        itemsAreIdenticalFactory: @escaping ItemComparatorFactory<Record>) throws
-        where Request: FetchRequest, Request.RowDecoder == Record
-    {
-        self.itemsAreIdenticalFactory = itemsAreIdenticalFactory
         self.request = ItemRequest(request)
-        (self.region, self.itemsAreIdentical) = try databaseWriter.unsafeRead { db in
-            let region = try request.databaseRegion(db)
-            let itemsAreIdentical = try itemsAreIdenticalFactory(db)
-            return (region, itemsAreIdentical)
-        }
         self.databaseWriter = databaseWriter
         self.queue = queue
         self.sectionColumn = sectionColumn
@@ -126,30 +98,74 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
     ///
     /// This method must be used from the controller's dispatch queue (the
     /// main queue unless stated otherwise in the controller's initializer).
-    public func performFetch() throws {
-        // If some changes are currently processed, make sure they are
-        // discarded. But preserve eventual changes processing for future
-        // changes.
-        let fetchAndNotifyChanges = observer?.fetchAndNotifyChanges
-        observer?.invalidate()
-        observer = nil
-        
-        // Fetch items on the writing dispatch queue, so that the transaction
-        // observer is added on the same serialized queue as transaction
-        // callbacks.
-        try databaseWriter.write { db in
-            let initialItems = try request.fetchAll(db)
-            fetchedItems = initialItems
-            if let fetchAndNotifyChanges = fetchAndNotifyChanges {
-                let observer = FetchedRecordsObserver(region: self.region, fetchAndNotifyChanges: fetchAndNotifyChanges)
-                self.observer = observer
-                observer.items = initialItems
-                db.add(transactionObserver: observer)
-            }
+    public func performFetch(async: Bool = false) throws {
+        guard observerToken == nil else {
+            return
         }
+
+        let reducer = { [weak self] (db: Database) -> AnyValueReducer<[Section], StagedChangeset<[Section]>> in
+            return AnyValueReducer(fetch: { [weak self] db -> [Section] in
+                guard let strongSelf = self else {
+                    return []
+                }
+                let rows = try Row.fetchAll(db, strongSelf.request)
+                if let sectionColumn = self?.sectionColumn {
+                    var dict: Dictionary<String, Section> = .init()
+                    var sectionIndex = 0
+                    rows.forEach { row in
+                        guard let columnValue = row[sectionColumn.name],
+                            let keyCharacter = "\(columnValue)".first?.uppercased() else {
+                            return
+                        }
+                        let key = "\(keyCharacter)"
+                        if var section = dict[key] {
+                            section.elements.append(.init(row: row))
+                            dict[key] = section
+                        } else {
+                            let newIndex: IndexPath = .init(item: 0, section: sectionIndex)
+                            let newInfo: FetchedRecordsSectionInfo<Record> = .init(indexPath: newIndex,
+                                                                                   name: key,
+                                                                                   controller: self)
+                            let newSection: Section = .init(model: newInfo, elements: [.init(row: row)])
+                            dict[key] = newSection
+                            sectionIndex += 1
+                        }
+                    }
+                    return dict.sorted { lhs, rhs -> Bool in
+                        return lhs.value.model.indexPath < rhs.value.model.indexPath
+                    }.compactMap { pair in
+                        return pair.value
+                    }
+                } else {
+                    let items: [Item<Record>] = rows.compactMap(Item.init)
+                    let sectionInfo: FetchedRecordsSectionInfo<Record> = .init(indexPath: .init(item: 0, section: 0),
+                                                                               name: "",
+                                                                               controller: self)
+                    return [.init(model: sectionInfo, elements: items)]
+                }
+            }, value: { (newSections: [Section]) -> StagedChangeset<[Section]> in
+                guard let strongSelf = self else {
+                    return StagedChangeset()
+                }
+                let oldSections = strongSelf.fetchedSections
+                strongSelf.fetchedSections = newSections
+                return StagedChangeset(source: oldSections, target: newSections)
+            })
+        }
+
+        var observation = ValueObservation.tracking(request, reducer: reducer)
+        if async {
+            observation.scheduling = .async(onQueue: queue, startImmediately: true)
+        }
+        observerToken = try observation.start(in: databaseWriter, onChange: { [weak self] result in
+            self?.changes?(result)
+        })
     }
-    
-    
+
+    public func track(changes: @escaping (StagedChangeset<[Section]>) -> Void) {
+        self.changes = changes
+    }
+
     // MARK: - Configuration
     
     /// The database writer used to fetch records.
@@ -163,208 +179,41 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
     /// Unless specified otherwise at initialization time, it is the main queue.
     public let queue: DispatchQueue
 
-    public private(set) var sectionColumn: ColumnExpression?
+    /// The column in which fetched records should be sectioned by.
+    ///
+    /// Setting a new sectionColumn will require another call to `performFetch()`
+    public var sectionColumn: ColumnExpression? {
+        didSet {
+            observerToken = nil
+        }
+    }
     
     /// Updates the fetch request, and eventually notifies the tracking
-    /// callbacks if performFetch() has been called.
+    /// callbacks if `performFetch()` has been called.
     ///
     /// This method must be used from the controller's dispatch queue (the
     /// main queue unless stated otherwise in the controller's initializer).
-    public func setRequest<Request>(_ request: Request)
-        throws
-        where Request: FetchRequest, Request.RowDecoder == Record
-    {
+    public func setRequest<Request>(_ request: Request) where Request: FetchRequest, Request.RowDecoder == Record {
+        self.observerToken = nil
         self.request = ItemRequest(request)
-        (self.region, self.itemsAreIdentical) = try databaseWriter.unsafeRead { db in
-            let region = try request.databaseRegion(db)
-            let itemsAreIdentical = try itemsAreIdenticalFactory(db)
-            return (region, itemsAreIdentical)
-        }
-        
-        // No observer: don't look for changes
-        guard let observer = observer else { return }
-        
-        // If some changes are currently processed, make sure they are
-        // discarded. But preserve eventual changes processing.
-        let fetchAndNotifyChanges = observer.fetchAndNotifyChanges
-        observer.invalidate()
-        self.observer = nil
-        
-        // Replace observer so that it tracks a new set of columns,
-        // and notify eventual changes
-        let initialItems = fetchedItems
-        databaseWriter.writeWithoutTransaction { db in
-            let observer = FetchedRecordsObserver(region: region, fetchAndNotifyChanges: fetchAndNotifyChanges)
-            self.observer = observer
-            observer.items = initialItems
-            db.add(transactionObserver: observer)
-            observer.fetchAndNotifyChanges(observer)
-        }
     }
     
     /// Updates the fetch request, and eventually notifies the tracking
-    /// callbacks if performFetch() has been called.
+    /// callbacks if `performFetch()` has been called.
     ///
     /// This method must be used from the controller's dispatch queue (the
     /// main queue unless stated otherwise in the controller's initializer).
-    public func setRequest(
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-        throws
-    {
-        try setRequest(SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
+    public func setRequest(sql: String,
+                           arguments: StatementArguments = StatementArguments(),
+                           adapter: RowAdapter? = nil) {
+        setRequest(SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
     }
-    
-    /// Registers changes notification callbacks.
-    ///
-    /// This method must be used from the controller's dispatch queue (the
-    /// main queue unless stated otherwise in the controller's initializer).
-    ///
-    /// - parameters:
-    ///     - willChange: Invoked before records are updated.
-    ///     - onChange: Invoked for each record that has been added,
-    ///       removed, moved, or updated.
-    ///     - didChange: Invoked after records have been updated.
-    public func trackChanges(
-        willChange: ((FetchedRecordsController<Record>) -> Void)? = nil,
-        onChange: ((FetchedRecordsController<Record>, Record, FetchedRecordChange) -> Void)? = nil,
-        didChange: ((FetchedRecordsController<Record>) -> Void)? = nil)
-    {
-        // Without SE-0110, we could simply:
-        //
-        //  trackChanges(
-        //      fetchAlongside: { _ in },
-        //      willChange: willChange.map { callback in { (controller, _) in callback(controller) } },
-        //      onChange: onChange,
-        //      didChange: didChange.map { callback in { (controller, _) in callback(controller) } })
-        //
-        // But instead:
-        let wrappedWillChange: ((FetchedRecordsController<Record>, Void) -> Void)?
-        if let willChange = willChange {
-            wrappedWillChange = { (controller, _) in willChange(controller) }
-        } else {
-            wrappedWillChange = nil
-        }
-        
-        let wrappedDidChange: ((FetchedRecordsController<Record>, Void) -> Void)?
-        if let didChange = didChange {
-            wrappedDidChange = { (controller, _) in didChange(controller) }
-        } else {
-            wrappedDidChange = nil
-        }
-        
-        trackChanges(
-            fetchAlongside: { _ in },
-            willChange: wrappedWillChange,
-            onChange: onChange,
-            didChange: wrappedDidChange)
-    }
-    
-    /// Registers changes notification callbacks.
-    ///
-    /// This method must be used from the controller's dispatch queue (the
-    /// main queue unless stated otherwise in the controller's initializer).
-    ///
-    /// - parameters:
-    ///     - fetchAlongside: The value returned from this closure is given to
-    ///       willChange and didChange callbacks, as their
-    ///       `fetchedAlongside` argument. The closure is guaranteed to see the
-    ///       database in the state it has just after eventual changes to the
-    ///       fetched records have been performed. Use it in order to fetch
-    ///       values that must be consistent with the fetched records.
-    ///     - willChange: Invoked before records are updated.
-    ///     - onChange: Invoked for each record that has been added,
-    ///       removed, moved, or updated.
-    ///     - didChange: Invoked after records have been updated.
-    public func trackChanges<T>(
-        fetchAlongside: @escaping (Database) throws -> T,
-        willChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> Void)? = nil,
-        onChange: ((FetchedRecordsController<Record>, Record, FetchedRecordChange) -> Void)? = nil,
-        didChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> Void)? = nil)
-    {
-        // If some changes are currently processed, make sure they are
-        // discarded because they would trigger previously set callbacks.
-        observer?.invalidate()
-        observer = nil
-        
-        guard (willChange != nil) || (onChange != nil) || (didChange != nil) else {
-            // Stop tracking
-            return
-        }
-        
-        var willProcessTransaction: () -> Void = { }
-        var didProcessTransaction: () -> Void = { }
-        #if os(iOS)
-        if let application = application {
-            var backgroundTaskID: UIBackgroundTaskIdentifier! = nil
-            willProcessTransaction = {
-                backgroundTaskID = application.beginBackgroundTask {
-                    application.endBackgroundTask(backgroundTaskID)
-                }
-            }
-            didProcessTransaction = {
-                application.endBackgroundTask(backgroundTaskID)
-            }
-        }
-        #endif
-        
-        let initialItems = fetchedItems
-        databaseWriter.writeWithoutTransaction { db in
-            let fetchAndNotifyChanges = makeFetchAndNotifyChangesFunction(
-                controller: self,
-                fetchAlongside: fetchAlongside,
-                itemsAreIdentical: itemsAreIdentical,
-                willProcessTransaction: willProcessTransaction,
-                willChange: willChange,
-                onChange: onChange,
-                didChange: didChange,
-                didProcessTransaction: didProcessTransaction)
-            let observer = FetchedRecordsObserver(region: region, fetchAndNotifyChanges: fetchAndNotifyChanges)
-            self.observer = observer
-            if let initialItems = initialItems {
-                observer.items = initialItems
-                db.add(transactionObserver: observer)
-                observer.fetchAndNotifyChanges(observer)
-            }
-        }
-    }
-    
-    /// Registers an error callback.
-    ///
-    /// Whenever the controller could not look for changes after a transaction
-    /// has potentially modified the tracked request, this error handler is
-    /// called.
-    ///
-    /// The request observation is not stopped, though: future transactions may
-    /// successfully be handled, and the notified changes will then be based on
-    /// the last successful fetch.
-    ///
-    /// This method must be used from the controller's dispatch queue (the
-    /// main queue unless stated otherwise in the controller's initializer).
-    public func trackErrors(_ errorHandler: @escaping (FetchedRecordsController<Record>, Error) -> Void) {
-        self.errorHandler = errorHandler
-    }
-    
-    #if os(iOS)
-    /// Call this method when changes performed while the application is
-    /// in the background should be processed before the application enters the
-    /// suspended state.
-    ///
-    /// Whenever the tracked request is changed, the fetched records controller
-    /// sets up a background task using
-    /// `UIApplication.beginBackgroundTask(expirationHandler:)` which is ended
-    /// after the `didChange` callback has completed.
-    public func allowBackgroundChangesTracking(in application: UIApplication) {
-        self.application = application
-    }
-    #endif
     
     // MARK: - Accessing Records
     
     /// The fetched records.
     ///
-    /// The value of this property is nil until performFetch() has been called.
+    /// The value of this property is empty until performFetch() has been called.
     ///
     /// The records reflect the state of the database after the initial
     /// call to performFetch, and after each database transaction that affects
@@ -373,41 +222,25 @@ public final class FetchedRecordsController<Record: FetchableRecord> {
     /// This property must be used from the controller's dispatch queue (the
     /// main queue unless stated otherwise in the controller's initializer).
     public var fetchedRecords: [Record] {
-        guard let fetchedItems = fetchedItems else {
-            fatalError("the performFetch() method must be called before accessing fetched records")
-        }
-        return fetchedItems.map { $0.record }
+        return fetchedSections.flatMap { $0.elements }.compactMap { $0.record }
     }
     
-    
     // MARK: - Not public
-    
-    #if os(iOS)
-    /// Support for allowBackgroundChangeTracking(in:)
-    var application: UIApplication?
-    #endif
-    
-    /// The items
-    fileprivate var fetchedItems: [Item<Record>]?
-    
-    /// The record comparator
-    private var itemsAreIdentical: ItemComparator<Record>
-    
-    /// The record comparator factory (support for request change)
-    private let itemsAreIdenticalFactory: ItemComparatorFactory<Record>
-    
+
+    /// The sections
+    fileprivate var fetchedSections: [Section] = []
+
+    /// The request typealias
+    private typealias ItemRequest = AnyFetchRequest<Item<Record>>
+
     /// The request
-    fileprivate typealias ItemRequest = AnyFetchRequest<Item<Record>>
-    fileprivate var request: ItemRequest
-    
-    /// The observed database region
-    private var region: DatabaseRegion
-    
-    /// The eventual current database observer
-    private var observer: FetchedRecordsObserver<Record>?
-    
-    /// The eventual error handler
-    fileprivate var errorHandler: ((FetchedRecordsController<Record>, Error) -> Void)?
+    private var request: ItemRequest
+
+    /// The transaction observer for change tracking
+    private var observerToken: TransactionObserver?
+
+    /// A closure that is invoked when changes are tracked
+    private var changes: ((StagedChangeset<[Section]>) -> Void)?
 }
 
 extension FetchedRecordsController where Record: TableRecord {
@@ -457,452 +290,9 @@ extension FetchedRecordsController where Record: TableRecord {
             queue: queue,
             sectionColumn: sectionColumn)
     }
-    
-    /// Creates a fetched records controller initialized from a fetch request
-    /// from the [Query Interface](https://github.com/groue/GRDB.swift#the-query-interface).
-    ///
-    ///     let request = Wine.order(Column("name"))
-    ///     let controller = FetchedRecordsController(
-    ///         dbQueue,
-    ///         request: request)
-    ///
-    /// The records are compared by primary key (single-column primary key,
-    /// compound primary key, or implicit rowid). For a database table which
-    /// has an `id` primary key, this initializer is equivalent to:
-    ///
-    ///     // Assuming the wine table has an `id` primary key:
-    ///     let controller = FetchedRecordsController<Wine>(
-    ///         dbQueue,
-    ///         request: request,
-    ///         isSameRecord: { (wine1, wine2) in wine1.id == wine2.id })
-    ///
-    /// - parameters:
-    ///     - databaseWriter: A DatabaseWriter (DatabaseQueue, or DatabasePool)
-    ///     - request: A fetch request.
-    ///     - queue: A serial dispatch queue (defaults to the main queue)
-    ///
-    ///         The fetched records controller tracking callbacks will be
-    ///         notified of changes in this queue. The controller itself must be
-    ///         used from this queue.
-    public convenience init<Request>(
-        _ databaseWriter: DatabaseWriter,
-        request: Request,
-        queue: DispatchQueue = .main,
-        sectionColumn: ColumnExpression? = nil) throws
-        where Request: FetchRequest, Request.RowDecoder == Record
-    {
-        // Builds a function that returns true if and only if two items
-        // have the same primary key and primary keys contain at least one
-        // non-null value.
-        let itemsAreIdenticalFactory: ItemComparatorFactory<Record> = { db in
-            // Extract primary key columns from database table
-            let columns = try db.primaryKey(Record.databaseTableName).columns
-            
-            // Compare primary keys
-            assert(!columns.isEmpty)
-            return { (lItem, rItem) in
-                var notNullValue = false
-                for column in columns {
-                    let lValue: DatabaseValue = lItem.row[column]
-                    let rValue: DatabaseValue = rItem.row[column]
-                    if lValue != rValue {
-                        // different primary keys
-                        return false
-                    }
-                    if !lValue.isNull || !rValue.isNull {
-                        notNullValue = true
-                    }
-                }
-                // identical primary keys iff at least one value is not null
-                return notNullValue
-            }
-        }
-        try self.init(
-            databaseWriter,
-            request: request,
-            queue: queue,
-            itemsAreIdenticalFactory: itemsAreIdenticalFactory)
-    }
 }
-
-
-// MARK: - FetchedRecordsObserver
-
-/// FetchedRecordsController adopts TransactionObserverType so that it can
-/// monitor changes to its fetched records.
-private final class FetchedRecordsObserver<Record: FetchableRecord>: TransactionObserver {
-    var isValid: Bool
-    var needsComputeChanges: Bool
-    var items: [Item<Record>]!  // ought to be not nil when observer has started tracking transactions
-    let queue: DispatchQueue // protects items
-    let region: DatabaseRegion
-    var fetchAndNotifyChanges: (FetchedRecordsObserver<Record>) -> Void
-    
-    init(region: DatabaseRegion, fetchAndNotifyChanges: @escaping (FetchedRecordsObserver<Record>) -> Void) {
-        self.isValid = true
-        self.items = nil
-        self.needsComputeChanges = false
-        self.queue = DispatchQueue(label: "GRDB.FetchedRecordsObserver")
-        self.region = region
-        self.fetchAndNotifyChanges = fetchAndNotifyChanges
-    }
-    
-    func invalidate() {
-        isValid = false
-    }
-    
-    func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool {
-        return region.isModified(byEventsOfKind: eventKind)
-    }
-    
-    /// Part of the TransactionObserverType protocol
-    func databaseDidChange(with event: DatabaseEvent) {
-        if region.isModified(by: event) {
-            needsComputeChanges = true
-            stopObservingDatabaseChangesUntilNextTransaction()
-        }
-    }
-    
-    /// Part of the TransactionObserverType protocol
-    func databaseDidRollback(_ db: Database) {
-        needsComputeChanges = false
-    }
-    
-    /// Part of the TransactionObserverType protocol
-    func databaseDidCommit(_ db: Database) {
-        // The databaseDidCommit callback is called in the database writer
-        // dispatch queue, which is serialized: it is guaranteed to process the
-        // last database transaction.
-        
-        // Were observed tables modified?
-        guard needsComputeChanges else { return }
-        needsComputeChanges = false
-        
-        fetchAndNotifyChanges(self)
-    }
-}
-
-
-// MARK: - Changes
-
-private typealias FetchCompletionHandler<Record: FetchableRecord, T> = (
-    DatabaseResult<(fetchedItems: [Item<Record>],
-    fetchedAlongside: T,
-    observer: FetchedRecordsObserver<Record>)>)
-    -> Void
-
-private func makeFetchFunction<Record, T>(
-    controller: FetchedRecordsController<Record>,
-    fetchAlongside: @escaping (Database) throws -> T,
-    willProcessTransaction: @escaping () -> Void,
-    completion: @escaping FetchCompletionHandler<Record, T>
-    ) -> (FetchedRecordsObserver<Record>) -> Void
-{
-    // Make sure we keep a weak reference to the fetched records controller,
-    // so that the user can use unowned references in callbacks:
-    //
-    //      controller.trackChanges { [unowned self] ... }
-    //
-    // Should controller become strong at any point before callbacks are
-    // called, such unowned reference would have an opportunity to crash.
-    return { [weak controller] observer in
-        // Return if observer has been invalidated, or if fetched records
-        // controller has been deallocated
-        guard observer.isValid,
-            let request = controller?.request,
-            let databaseWriter = controller?.databaseWriter
-            else { return }
-        
-        willProcessTransaction()
-        
-        // Perform a concurrent read so that writer dispatch queue is released
-        // as soon as possible.
-        let future = databaseWriter.concurrentRead { db in
-            try (fetchedItems: request.fetchAll(db),
-                 fetchedAlongside: fetchAlongside(db))
-        }
-        
-        // Dispatch processing immediately on observer.queue in order to
-        // process fetched values in the same order as transactions:
-        observer.queue.async { [weak observer] in
-            // Return if observer has been deallocated or invalidated
-            guard let observer = observer,
-                observer.isValid
-                else { return }
-            
-            do {
-                // Wait for concurrent read to complete
-                let values = try future.wait()
-                
-                completion(.success((
-                    fetchedItems: values.fetchedItems,
-                    fetchedAlongside: values.fetchedAlongside,
-                    observer: observer)))
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-}
-
-private func makeFetchAndNotifyChangesFunction<Record, T>(
-    controller: FetchedRecordsController<Record>,
-    fetchAlongside: @escaping (Database) throws -> T,
-    itemsAreIdentical: @escaping ItemComparator<Record>,
-    willProcessTransaction: @escaping () -> Void,
-    willChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> Void)?,
-    onChange: ((FetchedRecordsController<Record>, Record, FetchedRecordChange) -> Void)?,
-    didChange: ((FetchedRecordsController<Record>, _ fetchedAlongside: T) -> Void)?,
-    didProcessTransaction: @escaping () -> Void
-    ) -> (FetchedRecordsObserver<Record>) -> Void
-{
-    // Make sure we keep a weak reference to the fetched records controller,
-    // so that the user can use unowned references in callbacks:
-    //
-    //      controller.trackChanges { [unowned self] ... }
-    //
-    // Should controller become strong at any point before callbacks are
-    // called, such unowned reference would have an opportunity to crash.
-    return makeFetchFunction(
-        controller: controller,
-        fetchAlongside: fetchAlongside,
-        willProcessTransaction: willProcessTransaction)
-    { [weak controller] result in
-        // Return if fetched records controller has been deallocated
-        guard let callbackQueue = controller?.queue else { return }
-        
-        switch result {
-        case let .failure(error):
-            callbackQueue.async {
-                // Now we can retain controller
-                guard let strongController = controller else { return }
-                strongController.errorHandler?(strongController, error)
-                didProcessTransaction()
-            }
-            
-        case let .success((fetchedItems: fetchedItems, fetchedAlongside: fetchedAlongside, observer: observer)):
-            // Return if there is no change
-            let changes: [ItemChange<Record>]
-            if onChange != nil {
-                // Compute table view changes
-                changes = computeChanges(from: observer.items, to: fetchedItems, itemsAreIdentical: itemsAreIdentical)
-                if changes.isEmpty { return }
-            } else {
-                // Don't compute changes: just look for a row difference:
-                if identicalItemArrays(fetchedItems, observer.items) { return }
-                changes = []
-            }
-            
-            // Ready for next check
-            observer.items = fetchedItems
-            
-            callbackQueue.async { [weak observer] in
-                // Return if observer has been invalidated
-                guard let strongObserver = observer else { return }
-                guard strongObserver.isValid else { return }
-                
-                // Now we can retain controller
-                guard let strongController = controller else { return }
-                
-                // Notify changes
-                willChange?(strongController, fetchedAlongside)
-                strongController.fetchedItems = fetchedItems
-                if let onChange = onChange {
-                    for change in changes {
-                        onChange(strongController, change.record, change.fetchedRecordChange)
-                    }
-                }
-                didChange?(strongController, fetchedAlongside)
-                didProcessTransaction()
-            }
-        }
-    }
-}
-
-private func computeChanges<Record>(
-    from s: [Item<Record>],
-    to t: [Item<Record>],
-    itemsAreIdentical: ItemComparator<Record>)
-    -> [ItemChange<Record>]
-{
-    let m = s.count
-    let n = t.count
-    
-    // Fill first row and column of insertions and deletions.
-    
-    var d: [[[ItemChange<Record>]]] = Array(repeating: Array(repeating: [], count: n + 1), count: m + 1)
-    
-    var changes = [ItemChange<Record>]()
-    for (row, item) in s.enumerated() {
-        let deletion = ItemChange.deletion(item: item, indexPath: IndexPath(indexes: [0, row]))
-        changes.append(deletion)
-        d[row + 1][0] = changes
-    }
-    
-    changes.removeAll()
-    for (col, item) in t.enumerated() {
-        let insertion = ItemChange.insertion(item: item, indexPath: IndexPath(indexes: [0, col]))
-        changes.append(insertion)
-        d[0][col + 1] = changes
-    }
-    
-    if m == 0 || n == 0 {
-        // Pure deletions or insertions
-        return d[m][n]
-    }
-    
-    // Fill body of matrix.
-    for tx in 0..<n {
-        for sx in 0..<m {
-            if s[sx] == t[tx] {
-                d[sx+1][tx+1] = d[sx][tx] // no operation
-            } else {
-                var del = d[sx][tx+1]     // a deletion
-                var ins = d[sx+1][tx]     // an insertion
-                var sub = d[sx][tx]       // a substitution
-                
-                // Record operation.
-                let minimumCount = min(del.count, ins.count, sub.count)
-                if del.count == minimumCount {
-                    let deletion = ItemChange.deletion(item: s[sx], indexPath: IndexPath(indexes: [0, sx]))
-                    del.append(deletion)
-                    d[sx+1][tx+1] = del
-                } else if ins.count == minimumCount {
-                    let insertion = ItemChange.insertion(item: t[tx], indexPath: IndexPath(indexes: [0, tx]))
-                    ins.append(insertion)
-                    d[sx+1][tx+1] = ins
-                } else {
-                    let deletion = ItemChange.deletion(item: s[sx], indexPath: IndexPath(indexes: [0, sx]))
-                    let insertion = ItemChange.insertion(item: t[tx], indexPath: IndexPath(indexes: [0, tx]))
-                    sub.append(deletion)
-                    sub.append(insertion)
-                    d[sx+1][tx+1] = sub
-                }
-            }
-        }
-    }
-    
-    /// Returns an array where deletion/insertion pairs of the same element are replaced by `.move` change.
-    func standardize(changes: [ItemChange<Record>], itemsAreIdentical: ItemComparator<Record>) -> [ItemChange<Record>] {
-        
-        /// Returns a potential .move or .update if *change* has a matching change in *changes*:
-        /// If *change* is a deletion or an insertion, and there is a matching inverse
-        /// insertion/deletion with the same value in *changes*, a corresponding .move or .update is returned.
-        /// As a convenience, the index of the matched change is returned as well.
-        func merge(
-            change: ItemChange<Record>,
-            in changes: [ItemChange<Record>],
-            itemsAreIdentical: ItemComparator<Record>)
-            -> (mergedChange: ItemChange<Record>, mergedIndex: Int)?
-        {
-            /// Returns the changes between two rows: a dictionary [key: oldValue]
-            /// Precondition: both rows have the same columns
-            func changedValues(from oldRow: Row, to newRow: Row) -> [String: DatabaseValue] {
-                var changedValues: [String: DatabaseValue] = [:]
-                for (column, newValue) in newRow {
-                    let oldValue: DatabaseValue? = oldRow[column]
-                    if newValue != oldValue {
-                        changedValues[column] = oldValue
-                    }
-                }
-                return changedValues
-            }
-            
-            switch change {
-            case let .insertion(newItem, newIndexPath):
-                // Look for a matching deletion
-                for (index, otherChange) in changes.enumerated() {
-                    guard case let .deletion(oldItem, oldIndexPath) = otherChange else { continue }
-                    guard itemsAreIdentical(oldItem, newItem) else { continue }
-                    let rowChanges = changedValues(from: oldItem.row, to: newItem.row)
-                    if oldIndexPath == newIndexPath {
-                        return (
-                            ItemChange.update(
-                                item: newItem,
-                                indexPath: oldIndexPath,
-                                changes: rowChanges),
-                            index)
-                    } else {
-                        return (
-                            ItemChange.move(
-                                item: newItem,
-                                indexPath: oldIndexPath,
-                                newIndexPath: newIndexPath,
-                                changes: rowChanges),
-                            index)
-                    }
-                }
-                return nil
-                
-            case let .deletion(oldItem, oldIndexPath):
-                // Look for a matching insertion
-                for (index, otherChange) in changes.enumerated() {
-                    guard case let .insertion(newItem, newIndexPath) = otherChange else { continue }
-                    guard itemsAreIdentical(oldItem, newItem) else { continue }
-                    let rowChanges = changedValues(from: oldItem.row, to: newItem.row)
-                    if oldIndexPath == newIndexPath {
-                        return (
-                            ItemChange.update(
-                                item: newItem,
-                                indexPath: oldIndexPath,
-                                changes: rowChanges),
-                            index)
-                    } else {
-                        return (
-                            ItemChange.move(
-                                item: newItem,
-                                indexPath: oldIndexPath,
-                                newIndexPath: newIndexPath,
-                                changes: rowChanges),
-                            index)
-                    }
-                }
-                return nil
-                
-            default:
-                return nil
-            }
-        }
-        
-        // Updates must be pushed at the end
-        var mergedChanges: [ItemChange<Record>] = []
-        var updateChanges: [ItemChange<Record>] = []
-        for change in changes {
-            if let (mergedChange, mergedIndex)
-                = merge(change: change, in: mergedChanges, itemsAreIdentical: itemsAreIdentical)
-            {
-                mergedChanges.remove(at: mergedIndex)
-                switch mergedChange {
-                case .update:
-                    updateChanges.append(mergedChange)
-                default:
-                    mergedChanges.append(mergedChange)
-                }
-            } else {
-                mergedChanges.append(change)
-            }
-        }
-        return mergedChanges + updateChanges
-    }
-    
-    return standardize(changes: d[m][n], itemsAreIdentical: itemsAreIdentical)
-}
-
-private func identicalItemArrays<Record>(_ lhs: [Item<Record>], _ rhs: [Item<Record>]) -> Bool {
-    guard lhs.count == rhs.count else {
-        return false
-    }
-    for (lhs, rhs) in zip(lhs, rhs) where lhs.row != rhs.row {
-        return false
-    }
-    return true
-}
-
 
 // MARK: - UITableView Support
-
-private typealias ItemComparator<Record: FetchableRecord> = (Item<Record>, Item<Record>) -> Bool
-private typealias ItemComparatorFactory<Record: FetchableRecord> = (Database) throws -> ItemComparator<Record>
 
 extension FetchedRecordsController {
     
@@ -915,13 +305,8 @@ extension FetchedRecordsController {
     ///     If indexPath does not describe a valid index path in the fetched
     ///     records, a fatal error is raised.
     public func record(at indexPath: IndexPath) -> Record {
-        guard let fetchedItems = fetchedItems else {
-            // Programmer error
-            fatalError("performFetch() has not been called.")
-        }
-        return fetchedItems[indexPath[1]].record
+        return fetchedSections[indexPath.section].elements[indexPath.item].record
     }
-    
     
     // MARK: - Querying Sections Information
     
@@ -933,162 +318,79 @@ extension FetchedRecordsController {
     /// The sections array is never empty, even when there are no fetched
     /// records. In this case, there is a single empty section.
     public var sections: [FetchedRecordsSectionInfo<Record>] {
-        // We only support a single section so far.
-        // We also return a single section when there are no fetched
-        // records, just like NSFetchedResultsController.
-        return [FetchedRecordsSectionInfo(controller: self)]
+        if fetchedSections.isEmpty {
+            return [FetchedRecordsSectionInfo(indexPath: .init(item: 0, section: 0), name: "", controller: self)]
+        }
+        return fetchedSections.map { $0.model }
     }
 }
 
-extension FetchedRecordsController where Record: EncodableRecord {
-    
-    /// Returns the indexPath of a given record.
+extension FetchedRecordsController where Record: FetchableRecord & Equatable {
+
+    /// Returns the `indexPath` for a record if it exists
     ///
-    /// - returns: The index path of *record* in the fetched records, or nil
-    ///   if record could not be found.
+    /// - parameters:
+    ///     - object: A record to be searched for
     public func indexPath(for record: Record) -> IndexPath? {
-        let item = Item<Record>(row: Row(record))
-        guard
-            let fetchedItems = fetchedItems,
-            let index = fetchedItems.firstIndex(where: { itemsAreIdentical($0, item) })
-            else {
-                return nil
+        for (sectionIndex, section) in fetchedSections.enumerated() {
+            for (itemIndex, item) in section.elements.enumerated() where record == item.record {
+                return .init(item: itemIndex, section: sectionIndex)
+            }
         }
-        return IndexPath(indexes: [0, index])
-    }
-}
-
-private enum ItemChange<T: FetchableRecord> {
-    case insertion(item: Item<T>, indexPath: IndexPath)
-    case deletion(item: Item<T>, indexPath: IndexPath)
-    case move(item: Item<T>, indexPath: IndexPath, newIndexPath: IndexPath, changes: [String: DatabaseValue])
-    case update(item: Item<T>, indexPath: IndexPath, changes: [String: DatabaseValue])
-}
-
-extension ItemChange {
-    var record: T {
-        switch self {
-        case .insertion(item: let item, indexPath: _):
-            return item.record
-        case .deletion(item: let item, indexPath: _):
-            return item.record
-        case .move(item: let item, indexPath: _, newIndexPath: _, changes: _):
-            return item.record
-        case .update(item: let item, indexPath: _, changes: _):
-            return item.record
-        }
-    }
-    
-    var fetchedRecordChange: FetchedRecordChange {
-        switch self {
-        case let .insertion(item: _, indexPath: indexPath):
-            return .insertion(indexPath: indexPath)
-        case let .deletion(item: _, indexPath: indexPath):
-            return .deletion(indexPath: indexPath)
-        case let .move(item: _, indexPath: indexPath, newIndexPath: newIndexPath, changes: changes):
-            return .move(indexPath: indexPath, newIndexPath: newIndexPath, changes: changes)
-        case let .update(item: _, indexPath: indexPath, changes: changes):
-            return .update(indexPath: indexPath, changes: changes)
-        }
-    }
-}
-
-extension ItemChange: CustomStringConvertible {
-    var description: String {
-        switch self {
-        case let .insertion(item, indexPath):
-            return "Insert \(item) at \(indexPath)"
-            
-        case let .deletion(item, indexPath):
-            return "Delete \(item) from \(indexPath)"
-            
-        case let .move(item, indexPath, newIndexPath, changes: changes):
-            return "Move \(item) from \(indexPath) to \(newIndexPath) with changes: \(changes)"
-            
-        case let .update(item, indexPath, changes):
-            return "Update \(item) at \(indexPath) with changes: \(changes)"
-        }
-    }
-}
-
-/// A record change, given by a FetchedRecordsController to its change callback.
-///
-/// The move and update events hold a *changes* dictionary, whose keys are
-/// column names, and values the old values that have been changed.
-public enum FetchedRecordChange {
-    
-    /// An insertion event, at given indexPath.
-    case insertion(indexPath: IndexPath)
-    
-    /// A deletion event, at given indexPath.
-    case deletion(indexPath: IndexPath)
-    
-    /// A move event, from indexPath to newIndexPath. The *changes* are a
-    /// dictionary whose keys are column names, and values the old values that
-    /// have been changed.
-    case move(indexPath: IndexPath, newIndexPath: IndexPath, changes: [String: DatabaseValue])
-    
-    /// An update event, at given indexPath. The *changes* are a dictionary
-    /// whose keys are column names, and values the old values that have
-    /// been changed.
-    case update(indexPath: IndexPath, changes: [String: DatabaseValue])
-}
-
-extension FetchedRecordChange: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case let .insertion(indexPath):
-            return "Insertion at \(indexPath)"
-            
-        case let .deletion(indexPath):
-            return "Deletion from \(indexPath)"
-            
-        case let .move(indexPath, newIndexPath, changes: changes):
-            return "Move from \(indexPath) to \(newIndexPath) with changes: \(changes)"
-            
-        case let .update(indexPath, changes):
-            return "Update at \(indexPath) with changes: \(changes)"
-        }
+        return nil
     }
 }
 
 /// A section given by a FetchedRecordsController.
-public struct FetchedRecordsSectionInfo<Record: FetchableRecord> {
-    fileprivate let controller: FetchedRecordsController<Record>
-    
+public final class FetchedRecordsSectionInfo<Record: FetchableRecord>: Hashable, Differentiable {
+    public let indexPath: IndexPath
+    public let name: String
+    private(set) weak var controller: FetchedRecordsController<Record>?
+
+    public init(indexPath: IndexPath, name: String, controller: FetchedRecordsController<Record>?) {
+        self.indexPath = indexPath
+        self.name = name
+        self.controller = controller
+    }
+
     /// The number of records (rows) in the section.
     public var numberOfRecords: Int {
-        guard let items = controller.fetchedItems else {
-            // Programmer error
-            fatalError("the performFetch() method must be called before accessing section contents")
-        }
-        return items.count
+        return controller?.fetchedSections[indexPath.section].elements.count ?? 0
     }
     
     /// The array of records in the section.
     public var records: [Record] {
-        guard let items = controller.fetchedItems else {
-            // Programmer error
-            fatalError("the performFetch() method must be called before accessing section contents")
-        }
-        return items.map { $0.record }
+        return controller?.fetchedSections[indexPath.section].elements.map { $0.record } ?? []
+    }
+
+    public static func == (lhs: FetchedRecordsSectionInfo<Record>, rhs: FetchedRecordsSectionInfo<Record>) -> Bool {
+        return lhs.indexPath == rhs.indexPath && lhs.name == rhs.name
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(indexPath)
+        hasher.combine(name)
     }
 }
 
-
 // MARK: - Item
 
-private final class Item<T: FetchableRecord>: FetchableRecord, Equatable {
+/// An item given by a FetchedRecordsController diff
+public final class Item<T: FetchableRecord>: FetchableRecord, Hashable, ContentEquatable, ContentIdentifiable {
     let row: Row
     
     // Records are lazily loaded
-    lazy var record = T(row: self.row)
+    public lazy var record = T(row: self.row)
     
-    init(row: Row) {
+    public init(row: Row) {
         self.row = row.copy()
     }
     
-    static func ==<T> (lhs: Item<T>, rhs: Item<T>) -> Bool {
+    public static func ==<T> (lhs: Item<T>, rhs: Item<T>) -> Bool {
         return lhs.row == rhs.row
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(row)
     }
 }

--- a/GRDB/Utils/DifferenceKit-1.1.5/Algorithm.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Algorithm.swift
@@ -1,0 +1,688 @@
+// swiftlint:disable cyclomatic_complexity
+
+public extension StagedChangeset where Collection: RangeReplaceableCollection, Collection.Element: Differentiable {
+    /// Creates a new `StagedChangeset` from the two collections.
+    ///
+    /// Calculate the differences between the collections using
+    /// the algorithm optimized based on the Paul Heckel's diff algorithm.
+    ///
+    /// - Note: This algorithm can compute the differences at high performance with O(n) complexity.
+    ///         However, not always calculates the shortest differences.
+    ///
+    /// - Note: If the elements with the same identifier duplicated, the algorithm calculates
+    ///         the moves at best effort, and rest of the duplicates as insertion or deletion.
+    ///
+    /// - Note: The data and changes each changeset contains are represents the middle of whole the changes.
+    ///         Each changes are from the previous stage.
+    ///
+    /// - Parameters:
+    ///   - source: A source collection to calculate differences.
+    ///   - target: A target collection to calculate differences.
+    ///
+    /// - Complexity: O(n)
+    @inlinable
+    init(source: Collection, target: Collection) {
+        self.init(source: source, target: target, section: 0)
+    }
+
+    /// Creates a new `StagedChangeset` from the two collections.
+    ///
+    /// Calculate the differences between the collections using
+    /// the algorithm optimized based on the Paul Heckel's diff algorithm.
+    ///
+    /// - Note: This algorithm can compute the differences at high performance with O(n) complexity.
+    ///         However, not always calculates the shortest differences.
+    ///
+    /// - Note: If the elements with the same identifier duplicated, the algorithm calculates
+    ///         the moves at best effort, and rest of the duplicates as insertion or deletion.
+    ///
+    /// - Note: The data and changes each changeset contains are represents the middle of whole the changes.
+    ///         Each changes are from the previous stage.
+    ///
+    /// - Parameters:
+    ///   - source: A source collection to calculate differences.
+    ///   - target: A target collection to calculate differences.
+    ///   - section: An Int value to use as section index (or offset) of element.
+    ///
+    /// - Complexity: O(n)
+    @inlinable
+    init(source: Collection, target: Collection, section: Int) {
+        let sourceElements = ContiguousArray(source)
+        let targetElements = ContiguousArray(target)
+
+        // Return empty changesets if both are empty.
+        if sourceElements.isEmpty && targetElements.isEmpty {
+            self.init()
+            return
+        }
+
+        // Return changesets that all deletions if source is not empty and target is empty.
+        if !sourceElements.isEmpty && targetElements.isEmpty {
+            self.init([Changeset(data: target, elementDeleted: sourceElements.indices.map { ElementPath(element: $0, section: section) })])
+            return
+        }
+
+        // Return changesets that all insertions if source is empty and target is not empty.
+        if sourceElements.isEmpty && !targetElements.isEmpty {
+            self.init([Changeset(data: target, elementInserted: targetElements.indices.map { ElementPath(element: $0, section: section) })])
+            return
+        }
+
+        var firstStageElements = ContiguousArray<Collection.Element>()
+        var secondStageElements = ContiguousArray<Collection.Element>()
+
+        let result = diff(
+            source: sourceElements,
+            target: targetElements,
+            useTargetIndexForUpdated: false,
+            mapIndex: { ElementPath(element: $0, section: section) },
+            updatedElementsPointer: &firstStageElements,
+            notDeletedElementsPointer: &secondStageElements
+        )
+
+        var changesets = ContiguousArray<Changeset<Collection>>()
+
+        // The 1st stage changeset.
+        // - Includes:
+        //   - element updates
+        if !result.updated.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: Collection(firstStageElements),
+                    elementUpdated: result.updated
+                )
+            )
+        }
+
+        // The 2nd stage changeset.
+        // - Includes:
+        //   - element deletes
+        if !result.deleted.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: Collection(secondStageElements),
+                    elementDeleted: result.deleted
+                )
+            )
+        }
+
+        // The 3rd stage changeset.
+        // - Includes:
+        //   - element inserts
+        //   - element moves
+        if !result.inserted.isEmpty || !result.moved.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: target,
+                    elementInserted: result.inserted,
+                    elementMoved: result.moved
+                )
+            )
+        }
+
+        // Set the target to `data` of the last stage.
+        if !changesets.isEmpty {
+            let index = changesets.index(before: changesets.endIndex)
+            changesets[index].data = target
+        }
+
+        self.init(changesets)
+    }
+}
+
+public extension StagedChangeset where Collection: RangeReplaceableCollection, Collection.Element: DifferentiableSection {
+    /// Creates a new `StagedChangeset` from the two sectioned collections.
+    ///
+    /// Calculate the differences between the collections using
+    /// the algorithm optimized based on the Paul Heckel's diff algorithm.
+    ///
+    /// - Note: This algorithm can compute the differences at high performance with O(n) complexity.
+    ///         However, not always calculates the shortest differences.
+    ///
+    /// - Note: If the elements with the same identifier duplicated, the algorithm calculates
+    ///         the moves at best effort, and rest of the duplicates as insertion or deletion.
+    ///
+    /// - Note: The data and changes each changeset contains are represents the middle of whole the changes.
+    ///         Each changes are from the previous stage.
+    ///
+    /// - Parameters:
+    ///   - source: A source sectioned collection to calculate differences.
+    ///   - target: A target sectioned collection to calculate differences.
+    ///
+    /// - Complexity: O(n)
+    @inlinable
+    init(source: Collection, target: Collection) {
+        typealias Section = Collection.Element
+        typealias SectionIdentifier = Collection.Element.DifferenceIdentifier
+        typealias Element = Collection.Element.Collection.Element
+        typealias ElementIdentifier = Collection.Element.Collection.Element.DifferenceIdentifier
+
+        let sourceSections = ContiguousArray(source)
+        let targetSections = ContiguousArray(target)
+
+        let contiguousSourceSections = ContiguousArray(sourceSections.map { ContiguousArray($0.elements) })
+        let contiguousTargetSections = ContiguousArray(targetSections.map { ContiguousArray($0.elements) })
+
+        var firstStageSections = sourceSections
+        var secondStageSections = ContiguousArray<Section>()
+        var thirdStageSections = ContiguousArray<Section>()
+        var fourthStageSections = ContiguousArray<Section>()
+
+        var sourceElementTraces = contiguousSourceSections.map { section in
+            ContiguousArray(repeating: Trace<ElementPath>(), count: section.count)
+        }
+        var targetElementReferences = contiguousTargetSections.map { section in
+            ContiguousArray<ElementPath?>(repeating: nil, count: section.count)
+        }
+
+        let flattenSourceCount = contiguousSourceSections.reduce(into: 0) { $0 += $1.count }
+        var flattenSourceIdentifiers = ContiguousArray<ElementIdentifier>()
+        var flattenSourceElementPaths = ContiguousArray<ElementPath>()
+
+        thirdStageSections.reserveCapacity(contiguousTargetSections.count)
+        fourthStageSections.reserveCapacity(contiguousTargetSections.count)
+
+        flattenSourceIdentifiers.reserveCapacity(flattenSourceCount)
+        flattenSourceElementPaths.reserveCapacity(flattenSourceCount)
+
+        // Calculate section differences.
+
+        let sectionResult = diff(
+            source: sourceSections,
+            target: targetSections,
+            useTargetIndexForUpdated: true,
+            mapIndex: { $0 }
+        )
+
+        // Calculate element differences.
+
+        var elementDeleted = [ElementPath]()
+        var elementInserted = [ElementPath]()
+        var elementUpdated = [ElementPath]()
+        var elementMoved = [(source: ElementPath, target: ElementPath)]()
+
+        for sourceSectionIndex in contiguousSourceSections.indices {
+            for sourceElementIndex in contiguousSourceSections[sourceSectionIndex].indices {
+                let sourceElementPath = ElementPath(element: sourceElementIndex, section: sourceSectionIndex)
+                let sourceElement = contiguousSourceSections[sourceElementPath]
+                flattenSourceIdentifiers.append(sourceElement.differenceIdentifier)
+                flattenSourceElementPaths.append(sourceElementPath)
+            }
+        }
+
+        flattenSourceIdentifiers.withUnsafeBufferPointer { bufferPointer in
+            // The pointer and the table key are for optimization.
+            var sourceOccurrencesTable = [TableKey<ElementIdentifier>: Occurrence](minimumCapacity: flattenSourceCount)
+
+            // Track indices of elements found in flatten source collection into occurrences table.
+            for flattenSourceIndex in flattenSourceIdentifiers.indices {
+                let pointer = bufferPointer.baseAddress!.advanced(by: flattenSourceIndex)
+                let key = TableKey(pointer: pointer)
+
+                switch sourceOccurrencesTable[key] {
+                case .none:
+                    sourceOccurrencesTable[key] = .unique(index: flattenSourceIndex)
+
+                case .unique(let otherIndex)?:
+                    let reference = IndicesReference([otherIndex, flattenSourceIndex])
+                    sourceOccurrencesTable[key] = .duplicate(reference: reference)
+
+                case .duplicate(let reference)?:
+                    reference.push(flattenSourceIndex)
+                }
+            }
+
+            // Track target and source indices of the elements having same identifier.
+            for targetSectionIndex in contiguousTargetSections.indices {
+                let targetElements = contiguousTargetSections[targetSectionIndex]
+
+                for targetElementIndex in targetElements.indices {
+                    var targetIdentifier = targetElements[targetElementIndex].differenceIdentifier
+                    let key = TableKey(pointer: &targetIdentifier)
+
+                    switch sourceOccurrencesTable[key] {
+                    case .none:
+                        break
+
+                    case .unique(let flattenSourceIndex)?:
+                        let sourceElementPath = flattenSourceElementPaths[flattenSourceIndex]
+                        let targetElementPath = ElementPath(element: targetElementIndex, section: targetSectionIndex)
+
+                        if case .none = sourceElementTraces[sourceElementPath].reference {
+                            targetElementReferences[targetElementPath] = sourceElementPath
+                            sourceElementTraces[sourceElementPath].reference = targetElementPath
+                        }
+
+                    case .duplicate(let reference)?:
+                        if let flattenSourceIndex = reference.next() {
+                            let sourceElementPath = flattenSourceElementPaths[flattenSourceIndex]
+                            let targetElementPath = ElementPath(element: targetElementIndex, section: targetSectionIndex)
+                            targetElementReferences[targetElementPath] = sourceElementPath
+                            sourceElementTraces[sourceElementPath].reference = targetElementPath
+                        }
+                    }
+                }
+            }
+        }
+
+        // Track element deletes.
+        for sourceSectionIndex in contiguousSourceSections.indices {
+            let sourceSection = sourceSections[sourceSectionIndex]
+            let sourceElements = contiguousSourceSections[sourceSectionIndex]
+            var firstStageElements = sourceElements
+
+            // Should not track element deletes in the deleted section.
+            if case .some = sectionResult.sourceTraces[sourceSectionIndex].reference {
+                var offsetByDelete = 0
+
+                var secondStageElements = ContiguousArray<Element>()
+
+                for sourceElementIndex in sourceElements.indices {
+                    let sourceElementPath = ElementPath(element: sourceElementIndex, section: sourceSectionIndex)
+
+                    sourceElementTraces[sourceElementPath].deleteOffset = offsetByDelete
+
+                    // Track element deletes if target section is tracked as inserts.
+                    if let targetElementPath = sourceElementTraces[sourceElementPath].reference,
+                        case .some = sectionResult.targetReferences[targetElementPath.section] {
+                        let targetElement = contiguousTargetSections[targetElementPath]
+                        firstStageElements[sourceElementIndex] = targetElement
+                        secondStageElements.append(targetElement)
+                        continue
+                    }
+
+                    elementDeleted.append(sourceElementPath)
+                    sourceElementTraces[sourceElementPath].isTracked = true
+                    offsetByDelete += 1
+                }
+
+                let secondStageSection = Section(source: sourceSection, elements: secondStageElements)
+                secondStageSections.append(secondStageSection)
+
+            }
+
+            let firstStageSection = Section(source: sourceSection, elements: firstStageElements)
+            firstStageSections[sourceSectionIndex] = firstStageSection
+        }
+
+        // Track element updates / moves / inserts.
+        for targetSectionIndex in contiguousTargetSections.indices {
+            // Should not track element updates / moves / inserts in the inserted section.
+            guard let sourceSectionIndex = sectionResult.targetReferences[targetSectionIndex] else {
+                thirdStageSections.append(targetSections[targetSectionIndex])
+                fourthStageSections.append(targetSections[targetSectionIndex])
+                continue
+            }
+
+            var untrackedSourceIndex: Int? = 0
+            let targetElements = contiguousTargetSections[targetSectionIndex]
+
+            let sectionDeleteOffset = sectionResult.sourceTraces[sourceSectionIndex].deleteOffset
+
+            let thirdStageSection = secondStageSections[sourceSectionIndex - sectionDeleteOffset]
+            thirdStageSections.append(thirdStageSection)
+
+            var fourthStageElements = ContiguousArray<Element>()
+            fourthStageElements.reserveCapacity(targetElements.count)
+
+            for targetElementIndex in targetElements.indices {
+                untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
+                    sourceElementTraces[sourceSectionIndex].suffix(from: index).firstIndex { !$0.isTracked }
+                }
+
+                let targetElementPath = ElementPath(element: targetElementIndex, section: targetSectionIndex)
+                let targetElement = contiguousTargetSections[targetElementPath]
+
+                // Track element inserts if source section is tracked as deletes.
+                guard let sourceElementPath = targetElementReferences[targetElementPath],
+                    let movedSourceSectionIndex = sectionResult.sourceTraces[sourceElementPath.section].reference else {
+                        fourthStageElements.append(targetElement)
+                        elementInserted.append(targetElementPath)
+                        continue
+                }
+
+                sourceElementTraces[sourceElementPath].isTracked = true
+
+                let sourceElement = contiguousSourceSections[sourceElementPath]
+                fourthStageElements.append(targetElement)
+
+                if !targetElement.isContentEqual(to: sourceElement) {
+                    elementUpdated.append(sourceElementPath)
+                }
+
+                if sourceElementPath.section != sourceSectionIndex || sourceElementPath.element != untrackedSourceIndex {
+                    let deleteOffset = sourceElementTraces[sourceElementPath].deleteOffset
+                    let moveSourceElementPath = ElementPath(element: sourceElementPath.element - deleteOffset, section: movedSourceSectionIndex)
+                    elementMoved.append((source: moveSourceElementPath, target: targetElementPath))
+                }
+            }
+
+            let fourthStageSection = Section(source: thirdStageSection, elements: fourthStageElements)
+            fourthStageSections.append(fourthStageSection)
+        }
+
+        var changesets = ContiguousArray<Changeset<Collection>>()
+
+        // The 1st stage changeset.
+        // - Includes:
+        //   - element updates
+        if !elementUpdated.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: Collection(firstStageSections),
+                    elementUpdated: elementUpdated
+                )
+            )
+        }
+
+        // The 2nd stage changeset.
+        // - Includes:
+        //   - section deletes
+        //   - element deletes
+        if !sectionResult.deleted.isEmpty || !elementDeleted.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: Collection(secondStageSections),
+                    sectionDeleted: sectionResult.deleted,
+                    elementDeleted: elementDeleted
+                )
+            )
+        }
+
+        // The 3rd stage changeset.
+        // - Includes:
+        //   - section inserts
+        //   - section moves
+        if !sectionResult.inserted.isEmpty || !sectionResult.moved.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: Collection(thirdStageSections),
+                    sectionInserted: sectionResult.inserted,
+                    sectionMoved: sectionResult.moved
+                )
+            )
+        }
+
+        // The 4th stage changeset.
+        // - Includes:
+        //   - element inserts
+        //   - element moves
+        if !elementInserted.isEmpty || !elementMoved.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: Collection(fourthStageSections),
+                    elementInserted: elementInserted,
+                    elementMoved: elementMoved
+                )
+            )
+        }
+
+        // The 5th stage changeset.
+        // - Includes:
+        //   - section updates
+        if !sectionResult.updated.isEmpty {
+            changesets.append(
+                Changeset(
+                    data: target,
+                    sectionUpdated: sectionResult.updated
+                )
+            )
+        }
+
+        // Set the target to `data` of the last stage.
+        if !changesets.isEmpty {
+            let index = changesets.index(before: changesets.endIndex)
+            changesets[index].data = target
+        }
+
+        self.init(changesets)
+    }
+}
+
+/// The shared algorithm to calculate diffs between two linear collections.
+@inlinable
+@discardableResult
+internal func diff<E: Differentiable, I>(
+    source: ContiguousArray<E>,
+    target: ContiguousArray<E>,
+    useTargetIndexForUpdated: Bool,
+    mapIndex: (Int) -> I,
+    updatedElementsPointer: UnsafeMutablePointer<ContiguousArray<E>>? = nil,
+    notDeletedElementsPointer: UnsafeMutablePointer<ContiguousArray<E>>? = nil
+    ) -> DiffResult<I> {
+    var deleted = [I]()
+    var inserted = [I]()
+    var updated = [I]()
+    var moved = [(source: I, target: I)]()
+
+    var sourceTraces = ContiguousArray<Trace<Int>>()
+    var sourceIdentifiers = ContiguousArray<E.DifferenceIdentifier>()
+    var targetReferences = ContiguousArray<Int?>(repeating: nil, count: target.count)
+
+    sourceTraces.reserveCapacity(source.count)
+    sourceIdentifiers.reserveCapacity(source.count)
+
+    for sourceElement in source {
+        sourceTraces.append(Trace())
+        sourceIdentifiers.append(sourceElement.differenceIdentifier)
+    }
+
+    sourceIdentifiers.withUnsafeBufferPointer { bufferPointer in
+        // The pointer and the table key are for optimization.
+        var sourceOccurrencesTable = [TableKey<E.DifferenceIdentifier>: Occurrence](minimumCapacity: source.count)
+
+        // Track indices of elements found in source collection into occurrences table.
+        for sourceIndex in sourceIdentifiers.indices {
+            let pointer = bufferPointer.baseAddress!.advanced(by: sourceIndex)
+            let key = TableKey(pointer: pointer)
+
+            switch sourceOccurrencesTable[key] {
+            case .none:
+                sourceOccurrencesTable[key] = .unique(index: sourceIndex)
+
+            case .unique(let otherIndex)?:
+                let reference = IndicesReference([otherIndex, sourceIndex])
+                sourceOccurrencesTable[key] = .duplicate(reference: reference)
+
+            case .duplicate(let reference)?:
+                reference.push(sourceIndex)
+            }
+        }
+
+        // Track target and source indices of the elements having same identifier.
+        for targetIndex in target.indices {
+            var targetIdentifier = target[targetIndex].differenceIdentifier
+            let key = TableKey(pointer: &targetIdentifier)
+
+            switch sourceOccurrencesTable[key] {
+            case .none:
+                break
+
+            case .unique(let sourceIndex)?:
+                if case .none = sourceTraces[sourceIndex].reference {
+                    targetReferences[targetIndex] = sourceIndex
+                    sourceTraces[sourceIndex].reference = targetIndex
+                }
+
+            case .duplicate(let reference)?:
+                if let sourceIndex = reference.next() {
+                    targetReferences[targetIndex] = sourceIndex
+                    sourceTraces[sourceIndex].reference = targetIndex
+                }
+            }
+        }
+    }
+
+    var offsetByDelete = 0
+    var untrackedSourceIndex: Int? = 0
+
+    // Track deletes.
+    for sourceIndex in source.indices {
+        sourceTraces[sourceIndex].deleteOffset = offsetByDelete
+
+        if let targetIndex = sourceTraces[sourceIndex].reference {
+            let targetElement = target[targetIndex]
+            updatedElementsPointer?.pointee.append(targetElement)
+            notDeletedElementsPointer?.pointee.append(targetElement)
+        }
+        else {
+            let sourceElement = source[sourceIndex]
+            deleted.append(mapIndex(sourceIndex))
+            sourceTraces[sourceIndex].isTracked = true
+            offsetByDelete += 1
+            updatedElementsPointer?.pointee.append(sourceElement)
+        }
+    }
+
+    // Track updates / moves / inserts.
+    for targetIndex in target.indices {
+        untrackedSourceIndex = untrackedSourceIndex.flatMap { index in
+            sourceTraces.suffix(from: index).firstIndex { !$0.isTracked }
+        }
+
+        if let sourceIndex = targetReferences[targetIndex] {
+            sourceTraces[sourceIndex].isTracked = true
+
+            let sourceElement = source[sourceIndex]
+            let targetElement = target[targetIndex]
+
+            if !targetElement.isContentEqual(to: sourceElement) {
+                updated.append(mapIndex(useTargetIndexForUpdated ? targetIndex : sourceIndex))
+            }
+
+            if sourceIndex != untrackedSourceIndex {
+                let deleteOffset = sourceTraces[sourceIndex].deleteOffset
+                moved.append((source: mapIndex(sourceIndex - deleteOffset), target: mapIndex(targetIndex)))
+            }
+        }
+        else {
+            inserted.append(mapIndex(targetIndex))
+        }
+    }
+
+    return DiffResult(
+        deleted: deleted,
+        inserted: inserted,
+        updated: updated,
+        moved: moved,
+        sourceTraces: sourceTraces,
+        targetReferences: targetReferences
+    )
+}
+
+/// A set of changes and metadata as a result of calculating differences in linear collection.
+@usableFromInline
+internal struct DiffResult<Index> {
+    @usableFromInline
+    internal let deleted: [Index]
+    @usableFromInline
+    internal let inserted: [Index]
+    @usableFromInline
+    internal let updated: [Index]
+    @usableFromInline
+    internal let moved: [(source: Index, target: Index)]
+    @usableFromInline
+    internal let sourceTraces: ContiguousArray<Trace<Int>>
+    @usableFromInline
+    internal let targetReferences: ContiguousArray<Int?>
+
+    @usableFromInline
+    internal init(
+        deleted: [Index] = [],
+        inserted: [Index] = [],
+        updated: [Index] = [],
+        moved: [(source: Index, target: Index)] = [],
+        sourceTraces: ContiguousArray<Trace<Int>>,
+        targetReferences: ContiguousArray<Int?>
+        ) {
+        self.deleted = deleted
+        self.inserted = inserted
+        self.updated = updated
+        self.moved = moved
+        self.sourceTraces = sourceTraces
+        self.targetReferences = targetReferences
+    }
+}
+
+/// A set of informations in middle of difference calculation.
+@usableFromInline
+internal struct Trace<Index> {
+    @usableFromInline
+    internal var reference: Index?
+    @usableFromInline
+    internal var deleteOffset = 0
+    @usableFromInline
+    internal var isTracked = false
+
+    @usableFromInline
+    internal init() {}
+}
+
+/// The occurrences of element.
+@usableFromInline
+internal enum Occurrence {
+    case unique(index: Int)
+    case duplicate(reference: IndicesReference)
+}
+
+/// A mutable reference to indices of elements.
+@usableFromInline
+internal final class IndicesReference {
+    @usableFromInline
+    internal var indices: ContiguousArray<Int>
+    @usableFromInline
+    internal var position = 0
+
+    @usableFromInline
+    internal init(_ indices: ContiguousArray<Int>) {
+        self.indices = indices
+    }
+
+    @inlinable
+    internal func push(_ index: Int) {
+        indices.append(index)
+    }
+
+    @inlinable
+    internal func next() -> Int? {
+        guard position < indices.endIndex else {
+            return nil
+        }
+        defer { position += 1 }
+        return indices[position]
+    }
+}
+
+/// Dictionary key using UnsafePointer for performance optimization.
+@usableFromInline
+internal struct TableKey<T: Hashable>: Hashable {
+    @usableFromInline
+    internal let pointeeHashValue: Int
+    @usableFromInline
+    internal let pointer: UnsafePointer<T>
+
+    @usableFromInline
+    internal init(pointer: UnsafePointer<T>) {
+        self.pointeeHashValue = pointer.pointee.hashValue
+        self.pointer = pointer
+    }
+
+    @inlinable
+    internal static func == (lhs: TableKey, rhs: TableKey) -> Bool {
+        return lhs.pointeeHashValue == rhs.pointeeHashValue
+            && (lhs.pointer.distance(to: rhs.pointer) == 0 || lhs.pointer.pointee == rhs.pointer.pointee)
+    }
+
+    @inlinable
+    internal func hash(into hasher: inout Hasher) {
+        hasher.combine(pointeeHashValue)
+    }
+}
+
+internal extension MutableCollection where Element: MutableCollection, Index == Int, Element.Index == Int {
+    @inlinable
+    subscript(path: ElementPath) -> Element.Element {
+        get { return self[path.section][path.element] }
+        set { self[path.section][path.element] = newValue }
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/Algorithm.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Algorithm.swift
@@ -1,6 +1,6 @@
 // swiftlint:disable cyclomatic_complexity
 
-public extension StagedChangeset where Collection: RangeReplaceableCollection, Collection.Element: Differentiable {
+extension StagedChangeset where Collection: RangeReplaceableCollection, Collection.Element: Differentiable {
     /// Creates a new `StagedChangeset` from the two collections.
     ///
     /// Calculate the differences between the collections using
@@ -21,7 +21,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     ///
     /// - Complexity: O(n)
     @inlinable
-    init(source: Collection, target: Collection) {
+    public init(source: Collection, target: Collection) {
         self.init(source: source, target: target, section: 0)
     }
 
@@ -46,7 +46,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     ///
     /// - Complexity: O(n)
     @inlinable
-    init(source: Collection, target: Collection, section: Int) {
+    public init(source: Collection, target: Collection, section: Int) {
         let sourceElements = ContiguousArray(source)
         let targetElements = ContiguousArray(target)
 
@@ -58,13 +58,17 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
 
         // Return changesets that all deletions if source is not empty and target is empty.
         if !sourceElements.isEmpty && targetElements.isEmpty {
-            self.init([Changeset(data: target, elementDeleted: sourceElements.indices.map { ElementPath(element: $0, section: section) })])
+            self.init([Changeset(data: target,
+                                 elementDeleted: sourceElements.indices.map { ElementPath(element: $0,
+                                                                                          section: section) })])
             return
         }
 
         // Return changesets that all insertions if source is empty and target is not empty.
         if sourceElements.isEmpty && !targetElements.isEmpty {
-            self.init([Changeset(data: target, elementInserted: targetElements.indices.map { ElementPath(element: $0, section: section) })])
+            self.init([Changeset(data: target,
+                                 elementInserted: targetElements.indices.map { ElementPath(element: $0,
+                                                                                           section: section) })])
             return
         }
 
@@ -130,7 +134,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     }
 }
 
-public extension StagedChangeset where Collection: RangeReplaceableCollection, Collection.Element: DifferentiableSection {
+extension StagedChangeset where Collection: RangeReplaceableCollection, Collection.Element: DifferentiableSection {
     /// Creates a new `StagedChangeset` from the two sectioned collections.
     ///
     /// Calculate the differences between the collections using
@@ -151,7 +155,7 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
     ///
     /// - Complexity: O(n)
     @inlinable
-    init(source: Collection, target: Collection) {
+    public init(source: Collection, target: Collection) {
         typealias Section = Collection.Element
         typealias SectionIdentifier = Collection.Element.DifferenceIdentifier
         typealias Element = Collection.Element.Collection.Element
@@ -256,7 +260,8 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
                     case .duplicate(let reference)?:
                         if let flattenSourceIndex = reference.next() {
                             let sourceElementPath = flattenSourceElementPaths[flattenSourceIndex]
-                            let targetElementPath = ElementPath(element: targetElementIndex, section: targetSectionIndex)
+                            let targetElementPath = ElementPath(element: targetElementIndex,
+                                                                section: targetSectionIndex)
                             targetElementReferences[targetElementPath] = sourceElementPath
                             sourceElementTraces[sourceElementPath].reference = targetElementPath
                         }
@@ -350,9 +355,11 @@ public extension StagedChangeset where Collection: RangeReplaceableCollection, C
                     elementUpdated.append(sourceElementPath)
                 }
 
-                if sourceElementPath.section != sourceSectionIndex || sourceElementPath.element != untrackedSourceIndex {
+                if sourceElementPath.section != sourceSectionIndex
+                    || sourceElementPath.element != untrackedSourceIndex {
                     let deleteOffset = sourceElementTraces[sourceElementPath].deleteOffset
-                    let moveSourceElementPath = ElementPath(element: sourceElementPath.element - deleteOffset, section: movedSourceSectionIndex)
+                    let moveSourceElementPath = ElementPath(element: sourceElementPath.element - deleteOffset,
+                                                            section: movedSourceSectionIndex)
                     elementMoved.append((source: moveSourceElementPath, target: targetElementPath))
                 }
             }
@@ -524,8 +531,7 @@ internal func diff<E: Differentiable, I>(
             let targetElement = target[targetIndex]
             updatedElementsPointer?.pointee.append(targetElement)
             notDeletedElementsPointer?.pointee.append(targetElement)
-        }
-        else {
+        } else {
             let sourceElement = source[sourceIndex]
             deleted.append(mapIndex(sourceIndex))
             sourceTraces[sourceIndex].isTracked = true
@@ -554,8 +560,7 @@ internal func diff<E: Differentiable, I>(
                 let deleteOffset = sourceTraces[sourceIndex].deleteOffset
                 moved.append((source: mapIndex(sourceIndex - deleteOffset), target: mapIndex(targetIndex)))
             }
-        }
-        else {
+        } else {
             inserted.append(mapIndex(targetIndex))
         }
     }
@@ -573,18 +578,12 @@ internal func diff<E: Differentiable, I>(
 /// A set of changes and metadata as a result of calculating differences in linear collection.
 @usableFromInline
 internal struct DiffResult<Index> {
-    @usableFromInline
-    internal let deleted: [Index]
-    @usableFromInline
-    internal let inserted: [Index]
-    @usableFromInline
-    internal let updated: [Index]
-    @usableFromInline
-    internal let moved: [(source: Index, target: Index)]
-    @usableFromInline
-    internal let sourceTraces: ContiguousArray<Trace<Int>>
-    @usableFromInline
-    internal let targetReferences: ContiguousArray<Int?>
+    @usableFromInline internal let deleted: [Index]
+    @usableFromInline internal let inserted: [Index]
+    @usableFromInline internal let updated: [Index]
+    @usableFromInline internal let moved: [(source: Index, target: Index)]
+    @usableFromInline internal let sourceTraces: ContiguousArray<Trace<Int>>
+    @usableFromInline internal let targetReferences: ContiguousArray<Int?>
 
     @usableFromInline
     internal init(
@@ -607,12 +606,9 @@ internal struct DiffResult<Index> {
 /// A set of informations in middle of difference calculation.
 @usableFromInline
 internal struct Trace<Index> {
-    @usableFromInline
-    internal var reference: Index?
-    @usableFromInline
-    internal var deleteOffset = 0
-    @usableFromInline
-    internal var isTracked = false
+    @usableFromInline internal var reference: Index?
+    @usableFromInline internal var deleteOffset = 0
+    @usableFromInline internal var isTracked = false
 
     @usableFromInline
     internal init() {}
@@ -628,10 +624,8 @@ internal enum Occurrence {
 /// A mutable reference to indices of elements.
 @usableFromInline
 internal final class IndicesReference {
-    @usableFromInline
-    internal var indices: ContiguousArray<Int>
-    @usableFromInline
-    internal var position = 0
+    @usableFromInline internal var indices: ContiguousArray<Int>
+    @usableFromInline internal var position = 0
 
     @usableFromInline
     internal init(_ indices: ContiguousArray<Int>) {
@@ -656,10 +650,8 @@ internal final class IndicesReference {
 /// Dictionary key using UnsafePointer for performance optimization.
 @usableFromInline
 internal struct TableKey<T: Hashable>: Hashable {
-    @usableFromInline
-    internal let pointeeHashValue: Int
-    @usableFromInline
-    internal let pointer: UnsafePointer<T>
+    @usableFromInline internal let pointeeHashValue: Int
+    @usableFromInline internal let pointer: UnsafePointer<T>
 
     @usableFromInline
     internal init(pointer: UnsafePointer<T>) {
@@ -679,7 +671,7 @@ internal struct TableKey<T: Hashable>: Hashable {
     }
 }
 
-internal extension MutableCollection where Element: MutableCollection, Index == Int, Element.Index == Int {
+extension MutableCollection where Element: MutableCollection, Index == Int, Element.Index == Int {
     @inlinable
     subscript(path: ElementPath) -> Element.Element {
         get { return self[path.section][path.element] }

--- a/GRDB/Utils/DifferenceKit-1.1.5/AnyDifferentiable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/AnyDifferentiable.swift
@@ -1,0 +1,108 @@
+/// A type-erased differentiable value.
+///
+/// The `AnyDifferentiable` type hides the specific underlying types.
+/// Associated type `DifferenceIdentifier` is erased by `AnyHashable`.
+/// The comparisons of whether has updated is forwards to an underlying differentiable value.
+///
+/// You can store mixed-type elements in collection that require `Differentiable` conformance by
+/// wrapping mixed-type elements in `AnyDifferentiable`:
+///
+///     extension String: Differentiable {}
+///     extension Int: Differentiable {}
+///
+///     let source = [
+///         AnyDifferentiable("ABC"),
+///         AnyDifferentiable(100)
+///     ]
+///     let target = [
+///         AnyDifferentiable("ABC"),
+///         AnyDifferentiable(100),
+///         AnyDifferentiable(200)
+///     ]
+///
+///     let changeset = StagedChangeset(source: source, target: target)
+///     print(changeset.isEmpty)  // prints "false"
+public struct AnyDifferentiable: Differentiable {
+    /// The value wrapped by this instance.
+    @inlinable
+    public var base: Any {
+        return box.base
+    }
+
+    /// A type-erased identifier value for difference calculation.
+    @inlinable
+    public var differenceIdentifier: AnyHashable {
+        return box.differenceIdentifier
+    }
+
+    @usableFromInline
+    internal let box: AnyDifferentiableBox
+
+    /// Creates a type-erased differentiable value that wraps the given instance.
+    ///
+    /// - Parameters:
+    ///   - base: A differentiable value to wrap.
+    public init<D: Differentiable>(_ base: D) {
+        if let anyDifferentiable = base as? AnyDifferentiable {
+            self = anyDifferentiable
+        }
+        else {
+            box = DifferentiableBox(base)
+        }
+    }
+
+    /// Indicate whether the content of `base` is equals to the content of the given source value.
+    ///
+    /// - Parameters:
+    ///   - source: A source value to be compared.
+    ///
+    /// - Returns: A Boolean value indicating whether the content of `base` is equals
+    ///            to the content of `base` of the given source value.
+    @inlinable
+    public func isContentEqual(to source: AnyDifferentiable) -> Bool {
+        return box.isContentEqual(to: source.box)
+    }
+}
+
+extension AnyDifferentiable: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "AnyDifferentiable(\(String(reflecting: base)))"
+    }
+}
+
+@usableFromInline
+internal protocol AnyDifferentiableBox {
+    var base: Any { get }
+    var differenceIdentifier: AnyHashable { get }
+
+    func isContentEqual(to source: AnyDifferentiableBox) -> Bool
+}
+
+@usableFromInline
+internal struct DifferentiableBox<Base: Differentiable>: AnyDifferentiableBox {
+    @usableFromInline
+    internal let baseComponent: Base
+
+    @inlinable
+    internal var base: Any {
+        return baseComponent
+    }
+
+    @inlinable
+    internal var differenceIdentifier: AnyHashable {
+        return baseComponent.differenceIdentifier
+    }
+
+    @usableFromInline
+    internal init(_ base: Base) {
+        baseComponent = base
+    }
+
+    @inlinable
+    internal func isContentEqual(to source: AnyDifferentiableBox) -> Bool {
+        guard let sourceBase = source.base as? Base else {
+            return false
+        }
+        return baseComponent.isContentEqual(to: sourceBase)
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/AnyDifferentiable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/AnyDifferentiable.swift
@@ -24,19 +24,16 @@
 ///     print(changeset.isEmpty)  // prints "false"
 public struct AnyDifferentiable: Differentiable {
     /// The value wrapped by this instance.
-    @inlinable
-    public var base: Any {
+    @inlinable public var base: Any {
         return box.base
     }
 
     /// A type-erased identifier value for difference calculation.
-    @inlinable
-    public var differenceIdentifier: AnyHashable {
+    @inlinable public var differenceIdentifier: AnyHashable {
         return box.differenceIdentifier
     }
 
-    @usableFromInline
-    internal let box: AnyDifferentiableBox
+    @usableFromInline internal let box: AnyDifferentiableBox
 
     /// Creates a type-erased differentiable value that wraps the given instance.
     ///
@@ -45,8 +42,7 @@ public struct AnyDifferentiable: Differentiable {
     public init<D: Differentiable>(_ base: D) {
         if let anyDifferentiable = base as? AnyDifferentiable {
             self = anyDifferentiable
-        }
-        else {
+        } else {
             box = DifferentiableBox(base)
         }
     }
@@ -80,16 +76,13 @@ internal protocol AnyDifferentiableBox {
 
 @usableFromInline
 internal struct DifferentiableBox<Base: Differentiable>: AnyDifferentiableBox {
-    @usableFromInline
-    internal let baseComponent: Base
+    @usableFromInline internal let baseComponent: Base
 
-    @inlinable
-    internal var base: Any {
+    @inlinable internal var base: Any {
         return baseComponent
     }
 
-    @inlinable
-    internal var differenceIdentifier: AnyHashable {
+    @inlinable internal var differenceIdentifier: AnyHashable {
         return baseComponent.differenceIdentifier
     }
 

--- a/GRDB/Utils/DifferenceKit-1.1.5/ArraySection.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ArraySection.swift
@@ -1,0 +1,68 @@
+/// A differentiable section with model and array of elements.
+///
+/// Arrays are can not be identify each one and comparing whether has updated from other one.
+/// ArraySection is a generic wrapper to hold a model to allow it.
+public struct ArraySection<Model: Differentiable, Element: Differentiable>: DifferentiableSection {
+    /// The model of section for differentiated with other section.
+    public var model: Model
+    /// The array of element in the section.
+    public var elements: [Element]
+
+    /// An identifier value that of model for difference calculation.
+    @inlinable
+    public var differenceIdentifier: Model.DifferenceIdentifier {
+        return model.differenceIdentifier
+    }
+
+    /// Creates a section with the model and the elements.
+    ///
+    /// - Parameters:
+    ///   - model: A differentiable model of section.
+    ///   - elements: The collection of element in the section.
+    public init<C: Collection>(model: Model, elements: C) where C.Element == Element {
+        self.model = model
+        self.elements = Array(elements)
+    }
+
+    /// Creates a new section reproducing the given source section with replacing the elements.
+    ///
+    /// - Parameters:
+    ///   - source: A source section to reproduce.
+    ///   - elements: The collection of elements for the new section.
+    @inlinable
+    public init<C: Collection>(source: ArraySection, elements: C) where C.Element == Element {
+        self.init(model: source.model, elements: elements)
+    }
+
+    /// Indicate whether the content of `self` is equals to the content of
+    /// the given source section.
+    ///
+    /// - Note: It's compared by the model of `self` and the specified section.
+    ///
+    /// - Parameters:
+    ///   - source: A source section to compare.
+    ///
+    /// - Returns: A Boolean value indicating whether the content of `self` is equals
+    ///            to the content of the given source section.
+    @inlinable
+    public func isContentEqual(to source: ArraySection) -> Bool {
+        return model.isContentEqual(to: source.model)
+    }
+}
+
+extension ArraySection: Equatable where Model: Equatable, Element: Equatable {
+    public static func == (lhs: ArraySection, rhs: ArraySection) -> Bool {
+        return lhs.model == rhs.model && lhs.elements == rhs.elements
+    }
+}
+
+extension ArraySection: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return """
+        ArraySection(
+            model: \(model),
+            elements: \(elements)
+        )
+        """
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/ArraySection.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ArraySection.swift
@@ -18,7 +18,7 @@ public struct ArraySection<Model: Differentiable, Element: Differentiable>: Diff
     /// - Parameters:
     ///   - model: A differentiable model of section.
     ///   - elements: The collection of element in the section.
-    public init<C: Collection>(model: Model, elements: C) where C.Element == Element {
+    public init<C: Swift.Collection>(model: Model, elements: C) where C.Element == Element {
         self.model = model
         self.elements = Array(elements)
     }
@@ -29,7 +29,7 @@ public struct ArraySection<Model: Differentiable, Element: Differentiable>: Diff
     ///   - source: A source section to reproduce.
     ///   - elements: The collection of elements for the new section.
     @inlinable
-    public init<C: Collection>(source: ArraySection, elements: C) where C.Element == Element {
+    public init<C: Swift.Collection>(source: ArraySection, elements: C) where C.Element == Element {
         self.init(model: source.model, elements: elements)
     }
 

--- a/GRDB/Utils/DifferenceKit-1.1.5/ArraySection.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ArraySection.swift
@@ -9,8 +9,7 @@ public struct ArraySection<Model: Differentiable, Element: Differentiable>: Diff
     public var elements: [Element]
 
     /// An identifier value that of model for difference calculation.
-    @inlinable
-    public var differenceIdentifier: Model.DifferenceIdentifier {
+    @inlinable public var differenceIdentifier: Model.DifferenceIdentifier {
         return model.differenceIdentifier
     }
 

--- a/GRDB/Utils/DifferenceKit-1.1.5/Changeset.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Changeset.swift
@@ -1,0 +1,160 @@
+/// A set of changes in the sectioned collection.
+///
+/// Changes to the section of the linear collection should be empty.
+///
+/// Notice that the value of the changes represents offsets of collection not index.
+/// Since offsets are unordered, order is ignored when comparing two `Changeset`s.
+public struct Changeset<Collection: Swift.Collection> {
+    /// The collection after changed.
+    public var data: Collection
+
+    /// The offsets of deleted sections.
+    public var sectionDeleted: [Int]
+    /// The offsets of inserted sections.
+    public var sectionInserted: [Int]
+    /// The offsets of updated sections.
+    public var sectionUpdated: [Int]
+    /// The pairs of source and target offset of moved sections.
+    public var sectionMoved: [(source: Int, target: Int)]
+
+    /// The paths of deleted elements.
+    public var elementDeleted: [ElementPath]
+    /// The paths of inserted elements.
+    public var elementInserted: [ElementPath]
+    /// The paths of updated elements.
+    public var elementUpdated: [ElementPath]
+    /// The pairs of source and target path of moved elements.
+    public var elementMoved: [(source: ElementPath, target: ElementPath)]
+
+    /// Creates a new `Changeset`.
+    ///
+    /// - Parameters:
+    ///   - data: The collection after changed.
+    ///   - sectionDeleted: The offsets of deleted sections.
+    ///   - sectionInserted: The offsets of inserted sections.
+    ///   - sectionUpdated: The offsets of updated sections.
+    ///   - sectionMoved: The pairs of source and target offset of moved sections.
+    ///   - elementDeleted: The paths of deleted elements.
+    ///   - elementInserted: The paths of inserted elements.
+    ///   - elementUpdated: The paths of updated elements.
+    ///   - elementMoved: The pairs of source and target path of moved elements.
+    public init(
+        data: Collection,
+        sectionDeleted: [Int] = [],
+        sectionInserted: [Int] = [],
+        sectionUpdated: [Int] = [],
+        sectionMoved: [(source: Int, target: Int)] = [],
+        elementDeleted: [ElementPath] = [],
+        elementInserted: [ElementPath] = [],
+        elementUpdated: [ElementPath] = [],
+        elementMoved: [(source: ElementPath, target: ElementPath)] = []
+        ) {
+        self.data = data
+        self.sectionDeleted = sectionDeleted
+        self.sectionInserted = sectionInserted
+        self.sectionUpdated = sectionUpdated
+        self.sectionMoved = sectionMoved
+        self.elementDeleted = elementDeleted
+        self.elementInserted = elementInserted
+        self.elementUpdated = elementUpdated
+        self.elementMoved = elementMoved
+    }
+}
+
+public extension Changeset {
+    /// The number of section changes.
+    @inlinable
+    var sectionChangeCount: Int {
+        return sectionDeleted.count
+            + sectionInserted.count
+            + sectionUpdated.count
+            + sectionMoved.count
+    }
+
+    /// The number of element changes.
+    @inlinable
+    var elementChangeCount: Int {
+        return elementDeleted.count
+            + elementInserted.count
+            + elementUpdated.count
+            + elementMoved.count
+    }
+
+    /// The number of all changes.
+    @inlinable
+    var changeCount: Int {
+        return sectionChangeCount + elementChangeCount
+    }
+
+    /// A Boolean value indicating whether has section changes.
+    @inlinable
+    var hasSectionChanges: Bool {
+        return sectionChangeCount > 0
+    }
+
+    /// A Boolean value indicating whether has element changes.
+    @inlinable
+    var hasElementChanges: Bool {
+        return elementChangeCount > 0
+    }
+
+    /// A Boolean value indicating whether has changes.
+    @inlinable
+    var hasChanges: Bool {
+        return changeCount > 0
+    }
+}
+
+extension Changeset: Equatable where Collection: Equatable {
+    public static func == (lhs: Changeset, rhs: Changeset) -> Bool {
+        return lhs.data == rhs.data
+            && Set(lhs.sectionDeleted) == Set(rhs.sectionDeleted)
+            && Set(lhs.sectionInserted) == Set(rhs.sectionInserted)
+            && Set(lhs.sectionUpdated) == Set(rhs.sectionUpdated)
+            && Set(lhs.sectionMoved.map(HashablePair.init)) == Set(rhs.sectionMoved.map(HashablePair.init))
+            && Set(lhs.elementDeleted) == Set(rhs.elementDeleted)
+            && Set(lhs.elementInserted) == Set(rhs.elementInserted)
+            && Set(lhs.elementUpdated) == Set(rhs.elementUpdated)
+            && Set(lhs.elementMoved.map(HashablePair.init)) == Set(rhs.elementMoved.map(HashablePair.init))
+    }
+}
+
+extension Changeset: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        guard !data.isEmpty || hasChanges else {
+            return """
+            Changeset(
+                data: []
+            )"
+            """
+        }
+
+        var description = """
+        Changeset(
+            data: \(data.isEmpty ? "[]" : "[\n        \(data.map { "\($0)" }.joined(separator: ",\n").split(separator: "\n").joined(separator: "\n        "))\n    ]")
+        """
+
+        func appendDescription<T>(name: String, elements: [T]) {
+            guard !elements.isEmpty else { return }
+
+            description += ",\n    \(name): [\n        \(elements.map { "\($0)" }.joined(separator: ",\n").split(separator: "\n").joined(separator: "\n        "))\n    ]"
+        }
+
+        appendDescription(name: "sectionDeleted", elements: sectionDeleted)
+        appendDescription(name: "sectionInserted", elements: sectionInserted)
+        appendDescription(name: "sectionUpdated", elements: sectionUpdated)
+        appendDescription(name: "sectionMoved", elements: sectionMoved)
+        appendDescription(name: "elementDeleted", elements: elementDeleted)
+        appendDescription(name: "elementInserted", elements: elementInserted)
+        appendDescription(name: "elementUpdated", elements: elementUpdated)
+        appendDescription(name: "elementMoved", elements: elementMoved)
+
+        description += "\n)"
+        return description
+    }
+}
+
+private struct HashablePair<H: Hashable>: Hashable {
+    let first: H
+    let second: H
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/Changeset.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Changeset.swift
@@ -61,10 +61,9 @@ public struct Changeset<Collection: Swift.Collection> {
     }
 }
 
-public extension Changeset {
+extension Changeset {
     /// The number of section changes.
-    @inlinable
-    var sectionChangeCount: Int {
+    @inlinable public var sectionChangeCount: Int {
         return sectionDeleted.count
             + sectionInserted.count
             + sectionUpdated.count
@@ -72,8 +71,7 @@ public extension Changeset {
     }
 
     /// The number of element changes.
-    @inlinable
-    var elementChangeCount: Int {
+    @inlinable public var elementChangeCount: Int {
         return elementDeleted.count
             + elementInserted.count
             + elementUpdated.count
@@ -81,41 +79,65 @@ public extension Changeset {
     }
 
     /// The number of all changes.
-    @inlinable
-    var changeCount: Int {
+    @inlinable public var changeCount: Int {
         return sectionChangeCount + elementChangeCount
     }
 
     /// A Boolean value indicating whether has section changes.
-    @inlinable
-    var hasSectionChanges: Bool {
+    @inlinable public var hasSectionChanges: Bool {
         return sectionChangeCount > 0
     }
 
     /// A Boolean value indicating whether has element changes.
-    @inlinable
-    var hasElementChanges: Bool {
+    @inlinable public var hasElementChanges: Bool {
         return elementChangeCount > 0
     }
 
     /// A Boolean value indicating whether has changes.
-    @inlinable
-    var hasChanges: Bool {
+    @inlinable public var hasChanges: Bool {
         return changeCount > 0
     }
 }
 
 extension Changeset: Equatable where Collection: Equatable {
     public static func == (lhs: Changeset, rhs: Changeset) -> Bool {
-        return lhs.data == rhs.data
-            && Set(lhs.sectionDeleted) == Set(rhs.sectionDeleted)
-            && Set(lhs.sectionInserted) == Set(rhs.sectionInserted)
-            && Set(lhs.sectionUpdated) == Set(rhs.sectionUpdated)
-            && Set(lhs.sectionMoved.map(HashablePair.init)) == Set(rhs.sectionMoved.map(HashablePair.init))
-            && Set(lhs.elementDeleted) == Set(rhs.elementDeleted)
-            && Set(lhs.elementInserted) == Set(rhs.elementInserted)
-            && Set(lhs.elementUpdated) == Set(rhs.elementUpdated)
-            && Set(lhs.elementMoved.map(HashablePair.init)) == Set(rhs.elementMoved.map(HashablePair.init))
+        let a = lhs.data == rhs.data
+        if !a {
+            return false
+        }
+        let b = Set(lhs.sectionDeleted) == Set(rhs.sectionDeleted)
+        if !b {
+            return false
+        }
+        let c = Set(lhs.sectionInserted) == Set(rhs.sectionInserted)
+        if !c {
+            return false
+        }
+        let d = Set(lhs.sectionUpdated) == Set(rhs.sectionUpdated)
+        if !d {
+            return false
+        }
+        let e = Set(lhs.sectionMoved.map(HashablePair.init)) == Set(rhs.sectionMoved.map(HashablePair.init))
+        if !e {
+            return false
+        }
+        let f = Set(lhs.elementDeleted) == Set(rhs.elementDeleted)
+        if !f {
+            return false
+        }
+        let g = Set(lhs.elementInserted) == Set(rhs.elementInserted)
+        if !g {
+            return false
+        }
+        let h = Set(lhs.elementUpdated) == Set(rhs.elementUpdated)
+        if !h {
+            return false
+        }
+        let i = Set(lhs.elementMoved.map(HashablePair.init)) == Set(rhs.elementMoved.map(HashablePair.init))
+        if !i {
+            return false
+        }
+        return true
     }
 }
 
@@ -129,6 +151,7 @@ extension Changeset: CustomDebugStringConvertible {
             """
         }
 
+        // swiftlint:disable line_length
         var description = """
         Changeset(
             data: \(data.isEmpty ? "[]" : "[\n        \(data.map { "\($0)" }.joined(separator: ",\n").split(separator: "\n").joined(separator: "\n        "))\n    ]")

--- a/GRDB/Utils/DifferenceKit-1.1.5/ContentEquatable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ContentEquatable.swift
@@ -1,0 +1,52 @@
+/// Represents a value that can compare whether the content are equal.
+public protocol ContentEquatable {
+    /// Indicate whether the content of `self` is equals to the content of
+    /// the given source value.
+    ///
+    /// - Parameters:
+    ///   - source: A source value to be compared.
+    ///
+    /// - Returns: A Boolean value indicating whether the content of `self` is equals
+    ///            to the content of the given source value.
+    func isContentEqual(to source: Self) -> Bool
+}
+
+public extension ContentEquatable where Self: Equatable {
+    /// Indicate whether the content of `self` is equals to the content of the given source value.
+    /// Compared using `==` operator of `Equatable'.
+    ///
+    /// - Parameters:
+    ///   - source: A source value to be compared.
+    ///
+    /// - Returns: A Boolean value indicating whether the content of `self` is equals
+    ///            to the content of the given source value.
+    @inlinable
+    func isContentEqual(to source: Self) -> Bool {
+        return self == source
+    }
+}
+
+extension Optional: ContentEquatable where Wrapped: ContentEquatable {
+    /// Indicate whether the content of `self` is equals to the content of the given source value.
+    /// Returns `true` if both values compared are nil.
+    /// The result of comparison between nil and non-nil values is `false`.
+    ///
+    /// - Parameters:
+    ///   - source: An optional source value to be compared.
+    ///
+    /// - Returns: A Boolean value indicating whether the content of `self` is equals
+    ///            to the content of the given source value.
+    @inlinable
+    public func isContentEqual(to source: Wrapped?) -> Bool {
+        switch (self, source) {
+        case let (lhs?, rhs?):
+            return lhs.isContentEqual(to: rhs)
+
+        case (.none, .none):
+            return true
+
+        case (.none, .some), (.some, .none):
+            return false
+        }
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/ContentEquatable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ContentEquatable.swift
@@ -11,7 +11,7 @@ public protocol ContentEquatable {
     func isContentEqual(to source: Self) -> Bool
 }
 
-public extension ContentEquatable where Self: Equatable {
+extension ContentEquatable where Self: Equatable {
     /// Indicate whether the content of `self` is equals to the content of the given source value.
     /// Compared using `==` operator of `Equatable'.
     ///
@@ -21,7 +21,7 @@ public extension ContentEquatable where Self: Equatable {
     /// - Returns: A Boolean value indicating whether the content of `self` is equals
     ///            to the content of the given source value.
     @inlinable
-    func isContentEqual(to source: Self) -> Bool {
+    public func isContentEqual(to source: Self) -> Bool {
         return self == source
     }
 }

--- a/GRDB/Utils/DifferenceKit-1.1.5/ContentIdentifiable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ContentIdentifiable.swift
@@ -1,0 +1,16 @@
+/// Represents the value that identified for differentiate.
+public protocol ContentIdentifiable {
+    /// A type representing the identifier.
+    associatedtype DifferenceIdentifier: Hashable
+
+    /// An identifier value for difference calculation.
+    var differenceIdentifier: DifferenceIdentifier { get }
+}
+
+public extension ContentIdentifiable where Self: Hashable {
+    /// The `self` value as an identifier for difference calculation.
+    @inlinable
+    var differenceIdentifier: Self {
+        return self
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/ContentIdentifiable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ContentIdentifiable.swift
@@ -7,10 +7,9 @@ public protocol ContentIdentifiable {
     var differenceIdentifier: DifferenceIdentifier { get }
 }
 
-public extension ContentIdentifiable where Self: Hashable {
+extension ContentIdentifiable where Self: Hashable {
     /// The `self` value as an identifier for difference calculation.
-    @inlinable
-    var differenceIdentifier: Self {
+    @inlinable public var differenceIdentifier: Self {
         return self
     }
 }

--- a/GRDB/Utils/DifferenceKit-1.1.5/Differentiable.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Differentiable.swift
@@ -1,0 +1,2 @@
+/// Represents a type that can be used for identifying and comparing for equality.
+public typealias Differentiable = ContentIdentifiable & ContentEquatable

--- a/GRDB/Utils/DifferenceKit-1.1.5/DifferentiableSection.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/DifferentiableSection.swift
@@ -1,0 +1,15 @@
+/// Represents the section of collection that can be identified and compared to whether has updated.
+public protocol DifferentiableSection: Differentiable {
+    /// A type representing the elements in section.
+    associatedtype Collection: Swift.Collection where Collection.Element: Differentiable
+
+    /// The collection of element in the section.
+    var elements: Collection { get }
+
+    /// Creates a new section reproducing the given source section with replacing the elements.
+    ///
+    /// - Parameters:
+    ///   - source: A source section to reproduce.
+    ///   - elements: The collection of elements for the new section.
+    init<C: Swift.Collection>(source: Self, elements: C) where C.Element == Collection.Element
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/ElementPath.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/ElementPath.swift
@@ -1,0 +1,25 @@
+/// Represents the path to a specific element in a tree of nested collections.
+///
+/// - Note: `Foundation.IndexPath` is disadvantageous in performance.
+public struct ElementPath: Hashable {
+    /// The element index (or offset) of this path.
+    public var element: Int
+    /// The section index (or offset) of this path.
+    public var section: Int
+
+    /// Creates a new `ElementPath`.
+    ///
+    /// - Parameters:
+    ///   - element: The element index (or offset).
+    ///   - section: The section index (or offset).
+    public init(element: Int, section: Int) {
+        self.element = element
+        self.section = section
+    }
+}
+
+extension ElementPath: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "[element: \(element), section: \(section)]"
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/Extensions/AppKitExtension.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Extensions/AppKitExtension.swift
@@ -1,0 +1,145 @@
+#if os(macOS)
+import AppKit
+
+public extension NSTableView {
+    /// Applies multiple animated updates in stages using `StagedChangeset`.
+    ///
+    /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
+    ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
+    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///
+    /// - Parameters:
+    ///   - stagedChangeset: A staged set of changes.
+    ///   - animation: An option to animate the updates.
+    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - setData: A closure that takes the collection as a parameter.
+    ///              The collection should be set to data-source of NSTableView.
+
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        with animation: @autoclosure () -> NSTableView.AnimationOptions,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        reload(
+            using: stagedChangeset,
+            deleteRowsAnimation: animation(),
+            insertRowsAnimation: animation(),
+            reloadRowsAnimation: animation(),
+            interrupt: interrupt,
+            setData: setData
+        )
+    }
+
+    /// Applies multiple animated updates in stages using `StagedChangeset`.
+    ///
+    /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
+    ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
+    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///
+    /// - Parameters:
+    ///   - stagedChangeset: A staged set of changes.
+    ///   - deleteRowsAnimation: An option to animate the row deletion.
+    ///   - insertRowsAnimation: An option to animate the row insertion.
+    ///   - reloadRowsAnimation: An option to animate the row reload.
+    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - setData: A closure that takes the collection as a parameter.
+    ///              The collection should be set to data-source of NSTableView.
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        deleteRowsAnimation: @autoclosure () -> NSTableView.AnimationOptions,
+        insertRowsAnimation: @autoclosure () -> NSTableView.AnimationOptions,
+        reloadRowsAnimation: @autoclosure () -> NSTableView.AnimationOptions,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        if case .none = window, let data = stagedChangeset.last?.data {
+            setData(data)
+            return reloadData()
+        }
+
+        for changeset in stagedChangeset {
+            if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
+                setData(data)
+                return reloadData()
+            }
+
+            beginUpdates()
+            setData(changeset.data)
+
+            if !changeset.elementDeleted.isEmpty {
+                removeRows(at: IndexSet(changeset.elementDeleted.map { $0.element }), withAnimation: deleteRowsAnimation())
+            }
+
+            if !changeset.elementInserted.isEmpty {
+                insertRows(at: IndexSet(changeset.elementInserted.map { $0.element }), withAnimation: insertRowsAnimation())
+            }
+
+            if !changeset.elementUpdated.isEmpty {
+                reloadData(forRowIndexes: IndexSet(changeset.elementUpdated.map { $0.element }), columnIndexes: IndexSet(changeset.elementUpdated.map { $0.section }))
+            }
+
+            for (source, target) in changeset.elementMoved {
+                moveRow(at: source.element, to: target.element)
+            }
+
+            endUpdates()
+        }
+    }
+}
+
+@available(macOS 10.11, *)
+public extension NSCollectionView {
+    /// Applies multiple animated updates in stages using `StagedChangeset`.
+    ///
+    /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
+    ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
+    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///
+    /// - Parameters:
+    ///   - stagedChangeset: A staged set of changes.
+    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - setData: A closure that takes the collection as a parameter.
+    ///              The collection should be set to data-source of NSCollectionView.
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        if case .none = window, let data = stagedChangeset.last?.data {
+            setData(data)
+            return reloadData()
+        }
+
+        for changeset in stagedChangeset {
+            if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
+                setData(data)
+                return reloadData()
+            }
+
+            animator().performBatchUpdates({
+                setData(changeset.data)
+
+                if !changeset.elementDeleted.isEmpty {
+                    deleteItems(at: Set(changeset.elementDeleted.map { IndexPath(item: $0.element, section: $0.section) }))
+                }
+
+                if !changeset.elementInserted.isEmpty {
+                    insertItems(at: Set(changeset.elementInserted.map { IndexPath(item: $0.element, section: $0.section) }))
+                }
+
+                if !changeset.elementUpdated.isEmpty {
+                    reloadItems(at: Set(changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) }))
+                }
+
+                for (source, target) in changeset.elementMoved {
+                    moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
+                }
+            })
+        }
+    }
+}
+#endif

--- a/GRDB/Utils/DifferenceKit-1.1.5/Extensions/AppKitExtension.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Extensions/AppKitExtension.swift
@@ -1,12 +1,13 @@
 #if os(macOS)
 import AppKit
 
-public extension NSTableView {
+extension NSTableView {
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
     ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
-    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///         The data of the data-source needs to be updated synchronously before
+    ///         `performBatchUpdates` in every stages.
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
@@ -16,7 +17,7 @@ public extension NSTableView {
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSTableView.
 
-    func reload<C>(
+    public func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> NSTableView.AnimationOptions,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
@@ -36,7 +37,8 @@ public extension NSTableView {
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
     ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
-    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///         The data of the data-source needs to be updated synchronously before
+    ///         `performBatchUpdates` in every stages.
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
@@ -70,15 +72,18 @@ public extension NSTableView {
             setData(changeset.data)
 
             if !changeset.elementDeleted.isEmpty {
-                removeRows(at: IndexSet(changeset.elementDeleted.map { $0.element }), withAnimation: deleteRowsAnimation())
+                removeRows(at: IndexSet(changeset.elementDeleted.map { $0.element }),
+                           withAnimation: deleteRowsAnimation())
             }
 
             if !changeset.elementInserted.isEmpty {
-                insertRows(at: IndexSet(changeset.elementInserted.map { $0.element }), withAnimation: insertRowsAnimation())
+                insertRows(at: IndexSet(changeset.elementInserted.map { $0.element }),
+                           withAnimation: insertRowsAnimation())
             }
 
             if !changeset.elementUpdated.isEmpty {
-                reloadData(forRowIndexes: IndexSet(changeset.elementUpdated.map { $0.element }), columnIndexes: IndexSet(changeset.elementUpdated.map { $0.section }))
+                reloadData(forRowIndexes: IndexSet(changeset.elementUpdated.map { $0.element }),
+                           columnIndexes: IndexSet(changeset.elementUpdated.map { $0.section }))
             }
 
             for (source, target) in changeset.elementMoved {
@@ -91,12 +96,13 @@ public extension NSTableView {
 }
 
 @available(macOS 10.11, *)
-public extension NSCollectionView {
+extension NSCollectionView {
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
     ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
-    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///         The data of the data-source needs to be updated synchronously before
+    ///          `performBatchUpdates` in every stages.
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
@@ -104,7 +110,7 @@ public extension NSCollectionView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of NSCollectionView.
-    func reload<C>(
+    public  func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
@@ -124,19 +130,23 @@ public extension NSCollectionView {
                 setData(changeset.data)
 
                 if !changeset.elementDeleted.isEmpty {
-                    deleteItems(at: Set(changeset.elementDeleted.map { IndexPath(item: $0.element, section: $0.section) }))
+                    deleteItems(at: Set(changeset.elementDeleted.map { IndexPath(item: $0.element,
+                                                                                 section: $0.section) }))
                 }
 
                 if !changeset.elementInserted.isEmpty {
-                    insertItems(at: Set(changeset.elementInserted.map { IndexPath(item: $0.element, section: $0.section) }))
+                    insertItems(at: Set(changeset.elementInserted.map { IndexPath(item: $0.element,
+                                                                                  section: $0.section) }))
                 }
 
                 if !changeset.elementUpdated.isEmpty {
-                    reloadItems(at: Set(changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) }))
+                    reloadItems(at: Set(changeset.elementUpdated.map { IndexPath(item: $0.element,
+                                                                                 section: $0.section) }))
                 }
 
                 for (source, target) in changeset.elementMoved {
-                    moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
+                    moveItem(at: IndexPath(item: source.element, section: source.section),
+                             to: IndexPath(item: target.element, section: target.section))
                 }
             })
         }

--- a/GRDB/Utils/DifferenceKit-1.1.5/Extensions/UIKitExtension.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Extensions/UIKitExtension.swift
@@ -1,0 +1,194 @@
+#if os(iOS) || os(tvOS)
+import UIKit
+
+public extension UITableView {
+    /// Applies multiple animated updates in stages using `StagedChangeset`.
+    ///
+    /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
+    ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
+    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///
+    /// - Parameters:
+    ///   - stagedChangeset: A staged set of changes.
+    ///   - animation: An option to animate the updates.
+    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - setData: A closure that takes the collection as a parameter.
+    ///              The collection should be set to data-source of UITableView.
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        with animation: @autoclosure () -> RowAnimation,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        reload(
+            using: stagedChangeset,
+            deleteSectionsAnimation: animation(),
+            insertSectionsAnimation: animation(),
+            reloadSectionsAnimation: animation(),
+            deleteRowsAnimation: animation(),
+            insertRowsAnimation: animation(),
+            reloadRowsAnimation: animation(),
+            interrupt: interrupt,
+            setData: setData
+        )
+    }
+
+    /// Applies multiple animated updates in stages using `StagedChangeset`.
+    ///
+    /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
+    ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
+    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///
+    /// - Parameters:
+    ///   - stagedChangeset: A staged set of changes.
+    ///   - deleteSectionsAnimation: An option to animate the section deletion.
+    ///   - insertSectionsAnimation: An option to animate the section insertion.
+    ///   - reloadSectionsAnimation: An option to animate the section reload.
+    ///   - deleteRowsAnimation: An option to animate the row deletion.
+    ///   - insertRowsAnimation: An option to animate the row insertion.
+    ///   - reloadRowsAnimation: An option to animate the row reload.
+    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - setData: A closure that takes the collection as a parameter.
+    ///              The collection should be set to data-source of UITableView.
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        deleteSectionsAnimation: @autoclosure () -> RowAnimation,
+        insertSectionsAnimation: @autoclosure () -> RowAnimation,
+        reloadSectionsAnimation: @autoclosure () -> RowAnimation,
+        deleteRowsAnimation: @autoclosure () -> RowAnimation,
+        insertRowsAnimation: @autoclosure () -> RowAnimation,
+        reloadRowsAnimation: @autoclosure () -> RowAnimation,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        if case .none = window, let data = stagedChangeset.last?.data {
+            setData(data)
+            return reloadData()
+        }
+
+        for changeset in stagedChangeset {
+            if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
+                setData(data)
+                return reloadData()
+            }
+
+            _performBatchUpdates {
+                setData(changeset.data)
+
+                if !changeset.sectionDeleted.isEmpty {
+                    deleteSections(IndexSet(changeset.sectionDeleted), with: deleteSectionsAnimation())
+                }
+
+                if !changeset.sectionInserted.isEmpty {
+                    insertSections(IndexSet(changeset.sectionInserted), with: insertSectionsAnimation())
+                }
+
+                if !changeset.sectionUpdated.isEmpty {
+                    reloadSections(IndexSet(changeset.sectionUpdated), with: reloadSectionsAnimation())
+                }
+
+                for (source, target) in changeset.sectionMoved {
+                    moveSection(source, toSection: target)
+                }
+
+                if !changeset.elementDeleted.isEmpty {
+                    deleteRows(at: changeset.elementDeleted.map { IndexPath(row: $0.element, section: $0.section) }, with: deleteRowsAnimation())
+                }
+
+                if !changeset.elementInserted.isEmpty {
+                    insertRows(at: changeset.elementInserted.map { IndexPath(row: $0.element, section: $0.section) }, with: insertRowsAnimation())
+                }
+
+                if !changeset.elementUpdated.isEmpty {
+                    reloadRows(at: changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }, with: reloadRowsAnimation())
+                }
+
+                for (source, target) in changeset.elementMoved {
+                    moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
+                }
+            }
+        }
+    }
+
+    private func _performBatchUpdates(_ updates: () -> Void) {
+        if #available(iOS 11.0, tvOS 11.0, *) {
+            performBatchUpdates(updates)
+        }
+        else {
+            beginUpdates()
+            updates()
+            endUpdates()
+        }
+    }
+}
+
+public extension UICollectionView {
+    /// Applies multiple animated updates in stages using `StagedChangeset`.
+    ///
+    /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
+    ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
+    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///
+    /// - Parameters:
+    ///   - stagedChangeset: A staged set of changes.
+    ///   - interrupt: A closure that takes an changeset as its argument and returns `true` if the animated
+    ///                updates should be stopped and performed reloadData. Default is nil.
+    ///   - setData: A closure that takes the collection as a parameter.
+    ///              The collection should be set to data-source of UICollectionView.
+    func reload<C>(
+        using stagedChangeset: StagedChangeset<C>,
+        interrupt: ((Changeset<C>) -> Bool)? = nil,
+        setData: (C) -> Void
+        ) {
+        if case .none = window, let data = stagedChangeset.last?.data {
+            setData(data)
+            return reloadData()
+        }
+
+        for changeset in stagedChangeset {
+            if let interrupt = interrupt, interrupt(changeset), let data = stagedChangeset.last?.data {
+                setData(data)
+                return reloadData()
+            }
+
+            performBatchUpdates({
+                setData(changeset.data)
+
+                if !changeset.sectionDeleted.isEmpty {
+                    deleteSections(IndexSet(changeset.sectionDeleted))
+                }
+
+                if !changeset.sectionInserted.isEmpty {
+                    insertSections(IndexSet(changeset.sectionInserted))
+                }
+
+                if !changeset.sectionUpdated.isEmpty {
+                    reloadSections(IndexSet(changeset.sectionUpdated))
+                }
+
+                for (source, target) in changeset.sectionMoved {
+                    moveSection(source, toSection: target)
+                }
+
+                if !changeset.elementDeleted.isEmpty {
+                    deleteItems(at: changeset.elementDeleted.map { IndexPath(item: $0.element, section: $0.section) })
+                }
+
+                if !changeset.elementInserted.isEmpty {
+                    insertItems(at: changeset.elementInserted.map { IndexPath(item: $0.element, section: $0.section) })
+                }
+
+                if !changeset.elementUpdated.isEmpty {
+                    reloadItems(at: changeset.elementUpdated.map { IndexPath(item: $0.element, section: $0.section) })
+                }
+
+                for (source, target) in changeset.elementMoved {
+                    moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
+                }
+            })
+        }
+    }
+}
+#endif

--- a/GRDB/Utils/DifferenceKit-1.1.5/Extensions/UIKitExtension.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/Extensions/UIKitExtension.swift
@@ -1,12 +1,13 @@
 #if os(iOS) || os(tvOS)
 import UIKit
 
-public extension UITableView {
+extension UITableView {
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
     ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
-    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///         The data of the data-source needs to be updated synchronously before
+    ///          `performBatchUpdates` in every stages.
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
@@ -15,7 +16,7 @@ public extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
-    func reload<C>(
+    public func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         with animation: @autoclosure () -> RowAnimation,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
@@ -38,7 +39,8 @@ public extension UITableView {
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
     ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
-    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///         The data of the data-source needs to be updated synchronously before
+    ///         `performBatchUpdates` in every stages.
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
@@ -52,7 +54,7 @@ public extension UITableView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UITableView.
-    func reload<C>(
+    public func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         deleteSectionsAnimation: @autoclosure () -> RowAnimation,
         insertSectionsAnimation: @autoclosure () -> RowAnimation,
@@ -94,19 +96,26 @@ public extension UITableView {
                 }
 
                 if !changeset.elementDeleted.isEmpty {
-                    deleteRows(at: changeset.elementDeleted.map { IndexPath(row: $0.element, section: $0.section) }, with: deleteRowsAnimation())
+                    deleteRows(at: changeset.elementDeleted.map { IndexPath(row: $0.element,
+                                                                            section: $0.section) },
+                               with: deleteRowsAnimation())
                 }
 
                 if !changeset.elementInserted.isEmpty {
-                    insertRows(at: changeset.elementInserted.map { IndexPath(row: $0.element, section: $0.section) }, with: insertRowsAnimation())
+                    insertRows(at: changeset.elementInserted.map { IndexPath(row: $0.element,
+                                                                             section: $0.section) },
+                               with: insertRowsAnimation())
                 }
 
                 if !changeset.elementUpdated.isEmpty {
-                    reloadRows(at: changeset.elementUpdated.map { IndexPath(row: $0.element, section: $0.section) }, with: reloadRowsAnimation())
+                    reloadRows(at: changeset.elementUpdated.map { IndexPath(row: $0.element,
+                                                                            section: $0.section) },
+                               with: reloadRowsAnimation())
                 }
 
                 for (source, target) in changeset.elementMoved {
-                    moveRow(at: IndexPath(row: source.element, section: source.section), to: IndexPath(row: target.element, section: target.section))
+                    moveRow(at: IndexPath(row: source.element, section: source.section),
+                            to: IndexPath(row: target.element, section: target.section))
                 }
             }
         }
@@ -115,8 +124,7 @@ public extension UITableView {
     private func _performBatchUpdates(_ updates: () -> Void) {
         if #available(iOS 11.0, tvOS 11.0, *) {
             performBatchUpdates(updates)
-        }
-        else {
+        } else {
             beginUpdates()
             updates()
             endUpdates()
@@ -124,12 +132,13 @@ public extension UITableView {
     }
 }
 
-public extension UICollectionView {
+extension UICollectionView {
     /// Applies multiple animated updates in stages using `StagedChangeset`.
     ///
     /// - Note: There are combination of changes that crash when applied simultaneously in `performBatchUpdates`.
     ///         Assumes that `StagedChangeset` has a minimum staged changesets to avoid it.
-    ///         The data of the data-source needs to be updated synchronously before `performBatchUpdates` in every stages.
+    ///         The data of the data-source needs to be updated synchronously before
+    ///         `performBatchUpdates` in every stages.
     ///
     /// - Parameters:
     ///   - stagedChangeset: A staged set of changes.
@@ -137,7 +146,7 @@ public extension UICollectionView {
     ///                updates should be stopped and performed reloadData. Default is nil.
     ///   - setData: A closure that takes the collection as a parameter.
     ///              The collection should be set to data-source of UICollectionView.
-    func reload<C>(
+    public func reload<C>(
         using stagedChangeset: StagedChangeset<C>,
         interrupt: ((Changeset<C>) -> Bool)? = nil,
         setData: (C) -> Void
@@ -185,7 +194,8 @@ public extension UICollectionView {
                 }
 
                 for (source, target) in changeset.elementMoved {
-                    moveItem(at: IndexPath(item: source.element, section: source.section), to: IndexPath(item: target.element, section: target.section))
+                    moveItem(at: IndexPath(item: source.element, section: source.section),
+                             to: IndexPath(item: target.element, section: target.section))
                 }
             })
         }

--- a/GRDB/Utils/DifferenceKit-1.1.5/StagedChangeset.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/StagedChangeset.swift
@@ -1,0 +1,100 @@
+/// An ordered collection of `Changeset` as staged set of changes in the sectioned collection.
+///
+/// The order is representing the stages of changesets.
+///
+/// We know that there are combination of changes that crash when applied simultaneously
+/// in batch-updates of UI such as UITableView or UICollectionView.
+/// The `StagedChangeset` created from the two collection is split at the minimal stages
+/// that can be perform batch-updates with no crashes.
+///
+/// Example for calculating differences between the two linear collections.
+///
+///     extension String: Differentiable {}
+///
+///     let source = ["A", "B", "C"]
+///     let target = ["B", "C", "D"]
+///
+///     let changeset = StagedChangeset(source: source, target: target)
+///     print(changeset.isEmpty)  // prints "false"
+///
+/// Example for calculating differences between the two sectioned collections.
+///
+///     let source = [
+///         Section(model: "A", elements: ["😉"]),
+///     ]
+///     let target = [
+///         Section(model: "A", elements: ["😉, 😺"]),
+///         Section(model: "B", elements: ["😪"])
+///     ]
+///
+///     let changeset = StagedChangeset(source: sectionedSource, target: sectionedTarget)
+///     print(changeset.isEmpty)  // prints "false"
+public struct StagedChangeset<Collection: Swift.Collection> {
+    @usableFromInline
+    internal var changesets: ContiguousArray<Changeset<Collection>>
+
+    /// Creates a new `StagedChangeset`.
+    ///
+    /// - Parameters:
+    ///   - changesets: The collection of `Changeset`.
+    public init<C: Swift.Collection>(_ changesets: C) where C.Element == Changeset<Collection> {
+        self.changesets = ContiguousArray(changesets)
+    }
+}
+
+extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection, MutableCollection {
+    public typealias Element = Changeset<Collection>
+
+    @inlinable
+    public init() {
+        self.init([])
+    }
+
+    @inlinable
+    public var startIndex: Int {
+        return changesets.startIndex
+    }
+
+    @inlinable
+    public var endIndex: Int {
+        return changesets.endIndex
+    }
+
+    @inlinable
+    public func index(after i: Int) -> Int {
+        return changesets.index(after: i)
+    }
+
+    @inlinable
+    public subscript(position: Int) -> Changeset<Collection> {
+        get { return changesets[position] }
+        set { changesets[position] = newValue }
+    }
+
+    @inlinable
+    public mutating func replaceSubrange<C: Swift.Collection, R: RangeExpression>(_ subrange: R, with newElements: C) where C.Element == Changeset<Collection>, R.Bound == Int {
+        changesets.replaceSubrange(subrange, with: newElements)
+    }
+}
+
+extension StagedChangeset: Equatable where Collection: Equatable {
+    @inlinable
+    public static func == (lhs: StagedChangeset, rhs: StagedChangeset) -> Bool {
+        return lhs.changesets == rhs.changesets
+    }
+}
+
+extension StagedChangeset: ExpressibleByArrayLiteral {
+    @inlinable
+    public init(arrayLiteral elements: Changeset<Collection>...) {
+        self.init(elements)
+    }
+}
+
+extension StagedChangeset: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        guard !isEmpty else { return "[]" }
+
+        return "[\n\(map { "    \($0.debugDescription.split(separator: "\n").joined(separator: "\n    "))" }.joined(separator: ",\n"))\n]"
+    }
+}

--- a/GRDB/Utils/DifferenceKit-1.1.5/StagedChangeset.swift
+++ b/GRDB/Utils/DifferenceKit-1.1.5/StagedChangeset.swift
@@ -30,8 +30,7 @@
 ///     let changeset = StagedChangeset(source: sectionedSource, target: sectionedTarget)
 ///     print(changeset.isEmpty)  // prints "false"
 public struct StagedChangeset<Collection: Swift.Collection> {
-    @usableFromInline
-    internal var changesets: ContiguousArray<Changeset<Collection>>
+    @usableFromInline internal var changesets: ContiguousArray<Changeset<Collection>>
 
     /// Creates a new `StagedChangeset`.
     ///
@@ -50,13 +49,11 @@ extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection, M
         self.init([])
     }
 
-    @inlinable
-    public var startIndex: Int {
+    @inlinable public var startIndex: Int {
         return changesets.startIndex
     }
 
-    @inlinable
-    public var endIndex: Int {
+    @inlinable public var endIndex: Int {
         return changesets.endIndex
     }
 
@@ -72,7 +69,9 @@ extension StagedChangeset: RandomAccessCollection, RangeReplaceableCollection, M
     }
 
     @inlinable
-    public mutating func replaceSubrange<C: Swift.Collection, R: RangeExpression>(_ subrange: R, with newElements: C) where C.Element == Changeset<Collection>, R.Bound == Int {
+    public mutating func replaceSubrange<C: Swift.Collection, R: RangeExpression>(_ subrange: R,
+                                                                                  with newElements: C)
+        where C.Element == Changeset<Collection>, R.Bound == Int {
         changesets.replaceSubrange(subrange, with: newElements)
     }
 }
@@ -95,6 +94,7 @@ extension StagedChangeset: CustomDebugStringConvertible {
     public var debugDescription: String {
         guard !isEmpty else { return "[]" }
 
+        // swiftlint:disable:next line_length
         return "[\n\(map { "    \($0.debugDescription.split(separator: "\n").joined(separator: "\n    "))" }.joined(separator: ",\n"))\n]"
     }
 }

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -7,6 +7,30 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		04D30A9423D0D1E20089A6FD /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8723D0D1E20089A6FD /* ContentEquatable.swift */; };
+		04D30A9523D0D1E20089A6FD /* ContentEquatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8723D0D1E20089A6FD /* ContentEquatable.swift */; };
+		04D30A9623D0D1E20089A6FD /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8823D0D1E20089A6FD /* ArraySection.swift */; };
+		04D30A9723D0D1E20089A6FD /* ArraySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8823D0D1E20089A6FD /* ArraySection.swift */; };
+		04D30A9823D0D1E20089A6FD /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8923D0D1E20089A6FD /* Algorithm.swift */; };
+		04D30A9923D0D1E20089A6FD /* Algorithm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8923D0D1E20089A6FD /* Algorithm.swift */; };
+		04D30A9A23D0D1E20089A6FD /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8B23D0D1E20089A6FD /* AppKitExtension.swift */; };
+		04D30A9B23D0D1E20089A6FD /* AppKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8B23D0D1E20089A6FD /* AppKitExtension.swift */; };
+		04D30A9C23D0D1E20089A6FD /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8C23D0D1E20089A6FD /* UIKitExtension.swift */; };
+		04D30A9D23D0D1E20089A6FD /* UIKitExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8C23D0D1E20089A6FD /* UIKitExtension.swift */; };
+		04D30A9E23D0D1E20089A6FD /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8D23D0D1E20089A6FD /* ContentIdentifiable.swift */; };
+		04D30A9F23D0D1E20089A6FD /* ContentIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8D23D0D1E20089A6FD /* ContentIdentifiable.swift */; };
+		04D30AA023D0D1E20089A6FD /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8E23D0D1E20089A6FD /* AnyDifferentiable.swift */; };
+		04D30AA123D0D1E20089A6FD /* AnyDifferentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8E23D0D1E20089A6FD /* AnyDifferentiable.swift */; };
+		04D30AA223D0D1E20089A6FD /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8F23D0D1E20089A6FD /* StagedChangeset.swift */; };
+		04D30AA323D0D1E20089A6FD /* StagedChangeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A8F23D0D1E20089A6FD /* StagedChangeset.swift */; };
+		04D30AA423D0D1E20089A6FD /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9023D0D1E20089A6FD /* ElementPath.swift */; };
+		04D30AA523D0D1E20089A6FD /* ElementPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9023D0D1E20089A6FD /* ElementPath.swift */; };
+		04D30AA623D0D1E20089A6FD /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9123D0D1E20089A6FD /* DifferentiableSection.swift */; };
+		04D30AA723D0D1E20089A6FD /* DifferentiableSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9123D0D1E20089A6FD /* DifferentiableSection.swift */; };
+		04D30AA823D0D1E20089A6FD /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9223D0D1E20089A6FD /* Changeset.swift */; };
+		04D30AA923D0D1E20089A6FD /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9223D0D1E20089A6FD /* Changeset.swift */; };
+		04D30AAA23D0D1E20089A6FD /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9323D0D1E20089A6FD /* Differentiable.swift */; };
+		04D30AAB23D0D1E20089A6FD /* Differentiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D30A9323D0D1E20089A6FD /* Differentiable.swift */; };
 		56043296228F00A9009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */; };
 		56043297228F00A9009D3FE2 /* OrderedDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */; };
 		560432A6228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */; };
@@ -718,6 +742,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		04D30A8723D0D1E20089A6FD /* ContentEquatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentEquatable.swift; sourceTree = "<group>"; };
+		04D30A8823D0D1E20089A6FD /* ArraySection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArraySection.swift; sourceTree = "<group>"; };
+		04D30A8923D0D1E20089A6FD /* Algorithm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Algorithm.swift; sourceTree = "<group>"; };
+		04D30A8B23D0D1E20089A6FD /* AppKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppKitExtension.swift; sourceTree = "<group>"; };
+		04D30A8C23D0D1E20089A6FD /* UIKitExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitExtension.swift; sourceTree = "<group>"; };
+		04D30A8D23D0D1E20089A6FD /* ContentIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentIdentifiable.swift; sourceTree = "<group>"; };
+		04D30A8E23D0D1E20089A6FD /* AnyDifferentiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDifferentiable.swift; sourceTree = "<group>"; };
+		04D30A8F23D0D1E20089A6FD /* StagedChangeset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StagedChangeset.swift; sourceTree = "<group>"; };
+		04D30A9023D0D1E20089A6FD /* ElementPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementPath.swift; sourceTree = "<group>"; };
+		04D30A9123D0D1E20089A6FD /* DifferentiableSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DifferentiableSection.swift; sourceTree = "<group>"; };
+		04D30A9223D0D1E20089A6FD /* Changeset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Changeset.swift; sourceTree = "<group>"; };
+		04D30A9323D0D1E20089A6FD /* Differentiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Differentiable.swift; sourceTree = "<group>"; };
 		31A7787C1C6A4DD600F507F6 /* FetchedRecordsController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchedRecordsController.swift; sourceTree = "<group>"; };
 		56043295228F00A9009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
 		560432A5228F167A009D3FE2 /* AssociationPrefetchingObservationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingObservationTests.swift; sourceTree = "<group>"; };
@@ -1106,6 +1142,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		04D30A8623D0D1E20089A6FD /* DifferenceKit-1.1.5 */ = {
+			isa = PBXGroup;
+			children = (
+				04D30A8723D0D1E20089A6FD /* ContentEquatable.swift */,
+				04D30A8823D0D1E20089A6FD /* ArraySection.swift */,
+				04D30A8923D0D1E20089A6FD /* Algorithm.swift */,
+				04D30A8A23D0D1E20089A6FD /* Extensions */,
+				04D30A8D23D0D1E20089A6FD /* ContentIdentifiable.swift */,
+				04D30A8E23D0D1E20089A6FD /* AnyDifferentiable.swift */,
+				04D30A8F23D0D1E20089A6FD /* StagedChangeset.swift */,
+				04D30A9023D0D1E20089A6FD /* ElementPath.swift */,
+				04D30A9123D0D1E20089A6FD /* DifferentiableSection.swift */,
+				04D30A9223D0D1E20089A6FD /* Changeset.swift */,
+				04D30A9323D0D1E20089A6FD /* Differentiable.swift */,
+			);
+			path = "DifferenceKit-1.1.5";
+			sourceTree = "<group>";
+		};
+		04D30A8A23D0D1E20089A6FD /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				04D30A8B23D0D1E20089A6FD /* AppKitExtension.swift */,
+				04D30A8C23D0D1E20089A6FD /* UIKitExtension.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		5605F1471C672E4000235C62 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -1471,6 +1534,7 @@
 		5659F4861EA8D94E004A4992 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				04D30A8623D0D1E20089A6FD /* DifferenceKit-1.1.5 */,
 				5659F49F1EA8D997004A4992 /* DatabaseResult.swift */,
 				563EF44C2161F196007DAACD /* Inflections.swift */,
 				569BBA4B229170B300478429 /* Inflections+English.swift */,
@@ -2161,6 +2225,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5656A8722295BD56001FF3FF /* HasOneThroughAssociation.swift in Sources */,
+				04D30AA123D0D1E20089A6FD /* AnyDifferentiable.swift in Sources */,
 				5636E9C11D22574100B9B05F /* FetchRequest.swift in Sources */,
 				F3BA801B1CFB2886003DC1BA /* CGFloat.swift in Sources */,
 				5656A85E2295BD56001FF3FF /* VirtualTableModule.swift in Sources */,
@@ -2186,6 +2251,7 @@
 				566B91181FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				F3BA80181CFB2876003DC1BA /* SerializedDatabase.swift in Sources */,
 				5674A7051F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
+				04D30A9D23D0D1E20089A6FD /* UIKitExtension.swift in Sources */,
 				5659F4A51EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				564CE52521B312AD00652B19 /* ValueObservation+MapReducer.swift in Sources */,
 				F3BA800D1CFB2871003DC1BA /* DatabasePool.swift in Sources */,
@@ -2196,6 +2262,7 @@
 				56E9FAC52210468500C703A8 /* SQLInterpolation.swift in Sources */,
 				563EF421215F8A76007DAACD /* OrderedDictionary.swift in Sources */,
 				F3BA80161CFB2876003DC1BA /* Row.swift in Sources */,
+				04D30AA523D0D1E20089A6FD /* ElementPath.swift in Sources */,
 				569EF0E7200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */,
 				F3BA80101CFB2876003DC1BA /* DatabaseReader.swift in Sources */,
 				564F9C331F07611800877A00 /* DatabaseFunction.swift in Sources */,
@@ -2204,11 +2271,14 @@
 				5659F49D1EA8D989004A4992 /* Pool.swift in Sources */,
 				5674A6F61F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				5656A88A2295BD56001FF3FF /* SQLExpressible.swift in Sources */,
+				04D30AAB23D0D1E20089A6FD /* Differentiable.swift in Sources */,
 				5698AC3C1D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
 				5698AD171DAAD16F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				04D30A9F23D0D1E20089A6FD /* ContentIdentifiable.swift in Sources */,
 				569BBA4C229170B300478429 /* Inflections+English.swift in Sources */,
 				5656A8762295BD56001FF3FF /* RequestProtocols.swift in Sources */,
 				561729552235340E0006E219 /* EncodableRecord.swift in Sources */,
+				04D30AA923D0D1E20089A6FD /* Changeset.swift in Sources */,
 				5656A87E2295BD56001FF3FF /* SQLAssociation.swift in Sources */,
 				F3BA80131CFB2876003DC1BA /* DatabaseValue.swift in Sources */,
 				56C0539822ACEECD0029D27D /* ValueReducer.swift in Sources */,
@@ -2221,15 +2291,18 @@
 				5656A8822295BD56001FF3FF /* SQLCollection.swift in Sources */,
 				56D51D051EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				F3BA80151CFB2876003DC1BA /* DatabaseWriter.swift in Sources */,
+				04D30A9923D0D1E20089A6FD /* Algorithm.swift in Sources */,
 				F3BA800A1CFB286A003DC1BA /* Configuration.swift in Sources */,
 				5656A86C2295BD56001FF3FF /* HasManyAssociation.swift in Sources */,
 				5656A88E2295BD56001FF3FF /* SQLSelectable.swift in Sources */,
 				5671FC251DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
+				04D30A9723D0D1E20089A6FD /* ArraySection.swift in Sources */,
 				5656A8862295BD56001FF3FF /* SQLOrdering.swift in Sources */,
 				F3BA80311CFB289F003DC1BA /* Migration.swift in Sources */,
 				F3BA801D1CFB288C003DC1BA /* DatabaseDateComponents.swift in Sources */,
 				5674A6ED1F307F0E0095F066 /* DatabaseValueConvertible+Encodable.swift in Sources */,
 				5657AB141D10899D006283EF /* URL.swift in Sources */,
+				04D30A9523D0D1E20089A6FD /* ContentEquatable.swift in Sources */,
 				5613ED6A21A95E6100DC7A68 /* ValueObservation+FetchableRecord.swift in Sources */,
 				5644DE7920F8C8EA001FFDDE /* DatabaseValueConversion.swift in Sources */,
 				56DAA2E01DE9C827006E10C8 /* Cursor.swift in Sources */,
@@ -2260,6 +2333,7 @@
 				564CE43D21AA955B00652B19 /* ValueObserver.swift in Sources */,
 				5674A6FD1F307F600095F066 /* FetchableRecord+Decodable.swift in Sources */,
 				F3BA80141CFB2876003DC1BA /* DatabaseValueConvertible.swift in Sources */,
+				04D30AA323D0D1E20089A6FD /* StagedChangeset.swift in Sources */,
 				5656A8702295BD56001FF3FF /* Association.swift in Sources */,
 				5656A89C2295BD56001FF3FF /* SQLQuery.swift in Sources */,
 				5656A88C2295BD56001FF3FF /* SQLExpression+QueryInterface.swift in Sources */,
@@ -2269,6 +2343,7 @@
 				5656A8902295BD56001FF3FF /* Column.swift in Sources */,
 				564CE5B821B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */,
 				5613ED6C21A95E6100DC7A68 /* ValueObservation+DatabaseValueConvertible.swift in Sources */,
+				04D30A9B23D0D1E20089A6FD /* AppKitExtension.swift in Sources */,
 				5656A8622295BD56001FF3FF /* TableRecord+Association.swift in Sources */,
 				56C0539622ACEECD0029D27D /* ValueObservation+Row.swift in Sources */,
 				F3BA80301CFB289F003DC1BA /* DatabaseMigrator.swift in Sources */,
@@ -2278,6 +2353,7 @@
 				567071F5208A00BE006AD95A /* SQLiteDateParser.swift in Sources */,
 				5656A89A2295BD56001FF3FF /* SQLSelectable+QueryInterface.swift in Sources */,
 				F3BA80271CFB2891003DC1BA /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
+				04D30AA723D0D1E20089A6FD /* DifferentiableSection.swift in Sources */,
 				5657AABE1D107001006283EF /* NSData.swift in Sources */,
 				5674A6E61F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
 				5656A8662295BD56001FF3FF /* BelongsToAssociation.swift in Sources */,
@@ -2501,6 +2577,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5656A8712295BD56001FF3FF /* HasOneThroughAssociation.swift in Sources */,
+				04D30AA023D0D1E20089A6FD /* AnyDifferentiable.swift in Sources */,
 				5636E9BE1D22574100B9B05F /* FetchRequest.swift in Sources */,
 				F3BA80771CFB2E5C003DC1BA /* CGFloat.swift in Sources */,
 				5656A85D2295BD56001FF3FF /* VirtualTableModule.swift in Sources */,
@@ -2526,6 +2603,7 @@
 				566B91151FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				F3BA80741CFB2E55003DC1BA /* SerializedDatabase.swift in Sources */,
 				5674A7041F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
+				04D30A9C23D0D1E20089A6FD /* UIKitExtension.swift in Sources */,
 				5659F4A21EA8D997004A4992 /* DatabaseResult.swift in Sources */,
 				564CE52421B312AD00652B19 /* ValueObservation+MapReducer.swift in Sources */,
 				F3BA80691CFB2E55003DC1BA /* DatabasePool.swift in Sources */,
@@ -2536,6 +2614,7 @@
 				56E9FAC42210468500C703A8 /* SQLInterpolation.swift in Sources */,
 				563EF420215F8A76007DAACD /* OrderedDictionary.swift in Sources */,
 				F3BA80721CFB2E55003DC1BA /* Row.swift in Sources */,
+				04D30AA423D0D1E20089A6FD /* ElementPath.swift in Sources */,
 				569EF0E6200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */,
 				F3BA806C1CFB2E55003DC1BA /* DatabaseReader.swift in Sources */,
 				564F9C301F07611500877A00 /* DatabaseFunction.swift in Sources */,
@@ -2544,11 +2623,14 @@
 				5659F49A1EA8D989004A4992 /* Pool.swift in Sources */,
 				5674A6F51F307F600095F066 /* EncodableRecord+Encodable.swift in Sources */,
 				5656A8892295BD56001FF3FF /* SQLExpressible.swift in Sources */,
+				04D30AAA23D0D1E20089A6FD /* Differentiable.swift in Sources */,
 				5698AC391D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
 				5698AD161DAAD16F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				04D30A9E23D0D1E20089A6FD /* ContentIdentifiable.swift in Sources */,
 				569BBA4D229170B300478429 /* Inflections+English.swift in Sources */,
 				5656A8752295BD56001FF3FF /* RequestProtocols.swift in Sources */,
 				561729562235340E0006E219 /* EncodableRecord.swift in Sources */,
+				04D30AA823D0D1E20089A6FD /* Changeset.swift in Sources */,
 				5656A87D2295BD56001FF3FF /* SQLAssociation.swift in Sources */,
 				F3BA806F1CFB2E55003DC1BA /* DatabaseValue.swift in Sources */,
 				56C0539722ACEECD0029D27D /* ValueReducer.swift in Sources */,
@@ -2561,15 +2643,18 @@
 				5656A8812295BD56001FF3FF /* SQLCollection.swift in Sources */,
 				56D51D021EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				F3BA80711CFB2E55003DC1BA /* DatabaseWriter.swift in Sources */,
+				04D30A9823D0D1E20089A6FD /* Algorithm.swift in Sources */,
 				F3BA80661CFB2E55003DC1BA /* Configuration.swift in Sources */,
 				5656A86B2295BD56001FF3FF /* HasManyAssociation.swift in Sources */,
 				5656A88D2295BD56001FF3FF /* SQLSelectable.swift in Sources */,
 				5671FC221DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
+				04D30A9623D0D1E20089A6FD /* ArraySection.swift in Sources */,
 				5656A8852295BD56001FF3FF /* SQLOrdering.swift in Sources */,
 				F3BA808D1CFB2E75003DC1BA /* Migration.swift in Sources */,
 				F3BA80791CFB2E61003DC1BA /* DatabaseDateComponents.swift in Sources */,
 				5674A6EC1F307F0E0095F066 /* DatabaseValueConvertible+Encodable.swift in Sources */,
 				5657AB111D10899D006283EF /* URL.swift in Sources */,
+				04D30A9423D0D1E20089A6FD /* ContentEquatable.swift in Sources */,
 				5613ED6921A95E6100DC7A68 /* ValueObservation+FetchableRecord.swift in Sources */,
 				5644DE7820F8C8EA001FFDDE /* DatabaseValueConversion.swift in Sources */,
 				56DAA2DD1DE9C827006E10C8 /* Cursor.swift in Sources */,
@@ -2600,6 +2685,7 @@
 				564CE43C21AA955B00652B19 /* ValueObserver.swift in Sources */,
 				5674A6FC1F307F600095F066 /* FetchableRecord+Decodable.swift in Sources */,
 				F3BA80701CFB2E55003DC1BA /* DatabaseValueConvertible.swift in Sources */,
+				04D30AA223D0D1E20089A6FD /* StagedChangeset.swift in Sources */,
 				5656A86F2295BD56001FF3FF /* Association.swift in Sources */,
 				5656A89B2295BD56001FF3FF /* SQLQuery.swift in Sources */,
 				5656A88B2295BD56001FF3FF /* SQLExpression+QueryInterface.swift in Sources */,
@@ -2609,6 +2695,7 @@
 				5656A88F2295BD56001FF3FF /* Column.swift in Sources */,
 				564CE5B721B8FBEB00652B19 /* DatabaseRegionObservation.swift in Sources */,
 				5613ED6B21A95E6100DC7A68 /* ValueObservation+DatabaseValueConvertible.swift in Sources */,
+				04D30A9A23D0D1E20089A6FD /* AppKitExtension.swift in Sources */,
 				5656A8612295BD56001FF3FF /* TableRecord+Association.swift in Sources */,
 				56C0539522ACEECD0029D27D /* ValueObservation+Row.swift in Sources */,
 				F3BA808C1CFB2E75003DC1BA /* DatabaseMigrator.swift in Sources */,
@@ -2618,6 +2705,7 @@
 				567071F4208A00BE006AD95A /* SQLiteDateParser.swift in Sources */,
 				5656A8992295BD56001FF3FF /* SQLSelectable+QueryInterface.swift in Sources */,
 				F3BA80831CFB2E67003DC1BA /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
+				04D30AA623D0D1E20089A6FD /* DifferentiableSection.swift in Sources */,
 				5657AABB1D107001006283EF /* NSData.swift in Sources */,
 				5674A6E51F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
 				5656A8652295BD56001FF3FF /* BelongsToAssociation.swift in Sources */,

--- a/Tests/GRDBTests/FetchedRecordsControllerTests.swift
+++ b/Tests/GRDBTests/FetchedRecordsControllerTests.swift
@@ -6,40 +6,15 @@ import XCTest
 #endif
 
 private class ChangesRecorder<Record: FetchableRecord> {
-    var changes: [(record: Record, change: FetchedRecordChange)] = []
-    var recordsBeforeChanges: [Record]!
-    var recordsAfterChanges: [Record]!
-    var countBeforeChanges: Int?
-    var countAfterChanges: Int?
-    var recordsOnFirstEvent: [Record]!
+    var changes: [ArraySection<FetchedRecordsSectionInfo<Record>, Item<Record>>] = []
     var transactionExpectation: XCTestExpectation? {
         didSet {
             changes = []
-            recordsBeforeChanges = nil
-            recordsAfterChanges = nil
-            countBeforeChanges = nil
-            countAfterChanges = nil
-            recordsOnFirstEvent = nil
         }
     }
-    
-    func controllerWillChange(_ controller: FetchedRecordsController<Record>, count: Int? = nil) {
-        recordsBeforeChanges = controller.fetchedRecords
-        countBeforeChanges = count
-    }
-    
-    /// The default implementation does nothing.
-    func controller(_ controller: FetchedRecordsController<Record>, didChangeRecord record: Record, with change: FetchedRecordChange) {
-        if recordsOnFirstEvent == nil {
-            recordsOnFirstEvent = controller.fetchedRecords
-        }
-        changes.append((record: record, change: change))
-    }
-    
-    /// The default implementation does nothing.
-    func controllerDidChange(_ controller: FetchedRecordsController<Record>, count: Int? = nil) {
-        recordsAfterChanges = controller.fetchedRecords
-        countAfterChanges = count
+
+    func record(_ changeSet: StagedChangeset<[ArraySection<FetchedRecordsSectionInfo<Record>, Item<Record>>]>) {
+        changes.append(contentsOf: changeSet.flatMap { $0.data })
         if let transactionExpectation = transactionExpectation {
             transactionExpectation.fulfill()
         }
@@ -80,12 +55,6 @@ private class Person : Record {
     
     override func didInsert(with rowID: Int64, for column: String?) {
         id = rowID
-    }
-}
-
-extension Person: Diffable {
-    var primaryKeyValue: String {
-        return "\(String(describing: id))"
     }
 }
 
@@ -134,7 +103,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
             }
         }
     }
-    
+
     func testControllerFromSQL() throws {
         let dbQueue = try makeDatabaseQueue()
         let authorId: Int64 = try dbQueue.inDatabase { db in
@@ -152,6 +121,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         XCTAssertEqual(controller.fetchedRecords.count, 1)
         XCTAssertEqual(controller.fetchedRecords[0].title, "Don Quixote")
     }
+
 
     func testControllerFromSQLWithAdapter() throws {
         let dbQueue = try makeDatabaseQueue()
@@ -171,6 +141,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         XCTAssertEqual(controller.fetchedRecords.count, 1)
         XCTAssertEqual(controller.fetchedRecords[0].title, "Don Quixote")
     }
+
 
     func testControllerFromRequest() throws {
         let dbQueue = try makeDatabaseQueue()
@@ -207,6 +178,7 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         XCTAssertEqual(controller.indexPath(for: arthur), IndexPath(indexes: [0, 0]))
     }
 
+
     func testEmptyRequestGivesOneSection() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Person.all()
@@ -228,12 +200,13 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("id")))
         let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
+        controller.track { changes in
+            recorder.record(changes)
+        }
         try controller.performFetch()
-        
+
+        XCTAssertEqual(controller.fetchedRecords.count, 0)
+
         // First insert
         recorder.transactionExpectation = expectation(description: "expectation")
         try dbQueue.inTransaction { db in
@@ -242,19 +215,13 @@ class FetchedRecordsControllerTests: GRDBTestCase {
             return .commit
         }
         waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 0)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 1)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Arthur"])
+
         XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 1)
-        XCTAssertEqual(recorder.changes[0].record.name, "Arthur")
-        switch recorder.changes[0].change {
-        case .insertion(let indexPath):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-        default:
-            XCTFail()
-        }
+        XCTAssertEqual(recorder.changes.flatMap { $0.elements }.map { $0.record.name }, ["Arthur"])
+        XCTAssertEqual(recorder.changes[0].elements[0].record.id, 1)
+        XCTAssertEqual(recorder.changes[0].elements[0].record.name, "Arthur")
+        XCTAssertEqual(recorder.changes[0].model.indexPath, IndexPath(indexes: [0, 0]))
+        XCTAssertEqual(controller.indexPath(for: Person(id: 1, name: "Arthur")), IndexPath(indexes: [0, 0]))
         
         // Second insert
         recorder.transactionExpectation = expectation(description: "expectation")
@@ -265,30 +232,22 @@ class FetchedRecordsControllerTests: GRDBTestCase {
             return .commit
         }
         waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 1)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 2)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Arthur", "Barbara"])
+
         XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 2)
-        XCTAssertEqual(recorder.changes[0].record.name, "Barbara")
-        switch recorder.changes[0].change {
-        case .insertion(let indexPath):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 1]))
-        default:
-            XCTFail()
-        }
+        XCTAssertEqual(recorder.changes.flatMap { $0.elements }.map { $0.record.name }, ["Arthur", "Barbara"])
+        XCTAssertEqual(recorder.changes[0].elements[0].record.id, 1)
+        XCTAssertEqual(recorder.changes[0].elements[0].record.name, "Arthur")
+        XCTAssertEqual(recorder.changes[0].model.indexPath, IndexPath(indexes: [0, 0]))
+        XCTAssertEqual(controller.indexPath(for: Person(id: 2, name: "Barbara")), IndexPath(indexes: [0, 1]))
     }
 
     func testSimpleUpdate() throws {
         let dbQueue = try makeDatabaseQueue()
         let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("id")))
         let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
+        controller.track { changes in
+            recorder.record(changes)
+        }
         try controller.performFetch()
         
         // Insert
@@ -300,14 +259,11 @@ class FetchedRecordsControllerTests: GRDBTestCase {
             return .commit
         }
         waitForExpectations(timeout: 1, handler: nil)
+
+        var recordsBeforeChanges = controller.fetchedRecords
         
         // First update
         recorder.transactionExpectation = expectation(description: "expectation")
-        // No change should be recorded
-        try dbQueue.inTransaction { db in
-            try db.execute(sql: "UPDATE persons SET name = ? WHERE id = ?", arguments: ["Arthur", 1])
-            return .commit
-        }
         // One change should be recorded
         try dbQueue.inTransaction { db in
             try synchronizePersons(db, [
@@ -317,20 +273,11 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         }
         waitForExpectations(timeout: 1, handler: nil)
         
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 2)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Craig", "Barbara"])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 1)
-        XCTAssertEqual(recorder.changes[0].record.name, "Craig")
-        switch recorder.changes[0].change {
-        case .update(let indexPath, let changes):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-            XCTAssertEqual(changes, ["name": "Arthur".databaseValue])
-        default:
-            XCTFail()
-        }
+        XCTAssertEqual(recordsBeforeChanges.count, 2)
+        XCTAssertEqual(recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
+        XCTAssertEqual(controller.fetchedRecords.map { $0.name }, ["Craig", "Barbara"])
+
+        recordsBeforeChanges = controller.fetchedRecords
         
         // Second update
         recorder.transactionExpectation = expectation(description: "expectation")
@@ -342,601 +289,30 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         }
         waitForExpectations(timeout: 1, handler: nil)
         
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Craig", "Barbara"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 2)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Craig", "Danielle"])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 2)
-        XCTAssertEqual(recorder.changes[0].record.name, "Danielle")
-        switch recorder.changes[0].change {
-        case .update(let indexPath, let changes):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 1]))
-            XCTAssertEqual(changes, ["name": "Barbara".databaseValue])
-        default:
-            XCTFail()
-        }
+        XCTAssertEqual(recordsBeforeChanges.count, 2)
+        XCTAssertEqual(controller.fetchedRecords.map { $0.name }, ["Craig", "Danielle"])
     }
 
-    func testSimpleDelete() throws {
+    func testItSupportsMultipleSections() throws {
         let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("id")))
-        let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
+
+        try dbQueue.inDatabase { db in
+            try Person(name: "Plato").insert(db)
+            try Person(name: "Cervantes").insert(db)
+            try Person(name: "Carl").insert(db)
+        }
+
+        let controller = try FetchedRecordsController(dbQueue, request: Person.all(), sectionColumn: Column("name"))
         try controller.performFetch()
-        
-        // Insert
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur"),
-                Person(id: 2, name: "Barbara")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        // First delete
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 2, name: "Barbara")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 1)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Barbara"])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 1)
-        XCTAssertEqual(recorder.changes[0].record.name, "Arthur")
-        switch recorder.changes[0].change {
-        case .deletion(let indexPath):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-        default:
-            XCTFail()
-        }
-        
-        // Second delete
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 1)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Barbara"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 0)
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 2)
-        XCTAssertEqual(recorder.changes[0].record.name, "Barbara")
-        switch recorder.changes[0].change {
-        case .deletion(let indexPath):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-        default:
-            XCTFail()
-        }
-    }
 
-    func testSimpleMove() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("name")))
-        let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
+        XCTAssertEqual(controller.sections.count, 2)
+
+        controller.sectionColumn = Column("id")
         try controller.performFetch()
-        
-        // Insert
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur"),
-                Person(id: 2, name: "Barbara")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        // Move
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Craig"),
-                Person(id: 2, name: "Barbara")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 2)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Barbara", "Craig"])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 1)
-        XCTAssertEqual(recorder.changes[0].record.name, "Craig")
-        switch recorder.changes[0].change {
-        case .move(let indexPath, let newIndexPath, let changes):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-            XCTAssertEqual(newIndexPath, IndexPath(indexes: [0, 1]))
-            XCTAssertEqual(changes, ["name": "Arthur".databaseValue])
-        default:
-            XCTFail()
-        }
-    }
 
-    func testSideTableChange() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController<Person>(
-            dbQueue,
-            sql: """
-                SELECT persons.*, COUNT(books.id) AS bookCount
-                FROM persons
-                LEFT JOIN books ON books.authorId = persons.id
-                GROUP BY persons.id
-                ORDER BY persons.name
-                """)
-        let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
-        try controller.performFetch()
-        
-        // Insert
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try db.execute(sql: "INSERT INTO persons (name) VALUES (?)", arguments: ["Arthur"])
-            try db.execute(sql: "INSERT INTO books (authorId, title) VALUES (?, ?)", arguments: [1, "Moby Dick"])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        // Change books
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try db.execute(sql: "DELETE FROM books")
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 1)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur"])
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.bookCount! }, [1])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 1)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Arthur"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.bookCount! }, [0])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 1)
-        XCTAssertEqual(recorder.changes[0].record.name, "Arthur")
-        XCTAssertEqual(recorder.changes[0].record.bookCount, 0)
-        switch recorder.changes[0].change {
-        case .update(let indexPath, let changes):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-            XCTAssertEqual(changes, ["bookCount": 1.databaseValue])
-        default:
-            XCTFail()
-        }
-    }
-
-    func testComplexChanges() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("name")))
-        let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
-        try controller.performFetch()
-        
-        enum EventTest {
-            case I(String, Int) // insert string at index
-            case M(String, Int, Int, String) // move string from index to index with changed string
-            case D(String, Int) // delete string at index
-            case U(String, Int, String) // update string at index with changed string
-            
-            func match(name: String, event: FetchedRecordChange) -> Bool {
-                switch self {
-                case .I(let s, let i):
-                    switch event {
-                    case .insertion(let indexPath):
-                        return s == name && i == indexPath[1]
-                    default:
-                        return false
-                    }
-                case .M(let s, let i, let j, let c):
-                    switch event {
-                    case .move(let indexPath, let newIndexPath, let changes):
-                        return s == name && i == indexPath[1] && j == newIndexPath[1] && c == String.fromDatabaseValue(changes["name"]!)!
-                    default:
-                        return false
-                    }
-                case .D(let s, let i):
-                    switch event {
-                    case .deletion(let indexPath):
-                        return s == name && i == indexPath[1]
-                    default:
-                        return false
-                    }
-                case .U(let s, let i, let c):
-                    switch event {
-                    case .update(let indexPath, let changes):
-                        return s == name && i == indexPath[1] && c == String.fromDatabaseValue(changes["name"]!)!
-                    default:
-                        return false
-                    }
-                }
-            }
-        }
-        
-        // A list of random updates. We hope to cover most cases if not all cases here.
-        let steps: [(word: String, events: [EventTest])] = [
-            (word: "B", events: [.I("B",0)]),
-            (word: "BA", events: [.I("A",0)]),
-            (word: "ABF", events: [.M("B",0,1,"A"), .M("A",1,0,"B"), .I("F",2)]),
-            (word: "AB", events: [.D("F",2)]),
-            (word: "A", events: [.D("B",1)]),
-            (word: "C", events: [.U("C",0,"A")]),
-            (word: "", events: [.D("C",0)]),
-            (word: "C", events: [.I("C",0)]),
-            (word: "CD", events: [.I("D",1)]),
-            (word: "B", events: [.D("D",1), .U("B",0,"C")]),
-            (word: "BCAEFD", events: [.I("A",0), .I("C",2), .I("D",3), .I("E",4), .I("F",5)]),
-            (word: "CADBE", events: [.M("A",2,0,"C"), .D("D",3), .M("C",1,2,"B"), .M("B",4,1,"E"), .M("D",0,3,"A"), .M("E",5,4,"F")]),
-            (word: "EB", events: [.D("B",1), .D("D",3), .D("E",4), .M("E",2,1,"C"), .U("B",0,"A")]),
-            (word: "BEC", events: [.I("C",1), .M("B",1,0,"E"), .M("E",0,2,"B")]),
-            (word: "AB", events: [.D("C",1), .M("B",2,1,"E"), .U("A",0,"B")]),
-            (word: "ADEFCB", events: [.I("B",1), .I("C",2), .I("E",4), .M("D",1,3,"B"), .I("F",5)]),
-            (word: "DA", events: [.D("B",1), .D("C",2), .D("E",4), .M("A",3,0,"D"), .D("F",5), .M("D",0,1,"A")]),
-            (word: "BACEF", events: [.I("C",2), .I("E",3), .I("F",4), .U("B",1,"D")]),
-            (word: "BACD", events: [.D("F",4), .U("D",3,"E")]),
-            (word: "EABDFC", events: [.M("B",2,1,"C"), .I("C",2), .M("E",1,4,"B"), .I("F",5)]),
-            (word: "CAB", events: [.D("C",2), .D("D",3), .D("F",5), .M("C",4,2,"E")]),
-            (word: "CBAD", events: [.M("A",1,0,"B"), .M("B",0,1,"A"), .I("D",3)]),
-            (word: "BAC", events: [.M("A",1,0,"B"), .M("B",2,1,"C"), .D("D",3), .M("C",0,2,"A")]),
-            (word: "CBEADF", events: [.I("A",0), .M("B",0,1,"A"), .I("D",3), .M("C",1,2,"B"), .M("E",2,4,"C"), .I("F",5)]),
-            (word: "CBA", events: [.D("A",0), .D("D",3), .M("A",4,0,"E"), .D("F",5)]),
-            (word: "CBDAF", events: [.I("A",0), .M("D",0,3,"A"), .I("F",4)]),
-            (word: "B", events: [.D("A",0), .D("B",1), .D("D",3), .D("F",4), .M("B",2,0,"C")]),
-            (word: "BDECAF", events: [.I("A",0), .I("C",2), .I("D",3), .I("E",4), .I("F",5)]),
-            (word: "ABCDEF", events: [.M("A",1,0,"B"), .M("B",3,1,"D"), .M("D",2,3,"C"), .M("C",4,2,"E"), .M("E",0,4,"A")]),
-            (word: "ADBCF", events: [.M("B",2,1,"C"), .M("C",3,2,"D"), .M("D",1,3,"B"), .D("F",5), .U("F",4,"E")]),
-            (word: "A", events: [.D("B",1), .D("C",2), .D("D",3), .D("F",4)]),
-            (word: "AEBDCF", events: [.I("B",1), .I("C",2), .I("D",3), .I("E",4), .I("F",5)]),
-            (word: "B", events: [.D("B",1), .D("C",2), .D("D",3), .D("E",4), .D("F",5), .U("B",0,"A")]),
-            (word: "ABCDF", events: [.I("B",1), .I("C",2), .I("D",3), .I("F",4), .U("A",0,"B")]),
-            (word: "CAB", events: [.M("A",1,0,"B"), .D("D",3), .M("B",2,1,"C"), .D("F",4), .M("C",0,2,"A")]),
-            (word: "AC", events: [.D("B",1), .M("A",2,0,"C"), .M("C",0,1,"A")]),
-            (word: "DABC", events: [.I("B",1), .I("C",2), .M("A",1,0,"C"), .M("D",0,3,"A")]),
-            (word: "BACD", events: [.M("C",1,2,"B"), .M("B",3,1,"D"), .M("D",2,3,"C")]),
-            (word: "D", events: [.D("A",0), .D("C",2), .D("D",3), .M("D",1,0,"B")]),
-            (word: "CABDFE", events: [.I("A",0), .I("B",1), .I("D",3), .I("E",4), .M("C",0,2,"D"), .I("F",5)]),
-            (word: "BACDEF", events: [.M("B",2,1,"C"), .M("C",1,2,"B"), .M("E",5,4,"F"), .M("F",4,5,"E")]),
-            (word: "AB", events: [.D("C",2), .D("D",3), .D("E",4), .M("A",1,0,"B"), .D("F",5), .M("B",0,1,"A")]),
-            (word: "BACDE", events: [.I("C",2), .M("B",0,1,"A"), .I("D",3), .M("A",1,0,"B"), .I("E",4)]),
-            (word: "E", events: [.D("A",0), .D("C",2), .D("D",3), .D("E",4), .M("E",1,0,"B")]),
-            (word: "A", events: [.U("A",0,"E")]),
-            (word: "ABCDE", events: [.I("B",1), .I("C",2), .I("D",3), .I("E",4)]),
-            (word: "BA", events: [.D("C",2), .D("D",3), .M("A",1,0,"B"), .D("E",4), .M("B",0,1,"A")]),
-            (word: "A", events: [.D("A",0), .M("A",1,0,"B")]),
-            (word: "CAB", events: [.I("A",0), .I("B",1), .M("C",0,2,"A")]),
-            (word: "EA", events: [.D("B",1), .M("E",2,1,"C")]),
-            (word: "B", events: [.D("A",0), .M("B",1,0,"E")]),
-            ]
-        
-        for step in steps {
-            recorder.transactionExpectation = expectation(description: "expectation")
-            try dbQueue.inTransaction { db in
-                try synchronizePersons(db, step.word.enumerated().map { Person(id: Int64($0), name: String($1)) })
-                return .commit
-            }
-            waitForExpectations(timeout: 1, handler: nil)
-            
-            XCTAssertEqual(recorder.changes.count, step.events.count)
-            for (change, event) in zip(recorder.changes, step.events) {
-                XCTAssertTrue(event.match(name: change.record.name, event: change.change))
-            }
-        }
-    }
-
-    func testExternalTableChange() {
-        // TODO: test that delegate is not notified after a database change in a
-        // table not involved in the fetch request. The difficulty of this test
-        // lies in the "not" word.
-    }
-
-    func testCustomRecordIdentity() {
-        // TODO: test record comparison not based on primary key but based on
-        // custom function
-    }
-
-    func testRequestChange() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("name")))
-        let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
-        try controller.performFetch()
-        
-        // Insert
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur"),
-                Person(id: 2, name: "Barbara")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        // Change request with Request
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try controller.setRequest(Person.order(Column("name").desc))
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 2)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Barbara", "Arthur"])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 2)
-        XCTAssertEqual(recorder.changes[0].record.name, "Barbara")
-        switch recorder.changes[0].change {
-        case .move(let indexPath, let newIndexPath, let changes):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 1]))
-            XCTAssertEqual(newIndexPath, IndexPath(indexes: [0, 0]))
-            XCTAssertTrue(changes.isEmpty)
-        default:
-            XCTFail()
-        }
-        
-        // Change request with SQL and arguments
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try controller.setRequest(sql: "SELECT ? AS id, ? AS name", arguments: [1, "Craig"])
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Barbara", "Arthur"])
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 1)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Craig"])
-        XCTAssertEqual(recorder.changes.count, 2)
-        XCTAssertEqual(recorder.changes[0].record.id, 2)
-        XCTAssertEqual(recorder.changes[0].record.name, "Barbara")
-        XCTAssertEqual(recorder.changes[1].record.id, 1)
-        XCTAssertEqual(recorder.changes[1].record.name, "Craig")
-        switch recorder.changes[0].change {
-        case .deletion(let indexPath):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-        default:
-            XCTFail()
-        }
-        switch recorder.changes[1].change {
-        case .move(let indexPath, let newIndexPath, let changes):
-            // TODO: is it really what we should expect? Wouldn't an update fit better?
-            // What does UITableView think?
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 1]))
-            XCTAssertEqual(newIndexPath, IndexPath(indexes: [0, 0]))
-            XCTAssertEqual(changes, ["name": "Arthur".databaseValue])
-        default:
-            XCTFail()
-        }
-        
-        // Change request with a different set of tracked columns
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try controller.setRequest(Person.select(Column("id"), Column("name"), Column("email")).order(Column("name")))
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 1)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Craig"])
-        XCTAssertEqual(recorder.recordsAfterChanges.count, 2)
-        XCTAssertEqual(recorder.recordsAfterChanges.map { $0.name }, ["Arthur", "Barbara"])
-        
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try db.execute(sql: "UPDATE persons SET email = ? WHERE name = ?", arguments: ["arthur@example.com", "Arthur"])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.recordsAfterChanges.count, 2)
-        XCTAssertEqual(recorder.recordsAfterChanges.map { $0.name }, ["Arthur", "Barbara"])
-        
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try db.execute(sql: "UPDATE PERSONS SET EMAIL = ? WHERE NAME = ?", arguments: ["barbara@example.com", "Barbara"])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 2)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.recordsAfterChanges.count, 2)
-        XCTAssertEqual(recorder.recordsAfterChanges.map { $0.name }, ["Arthur", "Barbara"])
-    }
-
-    func testSetCallbacksAfterUpdate() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("name")))
-        let recorder = ChangesRecorder<Person>()
-        try controller.performFetch()
-        
-        // Insert
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur")])
-            return .commit
-        }
-        
-        // Set callbacks
-        recorder.transactionExpectation = expectation(description: "expectation")
-        controller.trackChanges(
-            willChange: { recorder.controllerWillChange($0) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { recorder.controllerDidChange($0) })
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 0)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.count, 1)
-        XCTAssertEqual(recorder.recordsOnFirstEvent.map { $0.name }, ["Arthur"])
-        XCTAssertEqual(recorder.changes.count, 1)
-        XCTAssertEqual(recorder.changes[0].record.id, 1)
-        XCTAssertEqual(recorder.changes[0].record.name, "Arthur")
-        switch recorder.changes[0].change {
-        case .insertion(let indexPath):
-            XCTAssertEqual(indexPath, IndexPath(indexes: [0, 0]))
-        default:
-            XCTFail()
-        }
-    }
-
-    func testTrailingClosureCallback() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("name")))
-        var persons: [Person] = []
-        try controller.performFetch()
-        
-        let expectation = self.expectation(description: "expectation")
-        controller.trackChanges {
-            persons = $0.fetchedRecords
-            expectation.fulfill()
-        }
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(persons.map { $0.name }, ["Arthur"])
-    }
-
-    func testFetchAlongside() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.order(Column("id")))
-        let recorder = ChangesRecorder<Person>()
-        controller.trackChanges(
-            fetchAlongside: { db in try Person.fetchCount(db) },
-            willChange: { (controller, count) in recorder.controllerWillChange(controller, count: count) },
-            onChange: { (controller, record, change) in recorder.controller(controller, didChangeRecord: record, with: change) },
-            didChange: { (controller, count) in recorder.controllerDidChange(controller, count: count) })
-        try controller.performFetch()
-        
-        // First insert
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 0)
-        XCTAssertEqual(recorder.recordsAfterChanges.count, 1)
-        XCTAssertEqual(recorder.recordsAfterChanges.map { $0.name }, ["Arthur"])
-        XCTAssertEqual(recorder.countBeforeChanges!, 1)
-        XCTAssertEqual(recorder.countAfterChanges!, 1)
-        
-        // Second insert
-        recorder.transactionExpectation = expectation(description: "expectation")
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur"),
-                Person(id: 2, name: "Barbara")])
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        
-        XCTAssertEqual(recorder.recordsBeforeChanges.count, 1)
-        XCTAssertEqual(recorder.recordsBeforeChanges.map { $0.name }, ["Arthur"])
-        XCTAssertEqual(recorder.recordsAfterChanges.count, 2)
-        XCTAssertEqual(recorder.recordsAfterChanges.map { $0.name }, ["Arthur", "Barbara"])
-        XCTAssertEqual(recorder.countBeforeChanges!, 2)
-        XCTAssertEqual(recorder.countAfterChanges!, 2)
-    }
-
-    func testFetchErrors() throws {
-        let dbQueue = try makeDatabaseQueue()
-        let controller = try FetchedRecordsController(dbQueue, request: Person.all())
-        
-        let expectation = self.expectation(description: "expectation")
-        var error: Error?
-        controller.trackErrors {
-            error = $1
-            expectation.fulfill()
-        }
-        controller.trackChanges { _ in }
-        try controller.performFetch()
-        try dbQueue.inTransaction { db in
-            try synchronizePersons(db, [
-                Person(id: 1, name: "Arthur")])
-            try db.drop(table: "persons")
-            return .commit
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        if let error = error as? DatabaseError {
-            XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
-            XCTAssertEqual(error.message, "no such table: persons")
-            XCTAssertEqual(error.sql!, "SELECT * FROM \"persons\"")
-            XCTAssertEqual(error.description, "SQLite error 1 with statement `SELECT * FROM \"persons\"`: no such table: persons")
-        } else {
-            XCTFail("Expected DatabaseError")
-        }
-    }
-    
-    func testObservationOfSpecificRowIds() throws {
-        let dbQueue = try makeDatabaseQueue()
-        
-        let generalController = try FetchedRecordsController(dbQueue, request: Person.all())
-        let specificController = try FetchedRecordsController(dbQueue, request: Person.filter(key: 1))
-
-        let generalExpectation = expectation(description: "expectation")
-        generalExpectation.expectedFulfillmentCount = 6
-        var generalChangeCount = 0
-        generalController.trackChanges(onChange: { (_, _, _) in
-            generalChangeCount += 1
-            generalExpectation.fulfill()
-        })
-        try generalController.performFetch()
-
-        let specificExpectation = expectation(description: "expectation")
-        specificExpectation.expectedFulfillmentCount = 3
-        var specificChangeCount = 0
-        specificController.trackChanges(onChange: { (_, _, _) in
-            specificChangeCount += 1
-            specificExpectation.fulfill()
-        })
-        try specificController.performFetch()
-
-        try dbQueue.writeWithoutTransaction { db in
-            try db.execute(sql: "INSERT INTO persons (id, name) VALUES (?, ?)", arguments: [1, "Arthur"])
-            try db.execute(sql: "INSERT INTO persons (id, name) VALUES (?, ?)", arguments: [2, "Barbara"])
-            try db.execute(sql: "UPDATE persons SET name = ? WHERE id = ?", arguments: ["Craig", 1])
-            try db.execute(sql: "UPDATE persons SET name = ? WHERE id = ?", arguments: ["David", 2])
-            try db.execute(sql: "DELETE FROM persons")
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-        XCTAssertEqual(generalChangeCount, 6)
-        XCTAssertEqual(specificChangeCount, 3)
-    }
-
-    func testDiff() {
-        let a: [Person] = [.init(id: 1, name: "greg", email: ""),
-                           .init(id: 2, name: "george", email: ""),
-                           .init(id: 3, name: "zapp", email: "")]
-        let b: [Person] = [.init(id: 2, name: "george", email: ""),
-                           .init(id: 1, name: "greg", email: "")]
-        let diff = a.diff(b)
-        print(diff)
+        XCTAssertEqual(controller.sections.count, 3)
     }
 }
-
 
 // Synchronizes the persons table with a JSON payload
 private func synchronizePersons(_ db: Database, _ newPersons: [Person]) throws {

--- a/Tests/GRDBTests/FetchedRecordsControllerTests.swift
+++ b/Tests/GRDBTests/FetchedRecordsControllerTests.swift
@@ -83,6 +83,25 @@ private class Person : Record {
     }
 }
 
+extension Person: Diffable {
+    var primaryKeyValue: String {
+        return "\(String(describing: id))"
+    }
+}
+
+extension Person: Hashable {
+    static func == (lhs: Person, rhs: Person) -> Bool {
+        return lhs.id == rhs.id && lhs.name == rhs.name && lhs.email == rhs.email && lhs.bookCount == rhs.bookCount
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(name)
+        hasher.combine(email)
+        hasher.combine(bookCount)
+    }
+}
+
 private struct Book : FetchableRecord {
     var id: Int64
     var authorID: Int64
@@ -905,6 +924,16 @@ class FetchedRecordsControllerTests: GRDBTestCase {
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(generalChangeCount, 6)
         XCTAssertEqual(specificChangeCount, 3)
+    }
+
+    func testDiff() {
+        let a: [Person] = [.init(id: 1, name: "greg", email: ""),
+                           .init(id: 2, name: "george", email: ""),
+                           .init(id: 3, name: "zapp", email: "")]
+        let b: [Person] = [.init(id: 2, name: "george", email: ""),
+                           .init(id: 1, name: "greg", email: "")]
+        let diff = a.diff(b)
+        print(diff)
     }
 }
 

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -707,13 +707,12 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
         }
         
         let expectation = self.expectation(description: "expectation")
-        let controller =
-            try FetchedRecordsController<Person>(dbQueue, request: Person.all())
+        let controller = try FetchedRecordsController<Person>(dbQueue, request: Person.all())
         var update = false
-        controller.trackChanges(
-            onChange: { (_, _, change) in if case .update = change { update = true /* identification by hidden rowid primary key has succeeded */ } },
-            didChange: { _ in expectation.fulfill()
-        })
+        controller.track { changes in
+            update = changes.last?.sectionInserted.count == 1
+            expectation.fulfill()
+        }
         try controller.performFetch()
         try dbQueue.inDatabase { db in
             person.name = "Barbara"


### PR DESCRIPTION
### Summary:
This is an exploration into adding multiple section support to `FetchedRecordsController`. I've closely followed the suggestions described in #500 (these were very helpful). Though #635 has mentioned that `FetchedRecordsController` is being sunset, I would hope that any discussion here would possibly show a path forward for possibly keeping the feature around. 

Essentially, the internals of `FetchedRecordsController` have been rewritten to utilize [ValueObservation](https://github.com/groue/GRDB.swift/blob/master/README.md#valueobservation) and the awesome [DifferenceKit](https://github.com/ra1028/DifferenceKit) library has been embedded to support diffing. I don't know if embedding the dependency is the correct path forward and am open to suggestions for alternatives.

I haven't gone too far into the implementation. Tests are pretty lacking. I didn't want to go too far before getting any feedback though, so that's why I've posted this now. If it turns out that this isn't something desirable for GRDB to have, perhaps it will at least serve as an implementation example for something else.

### Usage:
The main alteration to the API of `FetchedRecordsController` is an addition of a `sectionColumn` property that allows results to be grouped based on a row column. E.g:
```
let controller = try FetchedRecordsController(dbQueue, request: Person.all(), sectionColumn: Column("name"))
```

### For Review:
The change-set is quite large for this, but most of it is just embedding the DifferenceKit library. The files I think that are most important for review are `FetchedRecordsController.swift`, `PlayersViewController.swift` and `FetchedRecordsControllerTests.swift`.

### Media:
![multiple-sections](https://user-images.githubusercontent.com/3394908/72472418-5f807700-3799-11ea-96f2-fde6f9aab57e.gif)

### Pull Request Checklist

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [ ] Changes are tested.
