### PR TITLE
Expose SQLite 3.31.1 APIs to iOS, macOS, tvOS, watchOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ All notable changes to this project will be documented in this file.
 
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
-<!--
 [Next Release](#next-release)
--->
 
 #### 5.x Releases
 
@@ -70,9 +68,9 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - [0.110.0](#01100), ...
 
 
-<!--
 ## Next Release
--->
+
+- **New**: [#813](https://github.com/groue/GRDB.swift/pull/813): Expose SQLite 3.31.1 APIs to iOS, macOS, tvOS, watchOS
 
 
 ## 5.0.0-beta.8

--- a/GRDB/FTS/FTS3.swift
+++ b/GRDB/FTS/FTS3.swift
@@ -25,7 +25,7 @@ public struct FTS3: VirtualTableModule {
         /// Remove diacritics from Latin script characters. This
         /// option matches the raw "remove_diacritics=2" tokenizer argument,
         /// available from SQLite 3.27.0
-        @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+        @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
         case remove
         #endif
     }

--- a/GRDB/FTS/FTS3.swift
+++ b/GRDB/FTS/FTS3.swift
@@ -21,6 +21,12 @@ public struct FTS3: VirtualTableModule {
         /// option matches the raw "remove_diacritics=2" tokenizer argument,
         /// available from SQLite 3.27.0
         case remove
+        #elseif !GRDBCIPHER
+        /// Remove diacritics from Latin script characters. This
+        /// option matches the raw "remove_diacritics=2" tokenizer argument,
+        /// available from SQLite 3.27.0
+        @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+        case remove
         #endif
     }
     

--- a/GRDB/FTS/FTS3TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS3TokenizerDescriptor.swift
@@ -68,10 +68,13 @@ public struct FTS3TokenizerDescriptor {
             break
         case .keep:
             arguments.append("remove_diacritics=0")
-            #if GRDBCUSTOMSQLITE
+        #if GRDBCUSTOMSQLITE
         case .remove:
             arguments.append("remove_diacritics=2")
-            #endif
+        #elseif !GRDBCIPHER
+        case .remove:
+            arguments.append("remove_diacritics=2")
+        #endif
         }
         if !separators.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as separators, with

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -26,6 +26,12 @@ public struct FTS5: VirtualTableModule {
         /// option matches the raw "remove_diacritics=2" tokenizer argument,
         /// available from SQLite 3.27.0
         case remove
+        #elseif !GRDBCIPHER
+        /// Remove diacritics from Latin script characters. This
+        /// option matches the raw "remove_diacritics=2" tokenizer argument,
+        /// available from SQLite 3.27.0
+        @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+        case remove
         #endif
     }
     

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -30,7 +30,7 @@ public struct FTS5: VirtualTableModule {
         /// Remove diacritics from Latin script characters. This
         /// option matches the raw "remove_diacritics=2" tokenizer argument,
         /// available from SQLite 3.27.0
-        @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+        @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
         case remove
         #endif
     }

--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -144,10 +144,13 @@ public struct FTS5TokenizerDescriptor {
             break
         case .keep:
             components.append(contentsOf: ["remove_diacritics", "0"])
-            #if GRDBCUSTOMSQLITE
+        #if GRDBCUSTOMSQLITE
         case .remove:
             components.append(contentsOf: ["remove_diacritics", "2"])
-            #endif
+        #elseif !GRDBCIPHER
+        case .remove:
+            components.append(contentsOf: ["remove_diacritics", "2"])
+        #endif
         }
         if !separators.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as separators, with

--- a/GRDB/QueryInterface/SQL/SQLCollatedExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollatedExpression.swift
@@ -71,7 +71,7 @@ public struct SQLCollatedExpression {
     ///     Player.order(email.ascNullsLast)
     ///
     /// See https://github.com/groue/GRDB.swift/#the-query-interface
-    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
     public var ascNullsLast: SQLOrderingTerm {
         _SQLOrdering.ascNullsLast(sqlExpression)
     }
@@ -84,7 +84,7 @@ public struct SQLCollatedExpression {
     ///     Player.order(email.descNullsFirst)
     ///
     /// See https://github.com/groue/GRDB.swift/#the-query-interface
-    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
     public var descNullsFirst: SQLOrderingTerm {
         _SQLOrdering.descNullsFirst(sqlExpression)
     }

--- a/GRDB/QueryInterface/SQL/SQLCollatedExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollatedExpression.swift
@@ -62,6 +62,32 @@ public struct SQLCollatedExpression {
     public var descNullsFirst: SQLOrderingTerm {
         _SQLOrdering.descNullsFirst(sqlExpression)
     }
+    #elseif !GRDBCIPHER
+    /// Returns an ordering suitable for QueryInterfaceRequest.order()
+    ///
+    ///     let email: SQLCollatedExpression = Column("email").collating(.nocase)
+    ///
+    ///     // SELECT * FROM player ORDER BY email COLLATE NOCASE ASC NULLS LAST
+    ///     Player.order(email.ascNullsLast)
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    public var ascNullsLast: SQLOrderingTerm {
+        _SQLOrdering.ascNullsLast(sqlExpression)
+    }
+    
+    /// Returns an ordering suitable for QueryInterfaceRequest.order()
+    ///
+    ///     let email: SQLCollatedExpression = Column("email").collating(.nocase)
+    ///
+    ///     // SELECT * FROM player ORDER BY email COLLATE NOCASE DESC NULLS FIRST
+    ///     Player.order(email.descNullsFirst)
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    public var descNullsFirst: SQLOrderingTerm {
+        _SQLOrdering.descNullsFirst(sqlExpression)
+    }
     #endif
     
     init(_ expression: SQLExpression, collationName: Database.CollationName) {

--- a/GRDB/QueryInterface/SQL/SQLOrdering.swift
+++ b/GRDB/QueryInterface/SQL/SQLOrdering.swift
@@ -24,10 +24,11 @@ public protocol SQLOrderingTerm: _SQLOrderingTerm { }
 public enum _SQLOrdering: SQLOrderingTerm, Refinable {
     case asc(SQLExpression)
     case desc(SQLExpression)
-    #if GRDBCUSTOMSQLITE
+    
+    // Only available from 3.30.0. This enum is not public, so those cases don't
+    // harm as long as we don't expose them through public APIs.
     case ascNullsLast(SQLExpression)
     case descNullsFirst(SQLExpression)
-    #endif
     
     var expression: SQLExpression {
         get {
@@ -36,12 +37,10 @@ public enum _SQLOrdering: SQLOrderingTerm, Refinable {
                 return expression
             case .desc(let expression):
                 return expression
-                #if GRDBCUSTOMSQLITE
             case .ascNullsLast(let expression):
                 return expression
             case .descNullsFirst(let expression):
                 return expression
-                #endif
             }
         }
         set {
@@ -50,12 +49,10 @@ public enum _SQLOrdering: SQLOrderingTerm, Refinable {
                 self = .asc(newValue)
             case .desc:
                 self = .desc(newValue)
-                #if GRDBCUSTOMSQLITE
             case .ascNullsLast:
                 self = .ascNullsLast(newValue)
             case .descNullsFirst:
                 self = .descNullsFirst(newValue)
-                #endif
             }
         }
     }
@@ -67,12 +64,10 @@ public enum _SQLOrdering: SQLOrderingTerm, Refinable {
             return _SQLOrdering.desc(expression)
         case .desc(let expression):
             return _SQLOrdering.asc(expression)
-            #if GRDBCUSTOMSQLITE
         case .ascNullsLast(let expression):
             return _SQLOrdering.descNullsFirst(expression)
         case .descNullsFirst(let expression):
             return _SQLOrdering.ascNullsLast(expression)
-            #endif
         }
     }
     

--- a/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
@@ -35,7 +35,7 @@ extension SQLSpecificExpressible {
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
     /// See https://github.com/groue/GRDB.swift/#the-query-interface
-    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
     public var ascNullsLast: SQLOrderingTerm {
         _SQLOrdering.ascNullsLast(sqlExpression)
     }
@@ -43,7 +43,7 @@ extension SQLSpecificExpressible {
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
     /// See https://github.com/groue/GRDB.swift/#the-query-interface
-    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
     public var descNullsFirst: SQLOrderingTerm {
         _SQLOrdering.descNullsFirst(sqlExpression)
     }

--- a/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQL/SQLSpecificExpressible+QueryInterface.swift
@@ -31,6 +31,22 @@ extension SQLSpecificExpressible {
     public var descNullsFirst: SQLOrderingTerm {
         _SQLOrdering.descNullsFirst(sqlExpression)
     }
+    #elseif !GRDBCIPHER
+    /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    public var ascNullsLast: SQLOrderingTerm {
+        _SQLOrdering.ascNullsLast(sqlExpression)
+    }
+    
+    /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
+    ///
+    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    @available(OSX 11, iOS 14, tvOS 14, watchOS 7, *)
+    public var descNullsFirst: SQLOrderingTerm {
+        _SQLOrdering.descNullsFirst(sqlExpression)
+    }
     #endif
 }
 

--- a/GRDB/QueryInterface/SQLGeneration/SQLOrderingGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLOrderingGenerator.swift
@@ -26,17 +26,10 @@ private struct SQLOrderingGenerator: _SQLOrderingTermVisitor {
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " ASC"
         case .desc(let expression):
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " DESC"
-        #if GRDBCUSTOMSQLITE
         case .ascNullsLast(let expression):
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " ASC NULLS LAST"
         case .descNullsFirst(let expression):
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " DESC NULLS FIRST"
-        #elseif !GRDBCIPHER
-        case .ascNullsLast(let expression):
-            resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " ASC NULLS LAST"
-        case .descNullsFirst(let expression):
-            resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " DESC NULLS FIRST"
-        #endif
         }
     }
     

--- a/GRDB/QueryInterface/SQLGeneration/SQLOrderingGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLOrderingGenerator.swift
@@ -26,12 +26,17 @@ private struct SQLOrderingGenerator: _SQLOrderingTermVisitor {
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " ASC"
         case .desc(let expression):
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " DESC"
-            #if GRDBCUSTOMSQLITE
+        #if GRDBCUSTOMSQLITE
         case .ascNullsLast(let expression):
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " ASC NULLS LAST"
         case .descNullsFirst(let expression):
             resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " DESC NULLS FIRST"
-            #endif
+        #elseif !GRDBCIPHER
+        case .ascNullsLast(let expression):
+            resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " ASC NULLS LAST"
+        case .descNullsFirst(let expression):
+            resultSQL = try expression.expressionSQL(context, wrappedInParenthesis: false) + " DESC NULLS FIRST"
+        #endif
         }
     }
     

--- a/Tests/GRDBTests/FTS3TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS3TableBuilderTests.swift
@@ -76,7 +76,7 @@ class FTS3TableBuilderTests: GRDBTestCase {
     }
     #elseif !GRDBCIPHER
     func testUnicode61TokenizerDiacriticsRemove() throws {
-        guard #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) else {
+        guard #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) else {
             throw XCTSkip()
         }
         let dbQueue = try makeDatabaseQueue()

--- a/Tests/GRDBTests/FTS3TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS3TableBuilderTests.swift
@@ -74,6 +74,19 @@ class FTS3TableBuilderTests: GRDBTestCase {
             assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts3(tokenize=unicode61 \"remove_diacritics=2\")")
         }
     }
+    #elseif !GRDBCIPHER
+    func testUnicode61TokenizerDiacriticsRemove() throws {
+        guard #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip()
+        }
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS3()) { t in
+                t.tokenizer = .unicode61(diacritics: .remove)
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts3(tokenize=unicode61 \"remove_diacritics=2\")")
+        }
+    }
     #endif
 
     func testUnicode61TokenizerSeparators() throws {

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -130,7 +130,7 @@ class FTS5TableBuilderTests: GRDBTestCase {
     }
     #elseif !GRDBCIPHER
     func testUnicode61TokenizerDiacriticsRemove() throws {
-        guard #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) else {
+        guard #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) else {
             throw XCTSkip()
         }
         

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -128,6 +128,21 @@ class FTS5TableBuilderTests: GRDBTestCase {
             assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='unicode61 remove_diacritics 2')")
         }
     }
+    #elseif !GRDBCIPHER
+    func testUnicode61TokenizerDiacriticsRemove() throws {
+        guard #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip()
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .unicode61(diacritics: .remove)
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='unicode61 remove_diacritics 2')")
+        }
+    }
     #endif
 
     func testUnicode61TokenizerSeparators() throws {

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -745,7 +745,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.order(Col.age.descNullsFirst)),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
         #elseif !GRDBCIPHER
-        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+        if #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) {
             XCTAssertEqual(
                 sql(dbQueue, tableRequest.order(Col.age.ascNullsLast)),
                 "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
@@ -775,7 +775,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst)),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")
         #elseif !GRDBCIPHER
