### PR TITLE
make SQLOrdering helper functions public

### DIFF
--- a/GRDB/QueryInterface/SQL/SQLOrdering.swift
+++ b/GRDB/QueryInterface/SQL/SQLOrdering.swift
@@ -29,27 +29,27 @@ public struct SQLOrdering {
         case literal(SQLLiteral)
     }
     
-    static func expression(_ expression: SQLExpression) -> SQLOrdering {
+    public static func expression(_ expression: SQLExpression) -> SQLOrdering {
         self.init(impl: .expression(expression))
     }
     
-    static func asc(_ expression: SQLExpression) -> SQLOrdering {
+    public static func asc(_ expression: SQLExpression) -> SQLOrdering {
         self.init(impl: .asc(expression))
     }
     
-    static func desc(_ expression: SQLExpression) -> SQLOrdering {
+    public static func desc(_ expression: SQLExpression) -> SQLOrdering {
         self.init(impl: .desc(expression))
     }
     
-    static func ascNullsLast(_ expression: SQLExpression) -> SQLOrdering {
+    public static func ascNullsLast(_ expression: SQLExpression) -> SQLOrdering {
         self.init(impl: .ascNullsLast(expression))
     }
     
-    static func descNullsFirst(_ expression: SQLExpression) -> SQLOrdering {
+    public static func descNullsFirst(_ expression: SQLExpression) -> SQLOrdering {
         self.init(impl: .descNullsFirst(expression))
     }
     
-    static func literal(_ sqlLiteral: SQLLiteral) -> SQLOrdering {
+    public static func literal(_ sqlLiteral: SQLLiteral) -> SQLOrdering {
         self.init(impl: .literal(sqlLiteral))
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Pull Request Checklist

I would like to use these helper functions on `SQLOrdering`. However, they are `internal` and cannot be used by clients of the library.

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [ ] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
