### PR TITLE
Allow subqueries to refer to outer tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - [#772](https://github.com/groue/GRDB.swift/pull/772): Update the Database Sharing Guide with mention of the persistent WAL mode
 
+### Fixed
+
+- [#773](https://github.com/groue/GRDB.swift/pull/773): Allow subqueries to refer to outer tables
+
 
 ## 5.0.0-beta
 

--- a/GRDB/Core/FetchRequest.swift
+++ b/GRDB/Core/FetchRequest.swift
@@ -146,9 +146,7 @@ public struct AdaptedFetchRequest<Base: FetchRequest>: FetchRequest {
 ///
 /// An AnyFetchRequest forwards its operations to an underlying request,
 /// hiding its specifics.
-public struct AnyFetchRequest<T>: FetchRequest {
-    public typealias RowDecoder = T
-    
+public struct AnyFetchRequest<RowDecoder>: FetchRequest {
     private let _preparedRequest: (Database, _ singleResult: Bool) throws -> PreparedRequest
     private let _fetchCount: (Database) throws -> Int
     private let _databaseRegion: (Database) throws -> DatabaseRegion

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -7,6 +7,9 @@ import UIKit
 #endif
 
 extension AnyFetchRequest {
+    @available(*, unavailable, renamed: "RowDecoder")
+    typealias T = RowDecoder
+    
     @available(*, unavailable, message: "Define your own FetchRequest type instead.")
     public init(_ prepare: @escaping (Database, _ singleResult: Bool) throws -> (SelectStatement, RowAdapter?))
     { preconditionFailure() }

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,8 @@
 
 ## Features
 
+- [ ] Subqueries: request.isEmpty / request.exists
+- [ ] Subqueries: request.count
 - [ ] Extract one row from a hasMany association (the one with the maximum date, the one with a flag set, etc.) https://stackoverflow.com/questions/43188771/sqlite-join-query-most-recent-posts-by-each-user (failed PR: https://github.com/groue/GRDB.swift/pull/767)
 - [ ] Turn a hasMany to hasOne without first/last : hasMany(Book.self).filter(Column("isBest") /* assume a single book is flagged best */).asOne()
 - [ ] Support for more kinds of joins: https://github.com/groue/GRDB.swift/issues/740

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -100,6 +100,7 @@ class GRDBTestCase: XCTestCase {
         }
         
         dbConfiguration.trace = { [unowned self] sql in
+            #warning("TODO: make it thread-safe")
             self.sqlQueries.append(sql)
         }
         

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -548,9 +548,6 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             let parentAlias = TableAlias()
             // Some ugly subquery whose only purpose is to use a table alias
             // which requires disambiguation in the parent query.
-            // TODO: query.isEmpty
-            // TODO: query.count
-            // TODO: query.exists
             let subquery = Child.select(sql: "COUNT(*)").filter(Column("childParentId") == parentAlias[Column("id")])
             let request = Parent
                 .joining(optional: Parent.parent.aliased(parentAlias))

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -548,6 +548,9 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             let parentAlias = TableAlias()
             // Some ugly subquery whose only purpose is to use a table alias
             // which requires disambiguation in the parent query.
+            // TODO: query.isEmpty
+            // TODO: query.count
+            // TODO: query.exists
             let subquery = Child.select(sql: "COUNT(*)").filter(Column("childParentId") == parentAlias[Column("id")])
             let request = Parent
                 .joining(optional: Parent.parent.aliased(parentAlias))


### PR DESCRIPTION
This pull request fixes SQL generation for subqueries that refer to outer tables via `TableAlias`.