### PR TITLE
Enhance DatabaseMigrator isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - [#706](https://github.com/groue/GRDB.swift/pull/706): Enhance SQLLiteral and SQL interpolation again
 - [#712](https://github.com/groue/GRDB.swift/pull/712) by [@pakko972](https://github.com/pakko972): Automatic iOS memory management
+- [#713](https://github.com/groue/GRDB.swift/pull/713): Enhance DatabaseMigrator isolation
 
 ### Breaking Change
 

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -731,9 +731,12 @@ extension DatabasePool: DatabaseReader {
         return try writer.sync(updates)
     }
     
-    /// A barrier write ensures that no database access is executed until all
-    /// previous accesses have completed, and the specified updates have been
-    /// executed.
+    /// Synchronously executes database updates in a protected dispatch queue,
+    /// outside of any transaction, and returns the result.
+    ///
+    /// Updates are guaranteed an exclusive access to the database. They wait
+    /// until all pending writes and reads are completed. They postpone all
+    /// other writes and reads until they are completed.
     ///
     /// This method is *not* reentrant.
     ///

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -382,6 +382,20 @@ extension DatabaseQueue {
     /// Synchronously executes database updates in a protected dispatch queue,
     /// outside of any transaction, and returns the result.
     ///
+    /// Eventual concurrent database accesses are postponed until the updates
+    /// are completed.
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameter updates: The updates to the database.
+    /// - throws: The error thrown by the updates.
+    public func barrierWriteWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T {
+        return try writer.sync(updates)
+    }
+    
+    /// Synchronously executes database updates in a protected dispatch queue,
+    /// outside of any transaction, and returns the result.
+    ///
     ///     // INSERT INTO player ...
     ///     let players = try dbQueue.inDatabase { db in
     ///         try Player(...).insert(db)

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -278,18 +278,22 @@ extension DatabaseReader {
     /// the backup. Those writes may, or may not, be reflected in the backup,
     /// but they won't trigger any error.
     public func backup(to writer: DatabaseWriter) throws {
-        try backup(to: writer, afterBackupInit: nil, afterBackupStep: nil)
+        try writer.writeWithoutTransaction { dbDest in
+            try backup(to: dbDest)
+        }
     }
     
-    func backup(to writer: DatabaseWriter, afterBackupInit: (() -> Void)?, afterBackupStep: (() -> Void)?) throws {
+    func backup(
+        to dbDest: Database,
+        afterBackupInit: (() -> Void)? = nil,
+        afterBackupStep: (() -> Void)? = nil)
+        throws
+    {
         try read { dbFrom in
-            try writer.writeWithoutTransaction { dbDest in
-                try Database.backup(
-                    from: dbFrom,
-                    to: dbDest,
-                    afterBackupInit: afterBackupInit,
-                    afterBackupStep: afterBackupStep)
-            }
+            try dbFrom.backup(
+                to: dbDest,
+                afterBackupInit: afterBackupInit,
+                afterBackupStep: afterBackupStep)
         }
     }
 }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -56,7 +56,9 @@ public protocol DatabaseWriter: DatabaseReader {
     /// Synchronously executes database updates in a protected dispatch queue,
     /// outside of any transaction, and returns the result.
     ///
-    /// No concurrent write or read happens during the execution of the updates.
+    /// Updates are guaranteed an exclusive access to the database. They wait
+    /// until all pending writes and reads are completed. They postpone all
+    /// other writes and reads until they are completed.
     ///
     /// This method is *not* reentrant.
     ///

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -291,40 +291,7 @@ extension DatabaseWriter {
     /// - precondition: database is not accessed concurrently during the
     ///   execution of this method.
     public func erase() throws {
-        #if SQLITE_HAS_CODEC
-        // SQLCipher does not support the backup API:
-        // https://discuss.zetetic.net/t/using-the-sqlite-online-backup-api/2631
-        // So we'll drop all database objects one after the other.
-        try writeWithoutTransaction { db in
-            // Prevent foreign keys from messing with drop table statements
-            let foreignKeysEnabled = try Bool.fetchOne(db, sql: "PRAGMA foreign_keys")!
-            if foreignKeysEnabled {
-                try db.execute(sql: "PRAGMA foreign_keys = OFF")
-            }
-            
-            try throwingFirstError(
-                execute: {
-                    // Remove all database objects, one after the other
-                    try db.inTransaction {
-                        let sql = "SELECT type, name FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'"
-                        while let row = try Row.fetchOne(db, sql: sql) {
-                            let type: String = row["type"]
-                            let name: String = row["name"]
-                            try db.execute(sql: "DROP \(type) \(name.quotedDatabaseIdentifier)")
-                        }
-                        return .commit
-                    }
-            },
-                finally: {
-                    // Restore foreign keys if needed
-                    if foreignKeysEnabled {
-                        try db.execute(sql: "PRAGMA foreign_keys = ON")
-                    }
-            })
-        }
-        #else
-        try DatabaseQueue().backup(to: self)
-        #endif
+        try writeWithoutTransaction { try $0.erase() }
     }
     
     // MARK: - Claiming Disk Space

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -53,6 +53,17 @@ public protocol DatabaseWriter: DatabaseReader {
     /// - throws: The error thrown by the updates.
     func writeWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T
     
+    /// Synchronously executes database updates in a protected dispatch queue,
+    /// outside of any transaction, and returns the result.
+    ///
+    /// No concurrent write or read happens during the execution of the updates.
+    ///
+    /// This method is *not* reentrant.
+    ///
+    /// - parameter updates: The updates to the database.
+    /// - throws: The error thrown by the updates.
+    func barrierWriteWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T
+    
     #if compiler(>=5.0)
     /// Asynchronously executes database updates in a protected dispatch queue,
     /// wrapped inside a transaction.
@@ -650,6 +661,11 @@ public final class AnyDatabaseWriter: DatabaseWriter {
     /// :nodoc:
     public func writeWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T {
         return try base.writeWithoutTransaction(updates)
+    }
+    
+    /// :nodoc:
+    public func barrierWriteWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T {
+        return try base.barrierWriteWithoutTransaction(updates)
     }
     
     #if compiler(>=5.0)

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -136,38 +136,40 @@ public struct DatabaseMigrator {
     /// - targetIdentifier: The identifier of a registered migration.
     /// - throws: An eventual error thrown by the registered migration blocks.
     public func migrate(_ writer: DatabaseWriter, upTo targetIdentifier: String) throws {
-        if eraseDatabaseOnSchemaChange {
-            // Create a temporary witness database, on disk, just in case
-            // migrations would involve a lot of data.
-            let witness = try DatabaseQueue(path: "", configuration: writer.configuration)
-            
-            // Erase database if we detect a change in the current schema.
-            let (currentIdentifier, currentSchema) = try writer.writeWithoutTransaction { db -> (String?, SchemaInfo) in
-                try setupMigrations(db)
-                let identifiers = try appliedIdentifiers(db)
-                let currentIdentifier = migrations
-                    .reversed()
-                    .first { identifiers.contains($0.identifier) }?
-                    .identifier
-                return try (currentIdentifier, db.schema())
-            }
-            
-            if let currentIdentifier = currentIdentifier {
-                let witnessSchema: SchemaInfo = try witness.writeWithoutTransaction { db in
-                    try setupMigrations(db)
-                    try runMigrations(db, upTo: currentIdentifier)
-                    return try db.schema()
+        try writer.barrierWriteWithoutTransaction { db in
+            if eraseDatabaseOnSchemaChange {
+                // Fetch information about current database state
+                var info: (lastAppliedIdentifier: String, schema: SchemaInfo)?
+                try db.inTransaction(.deferred) {
+                    let identifiers = try appliedIdentifiers(db)
+                    if let lastAppliedIdentifier = migrations
+                        .last(where: { identifiers.contains($0.identifier) })?
+                        .identifier
+                    {
+                        info = try (lastAppliedIdentifier: lastAppliedIdentifier, schema: db.schema())
+                    }
+                    return .commit
                 }
                 
-                if currentSchema != witnessSchema {
-                    try writer.erase()
+                if let info = info {
+                    // Create a temporary witness database (on disk, just in case
+                    // migrations would involve a lot of data).
+                    let witness = try DatabaseQueue(path: "", configuration: writer.configuration)
+                    
+                    // Grab schema of migrated witness database
+                    let witnessSchema: SchemaInfo = try witness.writeWithoutTransaction { db in
+                        try runMigrations(db, upTo: info.lastAppliedIdentifier)
+                        return try db.schema()
+                    }
+                    
+                    // Erase database if we detect a schema change
+                    if info.schema != witnessSchema {
+                        try db.erase()
+                    }
                 }
             }
-        }
-        
-        // Migrate to target schema
-        try writer.writeWithoutTransaction { db in
-            try setupMigrations(db)
+            
+            // Migrate to target schema
             try runMigrations(db, upTo: targetIdentifier)
         }
     }
@@ -189,10 +191,6 @@ public struct DatabaseMigrator {
         migrations.append(migration)
     }
     
-    private func setupMigrations(_ db: Database) throws {
-        try db.execute(sql: "CREATE TABLE IF NOT EXISTS grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
-    }
-    
     private func appliedIdentifiers(_ db: Database) throws -> Set<String> {
         let tableExists = try Bool.fetchOne(db, sql: """
             SELECT EXISTS (SELECT 1 FROM sqlite_master WHERE type='table' AND name='grdb_migrations')
@@ -204,6 +202,8 @@ public struct DatabaseMigrator {
     }
     
     private func runMigrations(_ db: Database, upTo targetIdentifier: String) throws {
+        try db.execute(sql: "CREATE TABLE IF NOT EXISTS grdb_migrations (identifier TEXT NOT NULL PRIMARY KEY)")
+        
         var prefixMigrations: [Migration] = []
         for migration in migrations {
             prefixMigrations.append(migration)

--- a/Tests/GRDBTests/DatabasePoolBackupTests.swift
+++ b/Tests/GRDBTests/DatabasePoolBackupTests.swift
@@ -35,7 +35,7 @@ class DatabasePoolBackupTests: GRDBTestCase {
         }
     }
     
-    // TODO: this test is fragile: understand if somethig is wrong, or not:
+    // TODO: fix flaky test
 //    @available(OSX 10.10, *)
 //    func testConcurrentWriteDuringBackup() throws {
 //        let source = try makeDatabasePool(filename: "source.sqlite")
@@ -58,17 +58,19 @@ class DatabasePoolBackupTests: GRDBTestCase {
 //            }
 //        }
 //        
-//        try source.backup(
-//            to: destination,
-//            afterBackupInit: {
-//                s1.signal()
-//                _ = s2.wait(timeout: .distantFuture)
-//        },
-//            afterBackupStep: {
-//                try! source.write { db in
-//                    try db.execute(sql: "INSERT INTO items (id) VALUES (NULL)")
-//                }
-//        })
+//        try destination.writeWithoutTransaction { dbDestination in
+//            try source.backup(
+//                to: dbDestination,
+//                afterBackupInit: {
+//                    s1.signal()
+//                    _ = s2.wait(timeout: .distantFuture)
+//            },
+//                afterBackupStep: {
+//                    try! source.write { db in
+//                        try db.execute(sql: "INSERT INTO items (id) VALUES (NULL)")
+//                    }
+//            })
+//        }
 //        
 //        try source.read { db in
 //            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM items")!, 3)


### PR DESCRIPTION
This pull request prevents eventual concurrent reads from seeing intermediate migrations transactions.