### PR TITLE
Enhanced support for WAL Checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this project will be documented in this file.
 
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
-<!--
 [Next Release](#next-release)
--->
 
 #### 5.x Releases
 
@@ -70,9 +68,9 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+- [#795](https://github.com/groue/GRDB.swift/pull/795): **Breaking Change** Enhanced support for WAL Checkpoints
 
 
 ## 5.0.0-beta.4

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -632,20 +632,20 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// - parameter kind: The checkpoint mode (default passive)
     /// - parameter dbName: The database name (default "main")
     /// - returns: A tuple:
-    ///     - `logCount`: the total number of frames in the log file
-    ///     - `checkpointCount`: the total number of checkpointed frames in the
-    ///       log file
+    ///     - `walFrameCount`: the total number of frames in the log file
+    ///     - `checkpointedFrameCount`: the total number of checkpointed frames
+    ///       in the log file
     @discardableResult
     public func checkpoint(_ kind: Database.CheckpointMode = .passive, on dbName: String? = "main") throws
-        -> (logCount: Int, checkpointCount: Int)
+        -> (walFrameCount: Int, checkpointedFrameCount: Int)
     {
         SchedulingWatchdog.preconditionValidQueue(self)
-        var logCount: CInt = -1
-        var checkpointCount: CInt = -1
-        let code = sqlite3_wal_checkpoint_v2(sqliteConnection, dbName, kind.rawValue, &logCount, &checkpointCount)
+        var walFrameCount: CInt = -1
+        var checkpointedFrameCount: CInt = -1
+        let code = sqlite3_wal_checkpoint_v2(sqliteConnection, dbName, kind.rawValue, &walFrameCount, &checkpointedFrameCount)
         switch code {
         case SQLITE_OK:
-            return (logCount: Int(logCount), checkpointCount: Int(checkpointCount))
+            return (walFrameCount: Int(walFrameCount), checkpointedFrameCount: Int(checkpointedFrameCount))
         case SQLITE_MISUSE:
             throw DatabaseError(resultCode: code)
         default:

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -642,7 +642,8 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         SchedulingWatchdog.preconditionValidQueue(self)
         var walFrameCount: CInt = -1
         var checkpointedFrameCount: CInt = -1
-        let code = sqlite3_wal_checkpoint_v2(sqliteConnection, dbName, kind.rawValue, &walFrameCount, &checkpointedFrameCount)
+        let code = sqlite3_wal_checkpoint_v2(sqliteConnection, dbName, kind.rawValue,
+                                             &walFrameCount, &checkpointedFrameCount)
         switch code {
         case SQLITE_OK:
             return (walFrameCount: Int(walFrameCount), checkpointedFrameCount: Int(checkpointedFrameCount))

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -211,9 +211,9 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     /// This method must be called after database initialization
     func setup() throws {
+        setupBusyMode()
         setupDoubleQuotedStringLiterals()
         try setupForeignKeys()
-        setupBusyMode()
         setupDefaultFunctions()
         setupDefaultCollations()
         setupAuthorizer()

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -169,24 +169,6 @@ public final class DatabasePool: DatabaseWriter {
 
 extension DatabasePool {
     
-    // MARK: - WAL Checkpoints
-    
-    /// Runs a WAL checkpoint
-    ///
-    /// See https://www.sqlite.org/wal.html and
-    /// https://www.sqlite.org/c3ref/wal_checkpoint_v2.html) for
-    /// more information.
-    ///
-    /// - parameter kind: The checkpoint mode (default passive)
-    public func checkpoint(_ kind: Database.CheckpointMode = .passive) throws {
-        try writer.sync { db in
-            try db.checkpoint(kind)
-        }
-    }
-}
-
-extension DatabasePool {
-    
     // MARK: - Memory management
     
     /// Free as much memory as possible.

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -86,6 +86,9 @@ extension DatabaseMigrator {
 }
 
 extension DatabasePool {
+    @available(*, unavailable, message: "Use pool.writeWithoutTransaction { $0.checkpoint() } instead")
+    public func checkpoint(_ kind: Database.CheckpointMode = .passive) throws { preconditionFailure() }
+
     #if os(iOS)
     @available(*, unavailable, message: "Memory management is now enabled by default. This method does nothing.")
     public func setupMemoryManagement(in application: UIApplication) { preconditionFailure() }

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -442,8 +442,8 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 defer { s2.signal() }
                 try dbPool.writeWithoutTransaction { db in
                     try db.execute(sql: "DELETE FROM items")
+                    try db.checkpoint()
                 }
-                try dbPool.checkpoint()
             } catch {
                 XCTFail("error: \(error)")
             }
@@ -538,8 +538,8 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 defer { s2.signal() }
                 try dbPool.writeWithoutTransaction { db in
                     try db.execute(sql: "INSERT INTO items (id) VALUES (NULL)")
+                    try db.checkpoint()
                 }
-                try dbPool.checkpoint()
             } catch {
                 XCTFail("error: \(error)")
             }
@@ -759,8 +759,8 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 defer { s2.signal() }
                 try dbPool.writeWithoutTransaction { db in
                     try db.execute(sql: "DELETE FROM items")
+                    try db.checkpoint()
                 }
-                try dbPool.checkpoint()
             } catch {
                 XCTFail("error: \(error)")
             }
@@ -803,8 +803,8 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
                 defer { s2.signal() }
                 try dbPool.writeWithoutTransaction { db in
                     try db.execute(sql: "INSERT INTO items (id) VALUES (NULL)")
+                    try db.checkpoint()
                 }
-                try dbPool.checkpoint()
             } catch {
                 XCTFail("error: \(error)")
             }

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -270,7 +270,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let counter = try Counter(dbPool: dbPool)
         try dbPool.write(counter.increment)
         let snapshot = try dbPool.makeSnapshot()
-        try? dbPool.checkpoint(.passive) // ignore if error or not, that's not the point
+        try? dbPool.writeWithoutTransaction { _ = try $0.checkpoint(.passive) } // ignore if error or not, that's not the point
         try XCTAssertEqual(snapshot.read(counter.value), 1)
         try dbPool.write(counter.increment)
         try XCTAssertEqual(snapshot.read(counter.value), 1)
@@ -281,7 +281,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let counter = try Counter(dbPool: dbPool)
         try dbPool.write(counter.increment)
         let snapshot = try dbPool.makeSnapshot()
-        try? dbPool.checkpoint(.full) // ignore if error or not, that's not the point
+        try? dbPool.writeWithoutTransaction { _ = try $0.checkpoint(.full) } // ignore if error or not, that's not the point
         try XCTAssertEqual(snapshot.read(counter.value), 1)
         try dbPool.write(counter.increment)
         try XCTAssertEqual(snapshot.read(counter.value), 1)
@@ -292,7 +292,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let counter = try Counter(dbPool: dbPool)
         try dbPool.write(counter.increment)
         let snapshot = try dbPool.makeSnapshot()
-        try? dbPool.checkpoint(.restart) // ignore if error or not, that's not the point
+        try? dbPool.writeWithoutTransaction { _ = try $0.checkpoint(.restart) } // ignore if error or not, that's not the point
         try XCTAssertEqual(snapshot.read(counter.value), 1)
         try dbPool.write(counter.increment)
         try XCTAssertEqual(snapshot.read(counter.value), 1)
@@ -303,7 +303,7 @@ class DatabaseSnapshotTests: GRDBTestCase {
         let counter = try Counter(dbPool: dbPool)
         try dbPool.write(counter.increment)
         let snapshot = try dbPool.makeSnapshot()
-        try? dbPool.checkpoint(.truncate) // ignore if error or not, that's not the point
+        try? dbPool.writeWithoutTransaction { _ = try $0.checkpoint(.truncate) } // ignore if error or not, that's not the point
         try XCTAssertEqual(snapshot.read(counter.value), 1)
         try dbPool.write(counter.increment)
         try XCTAssertEqual(snapshot.read(counter.value), 1)

--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -353,8 +353,8 @@ class DatabaseTests : GRDBTestCase {
             let result = try dbQueue.inDatabase {
                 try $0.checkpoint()
             }
-            XCTAssertEqual(result.logCount, -1)
-            XCTAssertEqual(result.checkpointCount, -1)
+            XCTAssertEqual(result.walFrameCount, -1)
+            XCTAssertEqual(result.checkpointedFrameCount, -1)
         }
         do {
             // WAL database
@@ -362,8 +362,8 @@ class DatabaseTests : GRDBTestCase {
             let result = try dbPool.writeWithoutTransaction {
                 try $0.checkpoint()
             }
-            XCTAssertGreaterThanOrEqual(result.logCount, 0)
-            XCTAssertGreaterThanOrEqual(result.checkpointCount, 0)
+            XCTAssertGreaterThanOrEqual(result.walFrameCount, 0)
+            XCTAssertGreaterThanOrEqual(result.checkpointedFrameCount, 0)
         }
         do {
             // WAL database + TRUNCATE
@@ -371,8 +371,8 @@ class DatabaseTests : GRDBTestCase {
             let result = try dbPool.writeWithoutTransaction {
                 try $0.checkpoint(.truncate)
             }
-            XCTAssertEqual(result.logCount, 0)
-            XCTAssertEqual(result.checkpointCount, 0)
+            XCTAssertEqual(result.walFrameCount, 0)
+            XCTAssertEqual(result.checkpointedFrameCount, 0)
         }
     }
 }


### PR DESCRIPTION
This pull request addresses #793. It moves the `checkpoint` method from DatabasePool to Database, and fully exposes [sqlite3_wal_checkpoint_v2](https://www.sqlite.org/c3ref/wal_checkpoint_v2.html) to Swift:

```swift
// Before
try dbPool.checkpoint()

// After
let checkpoint = try dbPool.writeWithoutTransaction { db in
    try db.checkpoint()
}
print("\(checkpoint.walFrameCount) frames in the WAL")
print("\(checkpoint.checkpointedFrameCount) checkpointed frames in the WAL")
```

cc @charlesmchen-signal