### PR TITLE
Row Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - **Fixed**: [#881](https://github.com/groue/GRDB.swift/pull/881) by [@felixscheinost](https://github.com/felixscheinost) and [#883](https://github.com/groue/GRDB.swift/pull/883) by [@professordeng](https://github.com/professordeng): Documentation improvements
 - **Fixed**: [#885](https://github.com/groue/GRDB.swift/pull/885): Robustness of eager loading of to-many associations based on compound foreign keys
 - **Documentation update**: A new guide: [Common Table Expressions](https://github.com/groue/GRDB.swift/blob/master/Documentation/CommonTableExpressions.md)
-- **Documentation update**: The [Foreign Keys](https://github.com/groue/GRDB.swift/blob/master/Documentation/AssociationsBasics.md#foreign-keys) chapter of the Associations Guide clarifies the behavior of SQLite and GRDB regarding the presence of NULL if compound foreign keys.
+- **Documentation update**: The [Foreign Keys](https://github.com/groue/GRDB.swift/blob/master/Documentation/AssociationsBasics.md#foreign-keys) chapter of the Associations Guide clarifies the behavior of SQLite and GRDB regarding the presence of NULL in compound foreign keys.
 
 
 ## 5.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
+**Release Highlights**: [experimental](README.md#what-are-experimental-features) support for two SQLite features: [common table expressions](https://sqlite.org/lang_with.html), and [row values](https://www.sqlite.org/rowvalue.html).
+
 - **New**: [#880](https://github.com/groue/GRDB.swift/pull/880): Common Table Expressions
+- **New**: [#890](https://github.com/groue/GRDB.swift/pull/890): Row Values
 - **Fixed**: [#881](https://github.com/groue/GRDB.swift/pull/881) by [@felixscheinost](https://github.com/felixscheinost) and [#883](https://github.com/groue/GRDB.swift/pull/883) by [@professordeng](https://github.com/professordeng): Documentation improvements
 - **Fixed**: [#885](https://github.com/groue/GRDB.swift/pull/885): Robustness of eager loading of to-many associations based on compound foreign keys
 - **Documentation update**: A new guide: [Common Table Expressions](https://github.com/groue/GRDB.swift/blob/master/Documentation/CommonTableExpressions.md)

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -847,6 +847,10 @@
 		56DF001C228DDBA300D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0019228DDBA200D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF001D228DDBA300D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001A228DDBA300D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
 		56DF001E228DDBA300D611F3 /* AssociationPrefetchingCodableRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF001A228DDBA300D611F3 /* AssociationPrefetchingCodableRecordTests.swift */; };
+		56E33C2A2584F49C000AD57E /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E33C292584F49C000AD57E /* Assignment.swift */; };
+		56E33C2B2584F49C000AD57E /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E33C292584F49C000AD57E /* Assignment.swift */; };
+		56E33C2C2584F49C000AD57E /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E33C292584F49C000AD57E /* Assignment.swift */; };
+		56E33C2D2584F49C000AD57E /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E33C292584F49C000AD57E /* Assignment.swift */; };
 		56E4F7EE2392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E4F7ED2392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift */; };
 		56E4F7EF2392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E4F7ED2392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift */; };
 		56E4F7F02392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E4F7ED2392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift */; };
@@ -1634,6 +1638,7 @@
 		56DE7B101C3D93ED00861EB8 /* StatementArgumentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementArgumentsTests.swift; sourceTree = "<group>"; };
 		56DF0019228DDBA200D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
 		56DF001A228DDBA300D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
+		56E33C292584F49C000AD57E /* Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignment.swift; sourceTree = "<group>"; };
 		56E4F7ED2392E2D000A611F6 /* DatabaseAbortedTransactionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseAbortedTransactionTests.swift; sourceTree = "<group>"; };
 		56E5D7CA1B4D3FED00430942 /* GRDB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GRDB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		56E5D7D31B4D3FEE00430942 /* GRDBiOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2113,6 +2118,7 @@
 		5656A8172295B00E001FF3FF /* SQL */ = {
 			isa = PBXGroup;
 			children = (
+				56E33C292584F49C000AD57E /* Assignment.swift */,
 				56CEB5401EAA359A00BFAF62 /* Column.swift */,
 				56D91AA82205F2F000770D8D /* DatabasePromise.swift */,
 				5656A81D2295B12F001FF3FF /* SQLAssociation.swift */,
@@ -3023,6 +3029,7 @@
 				565490DF1D5AE252005622CB /* TableDefinition.swift in Sources */,
 				565490B71D5AE236005622CB /* Database.swift in Sources */,
 				5674A6E81F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
+				56E33C2C2584F49C000AD57E /* Assignment.swift in Sources */,
 				56E9FACD221046FD00C703A8 /* SQLInterpolation+QueryInterface.swift in Sources */,
 				5653EB2320944C7C00F46237 /* HasOneAssociation.swift in Sources */,
 				56F34F9B24AE78DE007513FC /* SQLExpressionVisitor.swift in Sources */,
@@ -3203,6 +3210,7 @@
 				5695962A222C462D002CB7C9 /* HasManyThroughAssociation.swift in Sources */,
 				563363C11C942C04000BE133 /* DatabaseReader.swift in Sources */,
 				56B964BC1DA51D0A0002DA19 /* FTS5Pattern.swift in Sources */,
+				56E33C2B2584F49C000AD57E /* Assignment.swift in Sources */,
 				5605F1661C672E4000235C62 /* NSNull.swift in Sources */,
 				5656A8AE2295BFD7001FF3FF /* TableRecord+Association.swift in Sources */,
 				569EF0E3200D2D8400A9FA45 /* DatabaseRegion.swift in Sources */,
@@ -3802,6 +3810,7 @@
 				AAA4DCC5230F1E0600C74B15 /* HasManyThroughAssociation.swift in Sources */,
 				AAA4DCC6230F1E0600C74B15 /* DatabaseReader.swift in Sources */,
 				AAA4DCC8230F1E0600C74B15 /* FTS5Pattern.swift in Sources */,
+				56E33C2D2584F49C000AD57E /* Assignment.swift in Sources */,
 				AAA4DCC9230F1E0600C74B15 /* NSNull.swift in Sources */,
 				AAA4DCCA230F1E0600C74B15 /* TableRecord+Association.swift in Sources */,
 				AAA4DCCB230F1E0600C74B15 /* DatabaseRegion.swift in Sources */,
@@ -4175,6 +4184,7 @@
 				566B912B1FA4D0CC0012D5B0 /* StatementAuthorizer.swift in Sources */,
 				56A2388B1B9C75030082EB20 /* Statement.swift in Sources */,
 				5656A8AD2295BFD7001FF3FF /* TableRecord+Association.swift in Sources */,
+				56E33C2A2584F49C000AD57E /* Assignment.swift in Sources */,
 				5690C3401D23E82A00E59934 /* Data.swift in Sources */,
 				5659F4881EA8D94E004A4992 /* Utils.swift in Sources */,
 				56FC98781D969DEF00E3C842 /* SQLExpression+QueryInterface.swift in Sources */,

--- a/GRDB/QueryInterface/Request/CommonTableExpression.swift
+++ b/GRDB/QueryInterface/Request/CommonTableExpression.swift
@@ -145,6 +145,19 @@ extension CommonTableExpression {
     public func all() -> QueryInterfaceRequest<RowDecoder> {
         QueryInterfaceRequest(relation: relationForAll)
     }
+    
+    /// An SQL expression that checks the inclusion of an expression in a
+    /// common table expression.
+    ///
+    ///     let playerNameCTE = CommonTableExpression<Void>(
+    ///         named: "playerName",
+    ///         request: Player.select(Column("name"))
+    ///
+    ///     // name IN playerName
+    ///     playerNameCTE.contains(Column("name"))
+    public func contains(_ element: SQLExpressible) -> SQLExpression {
+        _SQLTableCollection.tableName(tableName).contains(element)
+    }
 }
 
 /// A low-level common table expression

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -364,14 +364,14 @@ extension QueryInterfaceRequest where RowDecoder: MutablePersistableRecord {
     /// - parameter db: A database connection.
     /// - parameter conflictResolution: A policy for conflict resolution,
     ///   defaulting to the record's persistenceConflictPolicy.
-    /// - parameter assignments: An array of column assignments.
+    /// - parameter assignments: An array of assignments.
     /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public func updateAll(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
-        _ assignments: [ColumnAssignment]) throws -> Int
+        _ assignments: [Assignment]) throws -> Int
     {
         let conflictResolution = conflictResolution ?? RowDecoder.persistenceConflictPolicy.conflictResolutionForUpdate
         guard let updateStatement = try SQLQueryGenerator(query: query).makeUpdateStatement(
@@ -398,110 +398,16 @@ extension QueryInterfaceRequest where RowDecoder: MutablePersistableRecord {
     /// - parameter db: A database connection.
     /// - parameter conflictResolution: A policy for conflict resolution,
     ///   defaulting to the record's persistenceConflictPolicy.
-    /// - parameter assignment: A column assignment.
-    /// - parameter otherAssignments: Eventual other column assignments.
+    /// - parameter assignments: Assignments.
     /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public func updateAll(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
-        _ assignment: ColumnAssignment,
-        _ otherAssignments: ColumnAssignment...)
+        _ assignments: Assignment...)
         throws -> Int
     {
-        try updateAll(db, onConflict: conflictResolution, [assignment] + otherAssignments)
+        try updateAll(db, onConflict: conflictResolution, assignments)
     }
-}
-
-// MARK: - ColumnAssignment
-
-/// A ColumnAssignment can update rows in the database.
-///
-/// You create an assignment from a column and an assignment method or operator,
-/// such as `set(to:)` or `+=`:
-///
-///     try dbQueue.write { db in
-///         // UPDATE player SET score = 0
-///         let assignment = Column("score").set(to: 0)
-///         try Player.updateAll(db, assignment)
-///     }
-public struct ColumnAssignment {
-    var column: ColumnExpression
-    var value: SQLExpressible
-    
-    func sql(_ context: SQLGenerationContext) throws -> String {
-        try column.expressionSQL(context, wrappedInParenthesis: false) +
-            " = " +
-            value.sqlExpression.expressionSQL(context, wrappedInParenthesis: false)
-    }
-}
-
-extension ColumnExpression {
-    /// Creates an assignment to a value.
-    ///
-    ///     Column("valid").set(to: true)
-    ///     Column("score").set(to: 0)
-    ///     Column("score").set(to: nil)
-    ///     Column("score").set(to: Column("score") + Column("bonus"))
-    ///
-    ///     try dbQueue.write { db in
-    ///         // UPDATE player SET score = 0
-    ///         try Player.updateAll(db, Column("score").set(to: 0))
-    ///     }
-    public func set(to value: SQLExpressible?) -> ColumnAssignment {
-        ColumnAssignment(column: self, value: value ?? DatabaseValue.null)
-    }
-}
-
-/// Creates an assignment that adds a value
-///
-///     Column("score") += 1
-///     Column("score") += Column("bonus")
-///
-///     try dbQueue.write { db in
-///         // UPDATE player SET score = score + 1
-///         try Player.updateAll(db, Column("score") += 1)
-///     }
-public func += (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column.set(to: column + value)
-}
-
-/// Creates an assignment that subtracts a value
-///
-///     Column("score") -= 1
-///     Column("score") -= Column("bonus")
-///
-///     try dbQueue.write { db in
-///         // UPDATE player SET score = score - 1
-///         try Player.updateAll(db, Column("score") -= 1)
-///     }
-public func -= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column.set(to: column - value)
-}
-
-/// Creates an assignment that multiplies by a value
-///
-///     Column("score") *= 2
-///     Column("score") *= Column("factor")
-///
-///     try dbQueue.write { db in
-///         // UPDATE player SET score = score * 2
-///         try Player.updateAll(db, Column("score") *= 2)
-///     }
-public func *= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column.set(to: column * value)
-}
-
-/// Creates an assignment that divides by a value
-///
-///     Column("score") /= 2
-///     Column("score") /= Column("factor")
-///
-///     try dbQueue.write { db in
-///         // UPDATE player SET score = score / 2
-///         try Player.updateAll(db, Column("score") /= 2)
-///     }
-public func /= (column: ColumnExpression, value: SQLExpressible) -> ColumnAssignment {
-    column.set(to: column / value)
 }

--- a/GRDB/QueryInterface/SQL/Assignment.swift
+++ b/GRDB/QueryInterface/SQL/Assignment.swift
@@ -1,0 +1,95 @@
+/// The protocol for expressions that can be assigned in an UPDATE query.
+public protocol SQLAssignable: SQLExpressible { }
+
+/// An `Assignment` can update rows in the database.
+///
+/// You create an assignment from a column or a row value, and a method or
+/// operator such as `set(to:)` or `+=`:
+///
+///     try dbQueue.write { db in
+///         // UPDATE player SET score = 0
+///         let assignment = Column("score").set(to: 0)
+///         try Player.updateAll(db, assignment)
+///     }
+public struct Assignment {
+    var assigned: SQLAssignable
+    var value: SQLExpressible
+    
+    func sql(_ context: SQLGenerationContext) throws -> String {
+        try assigned.sqlExpression.expressionSQL(context, wrappedInParenthesis: false) +
+            " = " +
+            value.sqlExpression.expressionSQL(context, wrappedInParenthesis: false)
+    }
+}
+
+@available(*, deprecated, renamed: "Assignment")
+public typealias ColumnAssignment = Assignment
+
+extension SQLAssignable {
+    /// Creates an assignment to a value.
+    ///
+    ///     Column("valid").set(to: true)
+    ///     Column("score").set(to: 0)
+    ///     Column("score").set(to: nil)
+    ///     Column("score").set(to: Column("score") + Column("bonus"))
+    ///
+    ///     try dbQueue.write { db in
+    ///         // UPDATE player SET score = 0
+    ///         try Player.updateAll(db, Column("score").set(to: 0))
+    ///     }
+    public func set(to value: SQLExpressible?) -> Assignment {
+        Assignment(assigned: self, value: value ?? DatabaseValue.null)
+    }
+}
+
+/// Creates an assignment that adds a value
+///
+///     Column("score") += 1
+///     Column("score") += Column("bonus")
+///
+///     try dbQueue.write { db in
+///         // UPDATE player SET score = score + 1
+///         try Player.updateAll(db, Column("score") += 1)
+///     }
+public func += (column: ColumnExpression, value: SQLExpressible) -> Assignment {
+    column.set(to: column + value)
+}
+
+/// Creates an assignment that subtracts a value
+///
+///     Column("score") -= 1
+///     Column("score") -= Column("bonus")
+///
+///     try dbQueue.write { db in
+///         // UPDATE player SET score = score - 1
+///         try Player.updateAll(db, Column("score") -= 1)
+///     }
+public func -= (column: ColumnExpression, value: SQLExpressible) -> Assignment {
+    column.set(to: column - value)
+}
+
+/// Creates an assignment that multiplies by a value
+///
+///     Column("score") *= 2
+///     Column("score") *= Column("factor")
+///
+///     try dbQueue.write { db in
+///         // UPDATE player SET score = score * 2
+///         try Player.updateAll(db, Column("score") *= 2)
+///     }
+public func *= (column: ColumnExpression, value: SQLExpressible) -> Assignment {
+    column.set(to: column * value)
+}
+
+/// Creates an assignment that divides by a value
+///
+///     Column("score") /= 2
+///     Column("score") /= Column("factor")
+///
+///     try dbQueue.write { db in
+///         // UPDATE player SET score = score / 2
+///         try Player.updateAll(db, Column("score") /= 2)
+///     }
+public func /= (column: ColumnExpression, value: SQLExpressible) -> Assignment {
+    column.set(to: column / value)
+}

--- a/GRDB/QueryInterface/SQL/Column.swift
+++ b/GRDB/QueryInterface/SQL/Column.swift
@@ -17,7 +17,7 @@
 ///     let arthur = try Player.filter(nameColumn == "Arthur").fetchOne(db)
 ///
 /// See https://github.com/groue/GRDB.swift#the-query-interface
-public protocol ColumnExpression: SQLExpression {
+public protocol ColumnExpression: SQLExpression, SQLAssignable {
     /// The unqualified name of a database column.
     ///
     /// "score" is a valid unqualified name. "player.score" is not.

--- a/GRDB/QueryInterface/SQL/SQLCollection.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollection.swift
@@ -58,9 +58,33 @@ public struct _SQLExpressionsArray: SQLCollection {
     }
 }
 
+// MARK: - _SQLTableCollection
+
+/// _SQLTableCollection aims at generating `value IN table` expressions.
+///
+/// :nodoc:
+public enum _SQLTableCollection: SQLCollection {
+    case tableName(String)
+    
+    public func contains(_ value: SQLExpressible) -> SQLExpression {
+        return _SQLExpressionContains(value, self)
+    }
+    
+    /// :nodoc:
+    public func _qualifiedCollection(with alias: TableAlias) -> SQLCollection {
+        self
+    }
+    
+    /// :nodoc:
+    public func _accept<Visitor>(_ visitor: inout Visitor) throws where Visitor: _SQLCollectionVisitor {
+        try visitor.visit(self)
+    }
+}
+
 // MARK: - SQLCollectionExpressions
 
 extension SQLCollection {
+    /// The expressions in the collection, if possible
     func expressions() -> [SQLExpression]? {
         var visitor = SQLCollectionExpressions()
         try! _accept(&visitor)
@@ -75,6 +99,8 @@ private struct SQLCollectionExpressions: _SQLCollectionVisitor {
     mutating func visit(_ collection: _SQLExpressionsArray) throws {
         expressions = collection.expressions
     }
+    
+    mutating func visit(_ collection: _SQLTableCollection) throws { }
     
     // MARK: _FetchRequestVisitor
     

--- a/GRDB/QueryInterface/SQL/SQLCollectionVisitor.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollectionVisitor.swift
@@ -1,4 +1,5 @@
 /// :nodoc:
 public protocol _SQLCollectionVisitor: _FetchRequestVisitor {
     mutating func visit(_ collection: _SQLExpressionsArray) throws
+    mutating func visit(_ collection: _SQLTableCollection) throws
 }

--- a/GRDB/QueryInterface/SQL/SQLRowValue.swift
+++ b/GRDB/QueryInterface/SQL/SQLRowValue.swift
@@ -1,3 +1,5 @@
+// Row values are available in SQLite 3.15+
+
 /// A [row value](https://www.sqlite.org/rowvalue.html).
 ///
 /// :nodoc:
@@ -26,3 +28,91 @@ public struct _SQLRowValue: SQLExpression {
         }
     }
 }
+
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// A [row value](https://www.sqlite.org/rowvalue.html) made of two expressions.
+///
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+public struct RowValue2<A: SQLExpressible, B: SQLExpressible>: SQLSpecificExpressible {
+    private var a: A
+    private var b: B
+    
+    public init(_ a: A, _ b: B) {
+        self.a = a
+        self.b = b
+    }
+    
+    public var sqlExpression: SQLExpression {
+        _SQLRowValue([a.sqlExpression, b.sqlExpression])
+    }
+}
+
+extension RowValue2: SQLAssignable where A: SQLAssignable, B: SQLAssignable { }
+#else
+/// A [row value](https://www.sqlite.org/rowvalue.html) made of two expressions.
+///
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+@available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
+public struct RowValue2<A: SQLExpressible, B: SQLExpressible>: SQLSpecificExpressible {
+    private var a: A
+    private var b: B
+    
+    public init(_ a: A, _ b: B) {
+        self.a = a
+        self.b = b
+    }
+    
+    public var sqlExpression: SQLExpression {
+        _SQLRowValue([a.sqlExpression, b.sqlExpression])
+    }
+}
+
+@available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
+extension RowValue2: SQLAssignable where A: SQLAssignable, B: SQLAssignable { }
+#endif
+
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// A [row value](https://www.sqlite.org/rowvalue.html) made of three expressions.
+///
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+public struct RowValue3<A: SQLExpressible, B: SQLExpressible, C: SQLExpressible>: SQLSpecificExpressible {
+    private var a: A
+    private var b: B
+    private var c: C
+    
+    public init(_ a: A, _ b: B, _ c: C) {
+        self.a = a
+        self.b = b
+        self.c = c
+    }
+    
+    public var sqlExpression: SQLExpression {
+        _SQLRowValue([a.sqlExpression, b.sqlExpression, c.sqlExpression])
+    }
+}
+
+extension RowValue3: SQLAssignable where A: SQLAssignable, B: SQLAssignable, C: SQLAssignable { }
+#else
+/// A [row value](https://www.sqlite.org/rowvalue.html) made of three expressions.
+///
+/// [**Experimental**](http://github.com/groue/GRDB.swift#what-are-experimental-features)
+@available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
+public struct RowValue3<A: SQLExpressible, B: SQLExpressible, C: SQLExpressible>: SQLSpecificExpressible {
+    private var a: A
+    private var b: B
+    private var c: C
+    
+    public init(_ a: A, _ b: B, _ c: C) {
+        self.a = a
+        self.b = b
+        self.c = c
+    }
+    
+    public var sqlExpression: SQLExpression {
+        _SQLRowValue([a.sqlExpression, b.sqlExpression, c.sqlExpression])
+    }
+}
+
+@available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
+extension RowValue3: SQLAssignable where A: SQLAssignable, B: SQLAssignable, C: SQLAssignable { }
+#endif

--- a/GRDB/QueryInterface/SQL/SQLRowValue.swift
+++ b/GRDB/QueryInterface/SQL/SQLRowValue.swift
@@ -1,4 +1,5 @@
 // Row values are available in SQLite 3.15+
+// Assignment was available later, maybe in SQLite 3.23+
 
 /// A [row value](https://www.sqlite.org/rowvalue.html).
 ///
@@ -67,7 +68,7 @@ public struct RowValue2<A: SQLExpressible, B: SQLExpressible>: SQLSpecificExpres
     }
 }
 
-@available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
 extension RowValue2: SQLAssignable where A: ColumnExpression, B: ColumnExpression { }
 #endif
 
@@ -113,6 +114,6 @@ public struct RowValue3<A: SQLExpressible, B: SQLExpressible, C: SQLExpressible>
     }
 }
 
-@available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
 extension RowValue3: SQLAssignable where A: ColumnExpression, B: ColumnExpression, C: ColumnExpression { }
 #endif

--- a/GRDB/QueryInterface/SQL/SQLRowValue.swift
+++ b/GRDB/QueryInterface/SQL/SQLRowValue.swift
@@ -47,7 +47,7 @@ public struct RowValue2<A: SQLExpressible, B: SQLExpressible>: SQLSpecificExpres
     }
 }
 
