### PR TITLE
Deprecate the batch update `<-` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 **New**
 
-- Deprecate the batch update `<-` operator
+- [#761](https://github.com/groue/GRDB.swift/pull/761): Deprecate the batch update `<-` operator
 
 
 ## 4.12.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,12 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 **Fixed**
 
-- Restored support for Xcode 10.0 and Xcode 10.1
+- Restored support for Xcode 10.0 and Xcode 10.1, broken in 4.12.2
 - [#759](https://github.com/groue/GRDB.swift/pull/759): Fix batch updates of complex requests
+
+**New**
+
+- Deprecate the batch update `<-` operator
 
 
 ## 4.12.2

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -526,7 +526,7 @@ extension MutablePersistableRecord {
     ///
     ///     try dbQueue.write { db in
     ///         // UPDATE player SET score = 0
-    ///         try Player.updateAll(db, [Column("score") <- 0])
+    ///         try Player.updateAll(db, [Column("score").set(to: 0)])
     ///     }
     ///
     /// - parameter db: A database connection.
@@ -551,7 +551,7 @@ extension MutablePersistableRecord {
     ///
     ///     try dbQueue.write { db in
     ///         // UPDATE player SET score = 0
-    ///         try Player.updateAll(db, Column("score") <- 0)
+    ///         try Player.updateAll(db, Column("score").set(to: 0))
     ///     }
     ///
     /// - parameter db: A database connection.

--- a/README.md
+++ b/README.md
@@ -4696,29 +4696,32 @@ Player.deleteOne(db, key: ["email": "arthur@example.com"])
 
 ## Update Requests
 
-**Requests can batch update records**. The `updateAll()` method accepts *column assignments* defined with the `<-` operator:
+**Requests can batch update records**. The `updateAll()` method accepts *column assignments* defined with the `set(to:)` method:
 
 ```swift
 // UPDATE player SET score = 0, isHealthy = 1, bonus = NULL
-try Player.updateAll(db, scoreColumn <- 0, isHealthyColumn <- true, bonus <- nil)
+try Player.updateAll(db, 
+    scoreColumn.set(to: 0), 
+    isHealthyColumn.set(to: true), 
+    bonus.set(to: nil))
 
 // UPDATE player SET score = 0 WHERE team = 'red'
 try Player
     .filter(teamColumn == "red")
-    .updateAll(db, scoreColumn <- 0)
+    .updateAll(db, scoreColumn.set(to: 0))
 
 // UPDATE player SET top = 1 ORDER BY score DESC LIMIT 10
 try Player
     .order(scoreColumn.desc)
     .limit(10)
-    .updateAll(db, topColumn <- true)
+    .updateAll(db, topColumn.set(to: true))
 ```
 
 Column assignments accept any expression:
 
 ```swift
 // UPDATE player SET score = score + (bonus * 2)
-try Player.updateAll(db, scoreColumn <- scoreColumn + bonusColumn * 2)
+try Player.updateAll(db, scoreColumn.set(to: scoreColumn + bonusColumn * 2))
 ```
 
 As a convenience, you can also use the `+=`, `-=`, `*=`, or `/=` operators:

--- a/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
@@ -445,7 +445,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             }
             do {
                 // Regression test for https://github.com/groue/GRDB.swift/issues/758
-                try Player.including(required: Player.team.filter(Column("active") == 1)).updateAll(db, Column("score") <- 0)
+                try Player.including(required: Player.team.filter(Column("active") == 1)).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "player"."rowid" \

--- a/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordUpdateTests.swift
@@ -35,7 +35,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
     func testRequestUpdateAll() throws {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
-            let assignment = Columns.score <- 0
+            let assignment = Columns.score.set(to: 0)
             
             try Player.updateAll(db, assignment)
             XCTAssertEqual(self.lastSQLQuery, """
@@ -106,11 +106,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         }
     }
     
+    func testDeprecatedOperator() throws {
+        try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
+            try Player.updateAll(db, Columns.score <- 0)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = 0
+                """)
+        }
+    }
+    
     func testNilAssignment() throws {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Columns.score <- nil)
+            try Player.updateAll(db, Columns.score.set(to: nil))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = NULL
                 """)
@@ -121,7 +132,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Columns.score <- Columns.score * (Columns.bonus + 1))
+            try Player.updateAll(db, Columns.score.set(to: Columns.score * (Columns.bonus + 1)))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = "score" * ("bonus" + 1)
                 """)
@@ -236,22 +247,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Columns.score <- 0, Columns.bonus <- 1)
+            try Player.updateAll(db, Columns.score.set(to: 0), Columns.bonus.set(to: 1))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
             
-            try Player.updateAll(db, [Columns.score <- 0, Columns.bonus <- 1])
+            try Player.updateAll(db, [Columns.score.set(to: 0), Columns.bonus.set(to: 1)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
             
-            try Player.all().updateAll(db, Columns.score <- 0, Columns.bonus <- 1)
+            try Player.all().updateAll(db, Columns.score.set(to: 0), Columns.bonus.set(to: 1))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
             
-            try Player.all().updateAll(db, [Columns.score <- 0, Columns.bonus <- 1])
+            try Player.all().updateAll(db, [Columns.score.set(to: 0), Columns.bonus.set(to: 1)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0, "bonus" = 1
                 """)
@@ -316,22 +327,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try AbortPlayer.updateAll(db, Column("score") <- 0)
+            try AbortPlayer.updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try AbortPlayer.updateAll(db, [Column("score") <- 0])
+            try AbortPlayer.updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try AbortPlayer.all().updateAll(db, Column("score") <- 0)
+            try AbortPlayer.all().updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try AbortPlayer.all().updateAll(db, [Column("score") <- 0])
+            try AbortPlayer.all().updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
@@ -347,22 +358,22 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try IgnorePlayer.updateAll(db, Column("score") <- 0)
+            try IgnorePlayer.updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try IgnorePlayer.updateAll(db, [Column("score") <- 0])
+            try IgnorePlayer.updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try IgnorePlayer.all().updateAll(db, Column("score") <- 0)
+            try IgnorePlayer.all().updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try IgnorePlayer.all().updateAll(db, [Column("score") <- 0])
+            try IgnorePlayer.all().updateAll(db, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
@@ -373,27 +384,27 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)
             
-            try Player.updateAll(db, Column("score") <- 0)
+            try Player.updateAll(db, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE "player" SET "score" = 0
                 """)
             
-            try Player.updateAll(db, onConflict: .ignore, Column("score") <- 0)
+            try Player.updateAll(db, onConflict: .ignore, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try Player.updateAll(db, onConflict: .ignore, [Column("score") <- 0])
+            try Player.updateAll(db, onConflict: .ignore, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try Player.all().updateAll(db, onConflict: .ignore, Column("score") <- 0)
+            try Player.all().updateAll(db, onConflict: .ignore, Column("score").set(to: 0))
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
             
-            try Player.all().updateAll(db, onConflict: .ignore, [Column("score") <- 0])
+            try Player.all().updateAll(db, onConflict: .ignore, [Column("score").set(to: 0)])
             XCTAssertEqual(self.lastSQLQuery, """
                 UPDATE OR IGNORE "player" SET "score" = 0
                 """)
@@ -424,7 +435,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             }
             
             do {
-                try Player.including(required: Player.team).updateAll(db, Column("score") <- 0)
+                try Player.including(required: Player.team).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "player"."rowid" \
@@ -444,7 +455,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
             }
             do {
                 let alias = TableAlias(name: "p")
-                try Player.aliased(alias).including(required: Player.team).updateAll(db, Column("score") <- 0)
+                try Player.aliased(alias).including(required: Player.team).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "p"."rowid" \
@@ -453,7 +464,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Team.having(Team.players.isEmpty).updateAll(db, Column("active") <- false)
+                try Team.having(Team.players.isEmpty).updateAll(db, Column("active").set(to: false))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "team" SET "active" = 0 WHERE rowid IN (\
                     SELECT "team"."rowid" \
@@ -464,7 +475,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Team.including(all: Team.players).updateAll(db, Column("active") <- false)
+                try Team.including(all: Team.players).updateAll(db, Column("active").set(to: false))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "team" SET "active" = 0
                     """)
@@ -491,7 +502,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                 t.primaryKey(["countryCode", "citizenId"])
             }
             do {
-                try Player.all().groupByPrimaryKey().updateAll(db, Column("score") <- 0)
+                try Player.all().groupByPrimaryKey().updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "rowid" \
@@ -500,7 +511,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Player.all().group(Column.rowID).updateAll(db, Column("score") <- 0)
+                try Player.all().group(Column.rowID).updateAll(db, Column("score").set(to: 0))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "player" SET "score" = 0 WHERE rowid IN (\
                     SELECT "rowid" \
@@ -509,7 +520,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Passport.all().groupByPrimaryKey().updateAll(db, Column("active") <- true)
+                try Passport.all().groupByPrimaryKey().updateAll(db, Column("active").set(to: true))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "passport" SET "active" = 1 WHERE rowid IN (\
                     SELECT "rowid" \
@@ -518,7 +529,7 @@ class MutablePersistableRecordUpdateTests: GRDBTestCase {
                     """)
             }
             do {
-                try Passport.all().group(Column.rowID).updateAll(db, Column("active") <- true)
+                try Passport.all().group(Column.rowID).updateAll(db, Column("active").set(to: true))
                 XCTAssertEqual(self.lastSQLQuery, """
                     UPDATE "passport" SET "active" = 1 WHERE rowid IN (\
                     SELECT "rowid" \


### PR DESCRIPTION
This pull request deprecates the `<-` assignment operator in favor of the `set(to:)` method.

It is a backport of #750 into GRDB 4, which will ease the transition to GRDB 5.