### PR TITLE
Make ValueObservation error handling mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#722](https://github.com/groue/GRDB.swift/pull/722): SE-0253: Callable values of user-defined nominal types
 - [#723](https://github.com/groue/GRDB.swift/pull/723): SE-0255: Implicit returns from single-expression functions
 - [#724](https://github.com/groue/GRDB.swift/pull/724): SE-0242: Synthesize default values for the memberwise initializer
+- [#728](https://github.com/groue/GRDB.swift/pull/728): Make ValueObservation error handling mandatory
 
 
 ## 4.11.0

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -173,6 +173,14 @@ extension ValueObservation where Reducer == Void {
     { preconditionFailure() }
 }
 
+extension ValueObservation where Reducer: ValueReducer {
+    @available(*, unavailable, message: "Use start(in:onError:onChange:) instead.")
+    public func start(
+        in reader: DatabaseReader,
+        onChange: @escaping (Reducer.Value) -> Void) throws -> TransactionObserver
+    { preconditionFailure() }
+}
+
 extension ValueObservation where Reducer: ValueReducer, Reducer.Value: Equatable {
     @available(*, unavailable, renamed: "removeDuplicates")
     public func distinctUntilChanged() -> ValueObservation<ValueReducers.RemoveDuplicates<Reducer>>

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -201,11 +201,6 @@ extension ValueObservation where Reducer: ValueReducer {
     }
 }
 
-// TODO: remove when not needed any longer
-private class ErrorCatcher {
-    var error: Error?
-}
-
 extension ValueObservation where Reducer: ValueReducer {
     
     // MARK: - Creating ValueObservation from ValueReducer

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -161,30 +161,6 @@ extension ValueObservation where Reducer: ValueReducer {
     /// a database queue or database pool), and returns a transaction observer.
     ///
     /// - parameter reader: A DatabaseReader.
-    /// - parameter onChange: A closure that is provided fresh values
-    /// - returns: a TransactionObserver
-    public func start(
-        in reader: DatabaseReader,
-        onChange: @escaping (Reducer.Value) -> Void) throws -> TransactionObserver
-    {
-        // ErrorCatcher is a workaround this aging API.
-        // We catch the eventual error synchronously sent to the onError
-        // handler and rethrow it.
-        let errorCatcher = ErrorCatcher()
-        let observer = reader.add(
-            observation: self,
-            onError: { [weak errorCatcher] in errorCatcher?.error = $0 },
-            onChange: onChange)
-        if let error = errorCatcher.error {
-            throw error
-        }
-        return observer
-    }
-    
-    /// Starts the value observation in the provided database reader (such as
-    /// a database queue or database pool), and returns a transaction observer.
-    ///
-    /// - parameter reader: A DatabaseReader.
     /// - parameter onError: A closure that is provided eventual errors that
     /// happen during observation
     /// - parameter onChange: A closure that is provided fresh values
@@ -199,6 +175,9 @@ extension ValueObservation where Reducer: ValueReducer {
     
     // MARK: - Fetching Values
     
+    // TODO: make public if it helps fetching an initial value before starting
+    // the observation, in order to avoid waiting for long write transactions to
+    // complete.
     /// Returns the observed value.
     ///
     /// This method returns nil if observation would not notify any

--- a/README.md
+++ b/README.md
@@ -5892,15 +5892,6 @@ An error does not stop the observation. After an error has been received, subseq
 
 Depending on the way your application wants to deal with such errors, you may want to tighten your control on the scheduling of database accesses with [DatabaseRegionObservation]. See also the reactive companion libraries [GRDBCombine] and [RxGRDB], which stop observation whenever a ValueObservation error happens.
 
-The `onError` callback can be omitted, but this is **not recommended**:
-
-```swift
-// Not recommended: omitting the onError callback
-let observer = try observation.start(in: dbQueue) { value in
-    print("fresh value: \(value)")
-}
-```
-
 
 ### ValueObservation Options
 

--- a/Tests/GRDBTests/ValueObservationCombineTests.swift
+++ b/Tests/GRDBTests/ValueObservationCombineTests.swift
@@ -30,10 +30,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation1 = T1.observationForCount()
         let observation2 = T2.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2)
-        let observer = try observation.start(in: dbQueue) { v0, v1 in
-            values.append([v0, v1])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1 in
+                values.append([v0, v1])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -90,10 +93,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation2 = T2.observationForCount()
         let observation3 = T3.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2, observation3)
-        let observer = try observation.start(in: dbQueue) { v0, v1, v2 in
-            values.append([v0, v1, v2])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1, v2 in
+                values.append([v0, v1, v2])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -164,10 +170,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation3 = T3.observationForCount()
         let observation4 = T4.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4)
-        let observer = try observation.start(in: dbQueue) { v0, v1, v2, v3 in
-            values.append([v0, v1, v2, v3])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1, v2, v3 in
+                values.append([v0, v1, v2, v3])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -252,10 +261,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation4 = T4.observationForCount()
         let observation5 = T5.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5)
-        let observer = try observation.start(in: dbQueue) { v0, v1, v2, v3, v4 in
-            values.append([v0, v1, v2, v3, v4])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1, v2, v3, v4 in
+                values.append([v0, v1, v2, v3, v4])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -354,10 +366,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation5 = T5.observationForCount()
         let observation6 = T6.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6)
-        let observer = try observation.start(in: dbQueue) { v0, v1, v2, v3, v4, v5 in
-            values.append([v0, v1, v2, v3, v4, v5])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1, v2, v3, v4, v5 in
+                values.append([v0, v1, v2, v3, v4, v5])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -470,10 +485,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation6 = T6.observationForCount()
         let observation7 = T7.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6, observation7)
-        let observer = try observation.start(in: dbQueue) { v0, v1, v2, v3, v4, v5, v6 in
-            values.append([v0, v1, v2, v3, v4, v5, v6])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1, v2, v3, v4, v5, v6 in
+                values.append([v0, v1, v2, v3, v4, v5, v6])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -600,10 +618,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation7 = T7.observationForCount()
         let observation8 = T8.observationForCount()
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6, observation7, observation8)
-        let observer = try observation.start(in: dbQueue) { v0, v1, v2, v3, v4, v5, v6, v7 in
-            values.append([v0, v1, v2, v3, v4, v5, v6, v7])
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { v0, v1, v2, v3, v4, v5, v6, v7 in
+                values.append([v0, v1, v2, v3, v4, v5, v6, v7])
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.write { db in
                 try db.execute(sql: "INSERT INTO t1 DEFAULT VALUES")
@@ -703,7 +724,7 @@ class ValueObservationCombineTests: GRDBTestCase {
                 [2, 2, 2, 2, 2, 2, 2, 2]])
         }
     }
-
+    
     func testHeterogeneusCombine2() throws {
         struct V1 { }
         struct V2 { }
@@ -711,7 +732,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
         let observation = ValueObservation.combine(observation1, observation2)
         var value: (V1, V2)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -724,7 +748,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
         let observation = ValueObservation.combine(observation1, observation2, observation3)
         var value: (V1, V2, V3)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -739,7 +766,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4)
         var value: (V1, V2, V3, V4)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -756,7 +786,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5)
         var value: (V1, V2, V3, V4, V5)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -775,7 +808,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation6 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V6() })
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6)
         var value: (V1, V2, V3, V4, V5, V6)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -796,7 +832,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation7 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V7() })
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6, observation7)
         var value: (V1, V2, V3, V4, V5, V6, V7)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -819,7 +858,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation8 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V8() })
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6, observation7, observation8)
         var value: (V1, V2, V3, V4, V5, V6, V7, V8)?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -831,7 +873,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
         let observation = observation1.combine(observation2) { (v1: V1, v2: V2) -> Combined in Combined() }
         var value: Combined?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -845,7 +890,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
         let observation = observation1.combine(observation2, observation3) { (v1: V1, v2: V2, v3: V3) -> Combined in Combined() }
         var value: Combined?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -861,7 +909,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
         let observation = observation1.combine(observation2, observation3, observation4) { (v1: V1, v2: V2, v3: V3, v4: V4) -> Combined in Combined() }
         var value: Combined?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
     
