### PR TITLE
Force implicit database region for ValueObservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#731](https://github.com/groue/GRDB.swift/pull/731): Hide ValueObservation implementation details
 - [#732](https://github.com/groue/GRDB.swift/pull/732): Remove ValueObservation.compactMap
 - [#736](https://github.com/groue/GRDB.swift/pull/736): Relax ValueObservation Guarantees
+- [#737](https://github.com/groue/GRDB.swift/pull/737): Force implicit database region for ValueObservation
 
 
 ## 4.12.0

--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -45,6 +45,12 @@ public struct DatabaseRegion: CustomStringConvertible, Equatable {
         return tableRegions.isEmpty
     }
     
+    /// Returns whether the region covers the full database: all columns and all
+    /// rows from all tables.
+    public var isFullDatabase: Bool {
+        return tableRegions == nil
+    }
+    
     /// The region that covers the full database: all columns and all rows
     /// from all tables.
     public static let fullDatabase = DatabaseRegion(tableRegions: nil)

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -363,7 +363,6 @@ extension DatabaseWriter {
         
         let observer = ValueObserver<Reducer>(
             requiresWriteAccess: observation.requiresWriteAccess,
-            observesSelectedRegion: observation.observesSelectedRegion,
             writer: self,
             reducer: observation.makeReducer(),
             notificationQueue: notificationQueue,
@@ -374,7 +373,6 @@ extension DatabaseWriter {
         if initialFetchSync {
             do {
                 let initialValue: Reducer.Value = try unsafeReentrantWrite { db in
-                    observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
                     let initialValue = try observer.fetchInitialValue(db)
                     db.add(transactionObserver: observer, extent: .observerLifetime)
                     return initialValue
@@ -387,7 +385,6 @@ extension DatabaseWriter {
             asyncRead { dbResult in
                 do {
                     let db = try dbResult.get()
-                    observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
                     let initialValue = try observer.fetchInitialValue(db)
                     observer.send(initialValue)
                     
@@ -410,7 +407,6 @@ extension DatabaseWriter {
         } else {
             asyncWriteWithoutTransaction { db in
                 do {
-                    observer.baseRegion = try observation.baseRegion(db).ignoringViews(db)
                     let initialValue = try observer.fetchInitialValue(db)
                     observer.send(initialValue)
                     db.add(transactionObserver: observer, extent: .observerLifetime)

--- a/GRDB/Core/FetchRequest.swift
+++ b/GRDB/Core/FetchRequest.swift
@@ -98,7 +98,7 @@ extension FetchRequest {
     /// - parameter db: A database connection.
     public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
         let request = try makePreparedRequest(db, forSingleResult: false)
-        return request.statement.databaseRegion
+        return request.statement.selectedRegion
     }
 }
 

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -23,7 +23,7 @@ protocol StatementAuthorizer: AnyObject {
 /// A class that gathers information about one statement during its compilation.
 final class StatementCompilationAuthorizer: StatementAuthorizer {
     /// What this statements reads
-    var databaseRegion = DatabaseRegion()
+    var selectedRegion = DatabaseRegion()
     
     /// What this statements writes
     var databaseEventKinds: [DatabaseEventKind] = []
@@ -76,10 +76,10 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
             guard let columnName = cString2.map(String.init) else { return SQLITE_OK }
             if columnName.isEmpty {
                 // SELECT COUNT(*) FROM table
-                databaseRegion.formUnion(DatabaseRegion(table: tableName))
+                selectedRegion.formUnion(DatabaseRegion(table: tableName))
             } else {
                 // SELECT column FROM table
-                databaseRegion.formUnion(DatabaseRegion(table: tableName, columns: [columnName]))
+                selectedRegion.formUnion(DatabaseRegion(table: tableName, columns: [columnName]))
             }
             return SQLITE_OK
             
@@ -145,7 +145,7 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
             guard sqlite3_libversion_number() < 3019000 else { return SQLITE_OK }
             guard let cString2 = cString2 else { return SQLITE_OK }
             if sqlite3_stricmp(cString2, "COUNT") == 0 {
-                databaseRegion = .fullDatabase
+                selectedRegion = .fullDatabase
             }
             return SQLITE_OK
             

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -211,17 +211,23 @@ extension ValueObservation where Reducer == Never {
         where Request.RowDecoder == Row
     { preconditionFailure() }
     
-    @available(*, unavailable, message: "Use ValueObservation.tracking(value:) instead")
+    @available(*, unavailable, message: "Use ValueObservation.tracking(_:) instead")
     public static func tracking<Value>(
         _ regions: DatabaseRegionConvertible...,
         fetch: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     { preconditionFailure() }
     
-    @available(*, unavailable, message: "Use ValueObservation.tracking(value:) instead")
+    @available(*, unavailable, message: "Use ValueObservation.tracking(_:) instead")
     public static func tracking<Value>(
         _ regions: [DatabaseRegionConvertible],
         fetch: @escaping (Database) throws -> Value)
+        -> ValueObservation<ValueReducers.Fetch<Value>>
+    { preconditionFailure() }
+    
+    @available(*, unavailable, renamed: "tracking(_:)")
+    public static func tracking<Value>(
+        value: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     { preconditionFailure() }
 }

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -154,6 +154,12 @@ extension ValueObservation {
     @available(*, unavailable, message: "compactMap is no longer available")
     public func compactMap<T>(_ transform: @escaping (Reducer.Value) -> T?) -> ValueObservation<ValueReducers.CompactMap<Reducer, T>>
     { preconditionFailure() }
+    
+    @available(*, unavailable, message: "Use start(in:onError:onChange:) instead.")
+    public func start(
+        in reader: DatabaseReader,
+        onChange: @escaping (Reducer.Value) -> Void) throws -> TransactionObserver
+    { preconditionFailure() }
 }
 
 extension ValueObservation where Reducer == Never {
@@ -204,13 +210,19 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.OneRow>
         where Request.RowDecoder == Row
     { preconditionFailure() }
-}
-
-extension ValueObservation {
-    @available(*, unavailable, message: "Use start(in:onError:onChange:) instead.")
-    public func start(
-        in reader: DatabaseReader,
-        onChange: @escaping (Reducer.Value) -> Void) throws -> TransactionObserver
+    
+    @available(*, unavailable, message: "Use ValueObservation.tracking(value:) instead")
+    public static func tracking<Value>(
+        _ regions: DatabaseRegionConvertible...,
+        fetch: @escaping (Database) throws -> Value)
+        -> ValueObservation<ValueReducers.Fetch<Value>>
+    { preconditionFailure() }
+    
+    @available(*, unavailable, message: "Use ValueObservation.tracking(value:) instead")
+    public static func tracking<Value>(
+        _ regions: [DatabaseRegionConvertible],
+        fetch: @escaping (Database) throws -> Value)
+        -> ValueObservation<ValueReducers.Fetch<Value>>
     { preconditionFailure() }
 }
 

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -13,19 +13,18 @@ extension AnyFetchRequest {
 
 @available(*, unavailable, message: "Custom reducers are no longer supported")
 public struct AnyValueReducer<Fetched, Value>: _ValueReducer {
-    /// :nodoc:
+    public var isObservedRegionDeterministic: Bool
+    { preconditionFailure() }
+    
     public init(fetch: @escaping (Database) throws -> Fetched, value: @escaping (Fetched) -> Value?)
     { preconditionFailure() }
     
-    /// :nodoc:
     public init<Base: _ValueReducer>(_ reducer: Base) where Base.Fetched == Fetched, Base.Value == Value
     { preconditionFailure() }
     
-    /// :nodoc:
     public func fetch(_ db: Database) throws -> Fetched
     { preconditionFailure() }
     
-    /// :nodoc:
     public func value(_ fetched: Fetched) -> Value?
     { preconditionFailure() }
 }
@@ -224,6 +223,9 @@ extension ValueObservation where Reducer.Value: Equatable {
 extension ValueReducers {
     @available(*, unavailable, message: "ValueReducers.CompactMap is no longer available")
     public struct CompactMap<Base: _ValueReducer, Value>: _ValueReducer {
+        public var isObservedRegionDeterministic: Bool
+        { preconditionFailure() }
+        
         public func fetch(_ db: Database) throws -> Base.Fetched
         { preconditionFailure() }
         

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -162,7 +162,7 @@ extension ValueObservation {
     { preconditionFailure() }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     @available(*, unavailable, message: "Use request.observationForCount() instead")
     public static func trackingCount<Request: FetchRequest>(_ request: Request)
         -> ValueObservation<ValueReducers.RemoveDuplicates<ValueReducers.Fetch<Int>>>

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -84,7 +84,7 @@ extension QueryInterfaceRequest: FetchRequest {
     /// - parameter db: A database connection.
     /// :nodoc:
     public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
-        var region = try SQLQueryGenerator(query).makeSelectStatement(db).databaseRegion
+        var region = try SQLQueryGenerator(query).makeSelectStatement(db).selectedRegion
         
         // Iterate all prefetched associations
         var fifo = query.relation.prefetchedAssociations
@@ -103,7 +103,7 @@ extension QueryInterfaceRequest: FetchRequest {
             let prefetchedQuery = SQLQuery(relation: prefetchedRelation)
             
             // Union region
-            try region.formUnion(SQLQueryGenerator(prefetchedQuery).makeSelectStatement(db).databaseRegion)
+            try region.formUnion(SQLQueryGenerator(prefetchedQuery).makeSelectStatement(db).selectedRegion)
             
             // Append nested prefetched associations (support for
             // A.including(all: A.bs.including(all: B.cs))

--- a/GRDB/ValueObservation/ValueObservation+Count.swift
+++ b/GRDB/ValueObservation/ValueObservation+Count.swift
@@ -31,7 +31,7 @@ extension FetchRequest {
         ValueObservation<ValueReducers.RemoveDuplicates<ValueReducers.Fetch<Int>>>
     {
         return ValueObservation
-            .tracking(self, fetch: fetchCount)
+            .tracking(value: fetchCount)
             .removeDuplicates()
     }
 }

--- a/GRDB/ValueObservation/ValueObservation+Count.swift
+++ b/GRDB/ValueObservation/ValueObservation+Count.swift
@@ -10,9 +10,12 @@ extension FetchRequest {
     ///     let request = Player.all()
     ///     let observation = request.observationForCount()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { count: Int in
-    ///         print("Number of players has changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { count: Int in
+    ///             print("Number of players has changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -44,9 +47,12 @@ extension TableRecord {
     ///
     ///     let observation = Player.observationForCount()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { count: Int in
-    ///         print("Number of players has changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { count: Int in
+    ///             print("Number of players has changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///

--- a/GRDB/ValueObservation/ValueObservation+Count.swift
+++ b/GRDB/ValueObservation/ValueObservation+Count.swift
@@ -30,9 +30,7 @@ extension FetchRequest {
     public func observationForCount() ->
         ValueObservation<ValueReducers.RemoveDuplicates<ValueReducers.Fetch<Int>>>
     {
-        return ValueObservation
-            .tracking(value: fetchCount)
-            .removeDuplicates()
+        ValueObservation.tracking(fetchCount).removeDuplicates()
     }
 }
 

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -26,9 +26,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllValues<RowDecoder>> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.AllValues { try DatabaseValue.fetchAll($0, self) } })
+        ValueObservation(makeReducer: { ValueReducers.AllValues { try DatabaseValue.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -55,9 +53,7 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     /// - parameter request: the observed request.
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneValue<RowDecoder>> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
+        ValueObservation(makeReducer: { ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
     }
 }
 
@@ -89,9 +85,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: 
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllOptionalValues<RowDecoder.Wrapped>> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.AllOptionalValues { try DatabaseValue.fetchAll($0, self) } })
+        ValueObservation(makeReducer: { ValueReducers.AllOptionalValues { try DatabaseValue.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies
@@ -118,9 +112,7 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: 
     ///
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneValue<RowDecoder.Wrapped>> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
+        ValueObservation(makeReducer: { ValueReducers.OneValue { try DatabaseValue.fetchOne($0, self) } })
     }
 }
 
@@ -136,6 +128,7 @@ extension ValueReducers {
     {
         private let _fetch: (Database) throws -> [DatabaseValue]
         private var previousDbValues: [DatabaseValue]?
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> [DatabaseValue]) {
             self._fetch = fetch
@@ -169,6 +162,7 @@ extension ValueReducers {
         private let _fetch: (Database) throws -> DatabaseValue?
         private var previousDbValue: DatabaseValue??
         private var previousValueWasNil = false
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> DatabaseValue?) {
             self._fetch = fetch
@@ -210,6 +204,7 @@ extension ValueReducers {
     {
         private let _fetch: (Database) throws -> [DatabaseValue]
         private var previousDbValues: [DatabaseValue]?
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> [DatabaseValue]) {
             self._fetch = fetch

--- a/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
+++ b/GRDB/ValueObservation/ValueObservation+DatabaseValueConvertible.swift
@@ -11,9 +11,12 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     ///     let request = Player.select(Column("name"), as: String.self)
     ///     let observation = request.observationForAll()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { names: [String] in
-    ///         print("Player names have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { names: [String] in
+    ///             print("Player names have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -37,9 +40,12 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible {
     ///     let request = Player.select(max(Column("score")), as: Int.self)
     ///     let observation = request.observationForFirst()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { maxScore: Int? in
-    ///         print("Maximum score has changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { maxScore: Int? in
+    ///             print("Maximum score has changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -70,9 +76,12 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: 
     ///     let request = Player.select(Column("name"), as: Optional<String>.self)
     ///     let observation = request.observationForAll()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { names: [String?] in
-    ///         print("Player names have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { names: [String?] in
+    ///             print("Player names have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -97,9 +106,12 @@ extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: 
     ///     let request = Player.select(Column("name"), as: Optional<String>.self)
     ///     let observation = request.observationForAll()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { names: [String?] in
-    ///         print("Player names have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { names: [String?] in
+    ///             print("Player names have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -11,9 +11,12 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     ///     let request = Player.all()
     ///     let observation = request.observationForAll()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///         print("Players have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { players: [Player] in
+    ///             print("Players have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -37,9 +40,12 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     ///     let request = Player.filter(key: 1)
     ///     let observation = request.observationForFirst()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { player: Player? in
-    ///         print("Player has changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { player: Player? in
+    ///             print("Player has changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -68,9 +74,12 @@ extension TableRecord where Self: FetchableRecord {
     ///
     ///     let observation = Player.observationForAll()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///         print("Players have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { players: [Player] in
+    ///             print("Players have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -94,9 +103,12 @@ extension TableRecord where Self: FetchableRecord {
     ///
     ///     let observation = Player.observationForFirst()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { player: Player? in
-    ///         print("Player has changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { player: Player? in
+    ///             print("Player has changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///

--- a/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
+++ b/GRDB/ValueObservation/ValueObservation+FetchableRecord.swift
@@ -26,9 +26,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllRecords<RowDecoder>> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.AllRecords { try Row.fetchAll($0, self) } })
+        ValueObservation(makeReducer: { ValueReducers.AllRecords { try Row.fetchAll($0, self) } })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -54,9 +52,7 @@ extension FetchRequest where RowDecoder: FetchableRecord {
     ///
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneRecord<RowDecoder>> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.OneRecord { try Row.fetchOne($0, self) } })
+        ValueObservation(makeReducer: { ValueReducers.OneRecord { try Row.fetchOne($0, self) } })
     }
 }
 
@@ -130,6 +126,7 @@ extension ValueReducers {
     {
         private let _fetch: (Database) throws -> [Row]
         private var previousRows: [Row]?
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> [Row]) {
             self._fetch = fetch
@@ -160,6 +157,7 @@ extension ValueReducers {
     {
         private let _fetch: (Database) throws -> Row?
         private var previousRow: Row??
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> Row?) {
             self._fetch = fetch

--- a/GRDB/ValueObservation/ValueObservation+MapReducer.swift
+++ b/GRDB/ValueObservation/ValueObservation+MapReducer.swift
@@ -3,8 +3,6 @@ extension ValueObservation {
     func mapReducer<R>(_ transform: @escaping (Reducer) -> R) -> ValueObservation<R> {
         let makeReducer = self.makeReducer
         return ValueObservation<R>(
-            baseRegion: baseRegion,
-            observesSelectedRegion: observesSelectedRegion,
             makeReducer: { transform(makeReducer()) },
             requiresWriteAccess: requiresWriteAccess,
             scheduling: scheduling)

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -10,9 +10,12 @@ extension FetchRequest where RowDecoder == Row {
     ///     let request = SQLRequest<Row>(sql: "SELECT * FROM player")
     ///     let observation = request.observationForAll()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { rows: [Row] in
-    ///         print("Players have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { rows: [Row] in
+    ///             print("Players have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///
@@ -36,9 +39,12 @@ extension FetchRequest where RowDecoder == Row {
     ///     let request = SQLRequest<Row>(sql: "SELECT * FROM player WHERE id = ?", arguments: [1])
     ///     let observation = request.observationForFirst()
     ///
-    ///     let observer = try observation.start(in: dbQueue) { row: Row? in
-    ///         print("Players have changed")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { row: Row? in
+    ///             print("Players have changed")
+    ///         })
     ///
     /// The returned observation has the default configuration:
     ///

--- a/GRDB/ValueObservation/ValueObservation+Row.swift
+++ b/GRDB/ValueObservation/ValueObservation+Row.swift
@@ -25,9 +25,7 @@ extension FetchRequest where RowDecoder == Row {
     ///
     /// - returns: a ValueObservation.
     public func observationForAll() -> ValueObservation<ValueReducers.AllRows> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.AllRows(fetch: self.fetchAll) })
+        ValueObservation(makeReducer: { ValueReducers.AllRows(fetch: self.fetchAll) })
     }
     
     /// Creates a ValueObservation which observes *request*, and notifies a
@@ -53,9 +51,7 @@ extension FetchRequest where RowDecoder == Row {
     ///
     /// - returns: a ValueObservation.
     public func observationForFirst() -> ValueObservation<ValueReducers.OneRow> {
-        ValueObservation(
-            baseRegion: databaseRegion,
-            makeReducer: { ValueReducers.OneRow(fetch: self.fetchOne) })
+        ValueObservation(makeReducer: { ValueReducers.OneRow(fetch: self.fetchOne) })
     }
 }
 
@@ -69,6 +65,7 @@ extension ValueReducers {
     public struct AllRows: _ValueReducer {
         private let _fetch: (Database) throws -> [Row]
         private var previousRows: [Row]?
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> [Row]) {
             self._fetch = fetch
@@ -97,6 +94,7 @@ extension ValueReducers {
     public struct OneRow: _ValueReducer {
         private let _fetch: (Database) throws -> Row?
         private var previousRow: Row??
+        public var isObservedRegionDeterministic: Bool { true }
         
         init(fetch: @escaping (Database) throws -> Row?) {
             self._fetch = fetch

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -12,9 +12,12 @@ public enum ValueObservationScheduling {
     ///
     ///     // On main queue
     ///     let observation = Player.observationForAll()
-    ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///         print("fresh players: \(players)")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { players: [Player] in
+    ///             print("fresh players: \(players)")
+    ///         })
     ///     // <- here "fresh players" is already printed.
     ///
     /// If the observation does not start on the main queue, the initial value
@@ -23,9 +26,12 @@ public enum ValueObservationScheduling {
     ///     // Not on the main queue: "fresh players" is eventually printed
     ///     // on the main queue.
     ///     let observation = Player.observationForAll()
-    ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///         print("fresh players: \(players)")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { players: [Player] in
+    ///             print("fresh players: \(players)")
+    ///         })
     ///
     /// When the database changes, fresh values are asynchronously notified on
     /// the main queue:
@@ -47,9 +53,12 @@ public enum ValueObservationScheduling {
     ///     // On any queue
     ///     var observation = Player.observationForAll()
     ///     observation.scheduling = .unsafe
-    ///     let observer = try observation.start(in: dbQueue) { players: [Player] in
-    ///         print("fresh players: \(players)")
-    ///     }
+    ///     let observer = try observation.start(
+    ///         in: dbQueue,
+    ///         onError: { error in ... },
+    ///         onChange: { players: [Player] in
+    ///           print("fresh players: \(players)")
+    ///        })
     ///     // <- here "fresh players" is already printed.
     ///
     /// When the database changes, other values are notified on
@@ -65,9 +74,12 @@ public enum ValueObservationScheduling {
 /// For example:
 ///
 ///     let observation = Player.observationForAll()
-///     let observer = try observation.start(in: dbQueue) { players: [Player] in
-///         print("Players have changed.")
-///     }
+///     let observer = try observation.start(
+///         in: dbQueue,
+///         onError: { error in ... },
+///         onChange: { players: [Player] in
+///             print("Players have changed.")
+///         })
 public struct ValueObservation<Reducer: _ValueReducer> {
     /// The reducer is created when observation starts, and is triggered upon
     /// each database change in *observedRegion*.

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -162,7 +162,7 @@ extension ValueObservation where Reducer == Never {
     /// - parameter value: A function that fetches the observed value from
     ///   the database.
     public static func tracking<Value>(
-        value: @escaping (Database) throws -> Value)
+        _ value: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     {
         return ValueObservation<ValueReducers.Fetch<Value>>(makeReducer: {
@@ -176,7 +176,7 @@ extension ValueObservation where Reducer == Never {
     /// - parameter value: A function that fetches the observed value from
     ///   the database.
     public static func trackingVaryingRegion<Value>(
-        value: @escaping (Database) throws -> Value)
+        _ value: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     {
         return ValueObservation<ValueReducers.Fetch<Value>>(makeReducer: {

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -133,7 +133,7 @@ extension ValueObservation {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     
     // MARK: - Creating ValueObservation
     

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -138,13 +138,13 @@ extension ValueObservation where Reducer == ValueReducers.Auto {
     // MARK: - Creating ValueObservation
     
     /// Creates a ValueObservation which notifies the values returned by the
-    /// *value* function whenever a database transaction changes them.
+    /// *fetch* function whenever a database transaction changes them.
     ///
-    /// The *value* function must always performs the same database requests.
+    /// The *fetch* function must always performs the same database requests.
     /// The stability of the observed database region allows optimizations.
     ///
     /// When you want to observe a varying database region, use the
-    /// `ValueObservation.trackingVaryingRegion(value:)` method instead.
+    /// `ValueObservation.trackingVaryingRegion(_:)` method instead.
     ///
     /// For example:
     ///
@@ -159,28 +159,28 @@ extension ValueObservation where Reducer == ValueReducers.Auto {
     ///             print("Players have changed")
     ///         })
     ///
-    /// - parameter value: A function that fetches the observed value from
+    /// - parameter fetch: A function that fetches the observed value from
     ///   the database.
     public static func tracking<Value>(
-        _ value: @escaping (Database) throws -> Value)
+        _ fetch: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     {
         return ValueObservation<ValueReducers.Fetch<Value>>(makeReducer: {
-            ValueReducers.Fetch(isObservedRegionDeterministic: true, fetch: value)
+            ValueReducers.Fetch(isObservedRegionDeterministic: true, fetch: fetch)
         })
     }
     
     /// Creates a ValueObservation which notifies the values returned by the
-    /// *value* function whenever a database transaction changes them.
+    /// *fetch* function whenever a database transaction changes them.
     ///
-    /// - parameter value: A function that fetches the observed value from
+    /// - parameter fetch: A function that fetches the observed value from
     ///   the database.
     public static func trackingVaryingRegion<Value>(
-        _ value: @escaping (Database) throws -> Value)
+        _ fetch: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     {
         return ValueObservation<ValueReducers.Fetch<Value>>(makeReducer: {
-            ValueReducers.Fetch(isObservedRegionDeterministic: false, fetch: value)
+            ValueReducers.Fetch(isObservedRegionDeterministic: false, fetch: fetch)
         })
     }
 }

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -144,7 +144,7 @@ extension ValueObservation where Reducer == Never {
     /// The stability of the observed database region allows optimizations.
     ///
     /// When you want to observe a varying database region, use the
-    /// `ValueObservation.trackingVolatile(value:)` method instead.
+    /// `ValueObservation.trackingVaryingRegion(value:)` method instead.
     ///
     /// For example:
     ///
@@ -175,7 +175,7 @@ extension ValueObservation where Reducer == Never {
     ///
     /// - parameter value: A function that fetches the observed value from
     ///   the database.
-    public static func trackingVolatile<Value>(
+    public static func trackingVaryingRegion<Value>(
         value: @escaping (Database) throws -> Value)
         -> ValueObservation<ValueReducers.Fetch<Value>>
     {

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -12,6 +12,11 @@ extension ValueReducers {
         private var p1: R1.Value?
         private var p2: R2.Value?
         
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+        }
+        
         init(_ r1: R1, _ r2: R2) {
             self.r1 = r1
             self.r2 = r2
@@ -51,17 +56,11 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine2<R1, R2>>
     {
         return ValueObservation<ValueReducers.Combine2>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine2(
                 o1.makeReducer(),
                 o2.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
-                || o2.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o2.requiresWriteAccess)
     }
 }
 
@@ -93,6 +92,12 @@ extension ValueReducers {
         private var p1: R1.Value?
         private var p2: R2.Value?
         private var p3: R3.Value?
+        
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+                && r3.isObservedRegionDeterministic
+        }
         
         init(_ r1: R1, _ r2: R2, _ r3: R3) {
             self.r1 = r1
@@ -140,21 +145,13 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine3<R1, R2, R3>>
     {
         return ValueObservation<ValueReducers.Combine3>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0),
-                o3.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion
-                || o3.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine3(
                 o1.makeReducer(),
                 o2.makeReducer(),
                 o3.makeReducer()) },
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
-                || o3.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o3.requiresWriteAccess)
     }
 }
 
@@ -196,6 +193,13 @@ extension ValueReducers {
         private var p2: R2.Value?
         private var p3: R3.Value?
         private var p4: R4.Value?
+        
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+                && r3.isObservedRegionDeterministic
+                && r4.isObservedRegionDeterministic
+        }
         
         init(_ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4) {
             self.r1 = r1
@@ -250,15 +254,6 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine4<R1, R2, R3, R4>>
     {
         return ValueObservation<ValueReducers.Combine4>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0),
-                o3.baseRegion($0),
-                o4.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion
-                || o3.observesSelectedRegion
-                || o4.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine4(
                 o1.makeReducer(),
                 o2.makeReducer(),
@@ -267,8 +262,7 @@ extension ValueObservation where Reducer == Never {
             requiresWriteAccess: o1.requiresWriteAccess
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess
-                || o4.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o4.requiresWriteAccess)
     }
 }
 
@@ -316,6 +310,14 @@ extension ValueReducers {
         private var p3: R3.Value?
         private var p4: R4.Value?
         private var p5: R5.Value?
+        
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+                && r3.isObservedRegionDeterministic
+                && r4.isObservedRegionDeterministic
+                && r5.isObservedRegionDeterministic
+        }
         
         init(_ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5) {
             self.r1 = r1
@@ -377,17 +379,6 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine5<R1, R2, R3, R4, R5>>
     {
         return ValueObservation<ValueReducers.Combine5>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0),
-                o3.baseRegion($0),
-                o4.baseRegion($0),
-                o5.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion
-                || o3.observesSelectedRegion
-                || o4.observesSelectedRegion
-                || o5.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine5(
                 o1.makeReducer(),
                 o2.makeReducer(),
@@ -398,8 +389,7 @@ extension ValueObservation where Reducer == Never {
                 || o2.requiresWriteAccess
                 || o3.requiresWriteAccess
                 || o4.requiresWriteAccess
-                || o5.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o5.requiresWriteAccess)
     }
 }
 
@@ -453,6 +443,15 @@ extension ValueReducers {
         private var p4: R4.Value?
         private var p5: R5.Value?
         private var p6: R6.Value?
+        
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+                && r3.isObservedRegionDeterministic
+                && r4.isObservedRegionDeterministic
+                && r5.isObservedRegionDeterministic
+                && r6.isObservedRegionDeterministic
+        }
         
         init(_ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6) {
             self.r1 = r1
@@ -521,19 +520,6 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine6<R1, R2, R3, R4, R5, R6>>
     {
         return ValueObservation<ValueReducers.Combine6>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0),
-                o3.baseRegion($0),
-                o4.baseRegion($0),
-                o5.baseRegion($0),
-                o6.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion
-                || o3.observesSelectedRegion
-                || o4.observesSelectedRegion
-                || o5.observesSelectedRegion
-                || o6.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine6(
                 o1.makeReducer(),
                 o2.makeReducer(),
@@ -546,8 +532,7 @@ extension ValueObservation where Reducer == Never {
                 || o3.requiresWriteAccess
                 || o4.requiresWriteAccess
                 || o5.requiresWriteAccess
-                || o6.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o6.requiresWriteAccess)
     }
 }
 
@@ -579,6 +564,16 @@ extension ValueReducers {
         private var p5: R5.Value?
         private var p6: R6.Value?
         private var p7: R7.Value?
+        
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+                && r3.isObservedRegionDeterministic
+                && r4.isObservedRegionDeterministic
+                && r5.isObservedRegionDeterministic
+                && r6.isObservedRegionDeterministic
+                && r7.isObservedRegionDeterministic
+        }
         
         init(_ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7) {
             self.r1 = r1
@@ -654,21 +649,6 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine7<R1, R2, R3, R4, R5, R6, R7>>
     {
         return ValueObservation<ValueReducers.Combine7>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0),
-                o3.baseRegion($0),
-                o4.baseRegion($0),
-                o5.baseRegion($0),
-                o6.baseRegion($0),
-                o7.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion
-                || o3.observesSelectedRegion
-                || o4.observesSelectedRegion
-                || o5.observesSelectedRegion
-                || o6.observesSelectedRegion
-                || o7.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine7(
                 o1.makeReducer(),
                 o2.makeReducer(),
@@ -683,8 +663,7 @@ extension ValueObservation where Reducer == Never {
                 || o4.requiresWriteAccess
                 || o5.requiresWriteAccess
                 || o6.requiresWriteAccess
-                || o7.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o7.requiresWriteAccess)
     }
 }
 
@@ -720,6 +699,17 @@ extension ValueReducers {
         private var p6: R6.Value?
         private var p7: R7.Value?
         private var p8: R8.Value?
+        
+        public var isObservedRegionDeterministic: Bool {
+            r1.isObservedRegionDeterministic
+                && r2.isObservedRegionDeterministic
+                && r3.isObservedRegionDeterministic
+                && r4.isObservedRegionDeterministic
+                && r5.isObservedRegionDeterministic
+                && r6.isObservedRegionDeterministic
+                && r7.isObservedRegionDeterministic
+                && r8.isObservedRegionDeterministic
+        }
         
         init(_ r1: R1, _ r2: R2, _ r3: R3, _ r4: R4, _ r5: R5, _ r6: R6, _ r7: R7, _ r8: R8) {
             self.r1 = r1
@@ -802,23 +792,6 @@ extension ValueObservation where Reducer == Never {
         -> ValueObservation<ValueReducers.Combine8<R1, R2, R3, R4, R5, R6, R7, R8>>
     {
         return ValueObservation<ValueReducers.Combine8>(
-            baseRegion: { try DatabaseRegion.union(
-                o1.baseRegion($0),
-                o2.baseRegion($0),
-                o3.baseRegion($0),
-                o4.baseRegion($0),
-                o5.baseRegion($0),
-                o6.baseRegion($0),
-                o7.baseRegion($0),
-                o8.baseRegion($0)) },
-            observesSelectedRegion: o1.observesSelectedRegion
-                || o2.observesSelectedRegion
-                || o3.observesSelectedRegion
-                || o4.observesSelectedRegion
-                || o5.observesSelectedRegion
-                || o6.observesSelectedRegion
-                || o7.observesSelectedRegion
-                || o8.observesSelectedRegion,
             makeReducer: { ValueReducers.Combine8(
                 o1.makeReducer(),
                 o2.makeReducer(),
@@ -835,7 +808,6 @@ extension ValueObservation where Reducer == Never {
                 || o5.requiresWriteAccess
                 || o6.requiresWriteAccess
                 || o7.requiresWriteAccess
-                || o8.requiresWriteAccess,
-            scheduling: .mainQueue)
+                || o8.requiresWriteAccess)
     }
 }

--- a/GRDB/ValueObservation/ValueReducer/Combine.swift
+++ b/GRDB/ValueObservation/ValueReducer/Combine.swift
@@ -47,7 +47,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer>(
@@ -72,7 +72,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine2<Reducer, R1>, Combined>>
     {
-        return ValueObservation<Never>.combine(self, other).map(transform)
+        return ValueObservation<ValueReducers.Auto>.combine(self, other).map(transform)
     }
 }
 
@@ -134,7 +134,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -165,7 +165,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value, R2.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine3<Reducer, R1, R2>, Combined>>
     {
-        return ValueObservation<Never>
+        return ValueObservation<ValueReducers.Auto>
             .combine(
                 self,
                 observation1,
@@ -241,7 +241,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -278,7 +278,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value, R2.Value, R3.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine4<Reducer, R1, R2, R3>, Combined>>
     {
-        return ValueObservation<Never>
+        return ValueObservation<ValueReducers.Auto>
             .combine(
                 self,
                 observation1,
@@ -364,7 +364,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -407,7 +407,7 @@ extension ValueObservation where Reducer: _ValueReducer {
         _ transform: @escaping (Reducer.Value, R1.Value, R2.Value, R3.Value, R4.Value) -> Combined)
         -> ValueObservation<ValueReducers.Map<ValueReducers.Combine5<Reducer, R1, R2, R3, R4>, Combined>>
     {
-        return ValueObservation<Never>
+        return ValueObservation<ValueReducers.Auto>
             .combine(
                 self,
                 observation1,
@@ -503,7 +503,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -630,7 +630,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,
@@ -771,7 +771,7 @@ extension ValueReducers {
     }
 }
 
-extension ValueObservation where Reducer == Never {
+extension ValueObservation where Reducer == ValueReducers.Auto {
     public static func combine<
         R1: _ValueReducer,
         R2: _ValueReducer,

--- a/GRDB/ValueObservation/ValueReducer/Fetch.swift
+++ b/GRDB/ValueObservation/ValueReducer/Fetch.swift
@@ -6,8 +6,10 @@ extension ValueReducers {
     /// :nodoc:
     public struct Fetch<Value>: _ValueReducer {
         private let _fetch: (Database) throws -> Value
+        public let isObservedRegionDeterministic: Bool
         
-        public init(_ fetch: @escaping (Database) throws -> Value) {
+        public init(isObservedRegionDeterministic: Bool, fetch: @escaping (Database) throws -> Value) {
+            self.isObservedRegionDeterministic = isObservedRegionDeterministic
             self._fetch = fetch
         }
         

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -21,6 +21,7 @@ extension ValueReducers {
     public struct Map<Base: _ValueReducer, Value>: _ValueReducer {
         private var base: Base
         private let transform: (Base.Value) -> Value
+        public var isObservedRegionDeterministic: Bool { base.isObservedRegionDeterministic }
         
         init(_ base: Base, _ transform: @escaping (Base.Value) -> Value) {
             self.base = base

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -17,6 +17,7 @@ extension ValueReducers {
     public struct RemoveDuplicates<Base: _ValueReducer>: _ValueReducer where Base.Value: Equatable {
         private var base: Base
         private var previousValue: Base.Value?
+        public var isObservedRegionDeterministic: Bool { base.isObservedRegionDeterministic }
         
         init(_ base: Base) {
             self.base = base

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -8,7 +8,7 @@ public protocol _ValueReducer {
     /// The type of observed values
     associatedtype Value
     
-    /// Feches database values upon changes in an observed database region.
+    /// Fetches database values upon changes in an observed database region.
     ///
     /// _ValueReducer semantics require that this method does not depend on
     /// the state of the reducer.

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -8,13 +8,10 @@ public protocol _ValueReducer {
     /// The type of observed values
     associatedtype Value
     
-    /// If true, reducer wants to record the selected region.
-    ///
-    /// _ValueReducer semantics require that this property does not depend on
-    /// the state of the reducer.
+    /// Returns whether the database region selected by the fetch(_:) method
+    /// is constant.
     var isObservedRegionDeterministic: Bool { get }
     
-    // TODO: rename fetch(_ db: Database, recording selectedRegion: inout DatabaseRegion) throws -> Fetched
     /// Fetches database values upon changes in an observed database region.
     ///
     /// _ValueReducer semantics require that this method does not depend on

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -67,15 +67,15 @@ extension _ValueReducer {
 }
 
 /// A namespace for types related to the _ValueReducer protocol.
-public enum ValueReducers { }
-
-// TODO: define an empty NeverReducer enum instead of reusing Never.
-// This allows us to use Never as a marker for ValueObservation factory methods:
-//
-// For example, ValueObservation.tracking(_:) is, practically,
-// ValueObservation<Never>.tracking(_:).
-extension Never: _ValueReducer {
-    public var isObservedRegionDeterministic: Bool { preconditionFailure() }
-    public func fetch(_ db: Database) throws -> Never { preconditionFailure() }
-    public mutating func value(_ fetched: Never) -> Never? { }
+public enum ValueReducers {
+    // ValueReducers.Auto allows us to define ValueObservation factory methods.
+    //
+    // For example, ValueObservation.tracking(_:) is, practically,
+    // ValueObservation<ValueReducers.Auto>.tracking(_:).
+    /// :nodoc:
+    public enum Auto: _ValueReducer {
+        public var isObservedRegionDeterministic: Bool { preconditionFailure() }
+        public func fetch(_ db: Database) throws -> Never { preconditionFailure() }
+        public mutating func value(_ fetched: Never) -> Never? { }
+    }
 }

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -72,8 +72,8 @@ public enum ValueReducers { }
 // TODO: define an empty NeverReducer enum instead of reusing Never.
 // This allows us to use Never as a marker for ValueObservation factory methods:
 //
-// For example, ValueObservation.tracking(value:) is, practically,
-// ValueObservation<Never>.tracking(value:).
+// For example, ValueObservation.tracking(_:) is, practically,
+// ValueObservation<Never>.tracking(_:).
 extension Never: _ValueReducer {
     public var isObservedRegionDeterministic: Bool { preconditionFailure() }
     public func fetch(_ db: Database) throws -> Never { preconditionFailure() }

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -34,11 +34,7 @@ public protocol _ValueReducer {
 }
 
 extension _ValueReducer {
-    func fetch(
-        _ db: Database,
-        requiringWriteAccess: Bool)
-        throws -> Fetched
-    {
+    func fetch(_ db: Database, requiringWriteAccess: Bool) throws -> Fetched {
         if requiringWriteAccess {
             var fetchedValue: Fetched?
             try db.inSavepoint {
@@ -53,11 +49,7 @@ extension _ValueReducer {
         }
     }
     
-    mutating func fetchAndReduce(
-        _ db: Database,
-        requiringWriteAccess: Bool)
-        throws -> Value?
-    {
+    mutating func fetchAndReduce(_ db: Database, requiringWriteAccess: Bool) throws -> Value? {
         let fetchedValue = try fetch(db, requiringWriteAccess: requiringWriteAccess)
         return value(fetchedValue)
     }

--- a/README.md
+++ b/README.md
@@ -5857,23 +5857,7 @@ When needed, you can help GRDB optimize observations and reduce database content
 
 3. :bulb: **Tip**: Use a [DatabasePool](#database-pools), because it can perform multi-threaded database accesses.
 
-4. :bulb: **Tip**: Declare upfront the tracked database region, when possible:
-    
-    ```swift
-    // Plain observation
-    let observation = ValueObservation.tracking(Player.fetchAll)
-    
-    // Optimized observation
-    let observation = ValueObservation.tracking(Player.all(), fetch: Player.fetchAll)
-    ```
-    
-    The `ValueObservation.tracking(_:fetch:)` method is an alternative way to create an observation. Its first argument is one or several requests that define a [database region](#databaseregion). Its second argument is a regular function which fetches the observed value.
-    
-    Such an observation is only triggered by transactions that impact the tracked database region.
-    
-    It helps reducing database contention because it can refresh the observed value without blocking concurrent database writes.
-
-5. :bulb: **Tip**: When the observation processes some raw fetched values, use the [`map`](#valueobservationmap) operator:
+4. :bulb: **Tip**: When the observation processes some raw fetched values, use the [`map`](#valueobservationmap) operator:
 
     ```swift
     // Plain observation

--- a/README.md
+++ b/README.md
@@ -5505,7 +5505,7 @@ Tracked changes include changes performed by the [query interface](#the-query-in
     }
     
     // The same observation, with short-hand notation:
-    let observation = ValueObservation.tracking(value: Player.fetchAll)
+    let observation = ValueObservation.tracking(Player.fetchAll)
     ```
     
     The observation can perform multiple requests, from multiple database tables, and even use raw SQL.
@@ -5556,7 +5556,7 @@ import Combine
 import GRDB
 import GRDBCombine
 
-let observation = ValueObservation.tracking(value: Player.fetchAll)
+let observation = ValueObservation.tracking(Player.fetchAll)
 
 let cancellable = observation.publisher(in: dbQueue).sink(
     receiveCompletion: { completion in ... },
@@ -5575,7 +5575,7 @@ import GRDB
 import RxGRDB
 import RxSwift
 
-let observation = ValueObservation.tracking(value: Player.fetchAll)
+let observation = ValueObservation.tracking(Player.fetchAll)
 
 let disposable = observation.rx.changes(in: dbQueue).subscribe(
     onNext: { (players: [Player]) in
@@ -5786,7 +5786,7 @@ When needed, you can help GRDB optimize observations and reduce database content
             super.viewWillAppear(animated)
             
             // Start observing the database
-            let observation = ValueObservation.tracking(value: Player.fetchAll)
+            let observation = ValueObservation.tracking(Player.fetchAll)
             observer = observation.start(
                 in: dbQueue,
                 onError: { error in ... },
@@ -5820,7 +5820,7 @@ When needed, you can help GRDB optimize observations and reduce database content
     import RxGRDB
     import RxSwift
     
-    let observation = ValueObservation.tracking(value: Player.fetchAll)
+    let observation = ValueObservation.tracking(Player.fetchAll)
     let observable = observation.rx
         .changes(in: dbQueue)
         .share(replay: 1, scope: .whileConnected)
@@ -5832,7 +5832,7 @@ When needed, you can help GRDB optimize observations and reduce database content
     
     ```swift
     // Plain observation
-    let observation = ValueObservation.tracking(value: Player.fetchAll)
+    let observation = ValueObservation.tracking(Player.fetchAll)
     
     // Optimized observation
     let observation = ValueObservation.tracking(Player.all(), fetch: Player.fetchAll)

--- a/TODO.md
+++ b/TODO.md
@@ -53,8 +53,6 @@
 - [ ] https://forums.swift.org/t/how-to-encode-objects-of-unknown-type/12253/6
 - [ ] Configuration.crashOnError = true
 - [ ] Glossary (Database Access Methods, etc.)
-- [ ] ValueObservation.flatMap. Not sure it is still useful now that we have ValueObservation.tracking(value:)
-- [ ] rename fetchOne to fetchFirst. Not sure because it is a big breaking change. Not sure because ValueObservation.tracking(value:) has reduced the need for observationForFirst.
 - [ ] Not sure: type safety for SQL expressions
     - [ ] Introduce some record protocol with an associated primary key type. Restrict filter(key:) methods to this type. Allow distinguishing FooId from BarId types.
     - [ ] Replace Column with TypedColumn. How to avoid code duplication (repeated types)? Keypaths?

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -182,6 +182,8 @@ public struct AnyValueReducer<Fetched, Value>: _ValueReducer {
     private var _fetch: (Database) throws -> Fetched
     private var _value: (Fetched) -> Value?
     
+    public var isObservedRegionDeterministic: Bool { false }
+    
     public init(
         fetch: @escaping (Database) throws -> Fetched,
         value: @escaping (Fetched) -> Value?)
@@ -190,12 +192,10 @@ public struct AnyValueReducer<Fetched, Value>: _ValueReducer {
         self._value = value
     }
     
-    /// :nodoc:
     public func fetch(_ db: Database) throws -> Fetched {
         try _fetch(db)
     }
     
-    /// :nodoc:
     public func value(_ fetched: Fetched) -> Value? {
         _value(fetched)
     }

--- a/Tests/GRDBTests/ValueObservationCombineTests.swift
+++ b/Tests/GRDBTests/ValueObservationCombineTests.swift
@@ -658,8 +658,8 @@ class ValueObservationCombineTests: GRDBTestCase {
     func testHeterogeneusCombine2() throws {
         struct V1 { }
         struct V2 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
         let observation = ValueObservation.combine(observation1, observation2)
         var value: (V1, V2)?
         _ = try observation.start(
@@ -673,9 +673,9 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V1 { }
         struct V2 { }
         struct V3 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
         let observation = ValueObservation.combine(observation1, observation2, observation3)
         var value: (V1, V2, V3)?
         _ = try observation.start(
@@ -690,10 +690,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V2 { }
         struct V3 { }
         struct V4 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4)
         var value: (V1, V2, V3, V4)?
         _ = try observation.start(
@@ -709,11 +709,11 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V3 { }
         struct V4 { }
         struct V5 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
-        let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
+        let observation5 = ValueObservation.tracking { _ in V5() }
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5)
         var value: (V1, V2, V3, V4, V5)?
         _ = try observation.start(
@@ -730,12 +730,12 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V4 { }
         struct V5 { }
         struct V6 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
-        let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
-        let observation6 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V6() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
+        let observation5 = ValueObservation.tracking { _ in V5() }
+        let observation6 = ValueObservation.tracking { _ in V6() }
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6)
         var value: (V1, V2, V3, V4, V5, V6)?
         _ = try observation.start(
@@ -753,13 +753,13 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V5 { }
         struct V6 { }
         struct V7 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
-        let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
-        let observation6 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V6() })
-        let observation7 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V7() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
+        let observation5 = ValueObservation.tracking { _ in V5() }
+        let observation6 = ValueObservation.tracking { _ in V6() }
+        let observation7 = ValueObservation.tracking { _ in V7() }
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6, observation7)
         var value: (V1, V2, V3, V4, V5, V6, V7)?
         _ = try observation.start(
@@ -778,14 +778,14 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V6 { }
         struct V7 { }
         struct V8 { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
-        let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
-        let observation6 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V6() })
-        let observation7 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V7() })
-        let observation8 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V8() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
+        let observation5 = ValueObservation.tracking { _ in V5() }
+        let observation6 = ValueObservation.tracking { _ in V6() }
+        let observation7 = ValueObservation.tracking { _ in V7() }
+        let observation8 = ValueObservation.tracking { _ in V8() }
         let observation = ValueObservation.combine(observation1, observation2, observation3, observation4, observation5, observation6, observation7, observation8)
         var value: (V1, V2, V3, V4, V5, V6, V7, V8)?
         _ = try observation.start(
@@ -799,8 +799,8 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V1 { }
         struct V2 { }
         struct Combined { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
         let observation = observation1.combine(observation2) { (v1: V1, v2: V2) -> Combined in Combined() }
         var value: Combined?
         _ = try observation.start(
@@ -815,9 +815,9 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V2 { }
         struct V3 { }
         struct Combined { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
         let observation = observation1.combine(observation2, observation3) { (v1: V1, v2: V2, v3: V3) -> Combined in Combined() }
         var value: Combined?
         _ = try observation.start(
@@ -833,10 +833,10 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V3 { }
         struct V4 { }
         struct Combined { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
         let observation = observation1.combine(observation2, observation3, observation4) { (v1: V1, v2: V2, v3: V3, v4: V4) -> Combined in Combined() }
         var value: Combined?
         _ = try observation.start(
@@ -853,11 +853,11 @@ class ValueObservationCombineTests: GRDBTestCase {
         struct V4 { }
         struct V5 { }
         struct Combined { }
-        let observation1 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V1() })
-        let observation2 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V2() })
-        let observation3 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V3() })
-        let observation4 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V4() })
-        let observation5 = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in V5() })
+        let observation1 = ValueObservation.tracking { _ in V1() }
+        let observation2 = ValueObservation.tracking { _ in V2() }
+        let observation3 = ValueObservation.tracking { _ in V3() }
+        let observation4 = ValueObservation.tracking { _ in V4() }
+        let observation5 = ValueObservation.tracking { _ in V5() }
         let observation = observation1.combine(observation2, observation3, observation4, observation5) { (v1: V1, v2: V2, v3: V3, v4: V4, v5: V5) -> Combined in Combined() }
         var value: Combined?
         _ = try observation.start(

--- a/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
+++ b/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
@@ -171,7 +171,7 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
                 notificationExpectation.fulfill()
         })
         let token = observer as! ValueObserverToken<ValueReducers.AllValues<Name>> // Non-public implementation detail
-        XCTAssertEqual(token.observer.observedRegion.description, "t(id,name)") // view is not tracked
+        XCTAssertEqual(token.observer.observedRegion!.description, "t(id,name)") // view is not tracked
         try withExtendedLifetime(observer) {
             // Test view observation
             try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/ValueObservationExtentTests.swift
+++ b/Tests/GRDBTests/ValueObservationExtentTests.swift
@@ -23,14 +23,16 @@ class ValueObservationExtentTests: GRDBTestCase {
         notificationExpectation.expectedFulfillmentCount = 2
         
         // Create an observation
-        let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in })
+        let observation = ValueObservation.tracking {
+            try Int.fetchOne($0, sql: "SELECT * FROM t")
+        }
         
         // Start observation and deallocate observer after second change
         var observer: TransactionObserver?
         observer = observation.start(
             in: dbQueue,
             onError: { error in XCTFail("Unexpected error: \(error)") },
-            onChange: {
+            onChange: { _ in
                 changesCount += 1
                 if changesCount == 2 {
                     observer = nil

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -11,20 +11,11 @@ import XCTest
 #endif
 
 class ValueObservationFetchTests: GRDBTestCase {
-    func testRegionsAPI() {
-        // single region
-        _ = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
-        // variadic
-        _ = ValueObservation.tracking(DatabaseRegion(), DatabaseRegion(), fetch: { _ in })
-        // array
-        _ = ValueObservation.tracking([DatabaseRegion()], fetch: { _ in })
-    }
-    
     func testFetch() throws {
         try assertValueObservation(
-            ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            ValueObservation.tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            }),
+            },
             records: [0, 1, 1, 2],
             setup: { db in
                 try db.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)")
@@ -38,9 +29,9 @@ class ValueObservationFetchTests: GRDBTestCase {
     
     func testRemoveDuplicated() throws {
         try assertValueObservation(
-            ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
-                try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            }).removeDuplicates(),
+            ValueObservation
+                .tracking { try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")! }
+                .removeDuplicates(),
             records: [0, 1, 2],
             setup: { db in
                 try db.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)")

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -13,9 +13,9 @@ import XCTest
 class ValueObservationMapTests: GRDBTestCase {
     func testMap() throws {
         let valueObservation = ValueObservation
-            .tracking(DatabaseRegion.fullDatabase, fetch: {
+            .tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
+            }
             .map { "\($0)" }
         
         try assertValueObservation(
@@ -31,7 +31,7 @@ class ValueObservationMapTests: GRDBTestCase {
     }
     
     func testMapPreservesConfiguration() {
-        var observation = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
+        var observation = ValueObservation.tracking { _ in }
         observation.requiresWriteAccess = true
         observation.scheduling = .unsafe
         

--- a/Tests/GRDBTests/ValueObservationRecorder.swift
+++ b/Tests/GRDBTests/ValueObservationRecorder.swift
@@ -1,9 +1,9 @@
 // Inspired by https://github.com/groue/CombineExpectations
 import XCTest
 #if GRDBCUSTOMSQLITE
-import GRDBCustomSQLite
+@testable import GRDBCustomSQLite
 #else
-import GRDB
+@testable import GRDB
 #endif
 
 // MARK: - ValueObservationRecorder
@@ -379,7 +379,7 @@ extension GRDBTestCase {
             observation.scheduling = .async(onQueue: .main)
             try testRecordingEqual(writer: DatabaseQueue(), observation: observation)
             try testRecordingEqual(writer: makeDatabaseQueue(), observation: observation)
-            if valueObservation.requiresWriteAccess {
+            if valueObservation.requiresWriteAccess || !valueObservation.makeReducer().isObservedRegionDeterministic {
                 try testRecordingEqual(writer: makeDatabasePool(), observation: observation)
             } else {
                 // DatabasePool performs an immediate async fetch and may miss initial changes

--- a/Tests/GRDBTests/ValueObservationReducerTests.swift
+++ b/Tests/GRDBTests/ValueObservationReducerTests.swift
@@ -12,15 +12,6 @@ import Dispatch
 #endif
 
 class ValueObservationReducerTests: GRDBTestCase {
-    func testRegionsAPI() {
-        // single region
-        _ = ValueObservation.tracking(DatabaseRegion(), fetch: { _ in })
-        // variadic
-        _ = ValueObservation.tracking(DatabaseRegion(), DatabaseRegion(), fetch: { _ in })
-        // array
-        _ = ValueObservation.tracking([DatabaseRegion()], fetch: { _ in })
-    }
-    
     func testReducer() throws {
         func test(_ dbWriter: DatabaseWriter) throws {
             // We need something to change
@@ -123,7 +114,7 @@ class ValueObservationReducerTests: GRDBTestCase {
         func test(_ dbWriter: DatabaseWriter) throws {
             // Create an observation
             struct TestError: Error { }
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in throw TestError() })
+            let observation = ValueObservation.tracking { _ in throw TestError() }
             
             // Start observation
             var error: TestError?

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -123,7 +123,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             onChange: { (int: Int, string: String) in }) // <- destructure
     }
     
-    func testMainQueueScheduling() throws {
+    func testVolatileTrackingMainQueueScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -139,7 +139,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        let observation = ValueObservation.tracking { db -> Int in
+        let observation = ValueObservation.trackingVolatile { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
@@ -173,7 +173,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
-    func testAsyncScheduling() throws {
+    func testVolatileTrackingAsyncScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -189,7 +189,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.tracking { db -> Int in
+        var observation = ValueObservation.trackingVolatile { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
@@ -223,7 +223,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
-    func testUnsafeScheduling() throws {
+    func testVolatileTrackingUnsafeScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -239,7 +239,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.tracking { db -> Int in
+        var observation = ValueObservation.trackingVolatile { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -15,19 +15,50 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
                 """)
             
             do {
-                let (_, region) = db.recordingSelectedRegion { }
+                var region = DatabaseRegion()
+                _ = db.recordingSelection(&region) { }
                 XCTAssertTrue(region.isEmpty)
             }
             
             do {
-                let (_, region) = try db.recordingSelectedRegion {
+                var region = DatabaseRegion.fullDatabase
+                _ = db.recordingSelection(&region) { }
+                XCTAssertTrue(region.isFullDatabase)
+            }
+            
+            do {
+                var region = DatabaseRegion(table: "player")
+                _ = db.recordingSelection(&region) { }
+                XCTAssertEqual(region.description, "player(*)")
+            }
+            
+            do {
+                var region = DatabaseRegion()
+                _ = try db.recordingSelection(&region) {
                     _ = try Row.fetchAll(db, sql: "SELECT * FROM team")
                 }
                 XCTAssertEqual(region.description, "team(id,name)")
             }
             
             do {
-                let (_, region) = try db.recordingSelectedRegion {
+                var region = DatabaseRegion.fullDatabase
+                _ = try db.recordingSelection(&region) {
+                    _ = try Row.fetchAll(db, sql: "SELECT * FROM team")
+                }
+                XCTAssertTrue(region.isFullDatabase)
+            }
+            
+            do {
+                var region = DatabaseRegion(table: "player")
+                _ = try db.recordingSelection(&region) {
+                    _ = try Row.fetchAll(db, sql: "SELECT * FROM team")
+                }
+                XCTAssertEqual(region.description, "player(*),team(id,name)")
+            }
+            
+            do {
+                var region = DatabaseRegion()
+                _ = try db.recordingSelection(&region) {
                     _ = try Row.fetchAll(db, sql: "SELECT name FROM player")
                 }
                 XCTAssertEqual(region.description, "player(name)")
@@ -36,14 +67,16 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             do {
                 // Test for rowID optimization
                 struct Player: TableRecord, FetchableRecord, Decodable { }
-                let (_, region) = try db.recordingSelectedRegion {
+                var region = DatabaseRegion()
+                _ = try db.recordingSelection(&region) {
                     _ = try Player.fetchOne(db, key: 123)
                 }
-                XCTAssertEqual(region.description, "player(id,name)[123]")
+                XCTAssert(region.description.contains("player(id,name)[123]"))
             }
 
             do {
-                let (_, region) = try db.recordingSelectedRegion {
+                var region = DatabaseRegion()
+                _ = try db.recordingSelection(&region) {
                     _ = try Row.fetchAll(db, sql: "SELECT * FROM team")
                     _ = try Row.fetchAll(db, sql: "SELECT * FROM player")
                 }
@@ -55,20 +88,23 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
                 var region2 = DatabaseRegion()
                 var region3 = DatabaseRegion()
                 var region4 = DatabaseRegion()
-                (_, region1) = try db.recordingSelectedRegion {
+                var region5 = DatabaseRegion()
+                _ = try db.recordingSelection(&region1) {
                     _ = try Row.fetchAll(db, sql: "SELECT * FROM team")
-                    (_, region2) = try db.recordingSelectedRegion {
+                    _ = try db.recordingSelection(&region2) {
+                        _ = db.recordingSelection(&region3) { }
                         _ = try Row.fetchAll(db, sql: "SELECT name FROM player")
-                        (_, region3) = db.recordingSelectedRegion { }
+                        _ = db.recordingSelection(&region4) { }
                     }
-                    (_, region4) = try db.recordingSelectedRegion {
+                    _ = try db.recordingSelection(&region5) {
                         _ = try Row.fetchAll(db, sql: "SELECT * FROM player")
                     }
                 }
                 XCTAssertEqual(region1.description, "player(id,name),team(id,name)")
                 XCTAssertEqual(region2.description, "player(name)")
                 XCTAssertTrue(region3.isEmpty)
-                XCTAssertEqual(region4.description, "player(id,name)")
+                XCTAssertTrue(region4.isEmpty)
+                XCTAssertEqual(region5.description, "player(id,name)")
             }
         }
     }
@@ -117,7 +153,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         })
         
         let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-        XCTAssertEqual(token.observer.observedRegion.description, "a(value),source(name)")
+        XCTAssertEqual(token.observer.observedRegion!.description, "a(value),source(name)")
         
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
@@ -133,7 +169,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [0, 1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
+            XCTAssertEqual(token.observer.observedRegion!.description, "b(value),source(name)")
         }
     }
     
@@ -183,7 +219,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [0, 1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
+            XCTAssertEqual(token.observer.observedRegion!.description, "b(value),source(name)")
         }
     }
     
@@ -218,7 +254,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         })
         
         let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-        XCTAssertEqual(token.observer.observedRegion.description, "a(value),source(name)")
+        XCTAssertEqual(token.observer.observedRegion!.description, "a(value),source(name)")
         
         try withExtendedLifetime(observer) {
             try dbQueue.inDatabase { db in
@@ -234,7 +270,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             XCTAssertEqual(results, [0, 1, 2, 3])
             
             let token = observer as! ValueObserverToken<ValueReducers.Fetch<Int>> // Non-public implementation detail
-            XCTAssertEqual(token.observer.observedRegion.description, "b(value),source(name)")
+            XCTAssertEqual(token.observer.observedRegion!.description, "b(value),source(name)")
         }
     }
 }

--- a/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
+++ b/Tests/GRDBTests/ValueObservationRegionRecordingTests.swift
@@ -123,7 +123,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
             onChange: { (int: Int, string: String) in }) // <- destructure
     }
     
-    func testVolatileTrackingMainQueueScheduling() throws {
+    func testVaryingRegionTrackingMainQueueScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -139,7 +139,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        let observation = ValueObservation.trackingVolatile { db -> Int in
+        let observation = ValueObservation.trackingVaryingRegion { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
@@ -173,7 +173,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
-    func testVolatileTrackingAsyncScheduling() throws {
+    func testVaryingRegionTrackingAsyncScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -189,7 +189,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.trackingVolatile { db -> Int in
+        var observation = ValueObservation.trackingVaryingRegion { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }
@@ -223,7 +223,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         }
     }
     
-    func testVolatileTrackingUnsafeScheduling() throws {
+    func testVaryingRegionTrackingUnsafeScheduling() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {
             try $0.execute(sql: """
@@ -239,7 +239,7 @@ class ValueObservationRegionRecordingTests: GRDBTestCase {
         notificationExpectation.assertForOverFulfill = true
         notificationExpectation.expectedFulfillmentCount = 4
         
-        var observation = ValueObservation.trackingVolatile { db -> Int in
+        var observation = ValueObservation.trackingVaryingRegion { db -> Int in
             let table = try String.fetchOne(db, sql: "SELECT name FROM source")!
             return try Int.fetchOne(db, sql: "SELECT IFNULL(SUM(value), 0) FROM \(table)")!
         }

--- a/Tests/GRDBTests/ValueObservationSchedulingTests.swift
+++ b/Tests/GRDBTests/ValueObservationSchedulingTests.swift
@@ -108,12 +108,13 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             DispatchQueue.main.setSpecific(key: key, value: ())
             
             var nextError: Error? = nil // If not null, observation throws an error
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ -> Void in
+            let observation = ValueObservation.tracking { db in
+                _ = try Int.fetchOne(db, sql: "SELECT * FROM t")
                 if let error = nextError {
                     nextError = nil
                     throw error
                 }
-            })
+            }
             
             let observer = observation.start(
                 in: dbWriter,
@@ -235,12 +236,13 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             
             struct TestError: Error { }
             var shouldThrow = false
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in
+            var observation = ValueObservation.tracking { db in
+                _ = try Int.fetchOne(db, sql: "SELECT * FROM t")
                 if shouldThrow {
                     throw TestError()
                 }
                 shouldThrow = true
-            })
+            }
             observation.scheduling = .async(onQueue: queue)
             
             let observer = observation.start(
@@ -397,12 +399,13 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             
             struct TestError: Error { }
             var shouldThrow = false
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in
+            var observation = ValueObservation.tracking { db in
+                _ = try Int.fetchOne(db, sql: "SELECT * FROM t")
                 if shouldThrow {
                     throw TestError()
                 }
                 shouldThrow = true
-            })
+            }
             observation.scheduling = .unsafe
             
             let observer = observation.start(

--- a/Tests/GRDBTests/ValueObservationSchedulingTests.swift
+++ b/Tests/GRDBTests/ValueObservationSchedulingTests.swift
@@ -24,9 +24,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             DispatchQueue.main.setSpecific(key: key, value: ())
             
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            let observation = ValueObservation.tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
+            }
             let observer = observation.start(
                 in: dbWriter,
                 onError: { error in XCTFail("Unexpected error: \(error)") },
@@ -66,9 +66,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             DispatchQueue.main.setSpecific(key: key, value: ())
             
-            let observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            let observation = ValueObservation.tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
+            }
             var observer: TransactionObserver?
             DispatchQueue.global(qos: .default).async {
                 observer = observation.start(
@@ -157,9 +157,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             queue.setSpecific(key: key, value: ())
             
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            var observation = ValueObservation.tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
+            }
             observation.scheduling = .async(onQueue: queue)
             
             let observer = observation.start(
@@ -199,7 +199,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             queue.setSpecific(key: key, value: ())
             
             struct TestError: Error { }
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in throw TestError() })
+            var observation = ValueObservation.tracking { _ in throw TestError() }
             observation.scheduling = .async(onQueue: queue)
             
             let observer = observation.start(
@@ -280,9 +280,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             DispatchQueue.main.setSpecific(key: key, value: ())
             
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            var observation = ValueObservation.tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
+            }
             observation.scheduling = .unsafe
             
             let observer = observation.start(
@@ -324,9 +324,9 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             let key = DispatchSpecificKey<()>()
             queue.setSpecific(key: key, value: ())
             
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: {
+            var observation = ValueObservation.tracking {
                 try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM t")!
-            })
+            }
             observation.scheduling = .unsafe
             var observer: TransactionObserver?
             queue.async {
@@ -367,7 +367,7 @@ class ValueObservationSchedulingTests: GRDBTestCase {
             notificationExpectation.expectedFulfillmentCount = 1
             
             struct TestError: Error { }
-            var observation = ValueObservation.tracking(DatabaseRegion.fullDatabase, fetch: { _ in throw TestError() })
+            var observation = ValueObservation.tracking { _ in throw TestError() }
             observation.scheduling = .unsafe
             
             let observer = observation.start(


### PR DESCRIPTION
This pull request brings two breaking changes:

1. ValueObservation always tracks the region implicitly defined by its fetching function. The `ValueObservation.tracking(_:fetch)` method, which used to accept a list of tracked regions, is removed.
2. `ValueObservation.tracking(_:)` now assumes that the tracked region is constant, and performs the possible optimizations. A new method `ValueObservation.trackingVaryingRegion(_:)` handles the (rare) cases where the tracked region is varying.