### PR TITLE
Parse time zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,9 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 ## Next Release
 
 - **New**: [#868](https://github.com/groue/GRDB.swift/pull/868): ValueObservation optimization is opt-in.
-- **Documentation update**: The [ValueObservation Performance](https://github.com/groue/GRDB.swift#valueobservation-performance) chapter has been extanded with a tip for observations that track a constant database region.
+- **New**: [#872](https://github.com/groue/GRDB.swift/pull/872): Parse time zones
+- **Documentation update**: The [ValueObservation Performance](https://github.com/groue/GRDB.swift/blob/master/README.md#valueobservation-performance) chapter was extended with a tip for observations that track a constant database region.
+- **Documentation update**: The [Date and DateComponents](https://github.com/groue/GRDB.swift/blob/master/README.md#date-and-datecomponents) chapter describes the support for time zones.
 
 
 ## 5.1.0

--- a/GRDB/Core/Support/Foundation/SQLiteDateParser.swift
+++ b/GRDB/Core/Support/Foundation/SQLiteDateParser.swift
@@ -2,18 +2,7 @@ import Foundation
 
 // inspired by: http://jordansmith.io/performant-date-parsing/
 
-class SQLiteDateParser {
-    
-    private struct ParserComponents {
-        var year: Int32 = 0
-        var month: Int32 = 0
-        var day: Int32 = 0
-        var hour: Int32 = 0
-        var minute: Int32 = 0
-        var second: Int32 = 0
-        var nanosecond = ContiguousArray<CChar>(repeating: 0, count: 10) // 9 digits, and trailing \0
-    }
-    
+final class SQLiteDateParser {
     func components(from dateString: String) -> DatabaseDateComponents? {
         dateString.withCString { cString in
             components(cString: cString, length: strlen(cString))
@@ -29,17 +18,25 @@ class SQLiteDateParser {
         // "YYYY-..." -> datetime
         if cString[4] == UInt8(ascii: "-") {
             var components = DateComponents()
-            return parseDatetimeFormat(cString: cString, length: length, into: &components)
-                .map { DatabaseDateComponents(components, format: $0)
+            var parser = Parser(cString: cString, length: length)
+            guard let format = parseDatetimeFormat(parser: &parser, into: &components),
+                  parser.length == 0
+            else {
+                return nil
             }
+            return DatabaseDateComponents(components, format: format)
         }
         
         // "HH-:..." -> time
         if cString[2] == UInt8(ascii: ":") {
             var components = DateComponents()
-            return parseTimeFormat(cString: cString, length: length, into: &components)
-                .map { DatabaseDateComponents(components, format: $0)
+            var parser = Parser(cString: cString, length: length)
+            guard let format = parseTimeFormat(parser: &parser, into: &components),
+                  parser.length == 0
+            else {
+                return nil
             }
+            return DatabaseDateComponents(components, format: format)
         }
         
         // Invalid
@@ -54,35 +51,28 @@ class SQLiteDateParser {
     // - YYYY-MM-DDTHH:MM:SS
     // - YYYY-MM-DDTHH:MM:SS.SSS
     private func parseDatetimeFormat(
-        cString: UnsafePointer<CChar>,
-        length: Int,
+        parser: inout Parser,
         into components: inout DateComponents)
-        -> DatabaseDateComponents.Format?
+    -> DatabaseDateComponents.Format?
     {
-        var cString = cString
-        var remainingLength = length
-        
-        if remainingLength < 10 { return nil }
-        remainingLength -= 10
-        guard
-            let year = parseNNNN(cString: &cString),
-            parse("-", cString: &cString),
-            let month = parseNN(cString: &cString),
-            parse("-", cString: &cString),
-            let day = parseNN(cString: &cString)
-            else { return nil }
+        guard let year = parser.parseNNNN(),
+            parser.parse("-"),
+            let month = parser.parseNN(),
+            parser.parse("-"),
+            let day = parser.parseNN()
+        else { return nil }
         
         components.year = year
         components.month = month
         components.day = day
-        if remainingLength == 0 { return .YMD }
+        if parser.length == 0 { return .YMD }
         
-        remainingLength -= 1
-        guard parse(" ", cString: &cString) || parse("T", cString: &cString) else {
+        guard parser.parse(" ") || parser.parse("T")
+        else {
             return nil
         }
         
-        switch parseTimeFormat(cString: cString, length: remainingLength, into: &components) {
+        switch parseTimeFormat(parser: &parser, into: &components) {
         case .HM: return .YMD_HM
         case .HMS: return .YMD_HMS
         case .HMSS: return .YMD_HMSS
@@ -94,94 +84,145 @@ class SQLiteDateParser {
     // - HH:MM:SS
     // - HH:MM:SS.SSS
     private func parseTimeFormat(
-        cString: UnsafePointer<CChar>,
-        length: Int,
+        parser: inout Parser,
         into components: inout DateComponents)
-        -> DatabaseDateComponents.Format?
+    -> DatabaseDateComponents.Format?
     {
-        var cString = cString
-        var remainingLength = length
-        
-        if remainingLength < 5 { return nil }
-        remainingLength -= 5
-        guard
-            let hour = parseNN(cString: &cString),
-            parse(":", cString: &cString),
-            let minute = parseNN(cString: &cString)
-            else { return nil }
+        guard let hour = parser.parseNN(),
+            parser.parse(":"),
+            let minute = parser.parseNN()
+        else { return nil }
         
         components.hour = hour
         components.minute = minute
-        if remainingLength == 0 { return .HM }
+        if parser.length == 0 || parseTimeZone(parser: &parser, into: &components) { return .HM }
         
-        if remainingLength < 3 { return nil }
-        remainingLength -= 3
-        guard
-            parse(":", cString: &cString),
-            let second = parseNN(cString: &cString)
-            else { return nil }
+        guard parser.parse(":"),
+            let second = parser.parseNN()
+        else { return nil }
         
         components.second = second
-        if remainingLength == 0 { return .HMS }
+        if parser.length == 0 || parseTimeZone(parser: &parser, into: &components) { return .HMS }
         
-        if remainingLength < 1 { return nil }
-        remainingLength -= 1
-        guard parse(".", cString: &cString) else { return nil }
+        guard parser.parse(".") else { return nil }
         
-        // Parse three digits
+        // Parse one to three digits
         // Rationale: https://github.com/groue/GRDB.swift/pull/362
-        remainingLength = min(remainingLength, 3)
         var nanosecond = 0
-        for _ in 0..<remainingLength {
-            guard parseDigit(cString: &cString, into: &nanosecond) else { return nil }
+        guard parser.parseDigit(into: &nanosecond) else { return nil }
+        if parser.length == 0 || parseTimeZone(parser: &parser, into: &components) {
+            components.nanosecond = nanosecond * 100_000_000
+            return .HMSS
         }
-        nanosecond *= [1_000_000_000, 100_000_000, 10_000_000, 1_000_000][remainingLength]
-        components.nanosecond = nanosecond
+        guard parser.parseDigit(into: &nanosecond) else { return nil }
+        if parser.length == 0 || parseTimeZone(parser: &parser, into: &components) {
+            components.nanosecond = nanosecond * 10_000_000
+            return .HMSS
+        }
+        guard parser.parseDigit(into: &nanosecond) else { return nil }
+        components.nanosecond = nanosecond * 1_000_000
+        while parser.parseDigit() != nil { }
+        _ = parseTimeZone(parser: &parser, into: &components)
         return .HMSS
     }
     
-    @inline(__always)
-    private func parseNNNN(cString: inout UnsafePointer<CChar>) -> Int? {
-        var number = 0
-        guard parseDigit(cString: &cString, into: &number)
-            && parseDigit(cString: &cString, into: &number)
-            && parseDigit(cString: &cString, into: &number)
-            && parseDigit(cString: &cString, into: &number)
-        else {
-            return nil
+    private func parseTimeZone(
+        parser: inout Parser,
+        into components: inout DateComponents)
+    -> Bool
+    {
+        if parser.parse("Z") {
+            components.timeZone = TimeZone(secondsFromGMT: 0)
+            return true
         }
-        return number
+        
+        if parser.parse("+"),
+                  let hour = parser.parseNN(),
+                  parser.parse(":"),
+                  let minute = parser.parseNN()
+        {
+            components.timeZone = TimeZone(secondsFromGMT: hour * 3600 + minute * 60)
+            return true
+        }
+        
+        if parser.parse("-"),
+                  let hour = parser.parseNN(),
+                  parser.parse(":"),
+                  let minute = parser.parseNN()
+        {
+            components.timeZone = TimeZone(secondsFromGMT: -(hour * 3600 + minute * 60))
+            return true
+        }
+        
+        return false
     }
     
-    @inline(__always)
-    private func parseNN(cString: inout UnsafePointer<CChar>) -> Int? {
-        var number = 0
-        guard parseDigit(cString: &cString, into: &number)
-            && parseDigit(cString: &cString, into: &number)
-        else {
-            return nil
+    private struct Parser {
+        var cString: UnsafePointer<CChar>
+        var length: Int
+        
+        @inline(__always)
+        private mutating func shift() {
+            cString += 1
+            length -= 1
         }
-        return number
-    }
-    
-    @inline(__always)
-    private func parse(_ scalar: Unicode.Scalar, cString: inout UnsafePointer<CChar>) -> Bool {
-        guard cString[0] == UInt8(ascii: scalar) else {
-            return false
+
+        @inline(__always)
+        mutating func parse(_ scalar: Unicode.Scalar) -> Bool {
+            guard length > 0, cString[0] == UInt8(ascii: scalar) else {
+                return false
+            }
+            shift()
+            return true
         }
-        cString += 1
-        return true
-    }
-    
-    @inline(__always)
-    private func parseDigit(cString: inout UnsafePointer<CChar>, into number: inout Int) -> Bool {
-        let char = cString[0]
-        let digit = char - CChar(bitPattern: UInt8(ascii: "0"))
-        guard digit >= 0 && digit <= 9 else {
-            return false
+        
+        @inline(__always)
+        mutating func parseDigit() -> Int? {
+            guard length > 0 else {
+                return nil
+            }
+            let char = cString[0]
+            let digit = char - CChar(bitPattern: UInt8(ascii: "0"))
+            guard digit >= 0 && digit <= 9 else {
+                return nil
+            }
+            shift()
+            return Int(digit)
         }
-        cString += 1
-        number = number * 10 + Int(digit)
-        return true
+        
+        @inline(__always)
+        mutating func parseDigit(into number: inout Int) -> Bool {
+            guard let digit = parseDigit() else {
+                return false
+            }
+            number = number * 10 + digit
+            return true
+        }
+        
+        @inline(__always)
+        mutating func parseNNNN() -> Int? {
+            var number = 0
+            guard parseDigit(into: &number)
+                    && parseDigit(into: &number)
+                    && parseDigit(into: &number)
+                    && parseDigit(into: &number)
+            else {
+                // Don't restore self to initial state because we don't need it
+                return nil
+            }
+            return number
+        }
+        
+        @inline(__always)
+        mutating func parseNN() -> Int? {
+            var number = 0
+            guard parseDigit(into: &number)
+                    && parseDigit(into: &number)
+            else {
+                // Don't restore self to initial state because we don't need it
+                return nil
+            }
+            return number
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1284,7 +1284,7 @@ Here is how GRDB supports the various [date formats](https://www.sqlite.org/lang
 | Timestamps since unix epoch  |       Read ³       |                |
 | `now`                        |                    |                |
 
-¹ Missing components are assumed to be zero. Dates are stored and read in the UTC time zone, unless the format is followed by a timezone indicator².
+¹ Missing components are assumed to be zero. Dates are stored and read in the UTC time zone, unless the format is followed by a timezone indicator ⁽²⁾.
 
 ² This format may be optionally followed by a timezone indicator of the form `[+-]HH:MM` or just `Z`.
 

--- a/README.md
+++ b/README.md
@@ -1269,24 +1269,26 @@ The non-copied data does not live longer than the iteration step: make sure that
 
 Here is how GRDB supports the various [date formats](https://www.sqlite.org/lang_datefunc.html) supported by SQLite:
 
-| SQLite format                | Date         | DateComponents |
-|:---------------------------- |:------------:|:--------------:|
-| YYYY-MM-DD                   |     Read ¹   |   Read/Write   |
-| YYYY-MM-DD HH:MM             |     Read ¹   |   Read/Write   |
-| YYYY-MM-DD HH:MM:SS          |     Read ¹   |   Read/Write   |
-| YYYY-MM-DD HH:MM:SS.SSS      | Read/Write ¹ |   Read/Write   |
-| YYYY-MM-DD**T**HH:MM         |     Read ¹   |      Read      |
-| YYYY-MM-DD**T**HH:MM:SS      |     Read ¹   |      Read      |
-| YYYY-MM-DD**T**HH:MM:SS.SSS  |     Read ¹   |      Read      |
-| HH:MM                        |              |   Read/Write   |
-| HH:MM:SS                     |              |   Read/Write   |
-| HH:MM:SS.SSS                 |              |   Read/Write   |
-| Timestamps since unix epoch  |     Read ²   |                |
-| `now`                        |              |                |
+| SQLite format                | Date            | DateComponents |
+|:---------------------------- |:---------------:|:--------------:|
+| YYYY-MM-DD                   |      Read¹      |  Read / Write  |
+| YYYY-MM-DD HH:MM             |      Read¹²     |  Read² / Write |
+| YYYY-MM-DD HH:MM:SS          |      Read¹²     |  Read² / Write |
+| YYYY-MM-DD HH:MM:SS.SSS      | Read¹² / Write¹ |  Read² / Write |
+| YYYY-MM-DD**T**HH:MM         |      Read¹²     |       Read²    |
+| YYYY-MM-DD**T**HH:MM:SS      |      Read¹²     |       Read²    |
+| YYYY-MM-DD**T**HH:MM:SS.SSS  |      Read¹²     |       Read²    |
+| HH:MM                        |                 |  Read² / Write |
+| HH:MM:SS                     |                 |  Read² / Write |
+| HH:MM:SS.SSS                 |                 |  Read² / Write |
+| Timestamps since unix epoch  |      Read³      |                |
+| `now`                        |                 |                |
 
-¹ Dates are stored and read in the UTC time zone. Missing components are assumed to be zero.
+¹ Missing components are assumed to be zero. Dates are stored and read in the UTC time zone, unless the format is followed by a timezone indicator².
 
-² GRDB 2+ interprets numerical values as timestamps that fuel `Date(timeIntervalSince1970:)`. Previous GRDB versions used to interpret numbers as [julian days](https://en.wikipedia.org/wiki/Julian_day). Julian days are still supported, with the `Date(julianDay:)` initializer.
+² This format may be optionally followed by a timezone indicator of the form `[+-]HH:MM` or just `Z`.
+
+³ GRDB 2+ interprets numerical values as timestamps that fuel `Date(timeIntervalSince1970:)`. Previous GRDB versions used to interpret numbers as [julian days](https://en.wikipedia.org/wiki/Julian_day). Julian days are still supported, with the `Date(julianDay:)` initializer.
 
 
 #### Date

--- a/README.md
+++ b/README.md
@@ -1269,20 +1269,20 @@ The non-copied data does not live longer than the iteration step: make sure that
 
 Here is how GRDB supports the various [date formats](https://www.sqlite.org/lang_datefunc.html) supported by SQLite:
 
-| SQLite format                | Date            | DateComponents |
-|:---------------------------- |:---------------:|:--------------:|
-| YYYY-MM-DD                   |      Read¹      |  Read / Write  |
-| YYYY-MM-DD HH:MM             |      Read¹²     |  Read² / Write |
-| YYYY-MM-DD HH:MM:SS          |      Read¹²     |  Read² / Write |
-| YYYY-MM-DD HH:MM:SS.SSS      | Read¹² / Write¹ |  Read² / Write |
-| YYYY-MM-DD**T**HH:MM         |      Read¹²     |       Read²    |
-| YYYY-MM-DD**T**HH:MM:SS      |      Read¹²     |       Read²    |
-| YYYY-MM-DD**T**HH:MM:SS.SSS  |      Read¹²     |       Read²    |
-| HH:MM                        |                 |  Read² / Write |
-| HH:MM:SS                     |                 |  Read² / Write |
-| HH:MM:SS.SSS                 |                 |  Read² / Write |
-| Timestamps since unix epoch  |      Read³      |                |
-| `now`                        |                 |                |
+| SQLite format                | Date               | DateComponents |
+|:---------------------------- |:------------------:|:--------------:|
+| YYYY-MM-DD                   |       Read ¹       | Read / Write   |
+| YYYY-MM-DD HH:MM             |       Read ¹ ²     | Read ² / Write |
+| YYYY-MM-DD HH:MM:SS          |       Read ¹ ²     | Read ² / Write |
+| YYYY-MM-DD HH:MM:SS.SSS      | Read ¹ ² / Write ¹ | Read ² / Write |
+| YYYY-MM-DD**T**HH:MM         |       Read ¹ ²     |      Read ²    |
+| YYYY-MM-DD**T**HH:MM:SS      |       Read ¹ ²     |      Read ²    |
+| YYYY-MM-DD**T**HH:MM:SS.SSS  |       Read ¹ ²     |      Read ²    |
+| HH:MM                        |                    | Read ² / Write |
+| HH:MM:SS                     |                    | Read ² / Write |
+| HH:MM:SS.SSS                 |                    | Read ² / Write |
+| Timestamps since unix epoch  |       Read ³       |                |
+| `now`                        |                    |                |
 
 ¹ Missing components are assumed to be zero. Dates are stored and read in the UTC time zone, unless the format is followed by a timezone indicator².
 

--- a/Tests/GRDBTests/FoundationDateTests.swift
+++ b/Tests/GRDBTests/FoundationDateTests.swift
@@ -139,6 +139,25 @@ class FoundationDateTests : GRDBTestCase {
         }
     }
 
+    func testDateAcceptsFormatYMD_HMZ() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(
+                sql: "INSERT INTO dates (creationDate) VALUES (?)",
+                arguments: ["2015-07-22 01:02+01:15"])
+            let date = try Date.fetchOne(db, sql: "SELECT creationDate from dates")!
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+            XCTAssertEqual(calendar.component(.year, from: date), 2015)
+            XCTAssertEqual(calendar.component(.month, from: date), 7)
+            XCTAssertEqual(calendar.component(.day, from: date), 21)
+            XCTAssertEqual(calendar.component(.hour, from: date), 23)
+            XCTAssertEqual(calendar.component(.minute, from: date), 47)
+            XCTAssertEqual(calendar.component(.second, from: date), 0)
+            XCTAssertEqual(calendar.component(.nanosecond, from: date), 0)
+        }
+    }
+
     func testDateAcceptsFormatYMD_HMS() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -158,6 +177,25 @@ class FoundationDateTests : GRDBTestCase {
         }
     }
 
+    func testDateAcceptsFormatYMD_HMSZ() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(
+                sql: "INSERT INTO dates (creationDate) VALUES (?)",
+                arguments: ["2015-07-22 01:02:03+01:15"])
+            let date = try Date.fetchOne(db, sql: "SELECT creationDate from dates")!
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+            XCTAssertEqual(calendar.component(.year, from: date), 2015)
+            XCTAssertEqual(calendar.component(.month, from: date), 7)
+            XCTAssertEqual(calendar.component(.day, from: date), 21)
+            XCTAssertEqual(calendar.component(.hour, from: date), 23)
+            XCTAssertEqual(calendar.component(.minute, from: date), 47)
+            XCTAssertEqual(calendar.component(.second, from: date), 3)
+            XCTAssertEqual(calendar.component(.nanosecond, from: date), 0)
+        }
+    }
+
     func testDateAcceptsFormatYMD_HMSS() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -172,6 +210,25 @@ class FoundationDateTests : GRDBTestCase {
             XCTAssertEqual(calendar.component(.day, from: date), 22)
             XCTAssertEqual(calendar.component(.hour, from: date), 1)
             XCTAssertEqual(calendar.component(.minute, from: date), 2)
+            XCTAssertEqual(calendar.component(.second, from: date), 3)
+            XCTAssertTrue(abs(calendar.component(.nanosecond, from: date) - 4_000_000) < 10)  // We actually get 4_000_008. Some precision is lost during the DateComponents -> Date conversion. Not a big deal.
+        }
+    }
+
+    func testDateAcceptsFormatYMD_HMSSZ() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(
+                sql: "INSERT INTO dates (creationDate) VALUES (?)",
+                arguments: ["2015-07-22 01:02:03.00456+01:15"])
+            let date = try Date.fetchOne(db, sql: "SELECT creationDate from dates")!
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+            XCTAssertEqual(calendar.component(.year, from: date), 2015)
+            XCTAssertEqual(calendar.component(.month, from: date), 7)
+            XCTAssertEqual(calendar.component(.day, from: date), 21)
+            XCTAssertEqual(calendar.component(.hour, from: date), 23)
+            XCTAssertEqual(calendar.component(.minute, from: date), 47)
             XCTAssertEqual(calendar.component(.second, from: date), 3)
             XCTAssertTrue(abs(calendar.component(.nanosecond, from: date) - 4_000_000) < 10)  // We actually get 4_000_008. Some precision is lost during the DateComponents -> Date conversion. Not a big deal.
         }

--- a/Tests/Performance/GRDBProfiling/GRDBProfiling/AppDelegate.swift
+++ b/Tests/Performance/GRDBProfiling/GRDBProfiling/AppDelegate.swift
@@ -7,6 +7,8 @@ let insertedRowCount = 20_000
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        try! parseDateComponents()
+        try! parseDates()
         try! fetchValues()
         try! fetchPositionalValues()
         try! fetchNamedValues()
@@ -18,6 +20,46 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         try! insertStructs()
         try! insertCodables()
         try! insertRecords()
+    }
+    
+    // MARK: -
+    
+    func parseDateComponents() throws {
+        /// Selects many dates
+        let request = """
+            WITH RECURSIVE
+                cnt(x) AS (
+                    SELECT 1
+                    UNION ALL
+                    SELECT x+1 FROM cnt
+                    LIMIT 50000
+                )
+            SELECT '2018-04-20 14:47:12.345' FROM cnt;
+            """
+        
+        try DatabaseQueue().inDatabase { db in
+            let cursor = try DatabaseDateComponents.fetchCursor(db, sql: request)
+            while try cursor.next() != nil { }
+        }
+    }
+    
+    func parseDates() throws {
+        /// Selects many dates
+        let request = """
+            WITH RECURSIVE
+                cnt(x) AS (
+                    SELECT 1
+                    UNION ALL
+                    SELECT x+1 FROM cnt
+                    LIMIT 50000
+                )
+            SELECT '2018-04-20 14:47:12.345' FROM cnt;
+            """
+        
+        try DatabaseQueue().inDatabase { db in
+            let cursor = try Date.fetchCursor(db, sql: request)
+            while try cursor.next() != nil { }
+        }
     }
     
     // MARK: -


### PR DESCRIPTION
This pull request has GRDB parse timezones of the form `[+-]HH:MM` or just `Z` in [SQLite time strings](https://sqlite.org/lang_datefunc.html#time_strings), when it decodes Foundation's `Date` and `DateComponent`. Previous versions of GRDB would just happen to ignore them.

This change was triggered by the #869 issue by @yeahphil, but it only partially addresses it, as explained below. 

- `+0000` is a valid ISO8601 timezone, but SQLite [date functions](https://sqlite.org/lang_datefunc.html) won't accept it. The default date parser of GRDB won't parse it either, because it is only focused on SQLite time strings.

- Users who want to parse ISO8601 dates with GRDB should decode strings and use a `ISO8601DateFormatter`, or, when they use [Codable records](https://github.com/groue/GRDB.swift#codable-records), use an appropriate `databaseDateDecodingStrategy`.