### PR TITLE
DatabaseMigrator can check if it has been superseded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 ### New
 
 - [#772](https://github.com/groue/GRDB.swift/pull/772): Update the Database Sharing Guide with mention of the persistent WAL mode
+- [#775](https://github.com/groue/GRDB.swift/pull/775): DatabaseMigrator can check if it has been superseded
 
 ### Breaking Changes
 

--- a/Documentation/FullTextSearch.md
+++ b/Documentation/FullTextSearch.md
@@ -280,7 +280,7 @@ let pattern = FTS3Pattern(matchingAnyTokenIn: "")  // nil
 let pattern = FTS3Pattern(matchingAnyTokenIn: "*") // nil
 ```
 
-FTS3Pattern are regular [values](../README.md#values). You can use them as query [arguments](http://groue.github.io/GRDB.swift/docs/4.5/Structs/StatementArguments.html):
+FTS3Pattern are regular [values](../README.md#values). You can use them as query [arguments](http://groue.github.io/GRDB.swift/docs/5.0.0-beta/Structs/StatementArguments.html):
 
 ```swift
 let documents = try Document.fetchAll(db,
@@ -529,7 +529,7 @@ let pattern = FTS5Pattern(matchingAnyTokenIn: "")  // nil
 let pattern = FTS5Pattern(matchingAnyTokenIn: "*") // nil
 ```
 
-FTS5Pattern are regular [values](../README.md#values). You can use them as query [arguments](http://groue.github.io/GRDB.swift/docs/4.5/Structs/StatementArguments.html):
+FTS5Pattern are regular [values](../README.md#values). You can use them as query [arguments](http://groue.github.io/GRDB.swift/docs/5.0.0-beta/Structs/StatementArguments.html):
 
 ```swift
 let documents = try Document.fetchAll(db,

--- a/Documentation/Migrations.md
+++ b/Documentation/Migrations.md
@@ -42,7 +42,7 @@ You migrate the database up to the latest version with the `migrate(_:)` method:
 try migrator.migrate(dbQueue) // or migrator.migrate(dbPool)
 ```
 
-Migrate a database up to a specific version:
+Migrate a database up to a specific version (useful for testing):
 
 ```swift
 try migrator.migrate(dbQueue, upTo: "v2")
@@ -53,27 +53,24 @@ try migrator.migrate(dbQueue, upTo: "v1")
 // ^ fatal error: database is already migrated beyond migration "v1"
 ```
 
-Check if consecutive migrations have been applied:
+When several versions of your app are deployed in the wild, you may want to perform extra checks:
 
 ```swift
-if try dbQueue.read(migrator.hasCompletedMigrations) {
-    // All migrations have been applied, up to the last one.
-}
-if try dbQueue.read(migrator.completedMigrations).last == "v2" {
-    // All migrations up to "v2" have been applied, and no further.
-}
-if try dbQueue.read(migrator.completedMigrations).contains("v2") {
-    // All migrations up to "v2" have been applied, and maybe further.
+try dbQueue.read { db in
+    // Readonly apps may want to check if database lacks expected migrations:
+    if try migrator.hasCompletedMigrations(db) == false {
+        // database too old
+    }
+    
+    // All apps may want to check if database contains unknown (future) migrations:
+    if try migrator.hasBeenSuperseded(db) {
+        // database too new
+    }
 }
 ```
 
-Check if individual migrations have been applied:
+See the [DatabaseMigrator reference](http://groue.github.io/GRDB.swift/docs/5.0.0-beta/Structs/DatabaseMigrator.html) for more migrator methods.
 
-```swift
-if try dbQueue.read(migrator.appliedMigrations).contains("v2") {
-    // "v2" migration has been applied
-}
-```
 
 ## The `eraseDatabaseOnSchemaChange` Option
 

--- a/Documentation/ReleaseProcess.md
+++ b/Documentation/ReleaseProcess.md
@@ -17,6 +17,8 @@ To release a new GRDB version:
     - CHANGELOG.md
     - GRDB.swift.podspec
     - README.md
+    - Documentation/FullTextSearch.md
+    - Documentation/Migrations.md
     - Support/Info.plist
 - Commit and tag
 - Check tag authors: `git for-each-ref --format '%(refname) %(authorname)' refs/tags`

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -200,7 +200,19 @@ public struct DatabaseMigrator {
     public func hasCompletedMigrations(_ db: Database) throws -> Bool {
         try completedMigrations(db).last == migrations.last?.identifier
     }
-        
+    
+    /// Returns whether database contains unknown migration
+    /// identifiers, which is likely the sign that the database
+    /// has migrated further than the migrator itself supports.
+    ///
+    /// - parameter db: A database connection.
+    /// - throws: An eventual database error.
+    public func hasBeenSuperseded(_ db: Database) throws -> Bool {
+        let appliedIdentifiers = try self.appliedIdentifiers(db)
+        let knownIdentifiers = migrations.map(\.identifier)
+        return appliedIdentifiers.contains { !knownIdentifiers.contains($0) }
+    }
+    
     // MARK: - Non public
     
     private mutating func registerMigration(_ migration: Migration) {

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -311,37 +311,78 @@ class DatabaseMigratorTests : GRDBTestCase {
     
     func testMergedMigrators() throws {
         // Migrate a database
-        var oldMigrator = DatabaseMigrator()
-        oldMigrator.registerMigration("1", migrate: { _ in })
-        oldMigrator.registerMigration("3", migrate: { _ in })
+        var migrator1 = DatabaseMigrator()
+        migrator1.registerMigration("1", migrate: { _ in })
+        migrator1.registerMigration("3", migrate: { _ in })
         
         let dbQueue = try makeDatabaseQueue()
-        try oldMigrator.migrate(dbQueue)
+        try migrator1.migrate(dbQueue)
         
-        try XCTAssertEqual(dbQueue.read(oldMigrator.appliedMigrations), ["1", "3"])
-        try XCTAssertEqual(dbQueue.read(oldMigrator.completedMigrations), ["1", "3"])
-        try XCTAssertTrue(dbQueue.read(oldMigrator.hasCompletedMigrations))
+        try XCTAssertEqual(dbQueue.read(migrator1.appliedMigrations), ["1", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator1.appliedIdentifiers), ["1", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator1.completedMigrations), ["1", "3"])
+        try XCTAssertTrue(dbQueue.read(migrator1.hasCompletedMigrations))
+        try XCTAssertFalse(dbQueue.read(migrator1.hasBeenSuperseded))
         
+        // ---
         // A source code merge inserts a migration between "1" and "3"
-        var newMigrator = DatabaseMigrator()
-        newMigrator.registerMigration("1", migrate: { _ in })
-        newMigrator.registerMigration("2", migrate: { _ in })
-        newMigrator.registerMigration("3", migrate: { _ in })
+        var migrator2 = DatabaseMigrator()
+        migrator2.registerMigration("1", migrate: { _ in })
+        migrator2.registerMigration("2", migrate: { _ in })
+        migrator2.registerMigration("3", migrate: { _ in })
         
-        try XCTAssertEqual(dbQueue.read(newMigrator.appliedMigrations), ["1", "3"])
-        try XCTAssertEqual(dbQueue.read(newMigrator.completedMigrations), ["1"])
-        try XCTAssertFalse(dbQueue.read(newMigrator.hasCompletedMigrations))
+        try XCTAssertEqual(dbQueue.read(migrator2.appliedMigrations), ["1", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator2.appliedIdentifiers), ["1", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator2.completedMigrations), ["1"])
+        try XCTAssertFalse(dbQueue.read(migrator2.hasCompletedMigrations))
+        try XCTAssertFalse(dbQueue.read(migrator2.hasBeenSuperseded))
         
         // The new source code migrates the database
-        try newMigrator.migrate(dbQueue)
+        try migrator2.migrate(dbQueue)
         
-        try XCTAssertEqual(dbQueue.read(oldMigrator.appliedMigrations), ["1", "3"])
-        try XCTAssertEqual(dbQueue.read(oldMigrator.completedMigrations), ["1", "3"])
-        try XCTAssertTrue(dbQueue.read(oldMigrator.hasCompletedMigrations))
+        try XCTAssertEqual(dbQueue.read(migrator1.appliedMigrations), ["1", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator1.appliedIdentifiers), ["1", "2", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator1.completedMigrations), ["1", "3"])
+        try XCTAssertTrue(dbQueue.read(migrator1.hasCompletedMigrations))
+        try XCTAssertTrue(dbQueue.read(migrator1.hasBeenSuperseded))
         
-        try XCTAssertEqual(dbQueue.read(newMigrator.appliedMigrations), ["1", "2", "3"])
-        try XCTAssertEqual(dbQueue.read(newMigrator.completedMigrations), ["1", "2", "3"])
-        try XCTAssertTrue(dbQueue.read(newMigrator.hasCompletedMigrations))
+        try XCTAssertEqual(dbQueue.read(migrator2.appliedMigrations), ["1", "2", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator2.appliedIdentifiers), ["1", "2", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator2.completedMigrations), ["1", "2", "3"])
+        try XCTAssertTrue(dbQueue.read(migrator2.hasCompletedMigrations))
+        try XCTAssertFalse(dbQueue.read(migrator2.hasBeenSuperseded))
+        
+        // ---
+        // A source code merge appends a migration
+        var migrator3 = migrator2
+        migrator3.registerMigration("4", migrate: { _ in })
+        
+        try XCTAssertEqual(dbQueue.read(migrator3.appliedMigrations), ["1", "2", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator3.appliedIdentifiers), ["1", "2", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator3.completedMigrations), ["1", "2", "3"])
+        try XCTAssertFalse(dbQueue.read(migrator3.hasCompletedMigrations))
+        try XCTAssertFalse(dbQueue.read(migrator3.hasBeenSuperseded))
+        
+        // The new source code migrates the database
+        try migrator3.migrate(dbQueue)
+        
+        try XCTAssertEqual(dbQueue.read(migrator1.appliedMigrations), ["1", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator1.appliedIdentifiers), ["1", "2", "3", "4"])
+        try XCTAssertEqual(dbQueue.read(migrator1.completedMigrations), ["1", "3"])
+        try XCTAssertTrue(dbQueue.read(migrator1.hasCompletedMigrations))
+        try XCTAssertTrue(dbQueue.read(migrator1.hasBeenSuperseded))
+        
+        try XCTAssertEqual(dbQueue.read(migrator2.appliedMigrations), ["1", "2", "3"])
+        try XCTAssertEqual(dbQueue.read(migrator2.appliedIdentifiers), ["1", "2", "3", "4"])
+        try XCTAssertEqual(dbQueue.read(migrator2.completedMigrations), ["1", "2", "3"])
+        try XCTAssertTrue(dbQueue.read(migrator2.hasCompletedMigrations))
+        try XCTAssertTrue(dbQueue.read(migrator2.hasBeenSuperseded))
+        
+        try XCTAssertEqual(dbQueue.read(migrator3.appliedMigrations), ["1", "2", "3", "4"])
+        try XCTAssertEqual(dbQueue.read(migrator3.appliedIdentifiers), ["1", "2", "3", "4"])
+        try XCTAssertEqual(dbQueue.read(migrator3.completedMigrations), ["1", "2", "3", "4"])
+        try XCTAssertTrue(dbQueue.read(migrator3.hasCompletedMigrations))
+        try XCTAssertFalse(dbQueue.read(migrator3.hasBeenSuperseded))
     }
     
     // Regression test for https://github.com/groue/GRDB.swift/issues/741

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -230,13 +230,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // One migration
         
-        migrator.registerMigration("1") { db in
-            try db.create(table: "player") { t in
-                t.autoIncrementedPrimaryKey("id")
-                t.column("name", .text)
-                t.column("score", .integer)
-            }
-        }
+        migrator.registerMigration("1", migrate: { _ in })
         
         do {
             let dbQueue = try makeDatabaseQueue()
@@ -247,9 +241,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // Two migrations
         
-        migrator.registerMigration("2") { db in
-            try db.execute(sql: "INSERT INTO player (id, name, score) VALUES (NULL, 'Arthur', 1000)")
-        }
+        migrator.registerMigration("2", migrate: { _ in })
         
         do {
             let dbQueue = try makeDatabaseQueue()
@@ -273,13 +265,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // One migration
         
-        migrator.registerMigration("1") { db in
-            try db.create(table: "player") { t in
-                t.autoIncrementedPrimaryKey("id")
-                t.column("name", .text)
-                t.column("score", .integer)
-            }
-        }
+        migrator.registerMigration("1", migrate: { _ in })
         
         do {
             let dbQueue = try makeDatabaseQueue()
@@ -292,9 +278,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // Two migrations
         
-        migrator.registerMigration("2") { db in
-            try db.execute(sql: "INSERT INTO player (id, name, score) VALUES (NULL, 'Arthur', 1000)")
-        }
+        migrator.registerMigration("2", migrate: { _ in })
         
         do {
             let dbQueue = try makeDatabaseQueue()
@@ -320,13 +304,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // One migration
         
-        migrator.registerMigration("1") { db in
-            try db.create(table: "player") { t in
-                t.autoIncrementedPrimaryKey("id")
-                t.column("name", .text)
-                t.column("score", .integer)
-            }
-        }
+        migrator.registerMigration("1", migrate: { _ in })
         
         do {
             let dbQueue = try makeDatabaseQueue()
@@ -337,9 +315,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // Two migrations
         
-        migrator.registerMigration("2") { db in
-            try db.execute(sql: "INSERT INTO player (id, name, score) VALUES (NULL, 'Arthur', 1000)")
-        }
+        migrator.registerMigration("2", migrate: { _ in })
         
         do {
             let dbQueue = try makeDatabaseQueue()
@@ -501,7 +477,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             try db.create(table: "player") { t in
                 t.autoIncrementedPrimaryKey("id")
                 t.column("name", .text)
-                t.column("score", .integer) // <- schema change, because reasons (development)
+                t.column("score", .integer) // <- schema change
             }
             try db.execute(sql: "INSERT INTO player (id, name, score) VALUES (NULL, testFunction(), 1000)")
         }


### PR DESCRIPTION
This pull request introduces `DatabaseMigrator.hasBeenSuperseded(_:)` which helps apps check if a database has been migrated further than a migrator itself supports.