### PR TITLE
Fix a crash in the ValueObservation publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 ## Development Branch
 
 - **Fixed**: [#933](https://github.com/groue/GRDB.swift/pull/933): Fix DatabaseMigrator.eraseDatabaseOnSchemaChange in the context of shared databases
+- **Fixed**: [#934](https://github.com/groue/GRDB.swift/pull/934): Fix a crash in the ValueObservation publisher
 
 ## 5.5.0
 

--- a/GRDB/Utils/ReceiveValuesOn.swift
+++ b/GRDB/Utils/ReceiveValuesOn.swift
@@ -119,8 +119,22 @@ where
                     subscription.request(currentDemand)
                 }
                 
-            case .waitingForRequest, .subscribed, .finished:
+            case .waitingForRequest, .subscribed:
                 preconditionFailure()
+                
+            case .finished:
+                // We receive the upstream subscription requested by
+                // `upstream.receive(subscriber: self)` above.
+                //
+                // But self has been cancelled since, so let's cancel this
+                // upstream subscription that has turned purposeless.
+                //
+                // This cancellation avoids the bug described in
+                // https://github.com/groue/GRDB.swift/pull/932
+                // TODO: write a regression test.
+                sideEffect = {
+                    subscription.cancel()
+                }
             }
         }
     }


### PR DESCRIPTION
This pull request fixes #932 as suggested by @jameshurst.