### PR TITLE
Add Codable support to DatabaseDateComponents

### DIFF
--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -11,7 +11,7 @@ import SQLite3
 public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnConvertible, Codable {
     
     /// The available formats for reading and storing date components.
-    public enum Format: String, Codable {
+    public enum Format: String {
         
         /// The format "yyyy-MM-dd".
         case YMD = "yyyy-MM-dd"
@@ -162,19 +162,19 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
 
     // MARK: - Codable adoption
 
-    /// CodingKeys for codable conformance.
-    enum CodingKeys: String, CodingKey {
-        case date
-    }
 
     /// Creates a new instance by decoding from the given decoder.
     ///
     /// - parameters:
     ///     - decoder: The decoder to read data from.
     public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let stringValue = try container.decode(String.self, forKey: .date)
-        self = DatabaseDateComponents.fromDatabaseValue(stringValue.databaseValue)!
+        let container = try decoder.singleValueContainer()
+        let stringValue = try container.decode(String.self)
+        guard let decodedValue = DatabaseDateComponents.fromDatabaseValue(stringValue.databaseValue) else {
+            throw DecodingError.dataCorruptedError(in: container,
+                                                   debugDescription: "Unable to initialise databaseDateComponent")
+        }
+        self = decodedValue
     }
 
     /// Encodes this value into the given encoder.
@@ -182,7 +182,7 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
     /// - parameters:
     ///     - encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(String.fromDatabaseValue(databaseValue)!, forKey: .date)
+        var container = encoder.singleValueContainer()
+        try container.encode(String.fromDatabaseValue(databaseValue)!)
     }
 }

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -164,7 +164,7 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
 
     /// CodingKeys for codable conformance.
     enum CodingKeys: String, CodingKey {
-        case dateComponents, format
+        case date
     }
 
     /// Creates a new instance by decoding from the given decoder.
@@ -173,8 +173,8 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
     ///     - decoder: The decoder to read data from.
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        dateComponents = try container.decode(DateComponents.self, forKey: .dateComponents)
-        format = try container.decode(Format.self, forKey: .format)
+        let stringValue = try container.decode(String.self, forKey: .date)
+        self = DatabaseDateComponents.fromDatabaseValue(stringValue.databaseValue)!
     }
 
     /// Encodes this value into the given encoder.
@@ -183,7 +183,6 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
     ///     - encoder: The encoder to write data to.
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(dateComponents, forKey: .dateComponents)
-        try container.encode(format, forKey: .format)
+        try container.encode(String.fromDatabaseValue(databaseValue)!, forKey: .date)
     }
 }

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -8,10 +8,10 @@ import SQLite3
 #endif
 
 /// DatabaseDateComponents reads and stores DateComponents in the database.
-public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnConvertible {
+public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnConvertible, Codable {
     
     /// The available formats for reading and storing date components.
-    public enum Format: String {
+    public enum Format: String, Codable {
         
         /// The format "yyyy-MM-dd".
         case YMD = "yyyy-MM-dd"
@@ -158,5 +158,32 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
         }
         
         return SQLiteDateParser().components(from: string)
+    }
+
+    // MARK: - Codable adoption
+
+    /// CodingKeys for codable conformance.
+    enum CodingKeys: String, CodingKey {
+        case dateComponents, format
+    }
+
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// - parameters:
+    ///     - decoder: The decoder to read data from.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        dateComponents = try container.decode(DateComponents.self, forKey: .dateComponents)
+        format = try container.decode(Format.self, forKey: .format)
+    }
+
+    /// Encodes this value into the given encoder.
+    ///
+    /// - parameters:
+    ///     - encoder: The encoder to write data to.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(dateComponents, forKey: .dateComponents)
+        try container.encode(format, forKey: .format)
     }
 }

--- a/Tests/GRDBTests/FoundationDateComponentsTests.swift
+++ b/Tests/GRDBTests/FoundationDateComponentsTests.swift
@@ -506,4 +506,27 @@ class FoundationDateComponentsTests : GRDBTestCase {
         let databaseDateComponents = DatabaseDateComponents.fromDatabaseValue("foo".databaseValue)
         XCTAssertTrue(databaseDateComponents == nil)
     }
+
+    func testJSONEncodingOfDatabaseDateComponents() {
+        let year = 2018
+        let month = 12
+        let day = 31
+        let dbDateComponents = DatabaseDateComponents(
+        DateComponents(year: year, month: month, day: day, hour: nil, minute: nil, second: nil, nanosecond: nil),
+        format: .YMD)
+        let encoded = try! JSONEncoder().encode(dbDateComponents)
+        XCTAssertEqual(String(data: encoded, encoding: .utf8)!, "{\"date\":\"\(year)-\(month)-\(day)\"}")
+    }
+
+    func testJSONDecodingOfDatabaseDateComponents() {
+        let year = 2018
+        let month = 12
+        let day = 31
+        let dbDateComponents = DatabaseDateComponents(
+        DateComponents(year: year, month: month, day: day, hour: nil, minute: nil, second: nil, nanosecond: nil),
+        format: .YMD)
+        let json = "{\"date\":\"\(year)-\(month)-\(day)\"}".data(using: .utf8)!
+        let decodedDatabaseDateComponents = try! JSONDecoder().decode(DatabaseDateComponents.self, from: json)
+        XCTAssertEqual(decodedDatabaseDateComponents.dateComponents, dbDateComponents.dateComponents)
+    }
 }

--- a/Tests/GRDBTests/FoundationDateComponentsTests.swift
+++ b/Tests/GRDBTests/FoundationDateComponentsTests.swift
@@ -515,7 +515,7 @@ class FoundationDateComponentsTests : GRDBTestCase {
         DateComponents(year: year, month: month, day: day, hour: nil, minute: nil, second: nil, nanosecond: nil),
         format: .YMD)
         let encoded = try! JSONEncoder().encode(dbDateComponents)
-        XCTAssertEqual(String(data: encoded, encoding: .utf8)!, "{\"date\":\"\(year)-\(month)-\(day)\"}")
+        XCTAssertEqual(String(data: encoded, encoding: .utf8)!, "\"\(year)-\(month)-\(day)\"")
     }
 
     func testJSONDecodingOfDatabaseDateComponents() {
@@ -525,7 +525,7 @@ class FoundationDateComponentsTests : GRDBTestCase {
         let dbDateComponents = DatabaseDateComponents(
         DateComponents(year: year, month: month, day: day, hour: nil, minute: nil, second: nil, nanosecond: nil),
         format: .YMD)
-        let json = "{\"date\":\"\(year)-\(month)-\(day)\"}".data(using: .utf8)!
+        let json = "\"\(year)-\(month)-\(day)\"".data(using: .utf8)!
         let decodedDatabaseDateComponents = try! JSONDecoder().decode(DatabaseDateComponents.self, from: json)
         XCTAssertEqual(decodedDatabaseDateComponents.dateComponents, dbDateComponents.dateComponents)
     }


### PR DESCRIPTION
Add `Codable` conformance to `DatabaseDateComponents` as per discussion in #764 

Embarrassingly, after \*cough\* years of development, this is my first open source PR so apologies for anything I've done wrong. 

What if any tests would be needed for this? I had a look but couldn't figure out what to test as there doesn't appear to be anything much equivalent in the library that I could steal from.

It also didn't seem like there was anything in the Readme to update? But happy to add something if you point me to what needs updating.

Of course if this is embarrassingly bad, let's just delete it and pretend it never happened?

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
