### PR TITLE
Fix SQL generation for `COLLATE`, `IN`, `NOT IN`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - **Fixed**: `DatabaseQueue.read` is now declared `throws` instead of `rethrows`.
 
+- **Fixed**: [#930](https://github.com/groue/GRDB.swift/pull/930): Fix SQL generation for `COLLATE`, `IN`, `NOT IN`
+
 ## 5.4.0
 
 Released February 15, 2021 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v5.3.0...v5.4.0)

--- a/GRDB/QueryInterface/SQL/SQLOperators.swift
+++ b/GRDB/QueryInterface/SQL/SQLOperators.swift
@@ -506,7 +506,7 @@ extension Sequence where Self.Iterator.Element: SQLExpressible {
     ///     // name IN ('A', 'B') COLLATE NOCASE
     ///     ["A", "B"].contains(Column("name").collating(.nocase))
     public func contains(_ element: SQLCollatedExpression) -> SQLExpression {
-        .collated(contains(element.expression), element.collationName)
+        SQLCollection.array(map(\.sqlExpression)).contains(element.sqlExpression)
     }
 }
 
@@ -526,7 +526,7 @@ extension Sequence where Self.Iterator.Element == SQLExpressible {
     ///     // name IN ('A', 'B') COLLATE NOCASE
     ///     ["A", "B"].contains(Column("name").collating(.nocase))
     public func contains(_ element: SQLCollatedExpression) -> SQLExpression {
-        .collated(contains(element.expression), element.collationName)
+        SQLCollection.array(map(\.sqlExpression)).contains(element.sqlExpression)
     }
 }
 

--- a/GRDB/QueryInterface/SQL/SQLOperators.swift
+++ b/GRDB/QueryInterface/SQL/SQLOperators.swift
@@ -503,7 +503,7 @@ extension Sequence where Self.Iterator.Element: SQLExpressible {
     /// An SQL expression that checks the inclusion of an expression in
     /// a sequence.
     ///
-    ///     // name IN ('A', 'B') COLLATE NOCASE
+    ///     // (name COLLATE NOCASE) IN ('A', 'B')
     ///     ["A", "B"].contains(Column("name").collating(.nocase))
     public func contains(_ element: SQLCollatedExpression) -> SQLExpression {
         SQLCollection.array(map(\.sqlExpression)).contains(element.sqlExpression)
@@ -523,7 +523,7 @@ extension Sequence where Self.Iterator.Element == SQLExpressible {
     /// An SQL expression that checks the inclusion of an expression in
     /// a sequence.
     ///
-    ///     // name IN ('A', 'B') COLLATE NOCASE
+    ///     // (name COLLATE NOCASE) IN ('A', 'B')
     ///     ["A", "B"].contains(Column("name").collating(.nocase))
     public func contains(_ element: SQLCollatedExpression) -> SQLExpression {
         SQLCollection.array(map(\.sqlExpression)).contains(element.sqlExpression)

--- a/GRDB/QueryInterface/SQL/SQLSubquery.swift
+++ b/GRDB/QueryInterface/SQL/SQLSubquery.swift
@@ -110,7 +110,17 @@ extension SQLSubqueryable {
     ///     // 1000 IN (SELECT score FROM player)
     ///     let request = Player.select(Column("score"), as: Int.self)
     ///     let condition = request.contains(1000)
-    public func contains(_ value: SQLExpressible) -> SQLExpression {
-        SQLCollection.subquery(sqlSubquery).contains(value.sqlExpression)
+    public func contains(_ element: SQLExpressible) -> SQLExpression {
+        SQLCollection.subquery(sqlSubquery).contains(element.sqlExpression)
+    }
+    
+    /// Returns an expression that checks the inclusion of the expression in
+    /// the subquery.
+    ///
+    ///     // name COLLATE NOCASE IN (SELECT name FROM player)
+    ///     let request = Player.select(Column("name"), as: String.self)
+    ///     let condition = request.contains(Column("name").collating(.nocase))
+    public func contains(_ element: SQLCollatedExpression) -> SQLExpression {
+        SQLCollection.subquery(sqlSubquery).contains(element.sqlExpression)
     }
 }

--- a/Tests/GRDBTests/FetchRequestTests.swift
+++ b/Tests/GRDBTests/FetchRequestTests.swift
@@ -44,10 +44,19 @@ class FetchRequestTests: GRDBTestCase {
                 t.column("id", .integer).primaryKey()
             }
             
-            let derivedExpression = request.contains(0)
-            let sqlRequest: SQLRequest<Row> = "SELECT \(derivedExpression)"
-            let statement = try sqlRequest.makePreparedRequest(db, forSingleResult: false).statement
-            XCTAssertEqual(statement.sql, "SELECT ? IN (SELECT id FROM table1)")
+            do {
+                let derivedExpression = request.contains(0)
+                let sqlRequest: SQLRequest<Row> = "SELECT \(derivedExpression)"
+                let statement = try sqlRequest.makePreparedRequest(db, forSingleResult: false).statement
+                XCTAssertEqual(statement.sql, "SELECT ? IN (SELECT id FROM table1)")
+            }
+            
+            do {
+                let derivedExpression = request.contains("arthur".databaseValue.collating(.nocase))
+                let sqlRequest: SQLRequest<Row> = "SELECT \(derivedExpression)"
+                let statement = try sqlRequest.makePreparedRequest(db, forSingleResult: false).statement
+                XCTAssertEqual(statement.sql, "SELECT (? COLLATE NOCASE) IN (SELECT id FROM table1)")
+            }
         }
     }
     

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -178,22 +178,26 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         // Array.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(["arthur", "barbara"].contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE \"name\" IN ('arthur', 'barbara') COLLATE NOCASE")
+            "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) IN ('arthur', 'barbara')")
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter((["arthur", "barbara"] as [SQLExpressible]).contains(Col.name.collating(.nocase)))),
+            "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) IN ('arthur', 'barbara')")
         
         // Sequence.contains(): IN operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence(["arthur", "barbara"]).contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE \"name\" IN ('arthur', 'barbara') COLLATE NOCASE")
+            "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) IN ('arthur', 'barbara')")
         
         // Sequence.contains(): = operator
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(AnySequence([Col.name]).contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE \"name\" = \"name\" COLLATE NOCASE")
+            "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) = \"name\"")
         
         // Sequence.contains(): false
         XCTAssertEqual(
             sql(dbQueue, tableRequest.filter(EmptyCollection<Int>().contains(Col.name.collating(.nocase)))),
-            "SELECT * FROM \"readers\" WHERE 0 COLLATE NOCASE")
+            "SELECT * FROM \"readers\" WHERE 0")
 
         // ClosedInterval: BETWEEN operator
         let closedInterval = "A"..."z"

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -181,6 +181,10 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) IN ('arthur', 'barbara')")
         
         XCTAssertEqual(
+            sql(dbQueue, tableRequest.filter(!["arthur", "barbara"].contains(Col.name.collating(.nocase)))),
+            "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) NOT IN ('arthur', 'barbara')")
+        
+        XCTAssertEqual(
             sql(dbQueue, tableRequest.filter((["arthur", "barbara"] as [SQLExpressible]).contains(Col.name.collating(.nocase)))),
             "SELECT * FROM \"readers\" WHERE (\"name\" COLLATE NOCASE) IN ('arthur', 'barbara')")
         


### PR DESCRIPTION
Fix the generated SQL for expressions that involve the `IN` and `NOT IN` operators and collated expressions:

```swift
// name COLLATE NOCASE IN ('a', 'b')
["a", "b"].contains(Column("name").collating(.nocase))
```

Fixes #929 