### PR TITLE
Fix SPM installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ The [Swift Package Manager](https://swift.org/package-manager/) automates the di
 ```swift
 let package = Package(
     dependencies: [
-        .package(url: "https://github.com/groue/GRDB.swift.git", ...)
+        .package(name: "GRDB", url: "https://github.com/groue/GRDB.swift.git", ...)
     ]
 )
 ```


### PR DESCRIPTION
Without this change, SPM throw an error in Xcode 12.3 when integrated manually into another local package via `Package.swift`: 

> dependency 'GRDB' in target 'Services' requires explicit declaration; provide the name of the package dependency with '.package(name: "GRDB", url: "https://github.com/groue/GRDB.swift.git", from: "5.2.0")'


### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
