### PR TITLE
Add buildActiveScheme to playground settings so they'll build under Xcode 12

### DIFF
--- a/Documentation/Playgrounds/Associations.playground/contents.xcplayground
+++ b/Documentation/Playgrounds/Associations.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='macos'>
+<playground version='5.0' target-platform='macos' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Documentation/Playgrounds/CustomizedDecodingOfDatabaseRows.playground/contents.xcplayground
+++ b/Documentation/Playgrounds/CustomizedDecodingOfDatabaseRows.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='macos' display-mode='rendered'>
+<playground version='5.0' target-platform='macos' display-mode='rendered' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Documentation/Playgrounds/MyPlayground.playground/contents.xcplayground
+++ b/Documentation/Playgrounds/MyPlayground.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='macos'>
+<playground version='5.0' target-platform='macos' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Documentation/Playgrounds/Tour.playground/contents.xcplayground
+++ b/Documentation/Playgrounds/Tour.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='raw'>
+<playground version='5.0' target-platform='osx' display-mode='raw' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/Documentation/Playgrounds/TransactionObserver.playground/contents.xcplayground
+++ b/Documentation/Playgrounds/TransactionObserver.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='osx' display-mode='rendered'>
+<playground version='5.0' target-platform='osx' display-mode='rendered' buildActiveScheme='true'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>


### PR DESCRIPTION
Not sure if this is useful, but it was useful to me when I was trying to get the playgrounds to work, so I thought I'd submit a PR if it's wanted.

It seems that playgrounds fail to correctly import modules under Xcode 12 unless they playground has "buildActiveScheme" set to true for each playground. (This now gets set by default if you create a new playground under Xcode 12)

This PR just updates the 5 playgrounds in the documentation folder with that setting.

Without it, you get a "No such module" error on attempting to import GRDB and various related compiler errors when you try to build the playground.

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [ ] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [ ] Changes are tested.
