### PR TITLE
Enhance SQLLiteral and SQL interpolation again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -63,9 +61,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**New**
+
+- [#706](https://github.com/groue/GRDB.swift/pull/706): Enhance SQLLiteral and SQL interpolation again
 
 
 ## 4.10.0

--- a/Documentation/SQLInterpolation.md
+++ b/Documentation/SQLInterpolation.md
@@ -152,7 +152,7 @@ Such literal expressions can be returned by Swift functions:
 
 ```swift
 func date(_ value: SQLExpressible) -> SQLExpression {
-    SQLLiteral("DATE(\(lhs.sqlExpression))").sqlExpression
+    SQLLiteral("DATE(\(value))").sqlExpression
 }
 
 // SELECT * FROM "player" WHERE DATE("createdAt") = '2020-01-23'

--- a/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
@@ -57,7 +57,16 @@ extension SQLInterpolation {
     ///     let request: SQLRequest<Int> = """
     ///         SELECT score + \(bonus) FROM player
     ///         """
-    public mutating func appendInterpolation<T: SQLExpressible>(_ expressible: T?) {
+    ///
+    /// You can also derive literal expressions from other expressions:
+    ///
+    ///     func date(_ value: SQLExpressible) -> SQLExpression {
+    ///         SQLLiteral("DATE(\(value))").sqlExpression
+    ///     }
+    ///
+    ///     // SELECT * FROM player WHERE DATE(createdAt) = '2020-02-25'
+    ///     let request = Player.filter(date(Column("createdAt")) == "2020-02-25")
+    public mutating func appendInterpolation(_ expressible: SQLExpressible?) {
         if let expressible = expressible {
             elements.append(.expression(expressible.sqlExpression))
         } else {

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -478,7 +478,7 @@ extension SQLLiteralTests {
                 // Here we test that users can define functions that return
                 // literal expressions.
                 func date(_ value: SQLExpressible) -> SQLExpression {
-                    SQLLiteral("DATE(\(value))").sqlExpression
+                    return SQLLiteral("DATE(\(value))").sqlExpression
                 }
                 let createdAt = Column("createdAt")
                 let request = Player.filter(date(createdAt) == "2020-01-23")
@@ -492,7 +492,7 @@ extension SQLLiteralTests {
                 // return literal expressions with the previously
                 // supported technique.
                 func date(_ value: SQLExpressible) -> SQLExpression {
-                    SQLLiteral("DATE(\(value.sqlExpression))").sqlExpression
+                    return SQLLiteral("DATE(\(value.sqlExpression))").sqlExpression
                 }
                 let createdAt = Column("createdAt")
                 let request = Player.filter(date(createdAt) == "2020-01-23")

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -475,9 +475,24 @@ extension SQLLiteralTests {
             }
             
             do {
-                // Here we test that users can define functions that return literal expressions
+                // Here we test that users can define functions that return
+                // literal expressions.
                 func date(_ value: SQLExpressible) -> SQLExpression {
                     SQLLiteral("DATE(\(value))").sqlExpression
+                }
+                let createdAt = Column("createdAt")
+                let request = Player.filter(date(createdAt) == "2020-01-23")
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "player" WHERE (DATE("createdAt")) = '2020-01-23'
+                    """)
+            }
+            
+            do {
+                // Here we test that users can still define functions that
+                // return literal expressions with the previously
+                // supported technique.
+                func date(_ value: SQLExpressible) -> SQLExpression {
+                    SQLLiteral("DATE(\(value.sqlExpression))").sqlExpression
                 }
                 let createdAt = Column("createdAt")
                 let request = Player.filter(date(createdAt) == "2020-01-23")

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -473,6 +473,18 @@ extension SQLLiteralTests {
                     SELECT * FROM "player" WHERE (DATE("createdAt")) = '2020-01-23'
                     """)
             }
+            
+            do {
+                // Here we test that users can define functions that return literal expressions
+                func date(_ value: SQLExpressible) -> SQLExpression {
+                    SQLLiteral("DATE(\(value))").sqlExpression
+                }
+                let createdAt = Column("createdAt")
+                let request = Player.filter(date(createdAt) == "2020-01-23")
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "player" WHERE (DATE("createdAt")) = '2020-01-23'
+                    """)
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request improves over #690, so that it gets easier to define functions that build literal expressions with SQL interpolation:

```swift
func date(_ value: SQLExpressible) -> SQLExpression {
    SQLLiteral("DATE(\(value))").sqlExpression
}
```

The inspiration for this change comes from #705 by @martindufort. Support for the `INSTR` SQLite function can now be defined as below:

```swift
func instr(_ lhs: SQLExpressible, _ rhs: SQLExpressible) -> SQLExpression {
    SQLLiteral("INSTR(\(lhs), \(rhs))").sqlExpression
}

// Usage: SELECT * FROM "player" WHERE (INSTR("name", 'foo')) > 0
let players = try Player
    .filter(instr(Column("name"), "foo") > 0)
    .fetchAll(db)
```
