### PR TITLE
Add support for renaming columns within a table

### DIFF
--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -687,7 +687,21 @@ public final class TableAlteration {
         return column
     }
 
-    #if !os(OSX) || GRDBCUSTOMSQLITE || GRDBCIPHER
+    #if GRDBCUSTOMSQLITE
+    /// Renames a column in a table.
+    ///
+    ///     try db.alter(table: "player") { t in
+    ///         t.rename(column: "url", to: "home_url")
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_altertable.html
+    ///
+    /// - parameter name: the column name to rename.
+    /// - parameter newName: the new name of the column.
+    public func rename(column name: String, to newName: String) {
+        alterations.append(.rename(old: name, new: newName))
+    }
+    #elseif !os(OSX)
     /// Renames a column in a table.
     ///
     ///     try db.alter(table: "player") { t in

--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -657,6 +657,7 @@ public final class TableDefinition {
 public final class TableAlteration {
     private let name: String
     private var addedColumns: [ColumnDefinition] = []
+    private var renamedColumns: [(oldColumn: ColumnDefinition, newColumn: ColumnDefinition)] = []
     
     init(name: String) {
         self.name = name
@@ -680,9 +681,42 @@ public final class TableAlteration {
         addedColumns.append(column)
         return column
     }
+
+    #if !os(OSX)
+    /// Renames a column in a table.
+    ///
+    ///     try db.alter(table: "player") { t in
+    ///         t.rename(column: "url", to: "home_url")
+    ///     }
+    ///
+    /// See https://www.sqlite.org/lang_altertable.html
+    ///
+    /// - parameter name: the column name to rename.
+    /// - parameter newName: the new name of the column.
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    public func rename(column name: String, to newName: String) {
+        let old = ColumnDefinition(name: name, type: nil)
+        let new = ColumnDefinition(name: newName, type: nil)
+        renamedColumns.append((oldColumn: old, newColumn: new))
+    }
+    #endif
     
     fileprivate func sql(_ db: Database) throws -> String {
         var statements: [String] = []
+
+        #if !os(OSX)
+        for (oldColumn, newColumn) in renamedColumns {
+            var chunks: [String] = []
+            chunks.append("ALTER TABLE")
+            chunks.append(name.quotedDatabaseIdentifier)
+            chunks.append("RENAME COLUMN")
+            chunks.append(oldColumn.name.quotedDatabaseIdentifier)
+            chunks.append("TO")
+            chunks.append(newColumn.name.quotedDatabaseIdentifier)
+            let statement = chunks.joined(separator: " ")
+            statements.append(statement)
+        }
+        #endif
         
         for column in addedColumns {
             var chunks: [String] = []

--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -687,7 +687,7 @@ public final class TableAlteration {
         return column
     }
 
-    #if GRDBCUSTOMSQLITE
+    #if GRDBCUSTOMSQLITE || GRDBCipher
     /// Renames a column in a table.
     ///
     ///     try db.alter(table: "player") { t in
@@ -699,9 +699,9 @@ public final class TableAlteration {
     /// - parameter name: the column name to rename.
     /// - parameter newName: the new name of the column.
     public func rename(column name: String, to newName: String) {
-        alterations.append(.rename(old: name, new: newName))
+        _rename(column: name, to: newName)
     }
-    #elseif !os(OSX)
+    #else
     /// Renames a column in a table.
     ///
     ///     try db.alter(table: "player") { t in
@@ -714,9 +714,13 @@ public final class TableAlteration {
     /// - parameter newName: the new name of the column.
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     public func rename(column name: String, to newName: String) {
-        alterations.append(.rename(old: name, new: newName))
+        _rename(column: name, to: newName)
     }
     #endif
+
+    private func _rename(column name: String, to newName: String) {
+        alterations.append(.rename(old: name, new: newName))
+    }
     
     fileprivate func sql(_ db: Database) throws -> String {
         var statements: [String] = []

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -495,6 +495,27 @@ class TableDefinitionTests: GRDBTestCase {
             assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"e\"")
         }
     }
+
+    #if !os(OSX)
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    func testAlterTableRenameColumn() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "test") { t in
+                t.column("a", .text)
+            }
+
+            sqlQueries.removeAll()
+            try db.alter(table: "test") { t in
+                t.rename(column: "a", to: "b")
+                t.add(column: "e")
+            }
+
+            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" RENAME COLUMN \"a\" TO \"b\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"e\"")
+        }
+    }
+    #endif
     
     func testDropTable() throws {
         let dbQueue = try makeDatabaseQueue()

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -496,7 +496,7 @@ class TableDefinitionTests: GRDBTestCase {
         }
     }
 
-    #if !os(OSX)
+    #if !os(OSX) || GRDBCUSTOMSQLITE || GRDBCIPHER
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func testAlterTableRenameColumn() throws {
         let dbQueue = try makeDatabaseQueue()
@@ -508,11 +508,13 @@ class TableDefinitionTests: GRDBTestCase {
             sqlQueries.removeAll()
             try db.alter(table: "test") { t in
                 t.rename(column: "a", to: "b")
-                t.add(column: "e")
+                t.add(column: "c")
+                t.rename(column: "c", to: "d")
             }
 
-            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" RENAME COLUMN \"a\" TO \"b\"")
-            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" ADD COLUMN \"e\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 3], "ALTER TABLE \"test\" RENAME COLUMN \"a\" TO \"b\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" ADD COLUMN \"c\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" RENAME COLUMN \"c\" TO \"d\"")
         }
     }
     #endif

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -2,6 +2,13 @@ import XCTest
 #if GRDBCUSTOMSQLITE
     import GRDBCustomSQLite
 #else
+    #if GRDBCIPHER
+        import SQLCipher
+    #elseif SWIFT_PACKAGE
+        import CSQLite
+    #else
+        import SQLite3
+    #endif
     import GRDB
 #endif
 

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -496,7 +496,27 @@ class TableDefinitionTests: GRDBTestCase {
         }
     }
 
-    #if !os(OSX) || GRDBCUSTOMSQLITE || GRDBCIPHER
+    #if GRDBCUSTOMSQLITE
+    func testAlterTableRenameColumn() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "test") { t in
+                t.column("a", .text)
+            }
+
+            sqlQueries.removeAll()
+            try db.alter(table: "test") { t in
+                t.rename(column: "a", to: "b")
+                t.add(column: "c")
+                t.rename(column: "c", to: "d")
+            }
+
+            assertEqualSQL(sqlQueries[sqlQueries.count - 3], "ALTER TABLE \"test\" RENAME COLUMN \"a\" TO \"b\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 2], "ALTER TABLE \"test\" ADD COLUMN \"c\"")
+            assertEqualSQL(sqlQueries[sqlQueries.count - 1], "ALTER TABLE \"test\" RENAME COLUMN \"c\" TO \"d\"")
+        }
+    }
+    #elseif !os(OSX)
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func testAlterTableRenameColumn() throws {
         let dbQueue = try makeDatabaseQueue()


### PR DESCRIPTION
### Summary:
This adds support for renaming columns within a table using ALTER TABLE table RENAME COLUMN oldname TO newname.

[SQLite 3.25.0](https://www.sqlite.org/changes.html) introduced this feature in 2018 and newer os versions should have bundled versions higher than 3.25.0. Unfortunately, this is not true for macOS.

**Example:**
```swift
try db.alter(table: "player") { t in
  t.rename(column: "url", to: "home_url")
}
```

### Pull Request Checklist:
Wasn't sure if I should update documentation for a feature only available on very new os versions.

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
