### PR TITLE
Prevent filter misuse with a deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - **New**: Clarifications on [ValueObservation that track a varying database region](https://github.com/groue/GRDB.swift/blob/master/README.md#observing-a-varying-database-region).
 - **New**: FAQ [Why is ValueObservation not publishing value changes?](https://github.com/groue/GRDB.swift/blob/master/README.md#why-is-valueobservation-not-publishing-value-changes)
 - **New**: [#855](https://github.com/groue/GRDB.swift/pull/855) by [@mallman](https://github.com/mallman): Support for generated columns with custom SQLite build, and upgrade custom SQLite builds to version 3.33.0
+- **New**: [#864](https://github.com/groue/GRDB.swift/pull/864): Prevent filter misuse with a deprecation warning
 
 
 ## 5.0.3

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -145,10 +145,21 @@ extension FilteredRequest {
     /// Creates a request with the provided *predicate* added to the
     /// eventual set of already applied predicates.
     ///
+    ///     // SELECT * FROM player WHERE 0
+    ///     var request = Player.all()
+    ///     request = request.filter(false)
+    @available(*, deprecated, message: "Did you mean filter(key:)? If not, use filter(DatabaseValue) instead.")
+    public func filter(_ predicate: SQLExpressible) -> Self {
+        filter { _ in predicate }
+    }
+    
+    /// Creates a request with the provided *predicate* added to the
+    /// eventual set of already applied predicates.
+    ///
     ///     // SELECT * FROM player WHERE email = 'arthur@example.com'
     ///     var request = Player.all()
     ///     request = request.filter(Column("email") == "arthur@example.com")
-    public func filter(_ predicate: SQLExpressible) -> Self {
+    public func filter(_ predicate: SQLSpecificExpressible) -> Self {
         filter { _ in predicate }
     }
     
@@ -187,7 +198,7 @@ extension FilteredRequest {
     ///     var request = Player.all()
     ///     request = request.none()
     public func none() -> Self {
-        filter(false)
+        filter { _ in false }
     }
 }
 

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -153,6 +153,9 @@ extension FilteredRequest {
         filter { _ in predicate }
     }
     
+    // Accept SQLSpecificExpressible instead of SQLExpressible, so that we
+    // prevent the `Player.filter(42)` misuse.
+    // See https://github.com/groue/GRDB.swift/pull/864
     /// Creates a request with the provided *predicate* added to the
     /// eventual set of already applied predicates.
     ///

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -148,7 +148,7 @@ extension FilteredRequest {
     ///     // SELECT * FROM player WHERE 0
     ///     var request = Player.all()
     ///     request = request.filter(false)
-    @available(*, deprecated, message: "Did you mean filter(key:)? If not, use filter(DatabaseValue) instead.")
+    @available(*, deprecated, message: "Did you mean filter(key: id)? If not, prefer filter(value.databaseValue) instead. See also none().")
     public func filter(_ predicate: SQLExpressible) -> Self {
         filter { _ in predicate }
     }

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -148,7 +148,7 @@ extension FilteredRequest {
     ///     // SELECT * FROM player WHERE 0
     ///     var request = Player.all()
     ///     request = request.filter(false)
-    @available(*, deprecated, message: "Did you mean filter(key: id)? If not, prefer filter(value.databaseValue) instead. See also none().")
+    @available(*, deprecated, message: "Did you mean filter(key: id)? If not, prefer filter(value.databaseValue) instead. See also none().") // swiftlint:disable:this line_length
     public func filter(_ predicate: SQLExpressible) -> Self {
         filter { _ in predicate }
     }

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -154,7 +154,20 @@ extension TableRecord {
     /// The selection defaults to all columns. This default can be changed for
     /// all requests by the `TableRecord.databaseSelection` property, or
     /// for individual requests with the `TableRecord.select` method.
+    @available(*, deprecated, message: "Did you mean filter(key:)? If not, use filter(DatabaseValue) instead.")
     public static func filter(_ predicate: SQLExpressible) -> QueryInterfaceRequest<Self> {
+        all().filter(predicate.sqlExpression)
+    }
+    
+    /// Creates a request with the provided *predicate*.
+    ///
+    ///     // SELECT * FROM player WHERE email = 'arthur@example.com'
+    ///     let request = Player.filter(Column("email") == "arthur@example.com")
+    ///
+    /// The selection defaults to all columns. This default can be changed for
+    /// all requests by the `TableRecord.databaseSelection` property, or
+    /// for individual requests with the `TableRecord.select` method.
+    public static func filter(_ predicate: SQLSpecificExpressible) -> QueryInterfaceRequest<Self> {
         all().filter(predicate)
     }
     

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -154,7 +154,7 @@ extension TableRecord {
     /// The selection defaults to all columns. This default can be changed for
     /// all requests by the `TableRecord.databaseSelection` property, or
     /// for individual requests with the `TableRecord.select` method.
-    @available(*, deprecated, message: "Did you mean filter(key:)? If not, use filter(DatabaseValue) instead.")
+    @available(*, deprecated, message: "Did you mean filter(key: id)? If not, prefer filter(value.databaseValue) instead. See also all() and none().")
     public static func filter(_ predicate: SQLExpressible) -> QueryInterfaceRequest<Self> {
         all().filter(predicate.sqlExpression)
     }

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -159,6 +159,9 @@ extension TableRecord {
         all().filter(predicate.sqlExpression)
     }
     
+    // Accept SQLSpecificExpressible instead of SQLExpressible, so that we
+    // prevent the `Player.filter(42)` misuse.
+    // See https://github.com/groue/GRDB.swift/pull/864
     /// Creates a request with the provided *predicate*.
     ///
     ///     // SELECT * FROM player WHERE email = 'arthur@example.com'

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -154,7 +154,7 @@ extension TableRecord {
     /// The selection defaults to all columns. This default can be changed for
     /// all requests by the `TableRecord.databaseSelection` property, or
     /// for individual requests with the `TableRecord.select` method.
-    @available(*, deprecated, message: "Did you mean filter(key: id)? If not, prefer filter(value.databaseValue) instead. See also all() and none().")
+    @available(*, deprecated, message: "Did you mean filter(key: id)? If not, prefer filter(value.databaseValue) instead. See also all() and none().") // swiftlint:disable:this line_length
     public static func filter(_ predicate: SQLExpressible) -> QueryInterfaceRequest<Self> {
         all().filter(predicate.sqlExpression)
     }

--- a/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
@@ -307,7 +307,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
@@ -531,7 +531,7 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())

--- a/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingFetchableRecordTests.swift
@@ -375,7 +375,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
@@ -655,7 +655,7 @@ class AssociationPrefetchingFetchableRecordTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())

--- a/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
@@ -118,7 +118,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
             // Request with avoided prefetch
             do {
                 let request = A
-                    .filter(false)
+                    .none()
                     .including(all: A
                         .hasMany(B.self)
                         .orderByPrimaryKey())
@@ -258,7 +258,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
@@ -466,7 +466,7 @@ class AssociationPrefetchingRowTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -99,7 +99,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
             // Request with avoided prefetch
             do {
                 let request = A
-                    .filter(false)
+                    .none()
                     .including(all: A
                         .hasMany(B.self)
                         .orderByPrimaryKey())
@@ -207,7 +207,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
             // Request with avoided prefetch
             do {
                 let request = Parent
-                    .filter(false)
+                    .none()
                     .including(all: Parent
                         .hasMany(Child.self))
                     .orderByPrimaryKey()
@@ -288,7 +288,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(all: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())
@@ -434,7 +434,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                 let request = A
                     .including(all: A
                         .hasMany(C.self)
-                        .filter(false)
+                        .none()
                         .including(required: C
                             .hasMany(D.self)
                             .orderByPrimaryKey())

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -243,7 +243,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(10 > Col.age)),
             "SELECT * FROM \"readers\" WHERE 10 > \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(10 > 10)),
+            sql(dbQueue, tableRequest.filter { _ in 10 > 10 }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age > Col.age)),
@@ -256,7 +256,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter("B" > Col.name)),
             "SELECT * FROM \"readers\" WHERE 'B' > \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter("B" > "B")),
+            sql(dbQueue, tableRequest.filter { _ in "B" > "B" }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name > Col.name)),
@@ -288,7 +288,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(10 >= Col.age)),
             "SELECT * FROM \"readers\" WHERE 10 >= \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(10 >= 10)),
+            sql(dbQueue, tableRequest.filter { _ in 10 >= 10 }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age >= Col.age)),
@@ -301,7 +301,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter("B" >= Col.name)),
             "SELECT * FROM \"readers\" WHERE 'B' >= \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter("B" >= "B")),
+            sql(dbQueue, tableRequest.filter { _ in "B" >= "B" }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name >= Col.name)),
@@ -333,7 +333,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(10 < Col.age)),
             "SELECT * FROM \"readers\" WHERE 10 < \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(10 < 10)),
+            sql(dbQueue, tableRequest.filter { _ in 10 < 10 }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age < Col.age)),
@@ -346,7 +346,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter("B" < Col.name)),
             "SELECT * FROM \"readers\" WHERE 'B' < \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter("B" < "B")),
+            sql(dbQueue, tableRequest.filter { _ in "B" < "B" }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name < Col.name)),
@@ -378,7 +378,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(10 <= Col.age)),
             "SELECT * FROM \"readers\" WHERE 10 <= \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(10 <= 10)),
