### PR TITLE
Add support for renaming columns within a table

### DIFF
--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -495,6 +495,25 @@ class TableDefinitionTests: GRDBTestCase {
             assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"e\"")
         }
     }
+
+    @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testAlterTableRenameColumn() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "test") { t in
+                t.column("a", .text)
+            }
+
+            sqlQueries.removeAll()
+            try db.alter(table: "test") { t in
+                t.rename(column: "a", to: "b")
+                t.add(column: "e")
+            }
+
+            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" RENAME COLUMN \"a\" TO \"b\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"e\"")
+        }
+    }
     
     func testDropTable() throws {
         let dbQueue = try makeDatabaseQueue()


### PR DESCRIPTION
### Summary:
This adds support for renaming columns within a table using ALTER TABLE table RENAME COLUMN oldname TO newname.

[SQLite 3.25.0](https://www.sqlite.org/changes.html) introduced this feature in 2018 and newer os versions should have bundled versions higher than 3.25.0. 

### Pull Request Checklist:
Wasn't sure if I should update documentation for a feature only available on very new os versions.

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
