### PR TITLE
Fix observation of eager-loaded to-many associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this project will be documented in this file.
 
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
-<!--
 [Next Release](#next-release)
--->
 
 #### 5.x Releases
 
@@ -70,9 +68,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+### Fixed
+
+- [#784](https://github.com/groue/GRDB.swift/pull/784): Fix observation of eager-loaded to-many associations
 
 
 ## 5.0.0-beta.2

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -240,7 +240,7 @@ extension Database {
         try checkForSuspensionViolation(from: statement)
         
         if _isRecordingSelectedRegion {
-            _selectedRegion.formUnion(statement.selectedRegion)
+            _selectedRegion.formUnion(statement.databaseRegion)
         }
         
         let authorizer = observationBroker.updateStatementWillExecute(statement)
@@ -317,7 +317,7 @@ extension Database {
         try checkForSuspensionViolation(from: statement)
         
         if _isRecordingSelectedRegion {
-            _selectedRegion.formUnion(statement.selectedRegion)
+            _selectedRegion.formUnion(statement.databaseRegion)
         }
     }
     

--- a/GRDB/Core/FetchRequest.swift
+++ b/GRDB/Core/FetchRequest.swift
@@ -129,7 +129,7 @@ extension FetchRequest {
         let context = SQLGenerationContext(db)
         let sql = try requestSQL(context, forSingleResult: false)
         let statement = try db.makeSelectStatement(sql: sql)
-        return statement.selectedRegion
+        return statement.databaseRegion
     }
     
     /// Returns a PreparedRequest that is ready to be executed.

--- a/GRDB/Core/SQLRequest.swift
+++ b/GRDB/Core/SQLRequest.swift
@@ -111,7 +111,7 @@ extension SQLRequest: SQLRequestProtocol {
 
 extension SQLRequest: DatabaseRegionConvertible {
     public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
-        try makePreparedRequest(db, forSingleResult: false).statement.selectedRegion
+        try makePreparedRequest(db, forSingleResult: false).statement.databaseRegion
     }
 }
 

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -24,11 +24,12 @@ public class Statement {
             .trimmingCharacters(in: .sqlStatementSeparators)
     }
     
-    // Selected region is computed during statement compilation, and maybe
-    // optimized for select statements compiled by QueryInterfaceRequest, in
+    // Database region is computed during statement compilation, and maybe
+    // extended for select statements compiled by QueryInterfaceRequest, in
     // order to perform focused database observation. See
-    // SQLQueryGenerator.optimizedSelectedRegion(_:_:)
-    var selectedRegion = DatabaseRegion()
+    // SQLQueryGenerator.makeSelectStatement(_:)
+    /// The database region that the statement looks into.
+    public internal(set) var databaseRegion = DatabaseRegion()
     
     var isReadonly: Bool {
         sqlite3_stmt_readonly(sqliteStatement) != 0
@@ -87,7 +88,7 @@ public class Statement {
         
         self.database = database
         self.sqliteStatement = statement
-        self.selectedRegion = authorizer.selectedRegion
+        self.databaseRegion = authorizer.selectedRegion
     }
     
     deinit {
@@ -355,9 +356,6 @@ public final class SelectStatement: Statement {
             authorizer.transactionEffect == nil,
             "Invalid statement type for query \(String(reflecting: sql)): use UpdateStatement instead.")
     }
-    
-    /// The database region that the statement looks into.
-    public var databaseRegion: DatabaseRegion { selectedRegion }
     
     /// The number of columns in the resulting rows.
     public var columnCount: Int {

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -44,43 +44,9 @@ extension QueryInterfaceRequest: Refinable { }
 
 extension QueryInterfaceRequest: DatabaseRegionConvertible {
     public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
-        var region = try SQLQueryGenerator(query: query)
+        try SQLQueryGenerator(query: query)
             .makeSelectStatement(db)
             .selectedRegion
-        
-        // Iterate all prefetched associations
-        var fifo = query.relation.prefetchedAssociations
-        while !fifo.isEmpty {
-            let association = fifo.removeFirst()
-            
-            // Build the query for prefetched rows.
-            // CAUTION: Keep this code in sync with prefetch(_:associations:in:)
-            let pivotMappings = try association.pivot.condition.columnMappings(db)
-            let pivotColumns = pivotMappings.map(\.right)
-            let pivotAlias = TableAlias()
-            let prefetchedRelation = association
-                .map(\.pivot.relation, { $0.qualified(with: pivotAlias) })
-                // Use a `NullRow` in order to make sure all join condition
-                // columns are made visible to SQLite, and present in the
-                // selected region:
-                //  ... JOIN right ON right.leftId IS NULL
-                //                                    ^ content of the NullRow
-                .destinationRelation(fromOriginRows: { _ in [NullRow()] })
-                .annotated(with: pivotColumns.map { pivotAlias[Column($0)].forKey("grdb_\($0)") })
-            let prefetchedQuery = SQLQuery(relation: prefetchedRelation)
-            
-            // Union prefetched region
-            let prefetchedRegion = try SQLQueryGenerator(query: prefetchedQuery)
-                .makeSelectStatement(db)
-                .selectedRegion
-            region.formUnion(prefetchedRegion)
-            
-            // Append nested prefetched associations (support for
-            // A.including(all: A.bs.including(all: B.cs))
-            fifo.append(contentsOf: prefetchedRelation.prefetchedAssociations)
-        }
-        
-        return region
     }
 }
 

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -46,7 +46,7 @@ extension QueryInterfaceRequest: DatabaseRegionConvertible {
     public func databaseRegion(_ db: Database) throws -> DatabaseRegion {
         try SQLQueryGenerator(query: query)
             .makeSelectStatement(db)
-            .selectedRegion
+            .databaseRegion
     }
 }
 
@@ -473,7 +473,7 @@ private func prefetch(_ db: Database, associations: [SQLAssociation], in rows: [
         return
     }
     
-    // CAUTION: Keep this code in sync with QueryInterfaceRequest.databaseRegion(_:)
+    // CAUTION: Keep this code in sync with prefetchedRegion(_:_:)
     for association in associations {
         let pivotMappings = try association.pivot.condition.columnMappings(db)
         
@@ -518,6 +518,32 @@ private func prefetch(_ db: Database, associations: [SQLAssociation], in rows: [
             let prefetchedRows = prefetchedRows[groupingKey, default: []]
             row.prefetchedRows.setRows(prefetchedRows, forKeyPath: association.keyPath)
         }
+    }
+}
+
+// Returns the region of prefetched associations
+func prefetchedRegion(_ db: Database, associations: [SQLAssociation]) throws -> DatabaseRegion {
+    try associations.reduce(into: DatabaseRegion()) { (region, association) in
+        // CAUTION: Keep this code in sync with prefetch(_:associations:in:)
+        let pivotMappings = try association.pivot.condition.columnMappings(db)
+        let pivotColumns = pivotMappings.map(\.right)
+        let pivotAlias = TableAlias()
+        let prefetchedRelation = association
+            .map(\.pivot.relation, { $0.qualified(with: pivotAlias) })
+            // Use a `NullRow` in order to make sure all join condition
+            // columns are made visible to SQLite, and present in the
+            // selected region:
+            //  ... JOIN right ON right.leftId IS NULL
+            //                                    ^ content of the NullRow
+            .destinationRelation(fromOriginRows: { _ in [NullRow()] })
+            .annotated(with: pivotColumns.map { pivotAlias[Column($0)].forKey("grdb_\($0)") })
+        let prefetchedQuery = SQLQuery(relation: prefetchedRelation)
+        
+        // Union prefetched region
+        let prefetchedRegion = try SQLQueryGenerator(query: prefetchedQuery)
+            .makeSelectStatement(db)
+            .databaseRegion // contains region of nested associations
+        region.formUnion(prefetchedRegion)
     }
 }
 

--- a/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingObservationTests.swift
@@ -45,39 +45,6 @@ class AssociationPrefetchingObservationTests: GRDBTestCase {
                 t.column("cold2", .integer).references("c")
                 t.column("cold3", .text)
             }
-            try db.execute(
-                sql: """
-                    INSERT INTO a (cola1, cola2) VALUES (?, ?);
-                    INSERT INTO a (cola1, cola2) VALUES (?, ?);
-                    INSERT INTO a (cola1, cola2) VALUES (?, ?);
-                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
-                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
-                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
-                    INSERT INTO b (colb1, colb2, colb3) VALUES (?, ?, ?);
-                    INSERT INTO c (colc1, colc2) VALUES (?, ?);
-                    INSERT INTO c (colc1, colc2) VALUES (?, ?);
-                    INSERT INTO c (colc1, colc2) VALUES (?, ?);
-                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
-                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
-                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
-                    INSERT INTO d (cold1, cold2, cold3) VALUES (?, ?, ?);
-                    """,
-                arguments: [
-                    1, "a1",
-                    2, "a2",
-                    3, "a3",
-                    4, 1, "b1",
-                    5, 1, "b2",
-                    6, 2, "b3",
-                    14, nil, "b4",
-                    7, 1,
-                    8, 2,
-                    9, 2,
-                    10, 7, "d1",
-                    11, 8, "d2",
-                    12, 8, "d3",
-                    13, 9, "d4",
-                ])
         }
     }
     


### PR DESCRIPTION
This pull request fixes #783:

ValueObservation used to fail tracking changes in eager-loaded associations, when started from a empty database.