### PR TITLE
Provide SQLCipher passphrase as Data

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1237,7 +1237,9 @@ extension Database {
     ///         try db.usePassphrase("secret")
     ///     }
     public func usePassphrase(_ passphrase: String) throws {
-        var data = passphrase.data(using: .utf8)!
+        guard !passphrase.isEmpty, var data = passphrase.data(using: .utf8) else {
+            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
+        }
         defer {
             data.resetBytes(in: 0..<data.count)
         }
@@ -1254,6 +1256,9 @@ extension Database {
     ///         try db.usePassphrase(passphraseData)
     ///     }
     public func usePassphrase(_ passphrase: Data) throws {
+        guard !passphrase.isEmpty else {
+            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
+        }
         let code = passphrase.withUnsafeBytes {
             sqlite3_key(sqliteConnection, $0.baseAddress, Int32($0.count))
         }
@@ -1264,7 +1269,9 @@ extension Database {
     
     /// Changes the passphrase used by an SQLCipher encrypted database.
     public func changePassphrase(_ passphrase: String) throws {
-        var data = passphrase.data(using: .utf8)!
+        guard !passphrase.isEmpty, var data = passphrase.data(using: .utf8) else {
+            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
+        }
         defer {
             data.resetBytes(in: 0..<data.count)
         }
@@ -1283,6 +1290,10 @@ extension Database {
         // > schema of the original db into the new one:
         // > https://discuss.zetetic.net/t/how-to-encrypt-a-plaintext-sqlite-database-to-use-sqlcipher-and-avoid-file-is-encrypted-or-is-not-a-database-errors/
         // swiftlint:disable:previous line_length
+        guard !passphrase.isEmpty else {
+            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
+        }
+        
         let code = passphrase.withUnsafeBytes {
             sqlite3_rekey(sqliteConnection, $0.baseAddress, Int32($0.count))
         }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1237,11 +1237,11 @@ extension Database {
     ///         try db.usePassphrase("secret")
     ///     }
     public func usePassphrase(_ passphrase: String) throws {
-        guard !passphrase.isEmpty, var data = passphrase.data(using: .utf8) else {
-            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
+        guard var data = passphrase.data(using: .utf8) else {
+            throw DatabaseError(message: "invalid passphrase")
         }
         defer {
-            data.resetBytes(in: 0..<data.count)
+            if (data.count > 0) { data.resetBytes(in: 0..<data.count) }
         }
         try usePassphrase(data)
     }
@@ -1256,9 +1256,6 @@ extension Database {
     ///         try db.usePassphrase(passphraseData)
     ///     }
     public func usePassphrase(_ passphrase: Data) throws {
-        guard !passphrase.isEmpty else {
-            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
-        }
         let code = passphrase.withUnsafeBytes {
             sqlite3_key(sqliteConnection, $0.baseAddress, Int32($0.count))
         }
@@ -1269,11 +1266,11 @@ extension Database {
     
     /// Changes the passphrase used by an SQLCipher encrypted database.
     public func changePassphrase(_ passphrase: String) throws {
-        guard !passphrase.isEmpty, var data = passphrase.data(using: .utf8) else {
-            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
+        guard var data = passphrase.data(using: .utf8) else {
+            throw DatabaseError(message: "invalid passphrase")
         }
         defer {
-            data.resetBytes(in: 0..<data.count)
+            if data.count > 0 { data.resetBytes(in: 0..<data.count) }
         }
         try changePassphrase(data)
     }
@@ -1290,10 +1287,6 @@ extension Database {
         // > schema of the original db into the new one:
         // > https://discuss.zetetic.net/t/how-to-encrypt-a-plaintext-sqlite-database-to-use-sqlcipher-and-avoid-file-is-encrypted-or-is-not-a-database-errors/
         // swiftlint:disable:previous line_length
-        guard !passphrase.isEmpty else {
-            throw DatabaseError(message: "usePassphrase Failed: invalid or empty passphrase")
-        }
-        
         let code = passphrase.withUnsafeBytes {
             sqlite3_rekey(sqliteConnection, $0.baseAddress, Int32($0.count))
         }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1241,7 +1241,7 @@ extension Database {
             throw DatabaseError(message: "invalid passphrase")
         }
         defer {
-            if (data.count > 0) { data.resetBytes(in: 0..<data.count) }
+            data.resetBytes(in: 0..<data.count)
         }
         try usePassphrase(data)
     }
@@ -1270,7 +1270,7 @@ extension Database {
             throw DatabaseError(message: "invalid passphrase")
         }
         defer {
-            if data.count > 0 { data.resetBytes(in: 0..<data.count) }
+            data.resetBytes(in: 0..<data.count)
         }
         try changePassphrase(data)
     }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -493,7 +493,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     #if SQLITE_ENABLE_SNAPSHOT
     /// Returns a snapshot that must be freed with `sqlite3_snapshot_free`.
-    /// 
+    ///
     /// See https://www.sqlite.org/c3ref/snapshot.html
     func takeVersionSnapshot() throws -> UnsafeMutablePointer<sqlite3_snapshot> {
         var snapshot: UnsafeMutablePointer<sqlite3_snapshot>?
@@ -1237,8 +1237,24 @@ extension Database {
     ///         try db.usePassphrase("secret")
     ///     }
     public func usePassphrase(_ passphrase: String) throws {
-        let data = passphrase.data(using: .utf8)!
-        let code = data.withUnsafeBytes {
+        var data = passphrase.data(using: .utf8)!
+        defer {
+            data.resetBytes(in: 0..<data.count)
+        }
+        try usePassphrase(data)
+    }
+
+    /// Sets the passphrase used to crypt and decrypt an SQLCipher database.
+    ///
+    /// Call this method from `Configuration.prepareDatabase`,
+    /// as in the example below:
+    ///
+    ///     var config = Configuration()
+    ///     config.prepareDatabase { db in
+    ///         try db.usePassphrase(passphraseData)
+    ///     }
+    public func usePassphrase(_ passphrase: Data) throws {
+        let code = passphrase.withUnsafeBytes {
             sqlite3_key(sqliteConnection, $0.baseAddress, Int32($0.count))
         }
         guard code == SQLITE_OK else {
@@ -1248,6 +1264,15 @@ extension Database {
     
     /// Changes the passphrase used by an SQLCipher encrypted database.
     public func changePassphrase(_ passphrase: String) throws {
+        var data = passphrase.data(using: .utf8)!
+        defer {
+            data.resetBytes(in: 0..<data.count)
+        }
+        try changePassphrase(data)
+    }
+
+    /// Changes the passphrase used by an SQLCipher encrypted database.
+    public func changePassphrase(_ passphrase: Data) throws {
         // FIXME: sqlite3_rekey is discouraged.
         //
         // https://github.com/ccgus/fmdb/issues/547#issuecomment-259219320
@@ -1258,8 +1283,7 @@ extension Database {
         // > schema of the original db into the new one:
         // > https://discuss.zetetic.net/t/how-to-encrypt-a-plaintext-sqlite-database-to-use-sqlcipher-and-avoid-file-is-encrypted-or-is-not-a-database-errors/
         // swiftlint:disable:previous line_length
-        let data = passphrase.data(using: .utf8)!
-        let code = data.withUnsafeBytes {
+        let code = passphrase.withUnsafeBytes {
             sqlite3_rekey(sqliteConnection, $0.baseAddress, Int32($0.count))
         }
         guard code == SQLITE_OK else {

--- a/README.md
+++ b/README.md
@@ -6457,7 +6457,7 @@ config.prepareDatabase { db in
     defer {
         data.resetBytes(in: 0..<data.count)
     }
-    passphrase.resetBytes(in: 0..<passphrase.count)
+    try db.usePassphrase(passphrase)
 }
 ```
 

--- a/Tests/GRDBTests/EncryptionTests.swift
+++ b/Tests/GRDBTests/EncryptionTests.swift
@@ -29,6 +29,58 @@ class EncryptionTests: GRDBTestCase {
         }
     }
 
+    func testDatabaseQueueWithEmptyPassphraseToDatabaseQueueWithEmptyPassphrase() throws {
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase("")
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "CREATE TABLE data (value INTEGER)")
+                try db.execute(sql: "INSERT INTO data (value) VALUES (1)")
+            }
+        }
+        
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase("")
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 1)
+            }
+        }
+    }
+    
+    func testDatabaseQueueWithDataPassphraseToDatabaseQueueWithDataPassphrase() throws {
+        let secretData = "Secret".data(using: .utf8)
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase(secretData)
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "CREATE TABLE data (value INTEGER)")
+                try db.execute(sql: "INSERT INTO data (value) VALUES (1)")
+            }
+        }
+        
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase(secretData)
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 1)
+            }
+    
+        }
+    }
+    
     func testDatabaseQueueWithPassphraseToDatabaseQueueWithoutPassphrase() throws {
         do {
             var config = Configuration()
@@ -126,6 +178,54 @@ class EncryptionTests: GRDBTestCase {
         }
     }
 
+    func testDatabaseQueueWithDataPassphraseToDatabaseQueueWithNewDataPassphrase() throws {
+        let initialPassphrase = "Secret".data(using: .utf8)
+        let finalPassphrase = "MoreSecret".data(using: .utf8)
+        
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase(initialPassphrase)
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "CREATE TABLE data (value INTEGER)")
+                try db.execute(sql: "INSERT INTO data (value) VALUES (1)")
+            }
+        }
+        
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase(initialPassphrase)
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 1)
+            }
+            try dbQueue.write { db in
+                try db.changePassphrase(finalPassphrase)
+            }
+            try dbQueue.inDatabase { db in
+                try db.execute(sql: "INSERT INTO data (value) VALUES (2)")
+            }
+            try dbQueue.inDatabase { db in
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 2)
+            }
+        }
+        
+        do {
+            var config = Configuration()
+            config.prepareDatabase { db in
+                try db.usePassphrase(finalPassphrase)
+            }
+            let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
+            try dbQueue.inDatabase { db in
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 2)
+            }
+        }
+    }
+    
     func testDatabaseQueueWithPassphraseToDatabasePoolWithPassphrase() throws {
         do {
             var config = Configuration()

--- a/Tests/GRDBTests/EncryptionTests.swift
+++ b/Tests/GRDBTests/EncryptionTests.swift
@@ -28,12 +28,12 @@ class EncryptionTests: GRDBTestCase {
             }
         }
     }
-
-    func testDatabaseQueueWithEmptyPassphraseToDatabaseQueueWithEmptyPassphrase() throws {
+    
+    func testDatabaseConfigWithEmptyPassphrase() throws {
         do {
             var config = Configuration()
             config.prepareDatabase { db in
-                try db.usePassphrase("")
+                XCTAssertThrowsError(try db.usePassphrase(""))
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
             try dbQueue.inDatabase { db in
@@ -41,21 +41,24 @@ class EncryptionTests: GRDBTestCase {
                 try db.execute(sql: "INSERT INTO data (value) VALUES (1)")
             }
         }
-        
+    }
+    
+    func testDatabaseConfigWithEmptyDataPassphrase() throws {
         do {
             var config = Configuration()
             config.prepareDatabase { db in
-                try db.usePassphrase("")
+                XCTAssertThrowsError(try db.usePassphrase(Data()))
             }
             let dbQueue = try makeDatabaseQueue(filename: "test.sqlite", configuration: config)
             try dbQueue.inDatabase { db in
-                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM data")!, 1)
+                try db.execute(sql: "CREATE TABLE data (value INTEGER)")
+                try db.execute(sql: "INSERT INTO data (value) VALUES (1)")
             }
         }
     }
     
     func testDatabaseQueueWithDataPassphraseToDatabaseQueueWithDataPassphrase() throws {
-        let secretData = "Secret".data(using: .utf8)
+        let secretData = "Secret".data(using: .utf8)!
         do {
             var config = Configuration()
             config.prepareDatabase { db in
@@ -179,8 +182,8 @@ class EncryptionTests: GRDBTestCase {
     }
 
     func testDatabaseQueueWithDataPassphraseToDatabaseQueueWithNewDataPassphrase() throws {
-        let initialPassphrase = "Secret".data(using: .utf8)
-        let finalPassphrase = "MoreSecret".data(using: .utf8)
+        let initialPassphrase = "Secret".data(using: .utf8)!
+        let finalPassphrase = "MoreSecret".data(using: .utf8)!
         
         do {
             var config = Configuration()


### PR DESCRIPTION
Added the ability to specify passphrase for database encryption as a Data object.
Also added resetBytes call for Data objects created when using a string passphrase.
Updated the documentation with a section about passphrase datatypes.
Unit tests.

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
