### PR TITLE
Fix GRDB 5 regression with indexes on expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,117 +28,122 @@ jobs:
   include:
 
     ###########################################
-    ## Test GRDB Xcode 11.6
+    ## Test GRDB Xcode 12
     
-    - name: "Test GRDB Xcode 11.6 - GRDBOSX"
+    - name: "Test GRDB Xcode 12 - GRDBOSX - Swift 5.3"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBOSX_maxSwift
     
-    - name: "Test GRDB Xcode 11.6 - GRDBWatchOS"
+    - name: "Test GRDB Xcode 12 - GRDBOSX - Swift 5.2"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
+      script: make test_framework_GRDBOSX_minSwift
+    
+    - name: "Test GRDB Xcode 12 - GRDBWatchOS"
+      gemfile: .ci/gemfiles/Gemfile.travis
+      osx_image: xcode12
       script: make test_framework_GRDBWatchOS
     
-    - name: "Test GRDB Xcode 11.6 - GRDBiOS iOS maxTarget"
+    - name: "Test GRDB Xcode 12 - GRDBiOS iOS maxTarget"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBiOS_maxTarget_maxSwift
     
-    - name: "Test GRDB Xcode 11.6 - GRDBiOS iOS minTarget"
+    - name: "Test GRDB Xcode 12 - GRDBiOS iOS minTarget"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBiOS_minTarget
     
-    - name: "Test GRDB Xcode 11.6 - GRDBtvOS maxTarget"
+    - name: "Test GRDB Xcode 12 - GRDBtvOS maxTarget"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBtvOS_maxTarget_maxSwift
     
-    - name: "Test GRDB Xcode 11.6 - GRDBtvOS minTarget"
+    - name: "Test GRDB Xcode 12 - GRDBtvOS minTarget"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBtvOS_minTarget
     
-    - name: "Test GRDB Xcode 11.6 - SPM"
+    - name: "Test GRDB Xcode 12 - SPM"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_SPM
     
     ###########################################
-    ## Test GRDBCustom Xcode 11.6
+    ## Test GRDBCustom Xcode 12
     
-    - name: "Test GRDBCustom Xcode 11.6 - GRDBOSX"
+    - name: "Test GRDBCustom Xcode 12 - GRDBOSX"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBCustomSQLiteOSX
     
-    - name: "Test GRDBCustom Xcode 11.6 - GRDBiOS maxTarget"
+    - name: "Test GRDBCustom Xcode 12 - GRDBiOS maxTarget"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBCustomSQLiteiOS_maxTarget_maxSwift
     
-    - name: "Test GRDBCustom Xcode 11.6 - GRDBiOS minTarget"
+    - name: "Test GRDBCustom Xcode 12 - GRDBiOS minTarget"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_GRDBCustomSQLiteiOS_minTarget
     
     ###########################################
-    ## Test SQLCipher Xcode 11.6
+    ## Test SQLCipher Xcode 12
     
-    - name: "Test SQLCipher Xcode 11.6 - SQLCipher 3"
+    - name: "Test SQLCipher Xcode 12 - SQLCipher 3"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_SQLCipher3
     
-    - name: "Test SQLCipher Xcode 11.6 - SQLCipher 4"
+    - name: "Test SQLCipher Xcode 12 - SQLCipher 4"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_framework_SQLCipher4
     
     ###########################################
-    ## Test Installation Xcode 11.6
+    ## Test Installation Xcode 12
     
     # Manual Install
-    - name: "Test Installation Xcode 11.6 - Manual Install"
+    - name: "Test Installation Xcode 12 - Manual Install"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_install_manual
     
     # CocoaPods Lint
-    - name: "Test Installation Xcode 11.6 - CocoaPods Lint"
+    - name: "Test Installation Xcode 12 - CocoaPods Lint"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_CocoaPodsLint_GRDB
     
     # CocoaPods Install GRDB
-    - name: "Test Installation Xcode 11.6 - CocoaPods Framework"
+    - name: "Test Installation Xcode 12 - CocoaPods Framework"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_install_GRDB_CocoaPods_framework
     
     # CocoaPods Install GRDB
-    - name: "Test Installation Xcode 11.6 - CocoaPods Static"
+    - name: "Test Installation Xcode 12 - CocoaPods Static"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_install_GRDB_CocoaPods_static
     
     # SPM Install
-    - name: "Test Installation Xcode 11.6 - SPM Package"
+    - name: "Test Installation Xcode 12 - SPM Package"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_install_SPM_Package
     
     # SPM Install
-    - name: "Test Installation Xcode 11.6 - SPM Package in Xcode Project"
+    - name: "Test Installation Xcode 12 - SPM Package in Xcode Project"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_install_SPM_Project
     
     # Custom SQLite Install
-    - name: "Test Installation Xcode 11.6 - Custom SQLite"
+    - name: "Test Installation Xcode 12 - Custom SQLite"
       gemfile: .ci/gemfiles/Gemfile.travis
-      osx_image: xcode11.6
+      osx_image: xcode12
       script: make test_install_customSQLite
     
     ###########################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,9 @@ All notable changes to this project will be documented in this file.
 
 GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: APIs flagged [**:fire: EXPERIMENTAL**](README.md#what-are-experimental-features). Those are unstable, and may break between any two minor releases of the library.
 
-<!--
-[Next Release](#next-release)
--->
-
 #### 5.x Releases
 
+- [Next Release](#next-release)
 - `5.0.x` Releases - [5.0.0](#500)
 - `5.0.0` Betas - [5.0.0-beta](#500-beta) | [5.0.0-beta.2](#500-beta2) | [5.0.0-beta.3](#500-beta3) | [5.0.0-beta.4](#500-beta4) | [5.0.0-beta.5](#500-beta5) | [5.0.0-beta.6](#500-beta6) | [5.0.0-beta.7](#500-beta7) | [5.0.0-beta.8](#500-beta8) | [5.0.0-beta.9](#500-beta9) | [5.0.0-beta.10](#500-beta10) | [5.0.0-beta.11](#500-beta11)
 
@@ -69,6 +66,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 #### 0.x Releases
 
 - [0.110.0](#01100), ...
+
+
+## Next Release
+
+- **Fixed**: [#841](https://github.com/groue/GRDB.swift/issues/841): Fix GRDB 5 regression with indexes on expressions
 
 
 ## 5.0.0


### PR DESCRIPTION
This pull request fixes #840, and the `Database.indexes(on:)` method.

Since its introduction, `Database.indexes(on:)` had a bug which would make it crash with [indexes on expressions](https://www.sqlite.org/expridx.html).

Now `Database.indexes(on:)` no longer crashes, and just excludes such indexes from its result.

It happens that this bug has introduced regressions in GRDB 5, which would crash when running some query interface requests on tables indexed on an expression. The reason in that GRDB 5 performs a more precise analysis of requests in order to optimize the generated SQL or detect misuses, and querying indexes is part of this analysis.