@@ -879,7 +930,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
         let observation = observation1.combine(observation2, observation3, observation4, observation5) { (v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) -> Combined in Combined() }
         var value: Combined?
-        _ = try observation.start(in: makeDatabaseQueue()) { value = $0 }
+        _ = try observation.start(
+            in: makeDatabaseQueue(),
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { value = $0 })
         XCTAssertNotNil(value)
     }
 }

--- a/Tests/GRDBTests/ValueObservationCompactMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationCompactMapTests.swift
@@ -39,10 +39,13 @@ class ValueObservationCompactMapTests: GRDBTestCase {
             }
             
             // Start observation
-            let observer = try observation.start(in: dbWriter) { count in
-                counts.append(count)
-                notificationExpectation.fulfill()
-            }
+            let observer = observation.start(
+                in: dbWriter,
+                onError: { error in XCTFail("Unexpected error: \(error)") },
+                onChange: { count in
+                    counts.append(count)
+                    notificationExpectation.fulfill()
+            })
             try withExtendedLifetime(observer) {
                 try dbWriter.writeWithoutTransaction { db in
                     try db.execute(sql: "INSERT INTO t DEFAULT VALUES")

--- a/Tests/GRDBTests/ValueObservationCountTests.swift
+++ b/Tests/GRDBTests/ValueObservationCountTests.swift
@@ -22,10 +22,13 @@ class ValueObservationCountTests: GRDBTestCase {
         
         struct T: TableRecord { }
         let observation = T.all().observationForCount()
-        let observer = try observation.start(in: dbQueue) { count in
-            counts.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                counts.append(count)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t DEFAULT VALUES") // +1
@@ -56,10 +59,13 @@ class ValueObservationCountTests: GRDBTestCase {
         
         struct T: TableRecord { }
         let observation = T.observationForCount()
-        let observer = try observation.start(in: dbQueue) { count in
-            counts.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                counts.append(count)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t DEFAULT VALUES") // +1

--- a/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
+++ b/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
@@ -36,10 +36,13 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = SQLRequest<Name>(sql: "SELECT name FROM t ORDER BY id").observationForAll()
-        let observer = try observation.start(in: dbQueue) { names in
-            results.append(names)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { names in
+                results.append(names)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
@@ -72,10 +75,13 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 7
         
         let observation = SQLRequest<Name>(sql: "SELECT name FROM t ORDER BY id DESC").observationForFirst()
-        let observer = try observation.start(in: dbQueue) { name in
-            results.append(name)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { name in
+                results.append(name)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')")
@@ -116,10 +122,13 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = SQLRequest<Name?>(sql: "SELECT name FROM t ORDER BY id").observationForAll()
-        let observer = try observation.start(in: dbQueue) { names in
-            results.append(names)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { names in
+                results.append(names)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
@@ -152,10 +161,13 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 7
         
         let observation = SQLRequest<Name?>(sql: "SELECT name FROM t ORDER BY id DESC").observationForFirst()
-        let observer = try observation.start(in: dbQueue) { name in
-            results.append(name)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { name in
+                results.append(name)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')")
@@ -211,10 +223,13 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
         // This optimization helps observation of views that feed from a
         // single table.
         let observation = request.observationForAll()
-        let observer = try observation.start(in: dbQueue) { names in
-            results.append(names)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { names in
+                results.append(names)
+                notificationExpectation.fulfill()
+        })
         let token = observer as! ValueObserverToken<ValueReducers.AllValues<Name>> // Non-public implementation detail
         XCTAssertEqual(token.observer.observedRegion.description, "t(id,name)") // view is not tracked
         try withExtendedLifetime(observer) {

--- a/Tests/GRDBTests/ValueObservationExtentTests.swift
+++ b/Tests/GRDBTests/ValueObservationExtentTests.swift
@@ -32,13 +32,16 @@ class ValueObservationExtentTests: GRDBTestCase {
         
         // Start observation and deallocate observer after second change
         var observer: TransactionObserver?
-        observer = try observation.start(in: dbQueue) {
-            changesCount += 1
-            if changesCount == 2 {
-                observer = nil
-            }
-            notificationExpectation.fulfill()
-        }
+        observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: {
+                changesCount += 1
+                if changesCount == 2 {
+                    observer = nil
+                }
+                notificationExpectation.fulfill()
+        })
         
         // notified
         try dbQueue.write { db in

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -32,10 +32,13 @@ class ValueObservationFetchTests: GRDBTestCase {
             let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             })
-            let observer = try observation.start(in: dbWriter) { count in
-                counts.append(count)
-                notificationExpectation.fulfill()
-            }
+            let observer = observation.start(
+                in: dbWriter,
+                onError: { error in XCTFail("Unexpected error: \(error)") },
+                onChange: { count in
+                    counts.append(count)
+                    notificationExpectation.fulfill()
+            })
             try withExtendedLifetime(observer) {
                 try dbWriter.writeWithoutTransaction { db in
                     try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
@@ -64,10 +67,13 @@ class ValueObservationFetchTests: GRDBTestCase {
             let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
             }).removeDuplicates()
-            let observer = try observation.start(in: dbWriter) { count in
-                counts.append(count)
-                notificationExpectation.fulfill()
-            }
+            let observer = observation.start(
+                in: dbWriter,
+                onError: { error in XCTFail("Unexpected error: \(error)") },
+                onChange: { count in
+                    counts.append(count)
+                    notificationExpectation.fulfill()
+            })
             try withExtendedLifetime(observer) {
                 try dbWriter.writeWithoutTransaction { db in
                     try db.execute(sql: "INSERT INTO t DEFAULT VALUES")

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -36,10 +36,13 @@ class ValueObservationMapTests: GRDBTestCase {
                 .map { count -> String in return "\(count)" }
             
             // Start observation
-            let observer = try observation.start(in: dbWriter) { count in
-                counts.append(count)
-                notificationExpectation.fulfill()
-            }
+            let observer = observation.start(
+                in: dbWriter,
+                onError: { error in XCTFail("Unexpected error: \(error)") },
+                onChange: { count in
+                    counts.append(count)
+                    notificationExpectation.fulfill()
+            })
             try withExtendedLifetime(observer) {
                 try dbWriter.writeWithoutTransaction { db in
                     try db.execute(sql: "INSERT INTO t DEFAULT VALUES")

--- a/Tests/GRDBTests/ValueObservationQueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/ValueObservationQueryInterfaceRequestTests.swift
@@ -62,10 +62,13 @@ class ValueObservationQueryInterfaceRequestTests: GRDBTestCase {
             .orderByPrimaryKey()
             .asRequest(of: Row.self)
         let observation = request.observationForFirst()
-        let observer = try observation.start(in: dbQueue) { row in
-            results.append(row)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { row in
+                results.append(row)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "DELETE FROM child")
@@ -97,10 +100,13 @@ class ValueObservationQueryInterfaceRequestTests: GRDBTestCase {
             .orderByPrimaryKey()
             .asRequest(of: Row.self)
         let observation = request.observationForAll()
-        let observer = try observation.start(in: dbQueue) { rows in
-            results.append(rows)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { rows in
+                results.append(rows)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "DELETE FROM child")
@@ -139,10 +145,13 @@ class ValueObservationQueryInterfaceRequestTests: GRDBTestCase {
             .orderByPrimaryKey()
             .asRequest(of: ParentInfo.self)
         let observation = request.observationForFirst()
-        let observer = try observation.start(in: dbQueue) { parentInfo in
-            results.append(parentInfo)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { parentInfo in
+                results.append(parentInfo)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "DELETE FROM child")
@@ -176,10 +185,13 @@ class ValueObservationQueryInterfaceRequestTests: GRDBTestCase {
             .orderByPrimaryKey()
             .asRequest(of: ParentInfo.self)
         let observation = request.observationForAll()
-        let observer = try observation.start(in: dbQueue) { parentInfos in
-            results.append(parentInfos)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { parentInfos in
+                results.append(parentInfos)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "DELETE FROM child")

--- a/Tests/GRDBTests/ValueObservationRecordTests.swift
+++ b/Tests/GRDBTests/ValueObservationRecordTests.swift
@@ -34,10 +34,13 @@ class ValueObservationRecordTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = SQLRequest<Player>(sql: "SELECT * FROM t ORDER BY id").observationForAll()
-        let observer = try observation.start(in: dbQueue) { players in
-            results.append(players)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { players in
+                results.append(players)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
@@ -70,10 +73,13 @@ class ValueObservationRecordTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = Player.observationForAll()
-        let observer = try observation.start(in: dbQueue) { players in
-            results.append(players)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { players in
+                results.append(players)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
@@ -106,10 +112,13 @@ class ValueObservationRecordTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = SQLRequest<Player>(sql: "SELECT * FROM t ORDER BY id DESC").observationForFirst()
-        let observer = try observation.start(in: dbQueue) { player in
-            results.append(player)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { player in
+                results.append(player)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -108,10 +108,13 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
         
-        let observer = try observation.start(in: dbQueue) { count in
-            results.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                results.append(count)
+                notificationExpectation.fulfill()
+        })
         
         let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
         XCTAssertEqual(token.observer.observedRegion.description, "a(value),source(name)")
@@ -156,10 +159,13 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
         observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: false)
         
-        let observer = try observation.start(in: dbQueue) { count in
-            results.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                results.append(count)
+                notificationExpectation.fulfill()
+        })
         
         // Can't test observedRegion because it is defined asynchronously
         
@@ -203,10 +209,13 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
         observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: true)
         
-        let observer = try observation.start(in: dbQueue) { count in
-            results.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                results.append(count)
+                notificationExpectation.fulfill()
+        })
         
         // Can't test observedRegion because it is defined asynchronously
         
@@ -250,10 +259,13 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
         observation.scheduling = .unsafe(startImmediately: false)
         
-        let observer = try observation.start(in: dbQueue) { count in
-            results.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                results.append(count)
+                notificationExpectation.fulfill()
+        })
         
         // Can't test observedRegion because it is defined asynchronously
         
@@ -297,10 +309,13 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
         observation.scheduling = .unsafe(startImmediately: true)
         
-        let observer = try observation.start(in: dbQueue) { count in
-            results.append(count)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { count in
+                results.append(count)
+                notificationExpectation.fulfill()
+        })
         
         let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
         XCTAssertEqual(token.observer.observedRegion.description, "a(value),source(name)")

--- a/Tests/GRDBTests/ValueObservationRowTests.swift
+++ b/Tests/GRDBTests/ValueObservationRowTests.swift
@@ -21,10 +21,13 @@ class ValueObservationRowTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = SQLRequest<Row>(sql: "SELECT * FROM t ORDER BY id").observationForAll()
-        let observer = try observation.start(in: dbQueue) { rows in
-            results.append(rows)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { rows in
+                results.append(rows)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1
@@ -57,10 +60,13 @@ class ValueObservationRowTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 4
         
         let observation = SQLRequest<Row>(sql: "SELECT * FROM t ORDER BY id DESC").observationForFirst()
-        let observer = try observation.start(in: dbQueue) { row in
-            results.append(row)
-            notificationExpectation.fulfill()
-        }
+        let observer = observation.start(
+            in: dbQueue,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { row in
+                results.append(row)
+                notificationExpectation.fulfill()
+        })
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, 'foo')") // +1


### PR DESCRIPTION
Hiding database errors from user's sight was not a good idea.