### PR TITLE
Export the underlying SQLite library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - [#749](https://github.com/groue/GRDB.swift/pull/749): Drop submodules used by performance tests
 - [#754](https://github.com/groue/GRDB.swift/pull/754): Match DatabaseError on ResultCode
+- [#756](https://github.com/groue/GRDB.swift/pull/756): Export the underlying SQLite library
 
 ### Breaking Changes
 

--- a/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoWatchOS Extension/InterfaceController.swift
+++ b/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoWatchOS Extension/InterfaceController.swift
@@ -1,7 +1,6 @@
 import WatchKit
 import Foundation
 import GRDB
-import SQLite3
 
 class InterfaceController: WKInterfaceController {
     

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -579,6 +579,10 @@
 		56A238A41B9C753B0082EB20 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A238A11B9C753B0082EB20 /* Record.swift */; };
 		56A238A51B9C753B0082EB20 /* Record.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A238A11B9C753B0082EB20 /* Record.swift */; };
 		56A238B71B9CA2590082EB20 /* DatabaseTimestampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A238B51B9CA2590082EB20 /* DatabaseTimestampTests.swift */; };
+		56A2FA3624424D2A00E97D23 /* Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2FA3524424D2A00E97D23 /* Export.swift */; };
+		56A2FA3B24424F4700E97D23 /* Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2FA3524424D2A00E97D23 /* Export.swift */; };
+		56A2FA3C24424F4800E97D23 /* Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2FA3524424D2A00E97D23 /* Export.swift */; };
+		56A2FA3D24424F4800E97D23 /* Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2FA3524424D2A00E97D23 /* Export.swift */; };
 		56A4CDB41D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */; };
 		56A5E40A1BA2BCF900707640 /* RecordWithColumnNameManglingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A5E4081BA2BCF900707640 /* RecordWithColumnNameManglingTests.swift */; };
 		56A5EF0F1EF7F20B00F03071 /* ForeignKeyInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A5EF0E1EF7F20B00F03071 /* ForeignKeyInfoTests.swift */; };
@@ -1421,6 +1425,7 @@
 		56A238921B9C750B0082EB20 /* DatabaseMigrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseMigrator.swift; sourceTree = "<group>"; };
 		56A238A11B9C753B0082EB20 /* Record.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		56A238B51B9CA2590082EB20 /* DatabaseTimestampTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseTimestampTests.swift; sourceTree = "<group>"; };
+		56A2FA3524424D2A00E97D23 /* Export.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Export.swift; sourceTree = "<group>"; };
 		56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLExpressionLiteralTests.swift; sourceTree = "<group>"; };
 		56A5E4081BA2BCF900707640 /* RecordWithColumnNameManglingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordWithColumnNameManglingTests.swift; sourceTree = "<group>"; };
 		56A5EF0E1EF7F20B00F03071 /* ForeignKeyInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForeignKeyInfoTests.swift; sourceTree = "<group>"; };
@@ -2291,6 +2296,7 @@
 			isa = PBXGroup;
 			children = (
 				56A2386F1B9C75030082EB20 /* Core */,
+				56A2FA3524424D2A00E97D23 /* Export.swift */,
 				56D7E449221595FE0052464B /* Fixit */,
 				5698AC291D9E5A480056AF8C /* FTS */,
 				56A238911B9C750B0082EB20 /* Migration */,
@@ -2820,6 +2826,7 @@
 				56DAA2E11DE9C827006E10C8 /* Cursor.swift in Sources */,
 				5653EB0520944C7C00F46237 /* BelongsToAssociation.swift in Sources */,
 				5644DE6F20F8C32E001FFDDE /* DatabaseValueConversion.swift in Sources */,
+				56A2FA3C24424F4800E97D23 /* Export.swift in Sources */,
 				565490BC1D5AE236005622CB /* DatabaseSchemaCache.swift in Sources */,
 				563EF42F2161180D007DAACD /* AssociationAggregate.swift in Sources */,
 				565490BA1D5AE236005622CB /* DatabaseQueue.swift in Sources */,
@@ -2901,6 +2908,7 @@
 				56D51D031EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */,
 				56DDDDF5242F87C60025E381 /* ValueObservationScheduler.swift in Sources */,
 				560D924C1C672C4B00F4F92B /* TableRecord.swift in Sources */,
