### PR TITLE
Add tokenchars support for ascii tokenizer in FTS5.

### DIFF
--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -52,24 +52,43 @@ public struct FTS5TokenizerDescriptor {
     /// - parameters:
     ///     - separators: Unless empty (the default), SQLite will consider
     ///       these characters as token separators.
+    ///     - tokenCharacters: Unless empty (the default), SQLite will
+    ///       consider these characters as token characters.
     ///
     /// See https://www.sqlite.org/fts5.html#ascii_tokenizer
-    public static func ascii(separators: Set<Character> = []) -> FTS5TokenizerDescriptor {
-        let components: [String]
-        if separators.isEmpty {
-            components = ["ascii"]
-        } else {
-            components = DatabaseQueue().inDatabase { db in
-                // Assume quoting a string never fails
-                try! [
-                    "ascii",
-                    "separators",
-                    separators
-                        .map { String($0) }
-                        .joined()
-                        .sqlExpression
-                        .quotedSQL(db)]
-            }
+    public static func ascii(
+        separators: Set<Character> = [],
+        tokenCharacters: Set<Character> = [])
+        -> FTS5TokenizerDescriptor
+    {
+        var components: [String] = ["ascii"]
+        if !separators.isEmpty {
+            // TODO: test "=" and "\"", "(" and ")" as separators, with
+            // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
+            // and Database.create(virtualTable:using:)
+            components.append(contentsOf: [
+                "separators",
+                separators
+                    .sorted()
+                    .map { String($0) }
+                    .joined()
+                    .sqlExpression
+                    .quotedSQL()
+                ])
+        }
+        if !tokenCharacters.isEmpty {
+            // TODO: test "=" and "\"", "(" and ")" as tokenCharacters, with
+            // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
+            // and Database.create(virtualTable:using:)
+            components.append(contentsOf: [
+                "tokenchars",
+                tokenCharacters
+                    .sorted()
+                    .map { String($0) }
+                    .joined()
+                    .sqlExpression
+                    .quotedSQL()
+                ])
         }
         return FTS5TokenizerDescriptor(components: components)
     }


### PR DESCRIPTION
### Pull Request Checklist

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [ ] Changes are tested.

According to [SQLite FTS5 Documentation](https://www.sqlite.org/fts5.html#ascii_tokenizer), the `ascii` tokenizer supports all of the options provided by `unicode61` tokenizer, except for `remove_diacritics`. However, current FTS5 Tokenizer Descriptor only reflects `separators` but not `tokenchars`.

This pull request purposes changes to add support of `tokenchars` option for `ascii` tokenizer in FTS5.