+            sql(dbQueue, tableRequest.filter { _ in 10 <= 10 }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age <= Col.age)),
@@ -391,7 +391,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter("B" <= Col.name)),
             "SELECT * FROM \"readers\" WHERE 'B' <= \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter("B" <= "B")),
+            sql(dbQueue, tableRequest.filter { _ in "B" <= "B" }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name <= Col.name)),
@@ -429,7 +429,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter((10 as Int?) == Col.age)),
             "SELECT * FROM \"readers\" WHERE 10 = \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(10 == 10)),
+            sql(dbQueue, tableRequest.filter { _ in 10 == 10 }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age == Col.age)),
@@ -458,7 +458,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter("B" == Col.name)),
             "SELECT * FROM \"readers\" WHERE 'B' = \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter("B" == "B")),
+            sql(dbQueue, tableRequest.filter { _ in "B" == "B" }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name == Col.name)),
@@ -477,13 +477,13 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(false == Col.age)),
             "SELECT * FROM \"readers\" WHERE \"age\" = 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(true == true)),
+            sql(dbQueue, tableRequest.filter { _ in true == true }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(false == false)),
+            sql(dbQueue, tableRequest.filter { _ in false == false }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(true == false)),
+            sql(dbQueue, tableRequest.filter { _ in true == false }),
             "SELECT * FROM \"readers\" WHERE 0")
     }
     