-extension RowValue2: SQLAssignable where A: SQLAssignable, B: SQLAssignable { }
+extension RowValue2: SQLAssignable where A: ColumnExpression, B: ColumnExpression { }
 #else
 /// A [row value](https://www.sqlite.org/rowvalue.html) made of two expressions.
 ///
@@ -68,7 +68,7 @@ public struct RowValue2<A: SQLExpressible, B: SQLExpressible>: SQLSpecificExpres
 }
 
 @available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
-extension RowValue2: SQLAssignable where A: SQLAssignable, B: SQLAssignable { }
+extension RowValue2: SQLAssignable where A: ColumnExpression, B: ColumnExpression { }
 #endif
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
@@ -91,7 +91,7 @@ public struct RowValue3<A: SQLExpressible, B: SQLExpressible, C: SQLExpressible>
     }
 }
 
-extension RowValue3: SQLAssignable where A: SQLAssignable, B: SQLAssignable, C: SQLAssignable { }
+extension RowValue3: SQLAssignable where A: ColumnExpression, B: ColumnExpression, C: ColumnExpression { }
 #else
 /// A [row value](https://www.sqlite.org/rowvalue.html) made of three expressions.
 ///
@@ -114,5 +114,5 @@ public struct RowValue3<A: SQLExpressible, B: SQLExpressible, C: SQLExpressible>
 }
 
 @available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *)
