### PR TITLE
Simplify DatabaseMigrator API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,36 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
-**New**
+### New
 
 - [#706](https://github.com/groue/GRDB.swift/pull/706): Enhance SQLLiteral and SQL interpolation again
+
+### Breaking Change
+
 - [#709](https://github.com/groue/GRDB.swift/pull/709): Simplify DatabaseMigrator API
+
+Database migrations have a new behavior which is a breaking change. However, it is very unlikely to impact your application.
+
+In previous versions of GRDB, a foreign key violation would immediately prevent a migration from successfully complete. Now, foreign key checks are deferred until the end of each migration. This means that some migrations will change their behavior:
+
+```swift
+// Used to fail, now succeeds
+migrator.registerMigration(...) { db in
+    try violateForeignKeyConstraint(db)
+    try fixForeignKeyConstraint(db)
+}
+
+// The catch clause is no longer called
+migrator.registerMigration(...) { db in
+    do {
+        try performChanges(db)
+    } catch let error as DatabaseError where error.resultCode == .SQL_CONSTRAINT {
+        // Handle foreign key error
+    }
+}
+```
+
+If your application happens to define migrations that are impacted by this change, please open an issue so that we find a way to restore the previous behavior.
 
 
 ## 4.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ All notable changes to this project will be documented in this file.
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
 
-<!--
 [Next Release](#next-release)
--->
 
 
 #### 4.x Releases
@@ -63,9 +61,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+**New**
+
+- [#709](https://github.com/groue/GRDB.swift/pull/709): Simplify DatabaseMigrator API
 
 
 ## 4.10.0

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -91,66 +91,27 @@ public struct DatabaseMigrator {
         registerMigration(Migration(identifier: identifier, migrate: migrate))
     }
     
-    #if GRDBCUSTOMSQLITE || GRDBCIPHER
-    /// Registers an advanced migration, as described at https://www.sqlite.org/lang_altertable.html#otheralter
+    /// Registers a migration.
     ///
-    ///     // Add a NOT NULL constraint on players.name:
-    ///     migrator.registerMigrationWithDeferredForeignKeyCheck("AddNotNullCheckOnName") { db in
-    ///         try db.create(table: "new_player") { t in
+    ///     migrator.registerMigration("createAuthors") { db in
+    ///         try db.create(table: "author") { t in
     ///             t.autoIncrementedPrimaryKey("id")
+    ///             t.column("creationDate", .datetime)
     ///             t.column("name", .text).notNull()
     ///         }
-    ///         try db.execute(sql: "INSERT INTO new_player SELECT * FROM player")
-    ///         try db.drop(table: "player")
-    ///         try db.rename(table: "new_player", to: "player")
     ///     }
-    ///
-    /// While your migration code runs with disabled foreign key checks, those
-    /// are re-enabled and checked at the end of the migration, regardless of
-    /// eventual errors.
     ///
     /// - parameters:
     ///     - identifier: The migration identifier.
     ///     - block: The migration block that performs SQL statements.
     /// - precondition: No migration with the same same as already been registered.
-    ///
-    /// :nodoc:
+    @available(*, deprecated, renamed: "registerMigration(_:migrate:)")
     public mutating func registerMigrationWithDeferredForeignKeyCheck(
         _ identifier: String,
         migrate: @escaping (Database) throws -> Void)
     {
-        registerMigration(Migration(identifier: identifier, disabledForeignKeyChecks: true, migrate: migrate))
+        registerMigration(identifier, migrate: migrate)
     }
-    #else
-    @available(OSX 10.10, *)
-    /// Registers an advanced migration, as described at https://www.sqlite.org/lang_altertable.html#otheralter
-    ///
-    ///     // Add a NOT NULL constraint on players.name:
-    ///     migrator.registerMigrationWithDeferredForeignKeyCheck("AddNotNullCheckOnName") { db in
-    ///         try db.create(table: "new_player") { t in
-    ///             t.autoIncrementedPrimaryKey("id")
-    ///             t.column("name", .text).notNull()
-    ///         }
-    ///         try db.execute(sql: "INSERT INTO new_player SELECT * FROM player")
-    ///         try db.drop(table: "player")
-    ///         try db.rename(table: "new_player", to: "player")
-    ///     }
-    ///
-    /// While your migration code runs with disabled foreign key checks, those
-    /// are re-enabled and checked at the end of the migration, regardless of
-    /// eventual errors.
-    ///
-    /// - parameters:
-    ///     - identifier: The migration identifier.
-    ///     - block: The migration block that performs SQL statements.
-    /// - precondition: No migration with the same same as already been registered.
-    public mutating func registerMigrationWithDeferredForeignKeyCheck(
-        _ identifier: String,
-        migrate: @escaping (Database) throws -> Void)
-    {
-        registerMigration(Migration(identifier: identifier, disabledForeignKeyChecks: true, migrate: migrate))
-    }
-    #endif
     
     /// Iterate migrations in the same order as they were registered. If a
     /// migration has not yet been applied, its block is executed in

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -93,7 +93,7 @@ public struct DatabaseMigrator {
     
     /// Registers a migration.
     ///
-    ///     migrator.registerMigration("createAuthors") { db in
+    ///     migrator.registerMigrationWithDeferredForeignKeyCheck("createAuthors") { db in
     ///         try db.create(table: "author") { t in
     ///             t.autoIncrementedPrimaryKey("id")
     ///             t.column("creationDate", .datetime)

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -1,3 +1,11 @@
+#if SWIFT_PACKAGE
+import CSQLite
+#elseif GRDBCIPHER
+import SQLCipher
+#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
+import SQLite3
+#endif
+
 /// An internal struct that defines a migration.
 struct Migration {
     let identifier: String

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -50,7 +50,7 @@ struct Migration {
                     if try db
                         .makeSelectStatement(sql: "PRAGMA foreign_key_check")
                         .makeCursor()
-                        .next() != nil
+                        .isEmpty() == false
                     {
                         // https://www.sqlite.org/pragma.html#pragma_foreign_key_check
                         //

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -1,36 +1,19 @@
 /// An internal struct that defines a migration.
 struct Migration {
     let identifier: String
-    let disabledForeignKeyChecks: Bool
     let migrate: (Database) throws -> Void
     
-    #if GRDBCUSTOMSQLITE || GRDBCIPHER
-    init(identifier: String, disabledForeignKeyChecks: Bool = false, migrate: @escaping (Database) throws -> Void) {
-        self.identifier = identifier
-        self.disabledForeignKeyChecks = disabledForeignKeyChecks
-        self.migrate = migrate
-    }
-    #else
     init(identifier: String, migrate: @escaping (Database) throws -> Void) {
         self.identifier = identifier
-        self.disabledForeignKeyChecks = false
         self.migrate = migrate
     }
-    
-    @available(OSX 10.10, *)
-    // PRAGMA foreign_key_check was introduced in SQLite 3.7.16 http://www.sqlite.org/changes.html#version_3_7_16
-    // It is available from iOS 8.2 and OS X 10.10
-    // https://github.com/yapstudios/YapDatabase/wiki/SQLite-version-(bundled-with-OS)
-    init(identifier: String, disabledForeignKeyChecks: Bool, migrate: @escaping (Database) throws -> Void) {
-        self.identifier = identifier
-        self.disabledForeignKeyChecks = disabledForeignKeyChecks
-        self.migrate = migrate
-    }
-    #endif
     
     func run(_ db: Database) throws {
-        if try disabledForeignKeyChecks && (Bool.fetchOne(db, sql: "PRAGMA foreign_keys") ?? false) {
-            try runWithDisabledForeignKeys(db)
+        // PRAGMA foreign_key_check and SQLITE_CONSTRAINT_FOREIGNKEY were
+        // introduced in SQLite 3.7.16
+        // http://www.sqlite.org/changes.html#version_3_7_16
+        if try sqlite3_libversion_number() >= 3007016 && (Bool.fetchOne(db, sql: "PRAGMA foreign_keys") ?? false) {
+            try runWithDeferredForeignKeysChecks(db)
         } else {
             try runWithoutDisabledForeignKeys(db)
         }
@@ -45,7 +28,7 @@ struct Migration {
         }
     }
     
-    private func runWithDisabledForeignKeys(_ db: Database) throws {
+    private func runWithDeferredForeignKeysChecks(_ db: Database) throws {
         // Support for database alterations described at
         // https://www.sqlite.org/lang_altertable.html#otheralter
         //
@@ -60,18 +43,26 @@ struct Migration {
                     try migrate(db)
                     try insertAppliedIdentifier(db)
                     
-                    // > 10. If foreign key constraints were originally enabled then run PRAGMA
-                    // > foreign_key_check to verify that the schema change did not break any foreign key
-                    // > constraints.
-                    if try Row.fetchOne(db, sql: "PRAGMA foreign_key_check") != nil {
+                    // > 10. If foreign key constraints were originally enabled
+                    // > then run PRAGMA foreign_key_check to verify that the
+                    // > schema change did not break any foreign
+                    // > key constraints.
+                    if try db
+                        .makeSelectStatement(sql: "PRAGMA foreign_key_check")
+                        .makeCursor()
+                        .next() != nil
+                    {
                         // https://www.sqlite.org/pragma.html#pragma_foreign_key_check
                         //
                         // PRAGMA foreign_key_check does not return an error,
                         // but the list of violated foreign key constraints.
                         //
-                        // Let's turn any violation into an SQLITE_CONSTRAINT
-                        // error, and rollback the transaction.
-                        throw DatabaseError(resultCode: .SQLITE_CONSTRAINT, message: "FOREIGN KEY constraint failed")
+                        // Let's turn any violation into an
+                        // SQLITE_CONSTRAINT_FOREIGNKEY error, and rollback
+                        // the transaction.
+                        throw DatabaseError(
+                            resultCode: .SQLITE_CONSTRAINT_FOREIGNKEY,
+                            message: "FOREIGN KEY constraint failed")
                     }
                     
                     // > 11. Commit the transaction started in step 2.
@@ -79,7 +70,8 @@ struct Migration {
                 }
         },
             finally: {
-                // > 12. If foreign keys constraints were originally enabled, reenable them now.
+                // > 12. If foreign keys constraints were originally enabled,
+                // > reenable them now.
                 try db.execute(sql: "PRAGMA foreign_keys = ON")
         })
     }

--- a/README.md
+++ b/README.md
@@ -4986,11 +4986,11 @@ The `eraseDatabaseOnSchemaChange` option triggers a recreation of the database i
 
 SQLite does not support many schema changes, and won't let you drop a table column with "ALTER TABLE ... DROP COLUMN ...", for example.
 
-Yet any kind of schema change is still possible. The SQLite documentation explains in detail how to do so: https://www.sqlite.org/lang_altertable.html#otheralter. This technique requires the temporary disabling of foreign key checks, and is supported by the `registerMigrationWithDeferredForeignKeyCheck` function:
+Yet any kind of schema change is still possible, by recreating tables:
 
 ```swift
-// Add a NOT NULL constraint on player.name:
-migrator.registerMigrationWithDeferredForeignKeyCheck("AddNotNullCheckOnName") { db in
+migrator.registerMigration("AddNotNullCheckOnName") { db in
+    // Add a NOT NULL constraint on player.name:
     try db.create(table: "new_player") { t in
         t.autoIncrementedPrimaryKey("id")
         t.column("name", .text).notNull()
@@ -5001,7 +5001,7 @@ migrator.registerMigrationWithDeferredForeignKeyCheck("AddNotNullCheckOnName") {
 }
 ```
 
-While your migration code runs with disabled foreign key checks, those are re-enabled and checked at the end of the migration, regardless of eventual errors.
+> :point_up: **Note**: This technique requires SQLite 3.7.16+ (iOS 9.0+ / macOS 10.10+ / tvOS 9.0+ / watchOS 2.0+ / [custom SQLite build] / [SQLCipher](#encryption)).
 
 
 ## Joined Queries Support

--- a/README.md
+++ b/README.md
@@ -4921,6 +4921,8 @@ migrator.registerMigration("v2") { db in
 
 **Each migration runs in a separate transaction.** Should one throw an error, its transaction is rollbacked, subsequent migrations do not run, and the error is eventually thrown by `migrator.migrate(dbQueue)`.
 
+**Migrations run with deferred foreign key checks,** starting SQLite 3.7.16+ (iOS 9.0+ / macOS 10.10+ / tvOS 9.0+ / watchOS 2.0+ / [custom SQLite build] / [SQLCipher](#encryption)). This means that eventual foreign key violations are only checked at the end of the migration (and they make the migration fail).
+
 **The memory of applied migrations is stored in the database itself** (in a reserved table).
 
 You migrate the database up to the latest version with the `migrate(_:)` method:


### PR DESCRIPTION
All GRDB migrations now run with deferred foreign key checks, removing the need for two distinct methods `DatabaseMigrator.registerMigration()` and `DatabaseMigrator.registerMigrationWithDeferredForeignKeyCheck()`. The latter is deprecated in favor of the other.

In previous GRDB versions, foreign key violations executed by a migration would immediately throw an error. Now those violations still throw an error, but at the end of the migration.