### PR TITLE
Add tokenchars support for ascii tokenizer in FTS5.

### DIFF
--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -58,12 +58,12 @@ public struct FTS5TokenizerDescriptor {
         separators: Set<Character> = [],
         tokenCharacters: Set<Character> = [])
         -> FTS5TokenizerDescriptor {
-        let components: [String] = ["ascii"]
+        var components: [String] = ["ascii"]
         if !separators.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as separators, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
             // and Database.create(virtualTable:using:)
-            separatorComponents = DatabaseQueue().inDatabase { db in
+            let separatorComponents = DatabaseQueue().inDatabase { db in
                 // Assume quoting a string never fails
                 try! [
                     "separators",

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -40,6 +40,28 @@ class FTS5TableBuilderTests: GRDBTestCase {
         }
     }
 
+    func testAsciiTokenizerSeparators() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .ascii(separators: ["X"])
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='ascii separators ''X''')")
+        }
+    }
+
+    func testAsciiTokenizerTokenCharacters() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .ascii(tokenCharacters: Set(".-"))
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='ascii tokenchars ''-.''')")
+        }
+    }
+
     func testDefaultPorterTokenizer() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in


### PR DESCRIPTION
### Pull Request Checklist

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.

According to [SQLite FTS5 Documentation](https://www.sqlite.org/fts5.html#ascii_tokenizer), the `ascii` tokenizer supports all of the options provided by `unicode61` tokenizer, except for `remove_diacritics`. However, current FTS5 Tokenizer Descriptor only reflects `separators` but not `tokenchars`.

This pull request purposes changes to add support of `tokenchars` option for `ascii` tokenizer in FTS5.