### PR TITLE
Fetch the current value of a ValueObservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#729](https://github.com/groue/GRDB.swift/pull/729): ValueObservation always emits an initial value
 - [#731](https://github.com/groue/GRDB.swift/pull/731): Hide ValueObservation implementation details
 - [#732](https://github.com/groue/GRDB.swift/pull/732): Remove ValueObservation.compactMap
+- [#733](https://github.com/groue/GRDB.swift/pull/733): Fetch the current value of a ValueObservation
 
 
 ## 4.11.0

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -120,11 +120,10 @@ extension ValueObservation {
     
     // MARK: - Fetching Values
     
-    // TODO: make public if it helps fetching an initial value before starting
-    // the observation, in order to avoid waiting for long write transactions to
-    // complete.
-    /// Returns the value.
-    func fetchValue(_ db: Database) throws -> Reducer.Value {
+    /// Fetches the observed value.
+    ///
+    /// - parameter db: A database connection.
+    public func fetchValue(_ db: Database) throws -> Reducer.Value {
         var reducer = makeReducer()
         let fetchedValue = try reducer.fetch(db, requiringWriteAccess: requiresWriteAccess)
         guard let value = reducer.value(fetchedValue) else {


### PR DESCRIPTION
This pull request introduces the `ValueObservation.fetchValue(_:)` method.

The intent is to soothe a pain point of ValueObservation: a long running background transaction delays the notification of the first value of a ValueObservation, even when the application is using a DatabasePool. There are very good reasons for this unfortunate behavior, which is unlikely to change as long as ValueObservation comes with the hard guarantee that *absolutely all* changes are notified. See #601 by @zdnk for more information.

`ValueObservation.fetchValue(_:)`, as a regular fetching method, is not concerned by long running background transactions. It should help users prepend the current value to the regular  elements of a ValueObservation, and avoid unwanted delays.