### PR TITLE
Batch updates do not need any operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ Podfile.lock
 
 # SPM
 .build
+GRDB.xcworkspace/xcshareddata/swiftpm
 #Package.resolved
 Tests/SPM/Packages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#747](https://github.com/groue/GRDB.swift/pull/747): Rename GRDBCustomSQLite to GRDB
 - [#748](https://github.com/groue/GRDB.swift/pull/748): Rename QueryInterfaceRequest to Request
 - [#749](https://github.com/groue/GRDB.swift/pull/749): Drop submodules used by performance tests
+- [#750](https://github.com/groue/GRDB.swift/pull/750): Batch updates do not need any operator
 
 
 ## 4.12.1

--- a/GRDB/QueryInterface/Request/Request.swift
+++ b/GRDB/QueryInterface/Request/Request.swift
@@ -481,7 +481,7 @@ extension Request where T: MutablePersistableRecord {
     ///
     ///     try dbQueue.write { db in
     ///         // UPDATE player SET score = 0
-    ///         try Player.all().updateAll(db, [Column("score") <- 0])
+    ///         try Player.all().updateAll(db, [Column("score").set(to: 0)])
     ///     }
     ///
     /// - parameter db: A database connection.
@@ -515,7 +515,7 @@ extension Request where T: MutablePersistableRecord {
     ///
     ///     try dbQueue.write { db in
     ///         // UPDATE player SET score = 0
-    ///         try Player.all().updateAll(db, Column("score") <- 0)
+    ///         try Player.all().updateAll(db, Column("score").set(to: 0))
     ///     }
     ///
     /// - parameter db: A database connection.
@@ -622,22 +622,14 @@ extension Row {
 
 // MARK: - ColumnAssignment
 
-precedencegroup ColumnAssignment {
-    associativity: left
-    assignment: true
-    lowerThan: AssignmentPrecedence
-}
-
-infix operator <- : ColumnAssignment
-
 /// A ColumnAssignment can update rows in the database.
 ///
-/// You create an assignment from a column and an assignment operator, such as
-/// `<-` or `+=`:
+/// You create an assignment from a column and an assignment method or operator,
+/// such as `set(to:)` or `+=`:
 ///
 ///     try dbQueue.write { db in
 ///         // UPDATE player SET score = 0
-///         let assignment = Column("score") <- 0
+///         let assignment = Column("score").set(to: 0)
 ///         try Player.updateAll(db, assignment)
 ///     }
 public struct ColumnAssignment {
@@ -656,19 +648,21 @@ public struct ColumnAssignment {
     }
 }
 
-/// Creates an assignment to a value.
-///
-///     Column("valid") <- true
-///     Column("score") <- 0
-///     Column("score") <- nil
-///     Column("score") <- Column("score") + Column("bonus")
-///
-///     try dbQueue.write { db in
-///         // UPDATE player SET score = 0
-///         try Player.updateAll(db, Column("score") <- 0)
-///     }
-public func <- (column: ColumnExpression, value: SQLExpressible?) -> ColumnAssignment {
-    ColumnAssignment(column: column, value: value)
+extension ColumnExpression {
+    /// Creates an assignment to a value.
+    ///
+    ///     Column("valid").set(to: true)
+    ///     Column("score").set(to: 0)
+    ///     Column("score").set(to: nil)
+    ///     Column("score").set(to: Column("score") + Column("bonus"))
+    ///
+    ///     try dbQueue.write { db in
+    ///         // UPDATE player SET score = 0
+    ///         try Player.updateAll(db, Column("score").set(to: 0))
+    ///     }
+    public func set(to value: SQLExpressible?) -> ColumnAssignment {
+        ColumnAssignment(column: self, value: value)
+    }
 }
 
 /// Creates an assignment that adds a value
@@ -681,7 +675,7 @@ public func <- (column: ColumnExpression, value: SQLExpressible?) -> ColumnAssig
 ///         try Player.updateAll(db, Column("score") += 1)
 ///     }
 public func += (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column <- column + value
+    column.set(to: column + value)
 }
 
 /// Creates an assignment that subtracts a value
@@ -694,7 +688,7 @@ public func += (column: ColumnExpression, value: SQLExpressible) -> ColumnAssign
 ///         try Player.updateAll(db, Column("score") -= 1)
 ///     }
 public func -= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column <- column - value
+    column.set(to: column - value)
 }
 
 /// Creates an assignment that multiplies by a value
@@ -707,7 +701,7 @@ public func -= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssign
 ///         try Player.updateAll(db, Column("score") *= 2)
 ///     }
 public func *= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column <- column * value
+    column.set(to: column * value)
 }
 
 /// Creates an assignment that divides by a value
@@ -720,5 +714,5 @@ public func *= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssign
 ///         try Player.updateAll(db, Column("score") /= 2)
 ///     }
 public func /= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column <- column / value
+    column.set(to: column / value)
 }

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -526,7 +526,7 @@ extension MutablePersistableRecord {
     ///
     ///     try dbQueue.write { db in
     ///         // UPDATE player SET score = 0
-    ///         try Player.updateAll(db, [Column("score") <- 0])
+    ///         try Player.updateAll(db, [Column("score").set(to: 0)])
     ///     }
     ///
     /// - parameter db: A database connection.
@@ -551,7 +551,7 @@ extension MutablePersistableRecord {
     ///
     ///     try dbQueue.write { db in
     ///         // UPDATE player SET score = 0
-    ///         try Player.updateAll(db, Column("score") <- 0)
+    ///         try Player.updateAll(db, Column("score").set(to: 0))
     ///     }
     ///
     /// - parameter db: A database connection.

--- a/README.md
+++ b/README.md
@@ -4687,29 +4687,32 @@ Player.deleteOne(db, key: ["email": "arthur@example.com"])
 
 ## Update Requests
 
-**Requests can batch update records**. The `updateAll()` method accepts *column assignments* defined with the `<-` operator:
+**Requests can batch update records**. The `updateAll()` method accepts *column assignments* defined with the `set(to:)` method:
 
 ```swift
 // UPDATE player SET score = 0, isHealthy = 1, bonus = NULL
-try Player.updateAll(db, scoreColumn <- 0, isHealthyColumn <- true, bonus <- nil)
+try Player.updateAll(db, 
+    scoreColumn.set(to: 0), 
+    isHealthyColumn.set(to: true), 
+    bonus.set(to: nil))
 
 // UPDATE player SET score = 0 WHERE team = 'red'
 try Player
     .filter(teamColumn == "red")
-    .updateAll(db, scoreColumn <- 0)
+    .updateAll(db, scoreColumn.set(to: 0))
 
 // UPDATE player SET top = 1 ORDER BY score DESC LIMIT 10
 try Player
     .order(scoreColumn.desc)
     .limit(10)
-    .updateAll(db, topColumn <- true)
+    .updateAll(db, topColumn.set(to: true))
 ```
 
 Column assignments accept any expression:
 
 ```swift
 // UPDATE player SET score = score + (bonus * 2)
-try Player.updateAll(db, scoreColumn <- scoreColumn + bonusColumn * 2)
+try Player.updateAll(db, scoreColumn.set(to: scoreColumn + bonusColumn * 2))
 ```
 
 As a convenience, you can also use the `+=`, `-=`, `*=`, or `/=` operators:

--- a/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
@@ -31,7 +31,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     func testRequestUpdateAll() throws {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
-            let assignment = Columns.score <- 0
+            let assignment = Columns.score.set(to: 0)
             
             try Player.updateAll(db, assignment)
             XCTAssertEqual(self.lastSQLQuery, """
@@ -106,7 +106,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Columns.score <- nil)
+            try Player.updateAll(db, Columns.score.set(to: nil))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = NULL
                 """)
@@ -117,7 +117,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Columns.score <- Columns.score * (Columns.bonus + 1))
+            try Player.updateAll(db, Columns.score.set(to: Columns.score * (Columns.bonus + 1)))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" * ("bonus" + 1)
                 """)
@@ -232,22 +232,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Columns.score <- 0, Columns.bonus <- 1)
+            try Player.updateAll(db, Columns.score.set(to: 0), Columns.bonus.set(to: 1))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
             
-            try Player.updateAll(db, [Columns.score <- 0, Columns.bonus <- 1])
+            try Player.updateAll(db, [Columns.score.set(to: 0), Columns.bonus.set(to: 1)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
             
-            try Player.all().updateAll(db, Columns.score <- 0, Columns.bonus <- 1)
+            try Player.all().updateAll(db, Columns.score.set(to: 0), Columns.bonus.set(to: 1))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
             
-            try Player.all().updateAll(db, [Columns.score <- 0, Columns.bonus <- 1])
+            try Player.all().updateAll(db, [Columns.score.set(to: 0), Columns.bonus.set(to: 1)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
@@ -312,22 +312,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try AbortPlayer.updateAll(db, Column("score") <- 0)
+            try AbortPlayer.updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try AbortPlayer.updateAll(db, [Column("score") <- 0])
+            try AbortPlayer.updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try AbortPlayer.all().updateAll(db, Column("score") <- 0)
+            try AbortPlayer.all().updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try AbortPlayer.all().updateAll(db, [Column("score") <- 0])
+            try AbortPlayer.all().updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
@@ -343,22 +343,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try IgnorePlayer.updateAll(db, Column("score") <- 0)
+            try IgnorePlayer.updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try IgnorePlayer.updateAll(db, [Column("score") <- 0])
+            try IgnorePlayer.updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try IgnorePlayer.all().updateAll(db, Column("score") <- 0)
+            try IgnorePlayer.all().updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try IgnorePlayer.all().updateAll(db, [Column("score") <- 0])
+            try IgnorePlayer.all().updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
@@ -369,27 +369,27 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Column("score") <- 0)
+            try Player.updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try Player.updateAll(db, onConflict: .ignore, Column("score") <- 0)
+            try Player.updateAll(db, onConflict: .ignore, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try Player.updateAll(db, onConflict: .ignore, [Column("score") <- 0])
+            try Player.updateAll(db, onConflict: .ignore, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try Player.all().updateAll(db, onConflict: .ignore, Column("score") <- 0)
+            try Player.all().updateAll(db, onConflict: .ignore, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try Player.all().updateAll(db, onConflict: .ignore, [Column("score") <- 0])
+            try Player.all().updateAll(db, onConflict: .ignore, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
@@ -420,7 +420,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             }
             
             do {
-                try Player.including(required: Player.team).updateAll(db, Column("score") <- 0)
+                try Player.including(required: Player.team).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "player"."rowid" \
@@ -430,7 +430,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             }
             do {
                 let alias = TableAlias(name: "p")
-                try Player.aliased(alias).including(required: Player.team).updateAll(db, Column("score") <- 0)
+                try Player.aliased(alias).including(required: Player.team).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "p"."rowid" \
@@ -439,7 +439,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Team.having(Team.players.isEmpty).updateAll(db, Column("active") <- false)
+                try Team.having(Team.players.isEmpty).updateAll(db, Column("active").set(to: false))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "team" SET "active" = 0 WHERE rowid IN (\
                     SELECT "team"."rowid" \
@@ -450,7 +450,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Team.including(all: Team.players).updateAll(db, Column("active") <- false)
+                try Team.including(all: Team.players).updateAll(db, Column("active").set(to: false))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "team" SET "active" = 0
                     """)
@@ -477,7 +477,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                 t.primaryKey(["countryCode", "citizenId"])
             }
             do {
-                try Player.all().groupByPrimaryKey().updateAll(db, Column("score") <- 0)
+                try Player.all().groupByPrimaryKey().updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "rowid" \
@@ -486,7 +486,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Player.all().group(Column.rowID).updateAll(db, Column("score") <- 0)
+                try Player.all().group(Column.rowID).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "rowid" \
@@ -495,7 +495,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Passport.all().groupByPrimaryKey().updateAll(db, Column("active") <- true)
+                try Passport.all().groupByPrimaryKey().updateAll(db, Column("active").set(to: true))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "passport" SET "active" = 1 WHERE rowid IN (\
                     SELECT "rowid" \
@@ -504,7 +504,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Passport.all().group(Column.rowID).updateAll(db, Column("active") <- true)
+                try Passport.all().group(Column.rowID).updateAll(db, Column("active").set(to: true))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "passport" SET "active" = 1 WHERE rowid IN (\
                     SELECT "rowid" \

--- a/Tests/Performance/GRDBPerformance/InsertNamedValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertNamedValuesTests.swift
@@ -4,15 +4,6 @@ import GRDB
 import SQLite
 #endif
 
-// Avoid "Ambiguous operator declarations found for operator" error:
-// Redeclare operator in client module.
-precedencegroup ColumnAssignment {
-    associativity: left
-    assignment: true
-    lowerThan: AssignmentPrecedence
-}
-infix operator <- : ColumnAssignment
-
 private let insertedRowCount = 20_000
 
 // Here we insert rows, referencing statement arguments by name.


### PR DESCRIPTION
It was ill-advised to define an `<-` operator for batch updates, a feature that is only known and used by a few users.

Lesson learned: Swift operators must be *obvious* and *undisputed*, or they just become a nuisance which conflict with other librairies.

Batch updates are now based on the `set(to:)` method:

```swift
// UPDATE player SET score = 0
try Player.updateAll(db, Column("score").set(to: 0))
```
