### PR TITLE
ValueObservation always emits an initial value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#723](https://github.com/groue/GRDB.swift/pull/723): SE-0255: Implicit returns from single-expression functions
 - [#724](https://github.com/groue/GRDB.swift/pull/724): SE-0242: Synthesize default values for the memberwise initializer
 - [#728](https://github.com/groue/GRDB.swift/pull/728): Make ValueObservation error handling mandatory
+- [#729](https://github.com/groue/GRDB.swift/pull/729): ValueObservation always emits an initial value
 
 
 ## 4.11.0

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -277,7 +277,7 @@ extension DatabaseWriter {
     /// Default implementation for the DatabaseReader requirement.
     /// :nodoc:
     public func remove(transactionObserver: TransactionObserver) {
-        writeWithoutTransaction { $0.remove(transactionObserver: transactionObserver) }
+        unsafeReentrantWrite { $0.remove(transactionObserver: transactionObserver) }
     }
     
     // MARK: - Erasing the content of the database

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -193,6 +193,9 @@ extension ValueReducer where Value: Equatable {
     { preconditionFailure() }
 }
 
+@available(*, unavailable, renamed: "ValueObservationScheduling")
+typealias ValueScheduling = ValueObservationScheduling
+
 #if SQLITE_HAS_CODEC
 extension Configuration {
     @available(*, unavailable, message: "Use Database.usePassphrase(_:) in Configuration.prepareDatabase instead.")

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -46,7 +46,7 @@ public enum ValueObservationScheduling {
     ///
     ///     // On any queue
     ///     var observation = Player.observationForAll()
-    ///     observation.scheduling = .unsafe(startImmediately: true)
+    ///     observation.scheduling = .unsafe
     ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
     ///         print("fresh players: \(players)")
     ///     }
@@ -95,59 +95,6 @@ public struct ValueObservation<Reducer> {
     
     /// `scheduling` controls how fresh values are notified. Default
     /// is `.mainQueue`.
-    ///
-    /// - `.mainQueue`: all values are notified on the main queue.
-    ///
-    ///     If the observation starts on the main queue, an initial value is
-    ///     notified right upon subscription, synchronously::
-    ///
-    ///         // On main queue
-    ///         let observation = Player.observationForAll()
-    ///         let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///             print("fresh players: \(players)")
-    ///         }
-    ///         // <- here "fresh players" is already printed.
-    ///
-    ///     If the observation does not start on the main queue, an initial
-    ///     value is also notified on the main queue, but asynchronously:
-    ///
-    ///         // Not on the main queue: "fresh players" is eventually printed
-    ///         // on the main queue.
-    ///         let observation = Player.observationForAll()
-    ///         let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///             print("fresh players: \(players)")
-    ///         }
-    ///
-    ///     When the database changes, fresh values are asynchronously notified:
-    ///
-    ///         // Eventually prints "fresh players" on the main queue
-    ///         try dbQueue.write { db in
-    ///             try Player(...).insert(db)
-    ///         }
-    ///
-    /// - `.onQueue(_:startImmediately:)`: all values are asychronously notified
-    /// on the specified queue.
-    ///
-    ///     An initial value is fetched and notified if `startImmediately`
-    ///     is true.
-    ///
-    /// - `unsafe(startImmediately:)`: values are not all notified on the same
-    /// dispatch queue.
-    ///
-    ///     If `startImmediately` is true, an initial value is notified right
-    ///     upon subscription, synchronously, on the dispatch queue which starts
-    ///     the observation.
-    ///
-    ///         // On any queue
-    ///         var observation = Player.observationForAll()
-    ///         observation.scheduling = .unsafe(startImmediately: true)
-    ///         let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///             print("fresh players: \(players)")
-    ///         }
-    ///         // <- here "fresh players" is already printed.
-    ///
-    ///     When the database changes, other values are notified on
-    ///     unspecified queues.
     public var scheduling: ValueObservationScheduling
 }
 

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -7,7 +7,7 @@ import Dispatch
 public enum ValueObservationScheduling {
     /// All values are notified on the main queue.
     ///
-    /// If the observation starts on the main queue, an initial value is
+    /// If the observation starts on the main queue, the initial value is
     /// notified right upon subscription, synchronously:
     ///
     ///     // On main queue
@@ -17,7 +17,7 @@ public enum ValueObservationScheduling {
     ///     }
     ///     // <- here "fresh players" is already printed.
     ///
-    /// If the observation does not start on the main queue, an initial value
+    /// If the observation does not start on the main queue, the initial value
     /// is also notified on the main queue, but asynchronously:
     ///
     ///     // Not on the main queue: "fresh players" is eventually printed
@@ -37,16 +37,12 @@ public enum ValueObservationScheduling {
     case mainQueue
     
     /// All values are asychronously notified on the specified queue.
-    ///
-    /// An initial value is fetched and notified if `startImmediately`
-    /// is true.
-    case async(onQueue: DispatchQueue, startImmediately: Bool)
+    case async(onQueue: DispatchQueue)
     
     /// Values are not all notified on the same dispatch queue.
     ///
-    /// If `startImmediately` is true, an initial value is notified right upon
-    /// subscription, synchronously, on the dispatch queue which starts
-    /// the observation.
+    /// The initial value is notified right upon subscription, synchronously, on
+    /// the dispatch queue which starts the observation.
     ///
     ///     // On any queue
     ///     var observation = Player.observationForAll()
@@ -58,7 +54,7 @@ public enum ValueObservationScheduling {
     ///
     /// When the database changes, other values are notified on
     /// unspecified queues.
-    case unsafe(startImmediately: Bool)
+    case unsafe
 }
 
 // MARK: - ValueObservation
@@ -73,6 +69,8 @@ public enum ValueObservationScheduling {
 ///         print("Players have changed.")
 ///     }
 public struct ValueObservation<Reducer> {
+    // TODO: all calls to this closure are followed by ignoringViews().
+    // We should embed this ignoringViews() call.
     /// A closure that is evaluated when the observation starts, and returns
     /// a "base" observed database region.
     ///
@@ -178,6 +176,7 @@ extension ValueObservation where Reducer: ValueReducer {
     // TODO: make public if it helps fetching an initial value before starting
     // the observation, in order to avoid waiting for long write transactions to
     // complete.
+    // TODO: make the result non-optional when compactMap is removed.
     /// Returns the observed value.
     ///
     /// This method returns nil if observation would not notify any

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -2,9 +2,9 @@ import Dispatch
 
 // MARK: - ValueScheduling
 
-/// ValueScheduling controls how ValueObservation schedules the notifications
-/// of fresh values to your application.
-public enum ValueScheduling {
+/// ValueObservationScheduling controls how ValueObservation schedules the
+/// fresh values to your application.
+public enum ValueObservationScheduling {
     /// All values are notified on the main queue.
     ///
     /// If the observation starts on the main queue, an initial value is
@@ -150,7 +150,7 @@ public struct ValueObservation<Reducer> {
     ///
     ///     When the database changes, other values are notified on
     ///     unspecified queues.
-    public var scheduling: ValueScheduling
+    public var scheduling: ValueObservationScheduling
 }
 
 extension ValueObservation where Reducer: ValueReducer {

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -129,6 +129,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
     func reduce(future: DatabaseFuture<Reducer.Fetched>) {
         do {
             if let value = try reducer.value(future.wait()) {
+                if self.isCancelled { return }
                 if let queue = notificationQueue {
                     queue.async { [weak self] in
                         guard let self = self else { return }

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -3,10 +3,9 @@ import Foundation
 /// Support for ValueObservation.
 /// See DatabaseWriter.add(observation:onError:onChange:)
 class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
-    // Reducer and notificationQueue must be set before observer is
+    // Reducer must be set before observer is
     // added to a database.
     var reducer: Reducer!
-    var notificationQueue: DispatchQueue?
     
     var baseRegion = DatabaseRegion() {
         didSet { observedRegion = baseRegion.union(selectedRegion) }
@@ -15,9 +14,10 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
         didSet { observedRegion = baseRegion.union(selectedRegion) }
     }
     var observedRegion: DatabaseRegion! // internal for testability
-    private var requiresWriteAccess: Bool
-    private var observesSelectedRegion: Bool
-    private unowned var writer: DatabaseWriter
+    private let requiresWriteAccess: Bool
+    private let observesSelectedRegion: Bool
+    private unowned let writer: DatabaseWriter
+    private let notificationQueue: DispatchQueue?
     private let reduceQueue: DispatchQueue
     private let onError: (Error) -> Void
     private let onChange: (Reducer.Value) -> Void
@@ -28,6 +28,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
         requiresWriteAccess: Bool,
         observesSelectedRegion: Bool,
         writer: DatabaseWriter,
+        notificationQueue: DispatchQueue?,
         reduceQueue: DispatchQueue,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)
@@ -35,6 +36,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
         self.writer = writer
         self.requiresWriteAccess = requiresWriteAccess
         self.observesSelectedRegion = observesSelectedRegion
+        self.notificationQueue = notificationQueue
         self.reduceQueue = reduceQueue
         self.onError = onError
         self.onChange = onChange
@@ -84,7 +86,6 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
                     future = DatabaseFuture(.failure(error))
                 }
             } else {
-                // Synchronous read/write fetch
                 future = DatabaseFuture(Result {
                     var fetchedValue: Reducer.Fetched!
                     try db.inTransaction {

--- a/Tests/GRDBTests/ValueObservationCompactMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationCompactMapTests.swift
@@ -64,7 +64,7 @@ class ValueObservationCompactMapTests: GRDBTestCase {
     func testCompactMapPreservesConfiguration() {
         var observation = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
         observation.requiresWriteAccess = true
-        observation.scheduling = .unsafe(startImmediately: true)
+        observation.scheduling = .unsafe
         
         let mappedObservation = observation.compactMap { _ in }
         XCTAssertEqual(mappedObservation.requiresWriteAccess, observation.requiresWriteAccess)

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -61,7 +61,7 @@ class ValueObservationMapTests: GRDBTestCase {
     func testMapPreservesConfiguration() {
         var observation = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
         observation.requiresWriteAccess = true
-        observation.scheduling = .unsafe(startImmediately: true)
+        observation.scheduling = .unsafe
         
         let mappedObservation = observation.map { _ in }
         XCTAssertEqual(mappedObservation.requiresWriteAccess, observation.requiresWriteAccess)

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -137,57 +137,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
-    func testAsyncSchedulingWithoutInitialFetch() throws {
-        let dbQueue = try makeDatabaseQueue()
-        try dbQueue.write {
-            try $0.execute(sql: """
-                CREATE TABLE source(name TEXT);
-                INSERT INTO source VALUES ('a');
-                CREATE TABLE a(value INTEGER);
-                CREATE TABLE b(value INTEGER);
-                """)
-        }
-        
-        var results: [Int] = []
-        let notificationExpectation = expectation(description: "notification")
-        notificationExpectation.assertForOverFulfill = true
-        notificationExpectation.expectedFulfillmentCount = 3
-        
-        var observation = ValueObservation.tracking { db -> Int in
-            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
-        }
-        observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: false)
-        
-        let observer = observation.start(
-            in: dbQueue,
-            onError: { error in XCTFail("Unexpected error: \(error)") },
-            onChange: { count in
-                results.append(count)
-                notificationExpectation.fulfill()
-        })
-        
-        // Can't test observedRegion because it is defined asynchronously
-        
-        try withExtendedLifetime(observer) {
-            try dbQueue.inDatabase { db in
-                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
-                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
-                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
-                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
-                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
-                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
-            }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(results, [1, 2, 3])
-            
-            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
-        }
-    }
-    
-    func testAsyncSchedulingWithInitialFetch() throws {
+    func testAsyncScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -207,7 +157,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
-        observation.scheduling = .async(onQueue: DispatchQueue.main, startImmediately: true)
+        observation.scheduling = .async(onQueue: DispatchQueue.main)
         
         let observer = observation.start(
             in: dbQueue,
@@ -237,57 +187,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
-    func testUnsafeSchedulingWithoutInitialFetch() throws {
-        let dbQueue = try makeDatabaseQueue()
-        try dbQueue.write {
-            try $0.execute(sql: """
-                CREATE TABLE source(name TEXT);
-                INSERT INTO source VALUES ('a');
-                CREATE TABLE a(value INTEGER);
-                CREATE TABLE b(value INTEGER);
-                """)
-        }
-        
-        var results: [Int] = []
-        let notificationExpectation = expectation(description: "notification")
-        notificationExpectation.assertForOverFulfill = true
-        notificationExpectation.expectedFulfillmentCount = 3
-        
-        var observation = ValueObservation.tracking { db -> Int in
-            let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
-            return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
-        }
-        observation.scheduling = .unsafe(startImmediately: false)
-        
-        let observer = observation.start(
-            in: dbQueue,
-            onError: { error in XCTFail("Unexpected error: \(error)") },
-            onChange: { count in
-                results.append(count)
-                notificationExpectation.fulfill()
-        })
-        
-        // Can't test observedRegion because it is defined asynchronously
-        
-        try withExtendedLifetime(observer) {
-            try dbQueue.inDatabase { db in
-                try db.execute(sql: "INSERT INTO a VALUES (1)") // 1
-                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
-                try db.execute(sql: "INSERT INTO b VALUES (1)") // -
-                try db.execute(sql: "UPDATE source SET name = 'b'") // 2
-                try db.execute(sql: "INSERT INTO a VALUES (1)") // -
-                try db.execute(sql: "INSERT INTO b VALUES (1)") // 3
-            }
-            
-            waitForExpectations(timeout: 1, handler: nil)
-            XCTAssertEqual(results, [1, 2, 3])
-            
-            let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
-        }
-    }
-    
-    func testUnsafeSchedulingWithInitialFetch() throws {
+    func testUnsafeScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -307,7 +207,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
-        observation.scheduling = .unsafe(startImmediately: true)
+        observation.scheduling = .unsafe
         
         let observer = observation.start(
             in: dbQueue,


### PR DESCRIPTION
This pull request removes a feature.

In previous versions, it was possible to have ValueObservation emit fresh values only for changes performed after the observation is started.

Now ValueObservation always emits an initial value, even before any change is performed.

In order to restore the previous behavior, one can ignore the first emitted value, or use DatabaseRegionObservation instead.