-        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+        if #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) {
             XCTAssertEqual(
                 sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).ascNullsLast)),
                 "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
@@ -824,7 +824,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.order(Col.age.ascNullsLast).reversed()),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
         #elseif !GRDBCIPHER
-        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+        if #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) {
             XCTAssertEqual(
                 sql(dbQueue, tableRequest.order(Col.age.descNullsFirst).reversed()),
                 "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
@@ -854,7 +854,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst).reversed()),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
         #elseif !GRDBCIPHER
-        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+        if #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) {
             XCTAssertEqual(
                 sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).ascNullsLast).reversed()),
                 "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -744,6 +744,15 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.age.descNullsFirst)),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        #elseif !GRDBCIPHER
+        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.age.ascNullsLast)),
+                "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.age.descNullsFirst)),
+                "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        }
         #endif
     }
     
@@ -765,6 +774,15 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst)),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")
+        #elseif !GRDBCIPHER
+        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).ascNullsLast)),
+                "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst)),
+                "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")
+        }
         #endif
     }
     
@@ -805,6 +823,15 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.age.ascNullsLast).reversed()),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        #elseif !GRDBCIPHER
+        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.age.descNullsFirst).reversed()),
+                "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.age.ascNullsLast).reversed()),
+                "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        }
         #endif
     }
     
