### PR TITLE
Match DatabaseError on ResultCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [#749](https://github.com/groue/GRDB.swift/pull/749): Drop submodules used by performance tests
 - [#750](https://github.com/groue/GRDB.swift/pull/750): Batch updates do not need any operator
 - [#752](https://github.com/groue/GRDB.swift/pull/752): Remove ValueObservation.combine
+- [#754](https://github.com/groue/GRDB.swift/pull/754): Match DatabaseError on ResultCode
 
 
 ## 4.12.1

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -154,6 +154,27 @@ public struct ResultCode: RawRepresentable, Equatable, CustomStringConvertible {
     // swiftlint:enable operator_usage_whitespace line_length
 }
 
+extension ResultCode {
+    /// Returns true if the code on the left matches the error on the right.
+    ///
+    /// Primary result codes match themselves and their extended result codes,
+    /// while extended result codes match only themselves.
+    ///
+    ///     do {
+    ///         try ...
+    ///     } catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+    ///         // foreign key constraint error
+    ///     } catch ResultCode.SQLITE_CONSTRAINT {
+    ///         // any other constraint error
+    ///     } catch {
+    ///         // any other database error
+    ///     }
+    public static func ~= (lhs: Self, rhs: Error) -> Bool {
+        guard let error = rhs as? DatabaseError else { return false }
+        return lhs ~= error.extendedResultCode
+    }
+}
+
 // CustomStringConvertible
 extension ResultCode {
     var errorString: String? {

--- a/README.md
+++ b/README.md
@@ -6654,29 +6654,15 @@ do {
 }
 ```
 
-**SQLite uses codes to distinguish between various errors:**
+**SQLite uses [results codes](https://www.sqlite.org/rescode.html) to distinguish between various errors**.
 
-```swift
-do {
-    try ...
-} catch let error as DatabaseError where error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY {
-    // foreign key constraint error
-} catch let error as DatabaseError where error.resultCode == .SQLITE_CONSTRAINT {
-    // any other constraint error
-} catch let error as DatabaseError {
-    // any other database error
-}
-```
-
-In the example above, `error.extendedResultCode` is a precise [extended result code](https://www.sqlite.org/rescode.html#extended_result_code_list), and `error.resultCode` is a less precise [primary result code](https://www.sqlite.org/rescode.html#primary_result_code_list). Extended result codes are refinements of primary result codes, as `SQLITE_CONSTRAINT_FOREIGNKEY` is to `SQLITE_CONSTRAINT`, for example. See [SQLite result codes](https://www.sqlite.org/rescode.html) for more information.
-
-As a convenience, extended result codes match their primary result code in a switch statement:
+You can catch a DatabaseError and match on result codes:
 
 ```swift
 do {
     try ...
 } catch let error as DatabaseError {
-    switch error.extendedResultCode {
+    switch error {
     case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY:
         // foreign key constraint error
     case ResultCode.SQLITE_CONSTRAINT:
@@ -6686,6 +6672,22 @@ do {
     }
 }
 ```
+
+You can also directly match errors on result codes:
+
+```swift
+do {
+    try ...
+} catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+    // foreign key constraint error
+} catch ResultCode.SQLITE_CONSTRAINT {
+    // any other constraint error
+} catch {
+    // any other database error
+}
+```
+
+Each DatabaseError has two codes: an `extendedResultCode` (see [extended result code](https://www.sqlite.org/rescode.html#extended_result_code_list)), and a less precise `resultCode` (see [primary result code](https://www.sqlite.org/rescode.html#primary_result_code_list)). Extended result codes are refinements of primary result codes, as `SQLITE_CONSTRAINT_FOREIGNKEY` is to `SQLITE_CONSTRAINT`, for example.
 
 > :warning: **Warning**: SQLite has progressively introduced extended result codes across its versions. The [SQLite release notes](http://www.sqlite.org/changes.html) are unfortunately not quite clear about that: write your handling of extended result codes with care.
 

--- a/Tests/GRDBTests/ResultCodeTests.swift
+++ b/Tests/GRDBTests/ResultCodeTests.swift
@@ -44,4 +44,118 @@ class ResultCodeTests: GRDBTestCase {
         default: break
         }
     }
+    
+    func testCatchResultCode() throws {
+        do {
+            do {
+                throw DatabaseError(resultCode: .SQLITE_ERROR)
+            } catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+                XCTFail()
+            } catch ResultCode.SQLITE_CONSTRAINT {
+                XCTFail()
+            } catch ResultCode.SQLITE_OK {
+                XCTFail()
+            } catch {
+                // Success
+            }
+            
+            do {
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT)
+            } catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+                XCTFail()
+            } catch ResultCode.SQLITE_CONSTRAINT {
+                // Success
+            } catch ResultCode.SQLITE_OK {
+                XCTFail()
+            } catch {
+                XCTFail()
+            }
+            
+            do {
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT_FOREIGNKEY)
+            } catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+                // Success
+            } catch ResultCode.SQLITE_CONSTRAINT {
+                XCTFail()
+            } catch ResultCode.SQLITE_OK {
+                XCTFail()
+            } catch {
+                XCTFail()
+            }
+            
+            do {
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT_CHECK)
+            } catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
+                XCTFail()
+            } catch ResultCode.SQLITE_CONSTRAINT {
+                // Success
+            } catch ResultCode.SQLITE_OK {
+                XCTFail()
+            } catch {
+                XCTFail()
+            }
+        }
+        
+        do {
+            do {
+                throw DatabaseError(resultCode: .SQLITE_ERROR)
+            } catch let error as DatabaseError {
+                switch error {
+                case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY:
+                    XCTFail()
+                case ResultCode.SQLITE_CONSTRAINT:
+                    XCTFail()
+                case ResultCode.SQLITE_OK:
+                    XCTFail()
+                default:
+                    break // Success
+                }
+            }
+            
+            do {
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT)
+            } catch let error as DatabaseError {
+                switch error {
+                case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY:
+                    XCTFail()
+                case ResultCode.SQLITE_CONSTRAINT:
+                break // Success
+                case ResultCode.SQLITE_OK:
+                    XCTFail()
+                default:
+                    XCTFail()
+                }
+            }
+            
+            do {
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT_FOREIGNKEY)
+            } catch let error as DatabaseError {
+                switch error {
+                case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY:
+                break // Success
+                case ResultCode.SQLITE_CONSTRAINT:
+                    XCTFail()
+                case ResultCode.SQLITE_OK:
+                    XCTFail()
+                default:
+                    XCTFail()
+                }
+            }
+            
+            do {
+                throw DatabaseError(resultCode: .SQLITE_CONSTRAINT_CHECK)
+            } catch let error as DatabaseError {
+                switch error {
+                case ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY:
+                    XCTFail()
+                case ResultCode.SQLITE_CONSTRAINT:
+                break // Success
+                case ResultCode.SQLITE_OK:
+                    XCTFail()
+                default:
+                    XCTFail()
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pull request makes it possible to match database errors on their result code:

```swift
do {
    try Player(...).insert(db)
} catch ResultCode.SQLITE_CONSTRAINT_FOREIGNKEY {
    // foreign key constraint error
} catch ResultCode.SQLITE_CONSTRAINT {
    // any other constraint error
} catch {
    // any other database error
}
```
