### PR TITLE
Added direct values initializer

### DIFF
--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -649,6 +649,11 @@ public struct StatementArguments: CustomStringConvertible, Equatable,
     /// Creates empty StatementArguments.
     public init() {
     }
+
+    /// Creates a new StatementArguments with the given values
+    public init(values: [DatabaseValue]) {
+        self.values = values
+    }
     
     // MARK: Positional Arguments
     


### PR DESCRIPTION
This enables me to write code that directly sets values, like so:

`selectStatement.setUncheckedArguments(StatementArguments(values: [firstName.databaseValue]))`

This improves speed. 

I am close to finishing an ORM based on this library which uses Codable records. Instead of GRDB checking properties at runtime, the properties are checked at compile time (by using code generation).

This was the only thing I needed to add for the ORM. I will mention you when I put it on Github to verify if the generated code is correct if you want.