+				56A2FA3B24424F4700E97D23 /* Export.swift in Sources */,
 				569BBA4F229170F900478429 /* Inflections+English.swift in Sources */,
 				5656A81F2295B12F001FF3FF /* SQLAssociation.swift in Sources */,
 				5617294F223533F40006E219 /* EncodableRecord.swift in Sources */,
@@ -3441,6 +3449,7 @@
 				AAA4DCA6230F1E0600C74B15 /* FetchableRecord+TableRecord.swift in Sources */,
 				56DDDDF7242F87C70025E381 /* ValueObservationScheduler.swift in Sources */,
 				AAA4DCA7230F1E0600C74B15 /* TableRecord.swift in Sources */,
+				56A2FA3D24424F4800E97D23 /* Export.swift in Sources */,
 				AAA4DCA8230F1E0600C74B15 /* Inflections+English.swift in Sources */,
 				AAA4DCA9230F1E0600C74B15 /* SQLAssociation.swift in Sources */,
 				AAA4DCAA230F1E0600C74B15 /* EncodableRecord.swift in Sources */,
@@ -3775,6 +3784,7 @@
 				5656A81E2295B12F001FF3FF /* SQLAssociation.swift in Sources */,
 				5617294E223533F40006E219 /* EncodableRecord.swift in Sources */,
 				5698AD181DAAD17A0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				56A2FA3624424D2A00E97D23 /* Export.swift in Sources */,
 				56B964B11DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				560A37A71C8FF6E500949E71 /* SerializedDatabase.swift in Sources */,
 				5653EB252094A14400F46237 /* QueryInterfaceRequest+Association.swift in Sources */,

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -1,12 +1,5 @@
 import Foundation
 import Dispatch
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// Configuration for a DatabaseQueue or DatabasePool.
 public struct Configuration {

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -1,4 +1,3 @@
-
 extension Database {
     
     // MARK: - Database Schema

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 extension Database {
     

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 extension Database {
     

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// A raw SQLite connection, suitable for the SQLite C API.
 public typealias SQLiteConnection = OpaquePointer

--- a/GRDB/Core/DatabaseCollation.swift
+++ b/GRDB/Core/DatabaseCollation.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// A Collation is a string comparison function used by SQLite.
 public final class DatabaseCollation {

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 public struct ResultCode: RawRepresentable, Equatable, CustomStringConvertible {
     public let rawValue: Int32

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// An SQL function or aggregate.
 public final class DatabaseFunction: Hashable {

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -1,4 +1,3 @@
-
 /// An SQL function or aggregate.
 public final class DatabaseFunction: Hashable {
     // SQLite identifies functions by (name + argument count)

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -1,12 +1,5 @@
 import Foundation
 import Dispatch
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 #if os(iOS)
 import UIKit
 #endif

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -1,11 +1,4 @@
 import Dispatch
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// The protocol for all types that can fetch values from a database.
 ///

--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 // MARK: - DatabaseValue
 

--- a/GRDB/Core/DatabaseValueConversion.swift
+++ b/GRDB/Core/DatabaseValueConversion.swift
@@ -1,4 +1,3 @@
-
 // MARK: - Conversion Context and Errors
 
 /// A type that helps the user understanding value conversion errors

--- a/GRDB/Core/DatabaseValueConversion.swift
+++ b/GRDB/Core/DatabaseValueConversion.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 // MARK: - Conversion Context and Errors
 

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 // MARK: - DatabaseValueConvertible
 

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -1,6 +1,3 @@
-
-// MARK: - DatabaseValueConvertible
-
 /// Types that adopt DatabaseValueConvertible can be initialized from
 /// database values.
 ///

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// A database row.
 public final class Row: Equatable, Hashable, RandomAccessCollection,

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// A raw SQLite statement, suitable for the SQLite C API.
 public typealias SQLiteStatement = OpaquePointer

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -1,13 +1,6 @@
 #if os(Linux)
 import Glibc
 #endif
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// A protocol around sqlite3_set_authorizer
 protocol StatementAuthorizer: AnyObject {

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// The StatementColumnConvertible protocol grants access to the low-level C
 /// interface that extracts values from query results:

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -1,4 +1,3 @@
-
 /// The StatementColumnConvertible protocol grants access to the low-level C
 /// interface that extracts values from query results:
 /// https://www.sqlite.org/c3ref/column_blob.html. It can bring performance

--- a/GRDB/Core/Support/Foundation/Data.swift
+++ b/GRDB/Core/Support/Foundation/Data.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// Data is convertible to and from DatabaseValue.
 extension Data: DatabaseValueConvertible, StatementColumnConvertible {

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// DatabaseDateComponents reads and stores DateComponents in the database.
 public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnConvertible {

--- a/GRDB/Core/Support/Foundation/Date.swift
+++ b/GRDB/Core/Support/Foundation/Date.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 #if !os(Linux)
 /// NSDate is stored in the database using the format

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 #if !os(Linux)
 /// NSUUID adopts DatabaseValueConvertible

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 // MARK: - Value Types
 

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -1,4 +1,3 @@
-
 // MARK: - Value Types
 
 /// Bool adopts DatabaseValueConvertible and StatementColumnConvertible.

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 extension Database {
     

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -1,4 +1,3 @@
-
 extension Database {
     
     // MARK: - Database Observation

--- a/GRDB/Export.swift
+++ b/GRDB/Export.swift
@@ -1,0 +1,8 @@
+// Export the underlying SQLite library
+#if SWIFT_PACKAGE
+@_exported import CSQLite
+#elseif GRDBCIPHER
+@_exported import SQLCipher
+#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
+@_exported import SQLite3
+#endif

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -1,12 +1,5 @@
 #if SQLITE_ENABLE_FTS5
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// FTS5 lets you define "fts5" virtual tables.
 ///

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -1,11 +1,4 @@
 #if SQLITE_ENABLE_FTS5
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// The protocol for custom FTS5 tokenizers.
 public protocol FTS5CustomTokenizer: FTS5Tokenizer {

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -1,12 +1,5 @@
 #if SQLITE_ENABLE_FTS5
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// A low-level SQLite function that lets FTS5Tokenizer notify tokens.
 ///

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -1,12 +1,5 @@
 #if SQLITE_ENABLE_FTS5
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// Flags that tell SQLite how to register a token.
 ///

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -1,10 +1,3 @@
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// An internal struct that defines a migration.
 struct Migration {

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -1,4 +1,3 @@
-
 /// An internal struct that defines a migration.
 struct Migration {
     let identifier: String

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 extension FetchableRecord where Self: Decodable {
     public init(row: Row) {

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -1,11 +1,4 @@
 import Foundation
-#if SWIFT_PACKAGE
-import CSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
 
 /// Types that adopt FetchableRecord can be initialized from a database Row.
 ///

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -375,6 +375,8 @@
 		569BBA4D229170B300478429 /* Inflections+English.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569BBA4B229170B300478429 /* Inflections+English.swift */; };
 		569EF0E6200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */; };
 		569EF0E7200D37FD00A9FA45 /* DatabaseRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569EF0E5200D37FC00A9FA45 /* DatabaseRegion.swift */; };
+		56A2FA3924424F4200E97D23 /* Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2FA3724424F4200E97D23 /* Export.swift */; };
+		56A2FA3A24424F4200E97D23 /* Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A2FA3724424F4200E97D23 /* Export.swift */; };
 		56A4CDB31D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */; };
 		56A4CDB71D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */; };
 		56A5EF121EF7F20B00F03071 /* ForeignKeyInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A5EF0E1EF7F20B00F03071 /* ForeignKeyInfoTests.swift */; };
@@ -969,6 +971,7 @@
 		56A238921B9C750B0082EB20 /* DatabaseMigrator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseMigrator.swift; sourceTree = "<group>"; };
 		56A238A11B9C753B0082EB20 /* Record.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Record.swift; sourceTree = "<group>"; };
 		56A238B51B9CA2590082EB20 /* DatabaseTimestampTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseTimestampTests.swift; sourceTree = "<group>"; };
+		56A2FA3724424F4200E97D23 /* Export.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Export.swift; sourceTree = "<group>"; };
 		56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLExpressionLiteralTests.swift; sourceTree = "<group>"; };
 		56A5E4081BA2BCF900707640 /* RecordWithColumnNameManglingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordWithColumnNameManglingTests.swift; sourceTree = "<group>"; };
 		56A5EF0E1EF7F20B00F03071 /* ForeignKeyInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForeignKeyInfoTests.swift; sourceTree = "<group>"; };
@@ -1790,6 +1793,7 @@
 			isa = PBXGroup;
 			children = (
 				56A2386F1B9C75030082EB20 /* Core */,
+				56A2FA3724424F4200E97D23 /* Export.swift */,
 				5614089D221596A100DAD589 /* Fixit */,
 				5698AC291D9E5A480056AF8C /* FTS */,
 				56A238911B9C750B0082EB20 /* Migration */,
@@ -2186,6 +2190,7 @@
 				5656A87E2295BD56001FF3FF /* SQLAssociation.swift in Sources */,
 				F3BA80131CFB2876003DC1BA /* DatabaseValue.swift in Sources */,
 				56C0539822ACEECD0029D27D /* ValueReducer.swift in Sources */,
+				56A2FA3A24424F4200E97D23 /* Export.swift in Sources */,
 				56B964B61DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				F3BA80171CFB2876003DC1BA /* RowAdapter.swift in Sources */,
 				56CEB5061EAA2F4D00BFAF62 /* FTS4.swift in Sources */,
@@ -2520,6 +2525,7 @@
 				5656A87D2295BD56001FF3FF /* SQLAssociation.swift in Sources */,
 				F3BA806F1CFB2E55003DC1BA /* DatabaseValue.swift in Sources */,
 				56C0539722ACEECD0029D27D /* ValueReducer.swift in Sources */,
+				56A2FA3924424F4200E97D23 /* Export.swift in Sources */,
 				56B964B31DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
 				F3BA80731CFB2E55003DC1BA /* RowAdapter.swift in Sources */,
 				56CEB5031EAA2F4D00BFAF62 /* FTS4.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -2069,17 +2069,10 @@ row.scopes["remainder"] // [c:2 d:3]
 
 **If not all SQLite APIs are exposed in GRDB, you can still use the [SQLite C Interface](https://www.sqlite.org/c3ref/intro.html) and call [SQLite C functions](https://www.sqlite.org/c3ref/funclist.html).**
 
-Those functions are embedded right into the [GRDBCustom](Documentation/CustomSQLiteBuilds.md) module. Otherwise, you'll need to import `SQLite3`, `SQLCipher`, or `CSQLite`, depending on the GRDB flavor you are using:
+Those functions are embedded right into the GRDB module, regardless of the underlying SQLite implementation (system SQLite, [SQLCipher](#encryption), or [custom SQLite build]):
 
 ```swift
-// Swift Package Manager
-import CSQLite
-
-// SQLCipher
-import SQLCipher
-
-// System SQLite
-import SQLite3
+import GRDB
 
 let sqliteVersion = String(cString: sqlite3_libversion())
 ```
@@ -6451,9 +6444,6 @@ When you want to precisely manage the passphrase bytes, talk directly to SQLCiph
 For example:
 
 ```swift
-import GRDB
-import SQLCipher
-
 var config = Configuration()
 config.prepareDatabase = { db in
     ... // Carefully load passphrase bytes

--- a/Tests/GRDBTests/ColumnInfoTests.swift
+++ b/Tests/GRDBTests/ColumnInfoTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 class ColumnInfoTests: GRDBTestCase {

--- a/Tests/GRDBTests/DataMemoryTests.swift
+++ b/Tests/GRDBTests/DataMemoryTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 class DataMemoryTests: GRDBTestCase {

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class DatabaseConfigurationTests: GRDBTestCase {

--- a/Tests/GRDBTests/DatabaseRegionObservationTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionObservationTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class DatabaseRegionObservationTests: GRDBTestCase {

--- a/Tests/GRDBTests/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 class DatabaseRegionTests : GRDBTestCase {

--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 class DatabaseTests : GRDBTestCase {

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 // Support for Database.logError

--- a/Tests/GRDBTests/RowFetchTests.swift
+++ b/Tests/GRDBTests/RowFetchTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class RowFetchTests: GRDBTestCase {

--- a/Tests/GRDBTests/SelectStatementTests.swift
+++ b/Tests/GRDBTests/SelectStatementTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 class SelectStatementTests : GRDBTestCase {

--- a/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 // A type that adopts DatabaseValueConvertible and StatementColumnConvertible

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class TableDefinitionTests: GRDBTestCase {

--- a/Tests/GRDBTests/ValueObservationCountTests.swift
+++ b/Tests/GRDBTests/ValueObservationCountTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class ValueObservationCountTests: GRDBTestCase {

--- a/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
+++ b/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 private struct Name: DatabaseValueConvertible, Equatable, CustomDebugStringConvertible {

--- a/Tests/GRDBTests/ValueObservationFetchTests.swift
+++ b/Tests/GRDBTests/ValueObservationFetchTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class ValueObservationFetchTests: GRDBTestCase {

--- a/Tests/GRDBTests/ValueObservationMapTests.swift
+++ b/Tests/GRDBTests/ValueObservationMapTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class ValueObservationMapTests: GRDBTestCase {

--- a/Tests/GRDBTests/ValueObservationQueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/ValueObservationQueryInterfaceRequestTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 private struct Parent: TableRecord, FetchableRecord, Decodable, Equatable {

--- a/Tests/GRDBTests/ValueObservationReadonlyTests.swift
+++ b/Tests/GRDBTests/ValueObservationReadonlyTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class ValueObservationReadonlyTests: GRDBTestCase {

--- a/Tests/GRDBTests/ValueObservationRecordTests.swift
+++ b/Tests/GRDBTests/ValueObservationRecordTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 private struct Player: Equatable {

--- a/Tests/GRDBTests/ValueObservationRowTests.swift
+++ b/Tests/GRDBTests/ValueObservationRowTests.swift
@@ -1,11 +1,4 @@
 import XCTest
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 import GRDB
 
 class ValueObservationRowTests: GRDBTestCase {

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -1,12 +1,5 @@
 import XCTest
 import Dispatch
-#if GRDBCIPHER
-import SQLCipher
-#elseif SWIFT_PACKAGE
-import CSQLite
-#elseif !GRDBCUSTOMSQLITE
-import SQLite3
-#endif
 @testable import GRDB
 
 class ValueObservationTests: GRDBTestCase {

--- a/Tests/Performance/GRDBPerformance/FetchPositionalValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/FetchPositionalValuesTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SQLite3
 import GRDB
 #if GRDB_COMPARE
 import SQLite

--- a/Tests/Performance/GRDBPerformance/FetchRecordClassTests.swift
+++ b/Tests/Performance/GRDBPerformance/FetchRecordClassTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SQLite3
 import GRDB
 #if GRDB_COMPARE
 import CoreData

--- a/Tests/Performance/GRDBPerformance/FetchRecordCodableTests.swift
+++ b/Tests/Performance/GRDBPerformance/FetchRecordCodableTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SQLite3
 import GRDB
 #if GRDB_COMPARE
 import SQLite

--- a/Tests/Performance/GRDBPerformance/FetchRecordStructTests.swift
+++ b/Tests/Performance/GRDBPerformance/FetchRecordStructTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SQLite3
 import GRDB
 #if GRDB_COMPARE
 import SQLite

--- a/Tests/Performance/GRDBPerformance/InsertPositionalValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertPositionalValuesTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import SQLite3
 import GRDB
 #if GRDB_COMPARE
 import SQLite

--- a/Tests/SPM/PlainPackage/Sources/SPM/main.swift
+++ b/Tests/SPM/PlainPackage/Sources/SPM/main.swift
@@ -1,5 +1,4 @@
 import GRDB
-import CSQLite
 
 let cVersion = String(cString: sqlite3_libversion())
 print("SQLite version from C API: \(cVersion)")


### PR DESCRIPTION
This pull request exports the underlying SQLite library with GRDB.

This means that importing `GRDB` grants access to the [SQLite C interface](https://www.sqlite.org/c3ref/intro.html):

```swift
// BEFORE: GRDB 4
import CSQLite   // When GRDB is included with the Swift Package Manager
import SQLCipher // When GRDB is linked to SQLCipher
import SQLite3   // When GRDB is linked to System SQLite
let sqliteVersion = String(cString: sqlite3_libversion())

// NEW: GRDB 5
import GRDB
let sqliteVersion = String(cString: sqlite3_libversion())
```

This completes the goal of #747, which was to make users able to change their GRDB flavor without needing to change their code.