### PR TITLE
Hide ValueObservation implementation details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#724](https://github.com/groue/GRDB.swift/pull/724): SE-0242: Synthesize default values for the memberwise initializer
 - [#728](https://github.com/groue/GRDB.swift/pull/728): Make ValueObservation error handling mandatory
 - [#729](https://github.com/groue/GRDB.swift/pull/729): ValueObservation always emits an initial value
+- [#731](https://github.com/groue/GRDB.swift/pull/731): Hide ValueObservation implementation details
 
 
 ## 4.11.0

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -251,7 +251,7 @@ public protocol DatabaseReader: AnyObject {
     /// during observation
     /// - parameter onChange: a closure that is provided fresh values
     /// - returns: a TransactionObserver
-    func add<Reducer: ValueReducer>(
+    func add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)
@@ -367,7 +367,7 @@ public final class AnyDatabaseReader: DatabaseReader {
     // MARK: - Value Observation
     
     /// :nodoc:
-    public func add<Reducer: ValueReducer>(
+    public func add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -116,7 +116,7 @@ extension DatabaseSnapshot {
     
     // MARK: - Value Observation
     
-    public func add<Reducer: ValueReducer>(
+    public func add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -304,7 +304,7 @@ extension DatabaseWriter {
     
     /// Default implementation for the DatabaseReader requirement.
     /// :nodoc:
-    public func add<Reducer: ValueReducer>(
+    public func add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -361,34 +361,18 @@ extension DatabaseWriter {
             requiresWriteAccess: observation.requiresWriteAccess,
             observesSelectedRegion: observation.observesSelectedRegion,
             writer: self,
+            reducer: observation.makeReducer(),
             notificationQueue: notificationQueue,
             reduceQueue: configuration.makeDispatchQueue(defaultLabel: "GRDB", purpose: "ValueObservation.reducer"),
             onError: onError,
             onChange: onChange)
-        
-        // Fetch initial value, with two side effects:
-        // - observer.selectedRegion is set if observation.observesSelectedRegion
-        // - observer.reducer moves forward
-        func fetchInitialValue(_ db: Database) throws -> Reducer.Value? {
-            let fetchedValue: Reducer.Fetched
-            let requiresWriteAccess = observation.requiresWriteAccess
-            if observation.observesSelectedRegion {
-                (fetchedValue, observer.selectedRegion) = try db.recordingSelectedRegion {
-                    try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
-                }
-            } else {
-                fetchedValue = try observer.reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
-            }
-            return observer.reducer.value(fetchedValue)
-        }
         
         if initialSync {
             do {
                 // TODO: make initialValue non-optional when compactMap is removed.
                 let initialValue: Reducer.Value? = try unsafeReentrantWrite { db in
                     observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
-                    observer.reducer = try observation.makeReducer(db)
-                    let initialValue = try fetchInitialValue(db)
+                    let initialValue = try observer.fetchInitialValue(db)
                     db.add(transactionObserver: observer, extent: .observerLifetime)
                     return initialValue
                 }
@@ -402,8 +386,7 @@ extension DatabaseWriter {
             asyncWriteWithoutTransaction { db in
                 do {
                     observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
-                    observer.reducer = try observation.makeReducer(db)
-                    if let value = try fetchInitialValue(db) {
+                    if let value = try observer.fetchInitialValue(db) {
                         queue.async {
                             onChange(value)
                         }
@@ -419,8 +402,7 @@ extension DatabaseWriter {
             asyncWriteWithoutTransaction { db in
                 do {
                     observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
-                    observer.reducer = try observation.makeReducer(db)
-                    if let value = try fetchInitialValue(db) {
+                    if let value = try observer.fetchInitialValue(db) {
                         onChange(value)
                     }
                     db.add(transactionObserver: observer, extent: .observerLifetime)

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -142,7 +142,7 @@ extension Statement {
     { preconditionFailure() }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     @available(*, unavailable, message: "Use request.observationForCount() instead")
     public static func trackingCount<Request: FetchRequest>(_ request: Request)
         -> ValueObservation<ValueReducers.RemoveDuplicates<ValueReducers.Fetch<Int>>>
@@ -192,7 +192,7 @@ extension ValueObservation where Reducer == Void {
     { preconditionFailure() }
 }
 
-extension ValueObservation where Reducer: _ValueReducer {
+extension ValueObservation {
     @available(*, unavailable, message: "Use start(in:onError:onChange:) instead.")
     public func start(
         in reader: DatabaseReader,
@@ -200,7 +200,7 @@ extension ValueObservation where Reducer: _ValueReducer {
     { preconditionFailure() }
 }
 
-extension ValueObservation where Reducer: _ValueReducer, Reducer.Value: Equatable {
+extension ValueObservation where Reducer.Value: Equatable {
     @available(*, unavailable, renamed: "removeDuplicates")
     public func distinctUntilChanged() -> ValueObservation<ValueReducers.RemoveDuplicates<Reducer>>
     { preconditionFailure() }

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -220,12 +220,6 @@ extension ValueObservation where Reducer.Value: Equatable {
 @available(*, unavailable, message: "Custom reducers are no longer supported")
 typealias ValueReducer = _ValueReducer
 
-extension _ValueReducer where Value: Equatable {
-    @available(*, unavailable, renamed: "removeDuplicates")
-    public func distinctUntilChanged() -> ValueReducers.RemoveDuplicates<Self>
-    { preconditionFailure() }
-}
-
 @available(*, unavailable, renamed: "ValueObservationScheduling")
 typealias ValueScheduling = ValueObservationScheduling
 

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -10,6 +10,25 @@ extension AnyFetchRequest {
     { preconditionFailure() }
 }
 
+@available(*, unavailable, message: "Custom reducers are no longer supported")
+public struct AnyValueReducer<Fetched, Value>: _ValueReducer {
+    /// :nodoc:
+    public init(fetch: @escaping (Database) throws -> Fetched, value: @escaping (Fetched) -> Value?)
+    { preconditionFailure() }
+    
+    /// :nodoc:
+    public init<Base: _ValueReducer>(_ reducer: Base) where Base.Fetched == Fetched, Base.Value == Value
+    { preconditionFailure() }
+    
+    /// :nodoc:
+    public func fetch(_ db: Database) throws -> Fetched
+    { preconditionFailure() }
+    
+    /// :nodoc:
+    public func value(_ fetched: Fetched) -> Value?
+    { preconditionFailure() }
+}
+
 extension AssociationAggregate {
     @available(*, unavailable, renamed: "forKey(_:)")
     public func aliased(_ name: String) -> AssociationAggregate<RowDecoder>
@@ -173,7 +192,7 @@ extension ValueObservation where Reducer == Void {
     { preconditionFailure() }
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     @available(*, unavailable, message: "Use start(in:onError:onChange:) instead.")
     public func start(
         in reader: DatabaseReader,
@@ -181,13 +200,16 @@ extension ValueObservation where Reducer: ValueReducer {
     { preconditionFailure() }
 }
 
-extension ValueObservation where Reducer: ValueReducer, Reducer.Value: Equatable {
+extension ValueObservation where Reducer: _ValueReducer, Reducer.Value: Equatable {
     @available(*, unavailable, renamed: "removeDuplicates")
     public func distinctUntilChanged() -> ValueObservation<ValueReducers.RemoveDuplicates<Reducer>>
     { preconditionFailure() }
 }
 
-extension ValueReducer where Value: Equatable {
+@available(*, unavailable, message: "Custom reducers are no longer supported")
+typealias ValueReducer = _ValueReducer
+
+extension _ValueReducer where Value: Equatable {
     @available(*, unavailable, renamed: "removeDuplicates")
     public func distinctUntilChanged() -> ValueReducers.RemoveDuplicates<Self>
     { preconditionFailure() }

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -1,4 +1,5 @@
 // Fixits for changes introduced by GRDB 5.0.0
+// swiftlint:disable all
 
 #if os(iOS)
 import UIKit
@@ -139,6 +140,16 @@ extension Statement {
     
     @available(*, unavailable, renamed: "validateArguments(_:)")
     public func validate(arguments: StatementArguments) throws
+    { preconditionFailure() }
+}
+
+extension ValueObservation {
+    @available(*, unavailable, message: "Custom reducers are no longer supported")
+    public static func tracking(_ regions: DatabaseRegionConvertible..., reducer: @escaping (Database) throws -> Reducer) -> ValueObservation
+    { preconditionFailure() }
+
+    @available(*, unavailable, message: "Custom reducers are no longer supported")
+    public static func tracking(_ regions: [DatabaseRegionConvertible], reducer: @escaping (Database) throws -> Reducer) -> ValueObservation
     { preconditionFailure() }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -26,9 +26,9 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllValues<RowDecoder>> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.AllValues { try DatabaseValue.fetchAll($0, self) }
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.AllValues { try DatabaseValue.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -55,9 +55,9 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     /// - parameter request: the observed request.
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneValue<RowDecoder>> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) }
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
     }
 }
 
@@ -89,9 +89,9 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllOptionalValues<RowDecoder._Wrapped>> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.AllOptionalValues { try DatabaseValue.fetchAll($0, self) }
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.AllOptionalValues { try DatabaseValue.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies
@@ -118,9 +118,9 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     ///
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneValue<RowDecoder._Wrapped>> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) }
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -28,7 +28,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     public func observationForAll() -> ValueObservation<ValueReducers.AllValues<RowDecoder>> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.AllValues { try DatabaseValue.fetchAll($0, self) } })
+            makeReducer: { ValueReducers.AllValues { try DatabaseValue.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -57,7 +57,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     public func observationForFirst() -> ValueObservation<ValueReducers.OneValue<RowDecoder>> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
+            makeReducer: { ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
     }
 }
 
@@ -91,7 +91,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     public func observationForAll() -> ValueObservation<ValueReducers.AllOptionalValues<RowDecoder._Wrapped>> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.AllOptionalValues { try DatabaseValue.fetchAll($0, self) } })
+            makeReducer: { ValueReducers.AllOptionalValues { try DatabaseValue.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies
@@ -120,7 +120,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder._Wrapped:
     public func observationForFirst() -> ValueObservation<ValueReducers.OneValue<RowDecoder._Wrapped>> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
+            makeReducer: { ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -131,7 +131,7 @@ extension ValueReducers {
     /// identical database values.
     ///
     /// :nodoc:
-    public struct AllValues<RowDecoder>: ValueReducer
+    public struct AllValues<RowDecoder>: _ValueReducer
         where RowDecoder: DatabaseValueConvertible
     {
         private let _fetch: (Database) throws -> [DatabaseValue]
@@ -163,7 +163,7 @@ extension ValueReducers {
     /// identical database values.
     ///
     /// :nodoc:
-    public struct OneValue<RowDecoder>: ValueReducer
+    public struct OneValue<RowDecoder>: _ValueReducer
         where RowDecoder: DatabaseValueConvertible
     {
         private let _fetch: (Database) throws -> DatabaseValue?
@@ -205,7 +205,7 @@ extension ValueReducers {
     /// identical database values.
     ///
     /// :nodoc:
-    public struct AllOptionalValues<RowDecoder>: ValueReducer
+    public struct AllOptionalValues<RowDecoder>: _ValueReducer
         where RowDecoder: DatabaseValueConvertible
     {
         private let _fetch: (Database) throws -> [DatabaseValue]

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -26,9 +26,9 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllRecords<RowDecoder>> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.AllRecords { try Row.fetchAll($0, self) }
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.AllRecords { try Row.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -54,9 +54,9 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     ///
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneRecord<RowDecoder>> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.OneRecord { try Row.fetchOne($0, self) }
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.OneRecord { try Row.fetchOne($0, self) } })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -125,7 +125,7 @@ extension ValueReducers {
     /// identical database rows.
     ///
     /// :nodoc:
-    public struct AllRecords<RowDecoder>: ValueReducer
+    public struct AllRecords<RowDecoder>: _ValueReducer
         where RowDecoder: FetchableRecord
     {
         private let _fetch: (Database) throws -> [Row]
@@ -155,7 +155,7 @@ extension ValueReducers {
     /// identical database rows.
     ///
     /// :nodoc:
-    public struct OneRecord<RowDecoder>: ValueReducer
+    public struct OneRecord<RowDecoder>: _ValueReducer
         where RowDecoder: FetchableRecord
     {
         private let _fetch: (Database) throws -> Row?

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -28,7 +28,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     public func observationForAll() -> ValueObservation<ValueReducers.AllRecords<RowDecoder>> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.AllRecords { try Row.fetchAll($0, self) } })
+            makeReducer: { ValueReducers.AllRecords { try Row.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -56,7 +56,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     public func observationForFirst() -> ValueObservation<ValueReducers.OneRecord<RowDecoder>> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.OneRecord { try Row.fetchOne($0, self) } })
+            makeReducer: { ValueReducers.OneRecord { try Row.fetchOne($0, self) } })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+MapReducer.swift
+++ b/GRDB/ValueObservation/ValueObservation+MapReducer.swift
@@ -1,13 +1,11 @@
 extension ValueObservation {
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
     /// Returns a ValueObservation with a transformed reducer.
-    public func mapReducer<R>(_ transform: @escaping (Database, Reducer) throws -> R) -> ValueObservation<R> {
+    func mapReducer<R>(_ transform: @escaping (Reducer) -> R) -> ValueObservation<R> {
         let makeReducer = self.makeReducer
         return ValueObservation<R>(
             baseRegion: baseRegion,
             observesSelectedRegion: observesSelectedRegion,
-            makeReducer: { db in try transform(db, makeReducer(db)) },
+            makeReducer: { transform(makeReducer()) },
             requiresWriteAccess: requiresWriteAccess,
             scheduling: scheduling)
     }

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -66,7 +66,7 @@ extension ValueReducers {
     /// consecutive identical arrays.
     ///
     /// :nodoc:
-    public struct AllRows: ValueReducer {
+    public struct AllRows: _ValueReducer {
         private let _fetch: (Database) throws -> [Row]
         private var previousRows: [Row]?
         
@@ -94,7 +94,7 @@ extension ValueReducers {
     /// identical database rows.
     ///
     /// :nodoc:
-    public struct OneRow: ValueReducer {
+    public struct OneRow: _ValueReducer {
         private let _fetch: (Database) throws -> Row?
         private var previousRow: Row??
         

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -25,9 +25,9 @@ extension FetchRequest where RowDecoder == Row {
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllRows> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.AllRows(fetch: self.fetchAll)
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.AllRows(fetch: self.fetchAll) })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -53,9 +53,9 @@ extension FetchRequest where RowDecoder == Row {
     ///
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneRow> {
-        ValueObservation.tracking(self, reducer: { _ in
-            ValueReducers.OneRow(fetch: self.fetchOne)
-        })
+        ValueObservation(
+            baseRegion: databaseRegion,
+            makeReducer: { _ in ValueReducers.OneRow(fetch: self.fetchOne) })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -27,7 +27,7 @@ extension FetchRequest where RowDecoder == Row {
     public func observationForAll() -> ValueObservation<ValueReducers.AllRows> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.AllRows(fetch: self.fetchAll) })
+            makeReducer: { ValueReducers.AllRows(fetch: self.fetchAll) })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -55,7 +55,7 @@ extension FetchRequest where RowDecoder == Row {
     public func observationForFirst() -> ValueObservation<ValueReducers.OneRow> {
         ValueObservation(
             baseRegion: databaseRegion,
-            makeReducer: { _ in ValueReducers.OneRow(fetch: self.fetchOne) })
+            makeReducer: { ValueReducers.OneRow(fetch: self.fetchOne) })
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -83,7 +83,7 @@ public struct ValueObservation<Reducer: _ValueReducer> {
 
     /// The reducer is created when observation starts, and is triggered upon
     /// each database change in *observedRegion*.
-    var makeReducer: (Database) throws -> Reducer
+    var makeReducer: () -> Reducer
     
     /// Default is false. Set this property to true when the observation
     /// requires write access in order to fetch fresh values. Fetches are then
@@ -142,7 +142,7 @@ extension ValueObservation {
     ///         try observation.fetchFirst(db)
     ///     }
     func fetchFirst(_ db: Database) throws -> Reducer.Value? {
-        var reducer = try makeReducer(db)
+        var reducer = try makeReducer()
         return try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess))
     }
 }
@@ -172,7 +172,7 @@ extension ValueObservation where Reducer == Never {
         return ValueObservation<ValueReducers.Fetch<Value>>(
             baseRegion: { _ in DatabaseRegion() },
             observesSelectedRegion: true,
-            makeReducer: { _ in ValueReducers.Fetch(value) })
+            makeReducer: { ValueReducers.Fetch(value) })
     }
     
     /// Creates a ValueObservation which observes *regions*, and notifies the
@@ -222,6 +222,6 @@ extension ValueObservation where Reducer == Never {
     {
         return ValueObservation<ValueReducers.Fetch<Value>>(
             baseRegion: DatabaseRegion.union(regions),
-            makeReducer: { _ in ValueReducers.Fetch(fetch) })
+            makeReducer: { ValueReducers.Fetch(fetch) })
     }
 }

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -142,8 +142,9 @@ extension ValueObservation {
     ///         try observation.fetchFirst(db)
     ///     }
     func fetchFirst(_ db: Database) throws -> Reducer.Value? {
-        var reducer = try makeReducer()
-        return try reducer.value(reducer.fetch(db, requiringWriteAccess: requiresWriteAccess))
+        var reducer = makeReducer()
+        let fetchedValue = try reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
+        return reducer.value(fetchedValue)
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -68,7 +68,7 @@ public enum ValueObservationScheduling {
 ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
 ///         print("Players have changed.")
 ///     }
-public struct ValueObservation<Reducer> {
+public struct ValueObservation<Reducer: _ValueReducer> {
     // TODO: all calls to this closure are followed by ignoringViews().
     // We should embed this ignoringViews() call.
     /// A closure that is evaluated when the observation starts, and returns
@@ -98,7 +98,7 @@ public struct ValueObservation<Reducer> {
     public var scheduling: ValueObservationScheduling
 }
 
-extension ValueObservation where Reducer: _ValueReducer {
+extension ValueObservation {
     
     // MARK: - Starting Observation
     
@@ -147,7 +147,7 @@ extension ValueObservation where Reducer: _ValueReducer {
     }
 }
 
-extension ValueObservation where Reducer: _ValueReducer {
+extension ValueObservation {
     
     // MARK: - Creating ValueObservation from _ValueReducer
     
@@ -239,7 +239,7 @@ extension ValueObservation where Reducer: _ValueReducer {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     
     // MARK: - Creating ValueObservation from Fetch Closures
     

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -98,7 +98,7 @@ public struct ValueObservation<Reducer> {
     public var scheduling: ValueObservationScheduling
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     
     // MARK: - Starting Observation
     
@@ -147,9 +147,9 @@ extension ValueObservation where Reducer: ValueReducer {
     }
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     
-    // MARK: - Creating ValueObservation from ValueReducer
+    // MARK: - Creating ValueObservation from _ValueReducer
     
     /// Returns a ValueObservation which observes *regions*, and notifies the
     /// values returned by the *reducer* whenever one of the observed
@@ -183,7 +183,7 @@ extension ValueObservation where Reducer: ValueReducer {
     /// - parameter regions: A list of observed regions.
     /// - parameter reducer: A reducer that turns database changes in the
     /// modified regions into fresh values. Currently only reducers that adopt
-    /// the ValueReducer protocol are supported.
+    /// the _ValueReducer protocol are supported.
     public static func tracking(
         _ regions: DatabaseRegionConvertible...,
         reducer: @escaping (Database) throws -> Reducer)
@@ -224,7 +224,7 @@ extension ValueObservation where Reducer: ValueReducer {
     /// - parameter regions: A list of observed regions.
     /// - parameter reducer: A reducer that turns database changes in the
     /// modified regions into fresh values. Currently only reducers that adopt
-    /// the ValueReducer protocol are supported.
+    /// the _ValueReducer protocol are supported.
     public static func tracking(
         _ regions: [DatabaseRegionConvertible],
         reducer: @escaping (Database) throws -> Reducer)

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Support for ValueObservation.
 /// See DatabaseWriter.add(observation:onError:onChange:)
-class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
+class ValueObserver<Reducer: _ValueReducer>: TransactionObserver {
     // Reducer must be set before observer is
     // added to a database.
     var reducer: Reducer!
@@ -158,7 +158,7 @@ class ValueObserver<Reducer: ValueReducer>: TransactionObserver {
     }
 }
 
-class ValueObserverToken<Reducer: ValueReducer>: TransactionObserver {
+class ValueObserverToken<Reducer: _ValueReducer>: TransactionObserver {
     // Useless junk
     func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool { false }
     func databaseDidChange(with event: DatabaseEvent) { }

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -2,8 +2,8 @@
 
 extension ValueReducers {
     public struct Combine2<
-        R1: ValueReducer,
-        R2: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer>: _ValueReducer
     {
         public typealias Fetched = (R1.Fetched, R2.Fetched)
         public typealias Value = (R1.Value, R2.Value)
@@ -44,8 +44,8 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>)
         -> ValueObservation<ValueReducers.Combine2<R1, R2>>
@@ -65,9 +65,9 @@ extension ValueObservation where Reducer == Void {
     }
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     public func combine<
-        R1: ValueReducer,
+        R1: _ValueReducer,
         Combined>(
         _ other: ValueObservation<R1>,
         _ transform: @escaping (Reducer.Value, R1.Value) -> Combined)
@@ -81,9 +81,9 @@ extension ValueObservation where Reducer: ValueReducer {
 
 extension ValueReducers {
     public struct Combine3<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer>: _ValueReducer
     {
         public typealias Fetched = (R1.Fetched, R2.Fetched, R3.Fetched)
         public typealias Value = (R1.Value, R2.Value, R3.Value)
@@ -131,9 +131,9 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>,
         _ o3: ValueObservation<R3>)
@@ -158,10 +158,10 @@ extension ValueObservation where Reducer == Void {
     }
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     public func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
+        R1: _ValueReducer,
+        R2: _ValueReducer,
         Combined>(
         _ observation1: ValueObservation<R1>,
         _ observation2: ValueObservation<R2>,
@@ -181,10 +181,10 @@ extension ValueObservation where Reducer: ValueReducer {
 
 extension ValueReducers {
     public struct Combine4<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer>: _ValueReducer
     {
         public typealias Fetched = (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched)
         public typealias Value = (R1.Value, R2.Value, R3.Value, R4.Value)
@@ -239,10 +239,10 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>,
         _ o3: ValueObservation<R3>,
@@ -272,11 +272,11 @@ extension ValueObservation where Reducer == Void {
     }
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     public func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
         Combined>(
         _ observation1: ValueObservation<R1>,
         _ observation2: ValueObservation<R2>,
@@ -298,11 +298,11 @@ extension ValueObservation where Reducer: ValueReducer {
 
 extension ValueReducers {
     public struct Combine5<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer>: _ValueReducer
     {
         public typealias Fetched = (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched)
         public typealias Value = (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value)
@@ -364,11 +364,11 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>,
         _ o3: ValueObservation<R3>,
@@ -403,12 +403,12 @@ extension ValueObservation where Reducer == Void {
     }
 }
 
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     public func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
         Combined>(
         _ observation1: ValueObservation<R1>,
         _ observation2: ValueObservation<R2>,
@@ -432,12 +432,12 @@ extension ValueObservation where Reducer: ValueReducer {
 
 extension ValueReducers {
     public struct Combine6<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer,
-        R6: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer,
+        R6: _ValueReducer>: _ValueReducer
     {
         public typealias Fetched = (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched, R6.Fetched)
         public typealias Value = (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value, R6.Value)
@@ -506,12 +506,12 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer,
-        R6: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer,
+        R6: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>,
         _ o3: ValueObservation<R3>,
@@ -555,13 +555,13 @@ extension ValueObservation where Reducer == Void {
 
 extension ValueReducers {
     public struct Combine7<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer,
-        R6: ValueReducer,
-        R7: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer,
+        R6: _ValueReducer,
+        R7: _ValueReducer>: _ValueReducer
     {
         public typealias Fetched = (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched, R6.Fetched, R7.Fetched)
         public typealias Value = (R1.Value, R2.Value, R3.Value, R4.Value, R5.Value, R6.Value, R7.Value)
@@ -637,13 +637,13 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer,
-        R6: ValueReducer,
-        R7: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer,
+        R6: _ValueReducer,
+        R7: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>,
         _ o3: ValueObservation<R3>,
@@ -692,14 +692,14 @@ extension ValueObservation where Reducer == Void {
 
 extension ValueReducers {
     public struct Combine8<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer,
-        R6: ValueReducer,
-        R7: ValueReducer,
-        R8: ValueReducer>: ValueReducer
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer,
+        R6: _ValueReducer,
+        R7: _ValueReducer,
+        R8: _ValueReducer>: _ValueReducer
     {
         // swiftlint:disable:next line_length
         public typealias Fetched = (R1.Fetched, R2.Fetched, R3.Fetched, R4.Fetched, R5.Fetched, R6.Fetched, R7.Fetched, R8.Fetched)
@@ -783,14 +783,14 @@ extension ValueReducers {
 
 extension ValueObservation where Reducer == Void {
     public static func combine<
-        R1: ValueReducer,
-        R2: ValueReducer,
-        R3: ValueReducer,
-        R4: ValueReducer,
-        R5: ValueReducer,
-        R6: ValueReducer,
-        R7: ValueReducer,
-        R8: ValueReducer>(
+        R1: _ValueReducer,
+        R2: _ValueReducer,
+        R3: _ValueReducer,
+        R4: _ValueReducer,
+        R5: _ValueReducer,
+        R6: _ValueReducer,
+        R7: _ValueReducer,
+        R8: _ValueReducer>(
         _ o1: ValueObservation<R1>,
         _ o2: ValueObservation<R2>,
         _ o3: ValueObservation<R3>,

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -56,9 +56,9 @@ extension ValueObservation where Reducer == Never {
                 o2.baseRegion($0)) },
             observesSelectedRegion: o1.observesSelectedRegion
                 || o2.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine2(
-                o1.makeReducer($0),
-                o2.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine2(
+                o1.makeReducer(),
+                o2.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess,
             scheduling: .mainQueue)
@@ -147,10 +147,10 @@ extension ValueObservation where Reducer == Never {
             observesSelectedRegion: o1.observesSelectedRegion
                 || o2.observesSelectedRegion
                 || o3.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine3(
-                o1.makeReducer($0),
-                o2.makeReducer($0),
-                o3.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine3(
+                o1.makeReducer(),
+                o2.makeReducer(),
+                o3.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess,
@@ -259,11 +259,11 @@ extension ValueObservation where Reducer == Never {
                 || o2.observesSelectedRegion
                 || o3.observesSelectedRegion
                 || o4.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine4(
-                o1.makeReducer($0),
-                o2.makeReducer($0),
-                o3.makeReducer($0),
-                o4.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine4(
+                o1.makeReducer(),
+                o2.makeReducer(),
+                o3.makeReducer(),
+                o4.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess
@@ -388,12 +388,12 @@ extension ValueObservation where Reducer == Never {
                 || o3.observesSelectedRegion
                 || o4.observesSelectedRegion
                 || o5.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine5(
-                o1.makeReducer($0),
-                o2.makeReducer($0),
-                o3.makeReducer($0),
-                o4.makeReducer($0),
-                o5.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine5(
+                o1.makeReducer(),
+                o2.makeReducer(),
+                o3.makeReducer(),
+                o4.makeReducer(),
+                o5.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess
@@ -534,13 +534,13 @@ extension ValueObservation where Reducer == Never {
                 || o4.observesSelectedRegion
                 || o5.observesSelectedRegion
                 || o6.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine6(
-                o1.makeReducer($0),
-                o2.makeReducer($0),
-                o3.makeReducer($0),
-                o4.makeReducer($0),
-                o5.makeReducer($0),
-                o6.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine6(
+                o1.makeReducer(),
+                o2.makeReducer(),
+                o3.makeReducer(),
+                o4.makeReducer(),
+                o5.makeReducer(),
+                o6.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess
@@ -669,14 +669,14 @@ extension ValueObservation where Reducer == Never {
                 || o5.observesSelectedRegion
                 || o6.observesSelectedRegion
                 || o7.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine7(
-                o1.makeReducer($0),
-                o2.makeReducer($0),
-                o3.makeReducer($0),
-                o4.makeReducer($0),
-                o5.makeReducer($0),
-                o6.makeReducer($0),
-                o7.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine7(
+                o1.makeReducer(),
+                o2.makeReducer(),
+                o3.makeReducer(),
+                o4.makeReducer(),
+                o5.makeReducer(),
+                o6.makeReducer(),
+                o7.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess
@@ -819,15 +819,15 @@ extension ValueObservation where Reducer == Never {
                 || o6.observesSelectedRegion
                 || o7.observesSelectedRegion
                 || o8.observesSelectedRegion,
-            makeReducer: { try ValueReducers.Combine8(
-                o1.makeReducer($0),
-                o2.makeReducer($0),
-                o3.makeReducer($0),
-                o4.makeReducer($0),
-                o5.makeReducer($0),
-                o6.makeReducer($0),
-                o7.makeReducer($0),
-                o8.makeReducer($0)) },
+            makeReducer: { ValueReducers.Combine8(
+                o1.makeReducer(),
+                o2.makeReducer(),
+                o3.makeReducer(),
+                o4.makeReducer(),
+                o5.makeReducer(),
+                o6.makeReducer(),
+                o7.makeReducer(),
+                o8.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -42,7 +42,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer>(
@@ -73,7 +73,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine2<Reducer, R1>, Combined>>
     {
-        return ValueObservation<Void>.combine(self, other).map(transform)
+        return ValueObservation<Never>.combine(self, other).map(transform)
     }
 }
 
@@ -129,7 +129,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -168,7 +168,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value, R2.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine3<Reducer, R1, R2>, Combined>>
     {
-        return ValueObservation<Void>
+        return ValueObservation<Never>
             .combine(
                 self,
                 observation1,
@@ -237,7 +237,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -284,7 +284,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value, R2.Value, R3.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine4<Reducer, R1, R2, R3>, Combined>>
     {
-        return ValueObservation<Void>
+        return ValueObservation<Never>
             .combine(
                 self,
                 observation1,
@@ -362,7 +362,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -417,7 +417,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value, R2.Value, R3.Value, R4.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine5<Reducer, R1, R2, R3, R4>, Combined>>
     {
-        return ValueObservation<Void>
+        return ValueObservation<Never>
             .combine(
                 self,
                 observation1,
@@ -504,7 +504,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -635,7 +635,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -781,7 +781,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Void {
+extension ValueObservation where Reducer == Never {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,

--- a/GRDB/ValueObservation/ValueReducer/CompactMap.swift
+++ b/GRDB/ValueObservation/ValueReducer/CompactMap.swift
@@ -1,4 +1,4 @@
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     /// Returns a ValueObservation which notifies the non-nil results of calling
     /// the given transformation which each element notified by this
     /// value observation.
@@ -9,7 +9,7 @@ extension ValueObservation where Reducer: ValueReducer {
     }
 }
 
-extension ValueReducer {
+extension _ValueReducer {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
     /// Returns a reducer which outputs the non-nil results of calling the given
@@ -25,7 +25,7 @@ extension ValueReducers {
     /// See ValueObservation.compactMap(_:)
     ///
     /// :nodoc:
-    public struct CompactMap<Base: ValueReducer, Value>: ValueReducer {
+    public struct CompactMap<Base: _ValueReducer, Value>: _ValueReducer {
         private var base: Base
         private let transform: (Base.Value) -> Value?
         

--- a/GRDB/ValueObservation/ValueReducer/CompactMap.swift
+++ b/GRDB/ValueObservation/ValueReducer/CompactMap.swift
@@ -5,17 +5,7 @@ extension ValueObservation {
     public func compactMap<T>(_ transform: @escaping (Reducer.Value) -> T?)
         -> ValueObservation<ValueReducers.CompactMap<Reducer, T>>
     {
-        return mapReducer { $1.compactMap(transform) }
-    }
-}
-
-extension _ValueReducer {
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
-    /// Returns a reducer which outputs the non-nil results of calling the given
-    /// transformation which each element emitted by this reducer.
-    public func compactMap<T>(_ transform: @escaping (Value) -> T?) -> ValueReducers.CompactMap<Self, T> {
-        ValueReducers.CompactMap(self, transform)
+        mapReducer { ValueReducers.CompactMap($0, transform) }
     }
 }
 

--- a/GRDB/ValueObservation/ValueReducer/CompactMap.swift
+++ b/GRDB/ValueObservation/ValueReducer/CompactMap.swift
@@ -1,4 +1,4 @@
-extension ValueObservation where Reducer: _ValueReducer {
+extension ValueObservation {
     /// Returns a ValueObservation which notifies the non-nil results of calling
     /// the given transformation which each element notified by this
     /// value observation.

--- a/GRDB/ValueObservation/ValueReducer/Fetch.swift
+++ b/GRDB/ValueObservation/ValueReducer/Fetch.swift
@@ -4,7 +4,7 @@ extension ValueReducers {
     /// A reducer which pass raw fetched values through.
     ///
     /// :nodoc:
-    public struct Fetch<Value>: ValueReducer {
+    public struct Fetch<Value>: _ValueReducer {
         private let _fetch: (Database) throws -> Value
         
         public init(_ fetch: @escaping (Database) throws -> Value) {

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -1,4 +1,4 @@
-extension ValueObservation where Reducer: ValueReducer {
+extension ValueObservation where Reducer: _ValueReducer {
     /// Returns a ValueObservation which notifies the results of calling the
     /// given transformation which each element notified by this
     /// value observation.
@@ -9,7 +9,7 @@ extension ValueObservation where Reducer: ValueReducer {
     }
 }
 
-extension ValueReducer {
+extension _ValueReducer {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
     /// Returns a reducer which outputs the results of calling the given
@@ -22,13 +22,13 @@ extension ValueReducer {
 extension ValueReducers {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
-    /// A ValueReducer whose values consist of those in a Base ValueReducer passed
+    /// A _ValueReducer whose values consist of those in a Base _ValueReducer passed
     /// through a transform function.
     ///
-    /// See ValueReducer.map(_:)
+    /// See _ValueReducer.map(_:)
     ///
     /// :nodoc:
-    public struct Map<Base: ValueReducer, Value>: ValueReducer {
+    public struct Map<Base: _ValueReducer, Value>: _ValueReducer {
         private var base: Base
         private let transform: (Base.Value) -> Value
         

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -5,17 +5,7 @@ extension ValueObservation {
     public func map<T>(_ transform: @escaping (Reducer.Value) -> T)
         -> ValueObservation<ValueReducers.Map<Reducer, T>>
     {
-        return mapReducer { $1.map(transform) }
-    }
-}
-
-extension _ValueReducer {
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
-    /// Returns a reducer which outputs the results of calling the given
-    /// transformation which each element emitted by this reducer.
-    public func map<T>(_ transform: @escaping (Value) -> T) -> ValueReducers.Map<Self, T> {
-        ValueReducers.Map(self, transform)
+        mapReducer { ValueReducers.Map($0, transform) }
     }
 }
 

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -1,4 +1,4 @@
-extension ValueObservation where Reducer: _ValueReducer {
+extension ValueObservation {
     /// Returns a ValueObservation which notifies the results of calling the
     /// given transformation which each element notified by this
     /// value observation.

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -1,4 +1,5 @@
-extension ValueObservation where Reducer: _ValueReducer, Reducer.Value: Equatable {
+// TODO: add removeDuplicates(by:)
+extension ValueObservation where Reducer.Value: Equatable {
     /// Returns a ValueObservation which filters out consecutive equal values.
     public func removeDuplicates()
         -> ValueObservation<ValueReducers.RemoveDuplicates<Reducer>>

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -4,16 +4,7 @@ extension ValueObservation where Reducer.Value: Equatable {
     public func removeDuplicates()
         -> ValueObservation<ValueReducers.RemoveDuplicates<Reducer>>
     {
-        return mapReducer { $1.removeDuplicates() }
-    }
-}
-
-extension _ValueReducer where Value: Equatable {
-    /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-    ///
-    /// Returns a _ValueReducer which filters out consecutive equal values.
-    public func removeDuplicates() -> ValueReducers.RemoveDuplicates<Self> {
-        ValueReducers.RemoveDuplicates(self)
+        mapReducer { ValueReducers.RemoveDuplicates($0) }
     }
 }
 

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -1,4 +1,4 @@
-extension ValueObservation where Reducer: ValueReducer, Reducer.Value: Equatable {
+extension ValueObservation where Reducer: _ValueReducer, Reducer.Value: Equatable {
     /// Returns a ValueObservation which filters out consecutive equal values.
     public func removeDuplicates()
         -> ValueObservation<ValueReducers.RemoveDuplicates<Reducer>>
@@ -7,10 +7,10 @@ extension ValueObservation where Reducer: ValueReducer, Reducer.Value: Equatable
     }
 }
 
-extension ValueReducer where Value: Equatable {
+extension _ValueReducer where Value: Equatable {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
-    /// Returns a ValueReducer which filters out consecutive equal values.
+    /// Returns a _ValueReducer which filters out consecutive equal values.
     public func removeDuplicates() -> ValueReducers.RemoveDuplicates<Self> {
         ValueReducers.RemoveDuplicates(self)
     }
@@ -19,10 +19,10 @@ extension ValueReducer where Value: Equatable {
 extension ValueReducers {
     /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
     ///
-    /// See ValueReducer.removeDuplicates()
+    /// See _ValueReducer.removeDuplicates()
     ///
     /// :nodoc:
-    public struct RemoveDuplicates<Base: ValueReducer>: ValueReducer where Base.Value: Equatable {
+    public struct RemoveDuplicates<Base: _ValueReducer>: _ValueReducer where Base.Value: Equatable {
         private var base: Base
         private var previousValue: Base.Value?
         

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -1,7 +1,7 @@
 /// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
 ///
-/// The ValueReducer protocol supports ValueObservation.
-public protocol ValueReducer {
+/// The _ValueReducer protocol supports ValueObservation.
+public protocol _ValueReducer {
     /// The type of fetched database values
     associatedtype Fetched
     
@@ -18,8 +18,7 @@ public protocol ValueReducer {
     mutating func value(_ fetched: Fetched) -> Value?
 }
 
-extension ValueReducer {
-    /// Synchronous fetch
+extension _ValueReducer {
     func fetch(_ db: Database, requiringWriteAccess: Bool) throws -> Fetched {
         if requiringWriteAccess {
             var fetchedValue: Fetched?
@@ -36,56 +35,5 @@ extension ValueReducer {
     }
 }
 
-/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
-///
-/// A type-erased ValueReducer.
-///
-/// An AnyValueReducer forwards its operations to an underlying reducer,
-/// hiding its specifics.
-public struct AnyValueReducer<Fetched, Value>: ValueReducer {
-    private var _fetch: (Database) throws -> Fetched
-    private var _value: (Fetched) -> Value?
-    
-    /// Creates a reducer whose `fetch(_:)` and `value(_:)` methods wrap and
-    /// forward operations the argument closures.
-    ///
-    /// For example, this reducer counts the number of a times the player table
-    /// is modified:
-    ///
-    ///     var count = 0
-    ///     let reducer = AnyValueReducer(
-    ///         fetch: { _ in },
-    ///         value: { _ -> Int? in
-    ///             count += 1
-    ///             return count
-    ///     })
-    ///     let observer = ValueObservation
-    ///         .tracking(Player.all(), reducer: reducer)
-    ///         .start(in: dbQueue) { count: Int in
-    ///             print("Players have been modified \(count) times.")
-    ///         }
-    public init(fetch: @escaping (Database) throws -> Fetched, value: @escaping (Fetched) -> Value?) {
-        self._fetch = fetch
-        self._value = value
-    }
-    
-    /// Creates a reducer that wraps and forwards operations to `reducer`.
-    public init<Base: ValueReducer>(_ reducer: Base) where Base.Fetched == Fetched, Base.Value == Value {
-        var reducer = reducer
-        self._fetch = { try reducer.fetch($0) }
-        self._value = { reducer.value($0) }
-    }
-    
-    /// :nodoc:
-    public func fetch(_ db: Database) throws -> Fetched {
-        try _fetch(db)
-    }
-    
-    /// :nodoc:
-    public func value(_ fetched: Fetched) -> Value? {
-        _value(fetched)
-    }
-}
-
-/// A namespace for types related to the ValueReducer protocol.
+/// A namespace for types related to the _ValueReducer protocol.
 public enum ValueReducers { }

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -37,3 +37,12 @@ extension _ValueReducer {
 
 /// A namespace for types related to the _ValueReducer protocol.
 public enum ValueReducers { }
+
+// This allows us to use Never as a marker for ValueObservation factory methods:
+//
+// For example, ValueObservation.tracking(value:) is, practically,
+// ValueObservation<Never>.tracking(value:).
+extension Never: _ValueReducer {
+    public func fetch(_ db: Database) throws -> Never { preconditionFailure() }
+    public mutating func value(_ fetched: Never) -> Never? { }
+}

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -176,3 +176,27 @@ class GRDBTestCase: XCTestCase {
         }
     }
 }
+
+/// A type-erased ValueReducer.
+public struct AnyValueReducer<Fetched, Value>: _ValueReducer {
+    private var _fetch: (Database) throws -> Fetched
+    private var _value: (Fetched) -> Value?
+    
+    public init(
+        fetch: @escaping (Database) throws -> Fetched,
+        value: @escaping (Fetched) -> Value?)
+    {
+        self._fetch = fetch
+        self._value = value
+    }
+    
+    /// :nodoc:
+    public func fetch(_ db: Database) throws -> Fetched {
+        try _fetch(db)
+    }
+    
+    /// :nodoc:
+    public func value(_ fetched: Fetched) -> Value? {
+        _value(fetched)
+    }
+}

--- a/Tests/GRDBTests/ValueObservationCompactMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationCompactMapTests.swift
@@ -21,18 +21,13 @@ class ValueObservationCompactMapTests: GRDBTestCase {
             notificationExpectation.assertForOverFulfill = true
             notificationExpectation.expectedFulfillmentCount = 2
             
-            // The base reducer
+            // Create an observation
             var count = 0
-            let reducer = AnyValueReducer(
-                fetch: { _ in /* don't fetch anything */ },
-                value: { _ -> Int? in
+            let observation = ValueObservation
+                .tracking(DatabaseRegion.fullDatabase, fetch: { _ -> Int in
                     count += 1
                     return count
-            })
-            
-            // Create an observation
-            let observation = ValueObservation
-                .tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+                })
                 .compactMap { count -> String? in
                     if count % 2 == 0 { return nil }
                     return "\(count)"

--- a/Tests/GRDBTests/ValueObservationExtentTests.swift
+++ b/Tests/GRDBTests/ValueObservationExtentTests.swift
@@ -22,13 +22,8 @@ class ValueObservationExtentTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 2
         
-        // A reducer
-        let reducer = AnyValueReducer(
-            fetch: { _ in },
-            value: { $0 })
-        
         // Create an observation
-        let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+        let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in })
         
         // Start observation and deallocate observer after second change
         var observer: TransactionObserver?

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -21,18 +21,13 @@ class ValueObservationMapTests: GRDBTestCase {
             notificationExpectation.assertForOverFulfill = true
             notificationExpectation.expectedFulfillmentCount = 3
             
-            // The base reducer
+            // Create an observation
             var count = 0
-            let reducer = AnyValueReducer(
-                fetch: { _ in /* don't fetch anything */ },
-                value: { _ -> Int? in
+            let observation = ValueObservation
+                .tracking(DatabaseRegion.fullDatabase, fetch: { _ -> Int in
                     count += 1
                     return count
-            })
-            
-            // Create an observation
-            let observation = ValueObservation
-                .tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+                })
                 .map { count -> String in return "\(count)" }
             
             // Start observation

--- a/Tests/GRDBTests/ValueObservationReducerTests.swift
+++ b/Tests/GRDBTests/ValueObservationReducerTests.swift
@@ -54,7 +54,7 @@ class ValueObservationReducerTests: GRDBTestCase {
             
             // Create an observation
             let request = SQLRequest<Void>(sql: "SELECT * FROM t")
-            let observation = ValueObservation(baseRegion: request.databaseRegion, makeReducer: { _ in reducer })
+            let observation = ValueObservation(baseRegion: request.databaseRegion, makeReducer: { reducer })
             
             // Start observation
             let observer = observation.start(
@@ -283,7 +283,7 @@ class ValueObservationReducerTests: GRDBTestCase {
             })
             let observation = ValueObservation(
                 baseRegion: { _ in DatabaseRegion.fullDatabase },
-                makeReducer: { _ in reducer })
+                makeReducer: { reducer })
             let observer = observation.start(
                 in: dbWriter,
                 onError: { error in XCTFail("Unexpected error: \(error)") },
@@ -338,7 +338,7 @@ class ValueObservationReducerTests: GRDBTestCase {
                 var shouldStopObservation = false
                 var observation = ValueObservation(
                     baseRegion: { _ in DatabaseRegion.fullDatabase },
-                    makeReducer: { _ in
+                    makeReducer: {
                         AnyValueReducer<Void, Void>(
                             fetch: { _ in
                                 if shouldStopObservation {
@@ -382,7 +382,7 @@ class ValueObservationReducerTests: GRDBTestCase {
                 var shouldStopObservation = false
                 var observation = ValueObservation(
                     baseRegion: { _ in DatabaseRegion.fullDatabase },
-                    makeReducer: { _ in
+                    makeReducer: {
                         AnyValueReducer<Void, Void>(
                             fetch: { _ in },
                             value: { _ in

--- a/Tests/GRDBTests/ValueObservationReducerTests.swift
+++ b/Tests/GRDBTests/ValueObservationReducerTests.swift
@@ -1,26 +1,24 @@
 import XCTest
 import Dispatch
 #if GRDBCUSTOMSQLITE
-    import GRDBCustomSQLite
+    @testable import GRDBCustomSQLite
 #else
     #if SWIFT_PACKAGE
         import CSQLite
     #else
         import SQLite3
     #endif
-    import GRDB
+    @testable import GRDB
 #endif
 
 class ValueObservationReducerTests: GRDBTestCase {
     func testRegionsAPI() {
-        let reducer = AnyValueReducer(fetch: { _ in }, value: { })
-        
         // single region
-        _ = ValueObservation.tracking(DatabaseRegion(), reducer: { _ in reducer })
+        _ = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
         // variadic
-        _ = ValueObservation.tracking(DatabaseRegion(), DatabaseRegion(), reducer: { _ in reducer })
+        _ = ValueObservation.tracking(DatabaseRegion(), DatabaseRegion(), fetch: { _ in })
         // array
-        _ = ValueObservation.tracking([DatabaseRegion()], reducer: { _ in reducer })
+        _ = ValueObservation.tracking([DatabaseRegion()], fetch: { _ in })
     }
     
     func testReducer() throws {
@@ -56,7 +54,7 @@ class ValueObservationReducerTests: GRDBTestCase {
             
             // Create an observation
             let request = SQLRequest<Void>(sql: "SELECT * FROM t")
-            let observation = ValueObservation.tracking(request, reducer: { _ in reducer })
+            let observation = ValueObservation(baseRegion: request.databaseRegion, makeReducer: { _ in reducer })
             
             // Start observation
             let observer = observation.start(
@@ -124,13 +122,9 @@ class ValueObservationReducerTests: GRDBTestCase {
     
     func testInitialErrorWithErrorHandling() throws {
         func test(_ dbWriter: DatabaseWriter) throws {
-            struct TestError: Error { }
-            let reducer = AnyValueReducer(
-                fetch: { _ in throw TestError() },
-                value: { _ in fatalError() })
-            
             // Create an observation
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+            struct TestError: Error { }
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in throw TestError() })
             
             // Start observation
             var error: TestError?
@@ -157,20 +151,14 @@ class ValueObservationReducerTests: GRDBTestCase {
             notificationExpectation.assertForOverFulfill = true
             notificationExpectation.expectedFulfillmentCount = 3
             
-            // A reducer which throws an error is requested to do so
-            var nextError: Error? = nil // If not null, reducer throws an error
-            let reducer = AnyValueReducer(
-                fetch: { _ -> Void in
-                    if let error = nextError {
-                        nextError = nil
-                        throw error
-                    }
-            },
-                value: { $0 })
-            
-            // Create an observation
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
-            
+            var nextError: Error? = nil // If not null, observation throws an error
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ -> Void in
+                if let error = nextError {
+                    nextError = nil
+                    throw error
+                }
+            })
+
             // Start observation
             let observer = observation.start(
                 in: dbWriter,
@@ -216,12 +204,10 @@ class ValueObservationReducerTests: GRDBTestCase {
             
             // Create an observation
             var count = 0
-            let reducer = AnyValueReducer(
-                fetch: { _ in /* don't fetch anything */ },
-                value: { _ -> Int? in
-                    defer { count += 1 }
-                    return count })
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer})
+            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ -> Int in
+                defer { count += 1 }
+                return count
+            })
             
             // Start observation
             let observer = observation.start(
@@ -245,109 +231,6 @@ class ValueObservationReducerTests: GRDBTestCase {
         try test(makeDatabasePool())
     }
     
-    func testMapValueReducer() throws {
-        func test(_ dbWriter: DatabaseWriter) throws {
-            // We need something to change
-            try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
-            
-            // Track reducer process
-            var counts: [String] = []
-            let notificationExpectation = expectation(description: "notification")
-            notificationExpectation.assertForOverFulfill = true
-            notificationExpectation.expectedFulfillmentCount = 3
-            
-            // The base reducer
-            var count = 0
-            let baseReducer = AnyValueReducer(
-                fetch: { _ in /* don't fetch anything */ },
-                value: { _ -> Int? in
-                    count += 1
-                    return count
-            })
-            
-            // The mapped reducer
-            let reducer = baseReducer.map { count -> String in
-                return "\(count)"
-            }
-            
-            // Create an observation
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
-            
-            // Start observation
-            let observer = observation.start(
-                in: dbWriter,
-                onError: { error in XCTFail("Unexpected error: \(error)") },
-                onChange: { count in
-                    counts.append(count)
-                    notificationExpectation.fulfill()
-            })
-            try withExtendedLifetime(observer) {
-                try dbWriter.writeWithoutTransaction { db in
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                }
-                
-                waitForExpectations(timeout: 1, handler: nil)
-                XCTAssertEqual(counts, ["1", "2", "3"])
-            }
-        }
-        
-        try test(makeDatabaseQueue())
-        try test(makeDatabasePool())
-    }
-    
-    func testCompactMapValueReducer() throws {
-        func test(_ dbWriter: DatabaseWriter) throws {
-            // We need something to change
-            try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
-            
-            // Track reducer process
-            var counts: [String] = []
-            let notificationExpectation = expectation(description: "notification")
-            notificationExpectation.assertForOverFulfill = true
-            notificationExpectation.expectedFulfillmentCount = 2
-            
-            // The base reducer
-            var count = 0
-            let baseReducer = AnyValueReducer(
-                fetch: { _ in /* don't fetch anything */ },
-                value: { _ -> Int? in
-                    count += 1
-                    return count
-            })
-            
-            // The mapped reducer
-            let reducer = baseReducer.compactMap { count -> String? in
-                if count % 2 == 0 { return nil }
-                return "\(count)"
-            }
-            
-            // Create an observation
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
-            
-            // Start observation
-            let observer = observation.start(
-                in: dbWriter,
-                onError: { error in XCTFail("Unexpected error: \(error)") },
-                onChange: { count in
-                    counts.append(count)
-                    notificationExpectation.fulfill()
-            })
-            try withExtendedLifetime(observer) {
-                try dbWriter.writeWithoutTransaction { db in
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                    try db.execute(sql: "INSERT INTO t DEFAULT VALUES")
-                }
-                
-                waitForExpectations(timeout: 1, handler: nil)
-                XCTAssertEqual(counts, ["1", "3"])
-            }
-        }
-        
-        try test(makeDatabaseQueue())
-        try test(makeDatabasePool())
-    }
-
     func testValueObservationMap() throws {
         func test(_ dbWriter: DatabaseWriter) throws {
             try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
@@ -398,7 +281,9 @@ class ValueObservationReducerTests: GRDBTestCase {
                 }
                 reduceExpectation.fulfill()
             })
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in reducer })
+            let observation = ValueObservation(
+                baseRegion: { _ in DatabaseRegion.fullDatabase },
+                makeReducer: { _ in reducer })
             let observer = observation.start(
                 in: dbWriter,
                 onError: { error in XCTFail("Unexpected error: \(error)") },
@@ -451,15 +336,17 @@ class ValueObservationReducerTests: GRDBTestCase {
                 var observer: TransactionObserver? = nil
                 _ = observer // Avoid "Variable 'observer' was written to, but never read" warning
                 var shouldStopObservation = false
-                var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in
-                    AnyValueReducer<Void, Void>(
-                        fetch: { _ in
-                            if shouldStopObservation {
-                                observer = nil /* deallocation */
-                            }
-                            shouldStopObservation = true
-                    },
-                        value: { _ in () })
+                var observation = ValueObservation(
+                    baseRegion: { _ in DatabaseRegion.fullDatabase },
+                    makeReducer: { _ in
+                        AnyValueReducer<Void, Void>(
+                            fetch: { _ in
+                                if shouldStopObservation {
+                                    observer = nil /* deallocation */
+                                }
+                                shouldStopObservation = true
+                        },
+                            value: { _ in () })
                 })
                 observation.scheduling = .unsafe
                 observer = observation.start(
@@ -493,16 +380,18 @@ class ValueObservationReducerTests: GRDBTestCase {
                 var observer: TransactionObserver? = nil
                 _ = observer // Avoid "Variable 'observer' was written to, but never read" warning
                 var shouldStopObservation = false
-                var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, reducer: { _ in
-                    AnyValueReducer<Void, Void>(
-                        fetch: { _ in },
-                        value: { _ in
-                            if shouldStopObservation {
-                                observer = nil /* deallocation right before notification */
-                            }
-                            shouldStopObservation = true
-                            return ()
-                    })
+                var observation = ValueObservation(
+                    baseRegion: { _ in DatabaseRegion.fullDatabase },
+                    makeReducer: { _ in
+                        AnyValueReducer<Void, Void>(
+                            fetch: { _ in },
+                            value: { _ in
+                                if shouldStopObservation {
+                                    observer = nil /* deallocation right before notification */
+                                }
+                                shouldStopObservation = true
+                                return ()
+                        })
                 })
                 observation.scheduling = .unsafe
                 observer = observation.start(


### PR DESCRIPTION
ValueObservation used to expose an underling protocol, `ValueReducer`, shipped as an experimental interface.

It appears that it has no real use in applications, and that value reducers can be removed from the public API.

Making them an implementation detail was also an opportunity to simplify the implementation.