### PR TITLE
Fix inline documentation for the setupMemoryManagement() function

### DIFF
--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -188,10 +188,6 @@ extension DatabasePool {
     /// Listens to UIApplicationDidEnterBackgroundNotification and
     /// UIApplicationDidReceiveMemoryWarningNotification in order to release
     /// as much memory as possible.
-    ///
-    /// - param application: The UIApplication that will start a background
-    ///   task to let the database pool release its memory when the application
-    ///   enters background.
     private func setupMemoryManagement() {
         let center = NotificationCenter.default
         center.addObserver(

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -88,10 +88,6 @@ extension DatabaseQueue {
     /// Listens to UIApplicationDidEnterBackgroundNotification and
     /// UIApplicationDidReceiveMemoryWarningNotification in order to release
     /// as much memory as possible.
-    ///
-    /// - param application: The UIApplication that will start a background
-    ///   task to let the database queue release its memory when the application
-    ///   enters background.
     private func setupMemoryManagement() {
         let center = NotificationCenter.default
         center.addObserver(


### PR DESCRIPTION
This pull request fixes the inline documentation for the `setupMemoryManagement()` function. In GRDB 5.0.0 and later, the parameter `application` has been removed.

<!-- Please describe your pull request here. -->

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