-extension RowValue3: SQLAssignable where A: SQLAssignable, B: SQLAssignable, C: SQLAssignable { }
+extension RowValue3: SQLAssignable where A: ColumnExpression, B: ColumnExpression, C: ColumnExpression { }
 #endif

--- a/GRDB/QueryInterface/SQLGeneration/SQLCollectionGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLCollectionGenerator.swift
@@ -15,22 +15,29 @@ private struct SQLCollectionGenerator: _SQLCollectionVisitor {
     var resultSQL = ""
     
     mutating func visit(_ collection: _SQLExpressionsArray) throws {
-        resultSQL = try collection.expressions
+        resultSQL = try "(" + collection.expressions
             .map { try $0.expressionSQL(context, wrappedInParenthesis: false) }
-            .joined(separator: ", ")
+            .joined(separator: ", ") + ")"
     }
     
+    mutating func visit(_ collection: _SQLTableCollection) throws {
+        switch collection {
+        case let .tableName(tableName):
+            resultSQL = tableName.quotedDatabaseIdentifier
+        }
+    }
+
     // MARK: _FetchRequestVisitor
     
     mutating func visit<Base: FetchRequest>(_ request: AdaptedFetchRequest<Base>) throws {
-        resultSQL = try request.requestSQL(context, forSingleResult: false)
+        resultSQL = try "(" + request.requestSQL(context, forSingleResult: false) + ")"
     }
     
     mutating func visit<RowDecoder>(_ request: QueryInterfaceRequest<RowDecoder>) throws {
-        resultSQL = try request.requestSQL(context, forSingleResult: false)
+        resultSQL = try "(" + request.requestSQL(context, forSingleResult: false) + ")"
     }
     
     mutating func visit<RowDecoder>(_ request: SQLRequest<RowDecoder>) throws {
-        resultSQL = try request.requestSQL(context, forSingleResult: false)
+        resultSQL = try "(" + request.requestSQL(context, forSingleResult: false) + ")"
     }
 }