@@ -581,7 +581,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter((10 as Int?) != Col.age)),
             "SELECT * FROM \"readers\" WHERE 10 <> \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(10 != 10)),
+            sql(dbQueue, tableRequest.filter { _ in 10 != 10 }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age != Col.age)),
@@ -600,7 +600,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(!((10 as Int?) == Col.age))),
             "SELECT * FROM \"readers\" WHERE 10 <> \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(!(10 == 10))),
+            sql(dbQueue, tableRequest.filter { _ in !(10 == 10) }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == Col.age))),
@@ -645,7 +645,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter("B" != Col.name)),
             "SELECT * FROM \"readers\" WHERE 'B' <> \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter("B" != "B")),
+            sql(dbQueue, tableRequest.filter { _ in "B" != "B" }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.name != Col.name)),
@@ -658,7 +658,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(!("B" == Col.name))),
             "SELECT * FROM \"readers\" WHERE 'B' <> \"name\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(!("B" == "B"))),
+            sql(dbQueue, tableRequest.filter { _ in !("B" == "B") }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.name == Col.name))),
@@ -677,13 +677,13 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(false != Col.age)),
             "SELECT * FROM \"readers\" WHERE \"age\" <> 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(true != true)),
+            sql(dbQueue, tableRequest.filter { _ in true != true }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(false != false)),
+            sql(dbQueue, tableRequest.filter { _ in false != false }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(true != false)),
+            sql(dbQueue, tableRequest.filter { _ in true != false }),
             "SELECT * FROM \"readers\" WHERE 1")
         
         XCTAssertEqual(
@@ -699,13 +699,13 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(!(false == Col.age))),
             "SELECT * FROM \"readers\" WHERE \"age\" <> 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(!(true == true))),
+            sql(dbQueue, tableRequest.filter { _ in !(true == true) }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(!(false == false))),
+            sql(dbQueue, tableRequest.filter { _ in !(false == false) }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(!(true == false))),
+            sql(dbQueue, tableRequest.filter { _ in !(true == false) }),
             "SELECT * FROM \"readers\" WHERE 1")
     }
     
@@ -739,7 +739,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(!(10 == Col.age))),
             "SELECT * FROM \"readers\" WHERE 10 <> \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(!(10 == 10))),
+            sql(dbQueue, tableRequest.filter { _ in !(10 == 10) }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(!(Col.age == Col.age))),
@@ -1044,7 +1044,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(2 - Col.age)),
             "SELECT * FROM \"readers\" WHERE 2 - \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(2 - 2)),
+            sql(dbQueue, tableRequest.filter { _ in 2 - 2 }),
             "SELECT * FROM \"readers\" WHERE 0")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age - Col.age)),
@@ -1067,7 +1067,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(2 + Col.age)),
             "SELECT * FROM \"readers\" WHERE 2 + \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(2 + 2)),
+            sql(dbQueue, tableRequest.filter { _ in 2 + 2 }),
             "SELECT * FROM \"readers\" WHERE 4")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age + Col.age)),
@@ -1114,7 +1114,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(2 * Col.age)),
             "SELECT * FROM \"readers\" WHERE 2 * \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(2 * 2)),
+            sql(dbQueue, tableRequest.filter { _ in 2 * 2 }),
             "SELECT * FROM \"readers\" WHERE 4")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age * Col.age)),