@@ -826,6 +853,15 @@ class QueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst).reversed()),
             "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
+        #elseif !GRDBCIPHER
+        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).ascNullsLast).reversed()),
+                "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE DESC NULLS FIRST")
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.order(Col.name.collating(.nocase).descNullsFirst).reversed()),
+                "SELECT * FROM \"readers\" ORDER BY \"name\" COLLATE NOCASE ASC NULLS LAST")
+        }
         #endif
     }
     

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -259,6 +259,15 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, Reader.order(Col.age.descNullsFirst)),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        #elseif !GRDBCIPHER
+        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+            XCTAssertEqual(
+                sql(dbQueue, Reader.order(Col.age.ascNullsLast)),
+                "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")
+            XCTAssertEqual(
+                sql(dbQueue, Reader.order(Col.age.descNullsFirst)),
+                "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
+        }
         #endif
     }
     

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -260,7 +260,7 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, Reader.order(Col.age.descNullsFirst)),
             "SELECT * FROM \"readers\" ORDER BY \"age\" DESC NULLS FIRST")
         #elseif !GRDBCIPHER
-        if #available(OSX 11, iOS 14, tvOS 14, watchOS 7, *) {
+        if #available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *) {
             XCTAssertEqual(
                 sql(dbQueue, Reader.order(Col.age.ascNullsLast)),
                 "SELECT * FROM \"readers\" ORDER BY \"age\" ASC NULLS LAST")


### PR DESCRIPTION
Since iOS 14 ships with SQLite 3.31.1 (in the Xcode 12 beta 2 SDK), we can expose more APIs with availability checks.

SQLite 3.27.0 added the `remove_diacritics=2` option to FTS3 and FTS5:

```swift
try db.create(virtualTable: "documents", using: FTS3()) { t in
    t.tokenizer = .unicode61(diacritics: .remove)
}
try db.create(virtualTable: "documents", using: FTS5()) { t in
    t.tokenizer = .unicode61(diacritics: .remove)
    t.column("content")
}
```

SQLite 3.30.0 added support for the `NULLS FIRST` and `NULLS LAST` syntax in `ORDER BY` clauses:

```swift
let players = try Player.order(Column("score").ascNullsLast).fetchAll(db)
let players = try Player.order(Column("score").descNullsFirst).fetchAll(db)
```