--- a/GRDB/QueryInterface/SQLGeneration/SQLExpressionGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLExpressionGenerator.swift
@@ -98,7 +98,7 @@ private struct SQLExpressionGenerator: _SQLExpressionVisitor {
         resultSQL = try """
             \(expr.expression.expressionSQL(context, wrappedInParenthesis: true)) \
             \(expr.isNegated ? "NOT IN" : "IN") \
-            (\(expr.collection.collectionSQL(context)))
+            \(expr.collection.collectionSQL(context))
             """
         if wrappedInParenthesis {
             resultSQL = "(\(resultSQL))"

--- a/GRDB/QueryInterface/SQLGeneration/SQLPreparedRequestGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLPreparedRequestGenerator.swift
@@ -221,8 +221,7 @@ private func prefetch<RowDecoder>(
                 let baseCTE = CommonTableExpression<Void>(
                     named: "grdb_base",
                     request: baseRequest)
-                let pivotRowValue = _SQLRowValue(pivotColumns.map(Column.init))
-                let pivotFilter = SQLLiteral("\(pivotRowValue) IN grdb_base").sqlExpression
+                let pivotFilter = baseCTE.contains(_SQLRowValue(pivotColumns.map(Column.init)))
                 
                 prefetchRequest = makePrefetchRequest(
                     for: association,

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -295,9 +295,13 @@ struct SQLQueryGenerator: Refinable {
     func makeUpdateStatement(
         _ db: Database,
         conflictResolution: Database.ConflictResolution,
-        assignments: [ColumnAssignment])
+        assignments: [Assignment])
         throws -> UpdateStatement?
     {
+        if assignments.isEmpty {
+            return nil
+        }
+        
         switch try grouping(db) {
         case .none:
             guard relation.joins.isEmpty else {
@@ -305,12 +309,6 @@ struct SQLQueryGenerator: Refinable {
                     db,
                     conflictResolution: conflictResolution,
                     assignments: assignments)
-            }
-            
-            // Check for empty assignments after all programmer errors have
-            // been checked.
-            if assignments.isEmpty {
-                return nil
             }
             
             let context = SQLGenerationContext(db, aliases: relation.allAliases)
@@ -363,7 +361,7 @@ struct SQLQueryGenerator: Refinable {
     private func makeTrivialUpdateStatement(
         _ db: Database,
         conflictResolution: Database.ConflictResolution,
-        assignments: [ColumnAssignment])
+        assignments: [Assignment])
         throws -> UpdateStatement?
     {
         // Check for empty assignments after all programmer errors have

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -533,14 +533,14 @@ extension MutablePersistableRecord {
     /// - parameter db: A database connection.
     /// - parameter conflictResolution: A policy for conflict resolution,
     ///   defaulting to the record's persistenceConflictPolicy.
-    /// - parameter assignments: An array of column assignments.
+    /// - parameter assignments: An array of assignments.
     /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public static func updateAll(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
-        _ assignments: [ColumnAssignment])
+        _ assignments: [Assignment])
         throws -> Int
     {
         try all().updateAll(db, onConflict: conflictResolution, assignments)
@@ -558,16 +558,16 @@ extension MutablePersistableRecord {
     /// - parameter db: A database connection.
     /// - parameter conflictResolution: A policy for conflict resolution,
     ///   defaulting to the record's persistenceConflictPolicy.
-    /// - parameter assignment: A column assignment.
-    /// - parameter otherAssignments: Eventual other column assignments.
+    /// - parameter assignment: An assignment.
+    /// - parameter otherAssignments: Eventual other assignments.
     /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public static func updateAll(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
-        _ assignment: ColumnAssignment,
-        _ otherAssignments: ColumnAssignment...)
+        _ assignment: Assignment,
+        _ otherAssignments: Assignment...)
         throws -> Int
     {
         try updateAll(db, onConflict: conflictResolution, [assignment] + otherAssignments)

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -558,19 +558,17 @@ extension MutablePersistableRecord {
     /// - parameter db: A database connection.
     /// - parameter conflictResolution: A policy for conflict resolution,
     ///   defaulting to the record's persistenceConflictPolicy.
-    /// - parameter assignment: An assignment.
-    /// - parameter otherAssignments: Eventual other assignments.
+    /// - parameter assignments: Assignments.
     /// - returns: The number of updated rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     @discardableResult
     public static func updateAll(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
-        _ assignment: Assignment,
-        _ otherAssignments: Assignment...)
+        _ assignments: Assignment...)
         throws -> Int
     {
-        try updateAll(db, onConflict: conflictResolution, [assignment] + otherAssignments)
+        try updateAll(db, onConflict: conflictResolution, assignments)
     }
 }
 

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -499,6 +499,8 @@
 		56DF0018228DDB8300D611F3 /* AssociationPrefetchingRowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF0014228DDB8200D611F3 /* AssociationPrefetchingRowTests.swift */; };
 		56DF37A723D77AA0009AAA05 /* Refinable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF37A623D77AA0009AAA05 /* Refinable.swift */; };
 		56DF37A823D77AA0009AAA05 /* Refinable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DF37A623D77AA0009AAA05 /* Refinable.swift */; };
+		56E33C3F2584F4B9000AD57E /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E33C3D2584F4B9000AD57E /* Assignment.swift */; };
+		56E33C402584F4B9000AD57E /* Assignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E33C3D2584F4B9000AD57E /* Assignment.swift */; };
 		56E4F7F92392E2EE00A611F6 /* DatabaseAbortedTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E4F7F72392E2EE00A611F6 /* DatabaseAbortedTransactionTests.swift */; };
 		56E4F7FA2392E2EE00A611F6 /* DatabaseAbortedTransactionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E4F7F72392E2EE00A611F6 /* DatabaseAbortedTransactionTests.swift */; };
 		56E9FAC42210468500C703A8 /* SQLInterpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E9FAC32210468500C703A8 /* SQLInterpolation.swift */; };