@@ -1158,7 +1158,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(2 / Col.age)),
             "SELECT * FROM \"readers\" WHERE 2 / \"age\"")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(2 / 2)),
+            sql(dbQueue, tableRequest.filter { _ in 2 / 2 }),
             "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age / Col.age)),
@@ -1193,17 +1193,9 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testIfNull() throws {
         let dbQueue = try makeDatabaseQueue()
         
-        var optInt: Int? = nil
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age ?? 2)),
             "SELECT * FROM \"readers\" WHERE IFNULL(\"age\", 2)")
-        XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(optInt ?? Col.age)),
-            "SELECT * FROM \"readers\" WHERE \"age\"")
-        optInt = 1
-        XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(optInt ?? Col.age)),
-            "SELECT * FROM \"readers\" WHERE 1")
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(Col.age ?? Col.age)),
             "SELECT * FROM \"readers\" WHERE IFNULL(\"age\", \"age\")")

--- a/Tests/GRDBTests/QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceRequestTests.swift
@@ -569,7 +569,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(sql: "id <> 1")),
             "SELECT * FROM \"readers\" WHERE id <> 1")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(sql: "id <> 1").filter(true)),
+            sql(dbQueue, tableRequest.filter(sql: "id <> 1").filter(true.databaseValue)),
             "SELECT * FROM \"readers\" WHERE (id <> 1) AND 1")
     }
     
@@ -579,7 +579,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(sql: "id <> ?", arguments: [1])),
             "SELECT * FROM \"readers\" WHERE id <> 1")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(sql: "id <> ?", arguments: [1]).filter(true)),
+            sql(dbQueue, tableRequest.filter(sql: "id <> ?", arguments: [1]).filter(true.databaseValue)),
             "SELECT * FROM \"readers\" WHERE (id <> 1) AND 1")
     }
     
@@ -589,7 +589,7 @@ class QueryInterfaceRequestTests: GRDBTestCase {
             sql(dbQueue, tableRequest.filter(sql: "id <> :id", arguments: ["id": 1])),
             "SELECT * FROM \"readers\" WHERE id <> 1")
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(sql: "id <> :id", arguments: ["id": 1]).filter(true)),
+            sql(dbQueue, tableRequest.filter(sql: "id <> :id", arguments: ["id": 1]).filter(true.databaseValue)),
             "SELECT * FROM \"readers\" WHERE (id <> 1) AND 1")
     }
     
@@ -610,14 +610,14 @@ class QueryInterfaceRequestTests: GRDBTestCase {
     func testFilter() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(true)),
+            sql(dbQueue, tableRequest.filter(true.databaseValue)),
             "SELECT * FROM \"readers\" WHERE 1")
     }
     
     func testMultipleFilter() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
-            sql(dbQueue, tableRequest.filter(true).filter(false)),
+            sql(dbQueue, tableRequest.filter(true.databaseValue).filter(false.databaseValue)),
             "SELECT * FROM \"readers\" WHERE 1 AND 0")
     }
     

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -200,14 +200,14 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
     func testFilter() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
-            sql(dbQueue, Reader.filter(true)),
+            sql(dbQueue, Reader.filter(true.databaseValue)),
             "SELECT * FROM \"readers\" WHERE 1")
     }
     
     func testMultipleFilter() throws {
         let dbQueue = try makeDatabaseQueue()
         XCTAssertEqual(
-            sql(dbQueue, Reader.filter(true).filter(false)),
+            sql(dbQueue, Reader.filter(true.databaseValue).filter(false.databaseValue)),
             "SELECT * FROM \"readers\" WHERE 1 AND 0")
     }
     


### PR DESCRIPTION
@pakko972 raised the concern that the `filter(_:)` method is sometimes misused:

```swift
// MISUSE
let player = try Player.filter(42).fetchOne(db)
```

The above request performs `SELECT * FROM player WHERE 42`, which does not filter anything because 42 is a truthy value for SQLite. It fetches a random player!

The fixed request needs `filter(key:)`:

```swift
// FIXED: SELECT * FROM player WHERE id = 42
let player = try Player.filter(key: 42).fetchOne(db)
```

This misuse is not always easy to spot for the end user. And it is not always easy to fix, either.

In order to prevent such a misuse, `filter(_:)` now emits a deprecation warning when it is fed with an expression that does not "speak" SQL in a way or another.

```swift
// Speaks SQL: no warning
Player.filter(Column("score") >= 1000)

// Raw value: warning
Player.filter(42)
```

To fix the deprecation warning, you have various strategies:

- Use `filter(key:)` when your intent is to filter on the primary key
- Use `none()` instead of `filter(false)`
- Use nothing, or `all()`, instead of `filter(true)`
- Use `filter(value.databaseValue)` instead of `filter(value)`, when you know why you inject a value in the WHERE clause
