### PR TITLE
Fix DatabaseMigrator.eraseDatabaseOnSchemaChange in the context of shared databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 #### 5.x Releases
 
+- [Development Branch](#development-branch)
 - `5.5.x` Releases - [5.5.0](#550)
 - `5.4.x` Releases - [5.4.0](#540)
 - `5.3.x` Releases - [5.3.0](#530)
@@ -70,6 +71,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - [0.110.0](#01100), ...
 
+
+## Development Branch
+
+- **Fixed**: [#933](https://github.com/groue/GRDB.swift/pull/933): Fix DatabaseMigrator.eraseDatabaseOnSchemaChange in the context of shared databases
 
 ## 5.5.0
 


### PR DESCRIPTION
The `DatabaseMigrator.eraseDatabaseOnSchemaChange` flag creates a temporary database in order to look for potential changes in database migrations, and nuke the database if needed.

[Temporary on-disk databases](https://www.sqlite.org/c3ref/open.html) created with an empty path [do not support the WAL mode](https://sqlite.org/forum/forumpost/f4f9d58515). They can make the migration fail when the database configuration relies on the availability of the WAL mode. This is the case, for example, in the sample code provided in the [Sharing a Database](https://github.com/groue/GRDB.swift/blob/master/Documentation/SharingADatabase.md) Guide: `SQLITE_FCNTL_PERSIST_WAL` is not available for such temporary databases, as revealed by #931.

This pull request fixes this problem, and #931, by having `DatabaseMigrator` create a "regular" temporary database that supports the WAL mode.