@@ -1114,6 +1116,7 @@
 		56DF0013228DDB8200D611F3 /* AssociationPrefetchingCodableRecordTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingCodableRecordTests.swift; sourceTree = "<group>"; };
 		56DF0014228DDB8200D611F3 /* AssociationPrefetchingRowTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationPrefetchingRowTests.swift; sourceTree = "<group>"; };
 		56DF37A623D77AA0009AAA05 /* Refinable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refinable.swift; sourceTree = "<group>"; };
+		56E33C3D2584F4B9000AD57E /* Assignment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Assignment.swift; sourceTree = "<group>"; };
 		56E4F7F72392E2EE00A611F6 /* DatabaseAbortedTransactionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseAbortedTransactionTests.swift; sourceTree = "<group>"; };
 		56E8CE0C1BB4FA5600828BEC /* DatabaseValueConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleFetchTests.swift; sourceTree = "<group>"; };
 		56E8CE0F1BB4FE5B00828BEC /* StatementColumnConvertibleFetchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatementColumnConvertibleFetchTests.swift; sourceTree = "<group>"; };
@@ -1590,6 +1593,7 @@
 		5656A8402295BD56001FF3FF /* SQL */ = {
 			isa = PBXGroup;
 			children = (
+				56E33C3D2584F4B9000AD57E /* Assignment.swift */,
 				5656A84A2295BD56001FF3FF /* Column.swift */,
 				5656A8A52295BF44001FF3FF /* DatabasePromise.swift */,
 				5656A8412295BD56001FF3FF /* SQLAssociation.swift */,
@@ -2405,6 +2409,7 @@
 				F3BA80221CFB288C003DC1BA /* NSNumber.swift in Sources */,
 				5656A8582295BD56001FF3FF /* SQLQueryGenerator.swift in Sources */,
 				56F896C424BA042E005FB062 /* FetchRequestVisitor.swift in Sources */,
+				56E33C402584F4B9000AD57E /* Assignment.swift in Sources */,
 				5656A8842295BD56001FF3FF /* SQLExpression.swift in Sources */,
 				5659F48D1EA8D94E004A4992 /* Utils.swift in Sources */,
 				F3BA80231CFB288C003DC1BA /* NSString.swift in Sources */,
@@ -2778,6 +2783,7 @@
 				F3BA807E1CFB2E61003DC1BA /* NSNumber.swift in Sources */,
 				5656A8572295BD56001FF3FF /* SQLQueryGenerator.swift in Sources */,
 				56F896C324BA042E005FB062 /* FetchRequestVisitor.swift in Sources */,
+				56E33C3F2584F4B9000AD57E /* Assignment.swift in Sources */,
 				5656A8832295BD56001FF3FF /* SQLExpression.swift in Sources */,
 				5659F48A1EA8D94E004A4992 /* Utils.swift in Sources */,
 				F3BA807F1CFB2E61003DC1BA /* NSString.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -4533,6 +4533,17 @@ Feed [requests](#requests) with SQL expressions built from your Swift code:
     Player.filter(selectedPlayerIds.contains(idColumn))
     ```
     
+    To check inclusion inside a [common table expression], call the `contains` method as well:
+    
+    ```swift
+    // WITH selectedName AS (...)
+    // SELECT * FROM player WHERE name IN selectedName
+    let cte = CommonTableExpression<Void>(named: "selectedName", ...)
+    Player
+        .with(cte)
+        .filter(cte.contains(nameColumn))
+    ```
+    
     > :point_up: **Note**: SQLite string comparison, by default, is case-sensitive and not Unicode-aware. See [string comparison](#string-comparison) if you need more control.
 
 - `LIKE`

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -201,7 +201,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent") \
                     SELECT *, "pA" AS "grdb_pA", "pB" AS "grdb_pB" \
-                    FROM "child" WHERE ("pA", "pB") IN grdb_base
+                    FROM "child" WHERE ("pA", "pB") IN "grdb_base"
                     """])
             }
             
@@ -244,7 +244,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent" WHERE "parentA" = 'foo') \
                     SELECT *, "pA" AS "grdb_pA", "pB" AS "grdb_pB" \
                     FROM "child" \
-                    WHERE ("name" = 'foo') AND (("pA", "pB") IN grdb_base)
+                    WHERE ("name" = 'foo') AND (("pA", "pB") IN "grdb_base")
                     """])
             }
         }
@@ -459,16 +459,16 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent") \
                     SELECT *, "pA" AS "grdb_pA", "pB" AS "grdb_pB" \
-                    FROM "child" WHERE ("pA", "pB") IN grdb_base
+                    FROM "child" WHERE ("pA", "pB") IN "grdb_base"
                     """,
                     """
                     WITH "grdb_base" AS (\
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent") \
                     SELECT "childA", "childB" FROM "child" \
-                    WHERE ("pA", "pB") IN grdb_base\
+                    WHERE ("pA", "pB") IN "grdb_base"\
                     ) \
                     SELECT *, "cA" AS "grdb_cA", "cB" AS "grdb_cB" \
-                    FROM "grandChild" WHERE ("cA", "cB") IN grdb_base
+                    FROM "grandChild" WHERE ("cA", "cB") IN "grdb_base"
                     """])
             }
             
@@ -508,7 +508,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent") \
                     SELECT *, "pA" AS "grdb_pA", "pB" AS "grdb_pB" \
                     FROM "child" \
-                    WHERE 0 AND (("pA", "pB") IN grdb_base)
+                    WHERE 0 AND (("pA", "pB") IN "grdb_base")
                     """])
             }
 
@@ -533,17 +533,17 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
                     """
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent" WHERE "name" = 'foo') \
                     SELECT *, "pA" AS "grdb_pA", "pB" AS "grdb_pB" \
-                    FROM "child" WHERE ("name" = 'blue') AND (("pA", "pB") IN grdb_base)
+                    FROM "child" WHERE ("name" = 'blue') AND (("pA", "pB") IN "grdb_base")
                     """,
                     """
                     WITH "grdb_base" AS (\
                     WITH "grdb_base" AS (SELECT "parentA", "parentB" FROM "parent" WHERE "name" = 'foo') \
                     SELECT "childA", "childB" FROM "child" \
-                    WHERE ("name" = 'blue') AND (("pA", "pB") IN grdb_base)\
+                    WHERE ("name" = 'blue') AND (("pA", "pB") IN "grdb_base")\
                     ) \
                     SELECT *, "cA" AS "grdb_cA", "cB" AS "grdb_cB" \
                     FROM "grandChild" \
-                    WHERE ("name" = 'dog') AND (("cA", "cB") IN grdb_base)
+                    WHERE ("name" = 'dog') AND (("cA", "cB") IN "grdb_base")
                     """])
             }
         }

--- a/Tests/GRDBTests/CommonTableExpressionTests.swift
+++ b/Tests/GRDBTests/CommonTableExpressionTests.swift
@@ -579,8 +579,8 @@ class CommonTableExpressionTests: GRDBTestCase {
     }
     
     func testUpdateRowValue() throws {
-        guard #available(OSX 10.13, iOS 10.3.1, tvOS 10.3.1, watchOS 4, *) else {
-            throw XCTSkip("Row values are not available")
+        guard #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *) else {
+            throw XCTSkip("Row value assignment is not available")
         }
         
         try makeDatabaseQueue().write { db in


### PR DESCRIPTION
This pull request brings [experimental](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features) support for [row values](https://www.sqlite.org/rowvalue.html).

Row values let you write code like:

```swift
// WITH cte AS (...)
// SELECT * FROM player WHERE (a, b) IN cte
let cte = CommonTableExpression(...)
let request = Player
    .with(cte)
    .filter(cte.contains(RowValue2(Column("a"), Column("b"))))

// WITH cte AS (...)
// UPDATE player SET (a, b) = (SELECT * FROM cte)
let cte = CommonTableExpression(...)
try Player
    .with(cte)
    .updateAll(db, RowValue2(Column("a"), Column("b")).set(to: cte.all()))
```

The pull request comes with support for pairs and triples (`RowValue2` and `RowValue3`).

The API is experimental because it is not very satisfying. Ideally we'd represent SQL row values as Swift tuples:

```swift
// NOT IN THIS PULL REQUEST
let cte = CommonTableExpression(...)
let request = Player
    .with(cte)
    .filter(cte.contains((Column("a"), Column("b"))))

let cte = CommonTableExpression(...)
try Player
    .with(cte)
    .updateAll(db, (Column("a"), Column("b")).set(to: cte.all()))
```

Unfortunately, the Swift language does not let us define the `set(to:)` method on tuples (Swift tuples can't be extended).

Conclusion: a *nice* support for row values will have us redesign the assignment API. Until this happens, this pull request will do the job, even if it does not look good.

PS: also note the new `cte.contains(stuff)` api, which generates `stuff IN <cte table name>`.

cc @rpoelstra