### PR TITLE
Explicit ValueObservation cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#737](https://github.com/groue/GRDB.swift/pull/737): Force implicit database region for ValueObservation
 - [#738](https://github.com/groue/GRDB.swift/pull/738): Remove all observationForCount/All/First methods
 - [#742](https://github.com/groue/GRDB.swift/pull/742): ValueObservation scheduling is no longer an attribute of the observation
+- [#745](https://github.com/groue/GRDB.swift/pull/745): Explicit ValueObservation cancellation
 
 
 ## 4.12.0

--- a/Documentation/WhyAdoptGRDB.md
+++ b/Documentation/WhyAdoptGRDB.md
@@ -120,23 +120,24 @@ let players = try Player.fetchAll(db)
 In order to keep your views synchronized with the database content, you can use [ValueObservation]. It notifies fresh values after each database change. The [GRDBCombine] and [RxGRDB] companion libraries provide support for [Combine] and [RxSwift].
 
 ```swift
-let playersObservation = ValueObservation.tracking { db in
+/// An observation of [Player]
+let observation = ValueObservation.tracking { db in
     try Player.fetchAll(db)
 }
 
 // Vanilla GRDB
-let observer = playersObservation.start(in: dbQueue,
+let cancellable = observation.start(in: dbQueue,
     onError: { error in ... },
-    onChange: { (players: [Player]) in print("Players have changed") })
+    onChange: { (players: [Player]) in print("Fresh players") })
 
 // GRDBCombine
-let cancellable = playersObservation.publisher(in: dbQueue).sink(
+let cancellable = observation.publisher(in: dbQueue).sink(
     receiveCompletion: { completion in ... },
-    receiveValue: { (players: [Player]) in print("Players have changed") })
+    receiveValue: { (players: [Player]) in print("Fresh players") })
     
 // RxGRDB
-let disposable = playersObservation.rx.observe(in: dbQueue).subscribe(
-    onNext: { (players: [Player]) in print("Players have changed") },
+let disposable = observation.rx.observe(in: dbQueue).subscribe(
+    onNext: { (players: [Player]) in print("Fresh playerss") },
     onError: { error in ... })
 ```
 

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -138,6 +138,10 @@
 		56300B781C53F592005A543B /* QueryInterfaceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */; };
 		56300B791C53F592005A543B /* QueryInterfaceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */; };
 		56300B861C54DC95005A543B /* Record+QueryInterfaceRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56300B841C54DC95005A543B /* Record+QueryInterfaceRequestTests.swift */; };
+		563082E42430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563082E32430B6BE00C14A05 /* DatabaseCancellable.swift */; };
+		563082E52430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563082E32430B6BE00C14A05 /* DatabaseCancellable.swift */; };
+		563082E62430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563082E32430B6BE00C14A05 /* DatabaseCancellable.swift */; };
+		563082E72430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563082E32430B6BE00C14A05 /* DatabaseCancellable.swift */; };
 		563363B01C933FF8000BE133 /* MutablePersistableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563363A91C933FF8000BE133 /* MutablePersistableRecordTests.swift */; };
 		563363B21C933FF8000BE133 /* PersistableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563363AA1C933FF8000BE133 /* PersistableRecordTests.swift */; };
 		563363BE1C93FD5E000BE133 /* DatabaseQueueConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563363BC1C93FD5E000BE133 /* DatabaseQueueConcurrencyTests.swift */; };
