### PR TITLE
Name of Database Connections

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -19,7 +19,7 @@ let SQLITE_TRANSIENT = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_
 ///     try dbQueue.write { db in
 ///         try Player(...).insert(db)
 ///     }
-public final class Database {
+public final class Database: CustomStringConvertible {
     // The Database class is not thread-safe. An instance should always be
     // used through a SerializedDatabase.
     
@@ -58,6 +58,9 @@ public final class Database {
     
     /// The database configuration
     public let configuration: Configuration
+    
+    /// See `Configuration.label`
+    public let description: String
     
     // MARK: - Database Information
     
@@ -161,8 +164,14 @@ public final class Database {
     
     // MARK: - Initializer
     
-    init(path: String, configuration: Configuration, schemaCache: DatabaseSchemaCache) throws {
+    init(
+        path: String,
+        description: String,
+        configuration: Configuration,
+        schemaCache: DatabaseSchemaCache) throws
+    {
         self.sqliteConnection = try Database.openConnection(path: path, flags: configuration.SQLiteOpenFlags)
+        self.description = description
         self.configuration = configuration
         self.schemaCache = schemaCache
     }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -318,12 +318,15 @@ extension DatabaseWriter {
     {
         assert(!configuration.readonly, "Use _addReadOnly(observation:) instead")
         
+        let reduceQueueLabel = configuration.identifier(
+            defaultLabel: "GRDB",
+            purpose: "ValueObservation")
         let observer = ValueObserver<Reducer>(
             requiresWriteAccess: observation.requiresWriteAccess,
             writer: self,
             reducer: observation.makeReducer(),
             scheduling: scheduler,
-            reduceQueue: configuration.makeDispatchQueue(defaultLabel: "GRDB", purpose: "ValueObservation.reducer"),
+            reduceQueue: configuration.makeDispatchQueue(label: reduceQueueLabel),
             onError: onError,
             onChange: onChange)
         

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -43,8 +43,13 @@ final class SerializedDatabase {
         config.threadingMode = .multiThread
         
         self.path = path
-        self.db = try Database(path: path, configuration: config, schemaCache: schemaCache)
-        self.queue = configuration.makeDispatchQueue(defaultLabel: defaultLabel, purpose: purpose)
+        let identifier = configuration.identifier(defaultLabel: defaultLabel, purpose: purpose)
+        self.db = try Database(
+            path: path,
+            description: identifier,
+            configuration: config,
+            schemaCache: schemaCache)
+        self.queue = configuration.makeDispatchQueue(label: identifier)
         SchedulingWatchdog.allowDatabase(db, onQueue: queue)
         try queue.sync {
             do {

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -872,6 +872,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let dbPool = try makeDatabasePool()
         dbPool.writeWithoutTransaction { db in
             XCTAssertEqual(db.configuration.label, nil)
+            XCTAssertEqual(db.description, "GRDB.DatabasePool.writer")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
@@ -884,6 +885,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block1 = { () in
             try! dbPool.read { db in
                 XCTAssertEqual(db.configuration.label, nil)
+                XCTAssertEqual(db.description, "GRDB.DatabasePool.reader.1")
                 
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
@@ -899,6 +901,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             try! dbPool.read { db in
                 _ = s2.signal()
                 XCTAssertEqual(db.configuration.label, nil)
+                XCTAssertEqual(db.description, "GRDB.DatabasePool.reader.2")
                 
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
@@ -917,6 +920,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let dbPool = try makeDatabasePool()
         dbPool.writeWithoutTransaction { db in
             XCTAssertEqual(db.configuration.label, "Toreador")
+            XCTAssertEqual(db.description, "Toreador.writer")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
@@ -929,6 +933,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         let block1 = { () in
             try! dbPool.read { db in
                 XCTAssertEqual(db.configuration.label, "Toreador")
+                XCTAssertEqual(db.description, "Toreador.reader.1")
                 
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
@@ -944,6 +949,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
             try! dbPool.read { db in
                 _ = s2.signal()
                 XCTAssertEqual(db.configuration.label, "Toreador")
+                XCTAssertEqual(db.description, "Toreador.reader.2")
                 
                 // This test CAN break in future releases: the dispatch queue labels
                 // are documented to be a debug-only tool.
@@ -1319,7 +1325,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         }
         return dbPool!
     }
-
+    
     // Test for sample code in Documentation/SharingADatabase.md.
     // This test passes if this method compiles
     private func openDatabase(at databaseURL: URL) throws -> DatabasePool {
@@ -1348,7 +1354,7 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         }
         return dbPool
     }
-
+    
     // Test for sample code in Documentation/SharingADatabase.md.
     // This test passes if this method compiles
     private func openReadOnlyDatabase(at databaseURL: URL) throws -> DatabasePool? {

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -54,7 +54,7 @@ class DatabaseQueueTests: GRDBTestCase {
             XCTAssertEqual(error.description.lowercased(), "sqlite error 1 with statement `select succ(1)`: no such function: succ")
         }
     }
-
+    
     func testAddRemoveCollation() throws {
         // Adding a collation and then removing it should succeed
         let dbQueue = try makeDatabaseQueue()
@@ -100,6 +100,7 @@ class DatabaseQueueTests: GRDBTestCase {
         XCTAssertEqual(dbQueue.configuration.label, nil)
         dbQueue.inDatabase { db in
             XCTAssertEqual(db.configuration.label, nil)
+            XCTAssertEqual(db.description, "GRDB.DatabaseQueue")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
@@ -114,6 +115,7 @@ class DatabaseQueueTests: GRDBTestCase {
         XCTAssertEqual(dbQueue.configuration.label, "Toreador")
         dbQueue.inDatabase { db in
             XCTAssertEqual(db.configuration.label, "Toreador")
+            XCTAssertEqual(db.description, "Toreador")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -201,6 +201,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let snapshot1 = try dbPool.makeSnapshot()
         snapshot1.unsafeRead { db in
             XCTAssertEqual(db.configuration.label, nil)
+            XCTAssertEqual(db.description, "GRDB.DatabasePool.snapshot.1")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
@@ -211,6 +212,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let snapshot2 = try dbPool.makeSnapshot()
         snapshot2.unsafeRead { db in
             XCTAssertEqual(db.configuration.label, nil)
+            XCTAssertEqual(db.description, "GRDB.DatabasePool.snapshot.2")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
@@ -226,6 +228,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let snapshot1 = try dbPool.makeSnapshot()
         snapshot1.unsafeRead { db in
             XCTAssertEqual(db.configuration.label, "Toreador")
+            XCTAssertEqual(db.description, "Toreador.snapshot.1")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.
@@ -236,6 +239,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let snapshot2 = try dbPool.makeSnapshot()
         snapshot2.unsafeRead { db in
             XCTAssertEqual(db.configuration.label, "Toreador")
+            XCTAssertEqual(db.description, "Toreador.snapshot.2")
             
             // This test CAN break in future releases: the dispatch queue labels
             // are documented to be a debug-only tool.


### PR DESCRIPTION
This pull request defines the `Database.description` property, aka the "connection name".

**The connection name is intended for debugging only.** Its format may change between GRDB releases, without notice. Applications should not depend on any connection name.

It makes it possible to distinguish the various SQLite connections opened by an application. For example, when you log database statements:

```swift
var config = Configuration()
config.prepareDatabase = { db in
  // Log all database statements and the connection that performs them:
  let description = db.description
  db.trace { event in
    print("\(description): \(event)")
  }
}

let dbPool = try DatabasePool(path: "...", configuration: config)

// Prints "GRDB.DatabasePool.writer: INSERT INTO player (name) VALUES ('Arthur')"
try dbPool.write { db in
    try Player(name: "Arthur").insert(db)
}

// Prints "GRDB.DatabasePool.reader.1: SELECT COUNT(*) FROM player"
try dbPool.read(Player.fetchCount)
```

The value of `Database.description` is derived from `Configuration.label`.

If the configuration label is nil, the current GRDB implementation uses the following names:

- `GRDB.DatabaseQueue`: the (unique) connection of a DatabaseQueue
- `GRDB.DatabasePool.writer`: the (unique) writer connection of a DatabasePool
- `GRDB.DatabasePool.reader.N`, where N is 1, 2, ...: one of the reader connection(s) of a DatabasePool. N may get bigger than the maximum number of concurrent readers, as SQLite connections get closed and new ones are opened.
- `GRDB.DatabasePool.snapshot.N`: the connection of a DatabaseSnapshot. N grows with the number of snapshots.

If the configuration label is not nil, for example "MyDatabase", the current GRDB implementation uses the following names:

- `MyDatabase`: the (unique) connection of a DatabaseQueue
- `MyDatabase.writer`: the (unique) writer connection of a DatabasePool
- `MyDatabase.reader.N`, where N is 1, 2, ...: one of the reader connection(s) of a DatabasePool. N may get bigger than the maximum number of concurrent readers, as SQLite connections get closed and new ones are opened.
- `MyDatabase.snapshot.N`: the connection of a DatabaseSnapshot. N grows with the number of snapshots.