@@ -1218,6 +1222,7 @@
 		56300B6A1C53D3E8005A543B /* TableRecord+QueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TableRecord+QueryInterfaceRequestTests.swift"; sourceTree = "<group>"; };
 		56300B6F1C53F592005A543B /* QueryInterfaceRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryInterfaceRequest.swift; sourceTree = "<group>"; };
 		56300B841C54DC95005A543B /* Record+QueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Record+QueryInterfaceRequestTests.swift"; sourceTree = "<group>"; };
+		563082E32430B6BE00C14A05 /* DatabaseCancellable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseCancellable.swift; sourceTree = "<group>"; };
 		563363A91C933FF8000BE133 /* MutablePersistableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordTests.swift; sourceTree = "<group>"; };
 		563363AA1C933FF8000BE133 /* PersistableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistableRecordTests.swift; sourceTree = "<group>"; };
 		563363BC1C93FD5E000BE133 /* DatabaseQueueConcurrencyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueConcurrencyTests.swift; sourceTree = "<group>"; };
@@ -1662,6 +1667,7 @@
 		5613ED4221A95AFB00DC7A68 /* ValueObservation */ = {
 			isa = PBXGroup;
 			children = (
+				563082E32430B6BE00C14A05 /* DatabaseCancellable.swift */,
 				563B06AA217EF0CC00B38F35 /* ValueObservation.swift */,
 				56848972242DE36F002F9702 /* ValueObservationScheduler.swift */,
 				564CE43021AA901800652B19 /* ValueObserver.swift */,
@@ -2766,6 +2772,7 @@
 				56CEB5591EAA359A00BFAF62 /* SQLExpression.swift in Sources */,
 				5674A6FF1F307F600095F066 /* FetchableRecord+Decodable.swift in Sources */,
 				56E9FAD9221053DD00C703A8 /* SQLLiteral.swift in Sources */,
+				563082E62430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */,
 				56B964A31DA51B4C0002DA19 /* FTS5.swift in Sources */,
 				56D91AAB2205F2F100770D8D /* DatabasePromise.swift in Sources */,
 				566475A01D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
@@ -2881,6 +2888,7 @@
 				566475CF1D981D5E00FF74B8 /* SQLFunctions.swift in Sources */,
 				5659F49B1EA8D989004A4992 /* Pool.swift in Sources */,
 				5653EB2220944C7C00F46237 /* HasOneAssociation.swift in Sources */,
+				563082E52430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */,
 				56CEB51C1EAA328900BFAF62 /* FTS5+QueryInterface.swift in Sources */,
 				5698AC3A1D9E5A590056AF8C /* FTS3Pattern.swift in Sources */,
 				5664759D1D97D8A000FF74B8 /* SQLCollection.swift in Sources */,
@@ -3423,6 +3431,7 @@
 				AAA4DC8E230F1E0600C74B15 /* SQLFunctions.swift in Sources */,
 				AAA4DC8F230F1E0600C74B15 /* Pool.swift in Sources */,
 				AAA4DC90230F1E0600C74B15 /* HasOneAssociation.swift in Sources */,
+				563082E72430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */,
 				AAA4DC91230F1E0600C74B15 /* FTS5+QueryInterface.swift in Sources */,
 				AAA4DC92230F1E0600C74B15 /* FTS3Pattern.swift in Sources */,
 				AAA4DC93230F1E0600C74B15 /* SQLCollection.swift in Sources */,
@@ -3758,6 +3767,7 @@
 				566475D31D981D5E00FF74B8 /* SQLOperators.swift in Sources */,
 				56CEB5611EAA359A00BFAF62 /* SQLSelectable.swift in Sources */,
 				56CEB4FA1EAA2F4D00BFAF62 /* FTS3.swift in Sources */,
+				563082E42430B6BE00C14A05 /* DatabaseCancellable.swift in Sources */,
 				564CE59D21B7A8B500652B19 /* RemoveDuplicates.swift in Sources */,
 				5698AD351DABAF4A0056AF8C /* FTS5CustomTokenizer.swift in Sources */,
 				566B91131FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -885,7 +885,6 @@ extension DatabasePool: DatabaseReader {
                 // Now wait for the writer
                 _weakAsyncWriteWithoutTransaction { db in
                     guard let db = db else {
-                        observer.cancel()
                         return
                     }
                     if observer.isCompleted { return }
@@ -910,7 +909,6 @@ extension DatabasePool: DatabaseReader {
             // Fetch an initial value without waiting for the writer.
             _weakAsyncRead { [weak self] dbResult in
                 guard let dbResult = dbResult, let self = self else {
-                    observer.cancel()
                     return
                 }
                 if observer.isCompleted { return }
@@ -921,7 +919,6 @@ extension DatabasePool: DatabaseReader {
                     // Now wait for the writer
                     self._weakAsyncWriteWithoutTransaction { db in
                         guard let db = db else {
-                            observer.cancel()
                             return
                         }
                         if observer.isCompleted { return }

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -476,17 +476,27 @@ extension DatabaseQueue {
     
     // MARK: - Database Observation
     
-    public func add<Reducer: _ValueReducer>(
+    /// :nodoc:
+    public func _add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         scheduler: ValueObservationScheduler,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)
-        -> TransactionObserver
+        -> DatabaseCancellable
     {
         if configuration.readonly {
-            return addReadOnly(observation: observation, scheduler: scheduler, onError: onError, onChange: onChange)
+            return _addReadOnly(
+                observation: observation,
+                scheduler: scheduler,
+                onError: onError,
+                onChange: onChange)
         }
         
-        return addWriteOnly(observation: observation, scheduler: scheduler, onError: onError, onChange: onChange)
+        let observer = _addWriteOnly(
+            observation: observation,
+            scheduler: scheduler,
+            onError: onError,
+            onChange: onChange)
+        return AnyDatabaseCancellable(cancel: observer.cancel)
     }
 }

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -121,18 +121,18 @@ extension DatabaseSnapshot {
     
     // MARK: - Database Observation
     
-    public func add<Reducer: _ValueReducer>(
+    /// :nodoc:
+    public func _add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         scheduler: ValueObservationScheduler,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)
-        -> TransactionObserver
+        -> DatabaseCancellable
     {
-        return addReadOnly(observation: observation, scheduler: scheduler, onError: onError, onChange: onChange)
-    }
-    
-    // TODO: remove when we have proper support for Observation cancellation
-    public func remove(transactionObserver: TransactionObserver) {
-        // Can't remove an observer which could not be added :-)
+        return _addReadOnly(
+            observation: observation,
+            scheduler: scheduler,
+            onError: onError,
+            onChange: onChange)
     }
 }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -309,14 +309,14 @@ extension DatabaseWriter {
     // MARK: - Database Observation
     
     /// A write-only observation only uses the serialized writer
-    func addWriteOnly<Reducer: _ValueReducer>(
+    func _addWriteOnly<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         scheduler: ValueObservationScheduler,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)
-        -> TransactionObserver
+        -> ValueObserver<Reducer> // For testability
     {
-        assert(!configuration.readonly, "Use addReadOnly(observation:) instead")
+        assert(!configuration.readonly, "Use _addReadOnly(observation:) instead")
         
         let observer = ValueObserver<Reducer>(
             requiresWriteAccess: observation.requiresWriteAccess,
@@ -356,7 +356,7 @@ extension DatabaseWriter {
             }
         }
         
-        return ValueObserverToken(writer: self, observer: observer)
+        return observer
     }
 }
 
@@ -527,18 +527,17 @@ public final class AnyDatabaseWriter: DatabaseWriter {
     // MARK: - Database Observation
     
     /// :nodoc:
-    public func remove(transactionObserver: TransactionObserver) {
-        base.remove(transactionObserver: transactionObserver)
-    }
-    
-    /// :nodoc:
-    public func add<Reducer: _ValueReducer>(
+    public func _add<Reducer: _ValueReducer>(
         observation: ValueObservation<Reducer>,
         scheduler: ValueObservationScheduler,
         onError: @escaping (Error) -> Void,
         onChange: @escaping (Reducer.Value) -> Void)
-        -> TransactionObserver
+        -> DatabaseCancellable
     {
-        base.add(observation: observation, scheduler: scheduler, onError: onError, onChange: onChange)
+        base._add(
+            observation: observation,
+            scheduler: scheduler,
+            onError: onError,
+            onChange: onChange)
     }
 }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -342,7 +342,6 @@ extension DatabaseWriter {
         } else {
             _weakAsyncWriteWithoutTransaction { db in
                 guard let db = db else {
-                    observer.cancel()
                     return
                 }
                 if observer.isCompleted { return }

--- a/GRDB/ValueObservation/DatabaseCancellable.swift
+++ b/GRDB/ValueObservation/DatabaseCancellable.swift
@@ -1,0 +1,34 @@
+/// A protocol indicating that an activity or action supports cancellation.
+public protocol DatabaseCancellable {
+    /// Cancel the activity.
+    func cancel()
+}
+
+/// A type-erasing cancellable object that executes a provided closure
+/// when canceled.
+///
+/// An AnyDatabaseCancellable instance automatically calls cancel()
+///  when deinitialized.
+class AnyDatabaseCancellable: DatabaseCancellable {
+    private var _cancel: (() -> Void)?
+    
+    /// Initializes the cancellable object with the given cancel-time closure.
+    init(cancel: @escaping () -> Void) {
+        _cancel = cancel
+    }
+    
+    convenience init(_ cancellable: DatabaseCancellable) {
+        self.init(cancel: cancellable.cancel)
+    }
+
+    deinit {
+        _cancel?()
+    }
+    
+    func cancel() {
+        // Don't prevent multiple concurrent calls to _cancel, because it is
+        // pointless. But release memory!
+        _cancel?()
+        _cancel = nil
+    }
+}

--- a/GRDB/ValueObservation/ValueObservationScheduler.swift
+++ b/GRDB/ValueObservation/ValueObservationScheduler.swift
@@ -27,7 +27,7 @@ public class ValueObservationScheduler {
     ///         try Player.fetchAll(db)
     ///     }
     ///
-    ///     let observer = try observation.start(
+    ///     let cancellable = try observation.start(
     ///         in: dbQueue,
     ///         scheduler: .async(onQueue: .main),
     ///         onError: { error in ... },
@@ -47,7 +47,7 @@ public class ValueObservationScheduler {
     ///         try Player.fetchAll(db)
     ///     }
     ///
-    ///     let observer = try observation.start(
+    ///     let cancellable = try observation.start(
     ///         in: dbQueue,
     ///         scheduler: .immediate,
     ///         onError: { error in ... },

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -173,24 +173,3 @@ extension ValueObserver {
         }
     }
 }
-
-// TODO: remove when we have proper support for cancellation
-class ValueObserverToken<Reducer: _ValueReducer>: TransactionObserver {
-    // Useless junk
-    func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool { false }
-    func databaseDidChange(with event: DatabaseEvent) { }
-    func databaseDidCommit(_ db: Database) { }
-    func databaseDidRollback(_ db: Database) { }
-    
-    weak var writer: DatabaseWriter?
-    var observer: ValueObserver<Reducer>
-    
-    init(writer: DatabaseWriter, observer: ValueObserver<Reducer>) {
-        self.writer = writer
-        self.observer = observer
-    }
-    
-    deinit {
-        observer.cancel()
-    }
-}

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		562EA82D1F17B2AC00FA528C /* CompilationProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562EA8251F17B2AC00FA528C /* CompilationProtocolTests.swift */; };
 		562EA8321F17B9EB00FA528C /* CompilationSubClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562EA82E1F17B9EB00FA528C /* CompilationSubClassTests.swift */; };
 		562EA8361F17B9EB00FA528C /* CompilationSubClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562EA82E1F17B9EB00FA528C /* CompilationSubClassTests.swift */; };
+		563082EA2430B6CD00C14A05 /* DatabaseCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563082E82430B6CD00C14A05 /* DatabaseCancellable.swift */; };
+		563082EB2430B6CD00C14A05 /* DatabaseCancellable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563082E82430B6CD00C14A05 /* DatabaseCancellable.swift */; };
 		5636E9BE1D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
 		5636E9C11D22574100B9B05F /* FetchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5636E9BB1D22574100B9B05F /* FetchRequest.swift */; };
 		563A4B71242E7CE60075D8CF /* ValueObservationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 563A4B6F242E7CE50075D8CF /* ValueObservationScheduler.swift */; };
@@ -760,6 +762,7 @@
 		56300B671C53D25E005A543B /* QueryInterfaceExpressionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueryInterfaceExpressionsTests.swift; sourceTree = "<group>"; };
 		56300B6A1C53D3E8005A543B /* TableRecord+QueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "TableRecord+QueryInterfaceRequestTests.swift"; sourceTree = "<group>"; };
 		56300B841C54DC95005A543B /* Record+QueryInterfaceRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Record+QueryInterfaceRequestTests.swift"; sourceTree = "<group>"; };
+		563082E82430B6CD00C14A05 /* DatabaseCancellable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseCancellable.swift; sourceTree = "<group>"; };
 		563363A91C933FF8000BE133 /* MutablePersistableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordTests.swift; sourceTree = "<group>"; };
 		563363AA1C933FF8000BE133 /* PersistableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistableRecordTests.swift; sourceTree = "<group>"; };
 		563363BC1C93FD5E000BE133 /* DatabaseQueueConcurrencyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueConcurrencyTests.swift; sourceTree = "<group>"; };
@@ -1179,6 +1182,7 @@
 		5613ED5821A95E6100DC7A68 /* ValueObservation */ = {
 			isa = PBXGroup;
 			children = (
+				563082E82430B6CD00C14A05 /* DatabaseCancellable.swift */,
 				5613ED5921A95E6100DC7A68 /* ValueObservation.swift */,
 				563A4B6F242E7CE50075D8CF /* ValueObservationScheduler.swift */,
 				564CE43B21AA955B00652B19 /* ValueObserver.swift */,
@@ -2165,6 +2169,7 @@
 				566B91181FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				F3BA80181CFB2876003DC1BA /* SerializedDatabase.swift in Sources */,
 				5674A7051F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
+				563082EB2430B6CD00C14A05 /* DatabaseCancellable.swift in Sources */,
 				F3BA800D1CFB2871003DC1BA /* DatabasePool.swift in Sources */,
 				5656A87C2295BD56001FF3FF /* QueryInterfaceRequest+Association.swift in Sources */,
 				F3BA800B1CFB286D003DC1BA /* Database.swift in Sources */,
@@ -2500,6 +2505,7 @@
 				566B91151FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				F3BA80741CFB2E55003DC1BA /* SerializedDatabase.swift in Sources */,
 				5674A7041F307FCD0095F066 /* DatabaseValueConvertible+ReferenceConvertible.swift in Sources */,
+				563082EA2430B6CD00C14A05 /* DatabaseCancellable.swift in Sources */,
 				F3BA80691CFB2E55003DC1BA /* DatabasePool.swift in Sources */,
 				5656A87B2295BD56001FF3FF /* QueryInterfaceRequest+Association.swift in Sources */,
 				F3BA80671CFB2E55003DC1BA /* Database.swift in Sources */,


### PR DESCRIPTION
ValueObservation used to be stopped when the result of the `start` method would get deinitialized.

Now you can also call the `cancel()` method explicitly:

```swift
let cancellable = observation.start(...)
cancellable.cancel()
```
