### PR TITLE
Prevent ValueObservation from notifying duplicate initial values when no concurrent write is observed

### DIFF
--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -11,6 +11,13 @@ final class SerializedDatabase {
     /// The path to the database file
     var path: String
     
+    /// The number of attempted SQLite commits.
+    ///
+    /// See `DatabaseObservationBroker.attemptedCommitCount`
+    var attemptedCommitCount: Int {
+        db.observationBroker.attemptedCommitCount
+    }
+    
     /// The dispatch queue
     private let queue: DispatchQueue
     


### PR DESCRIPTION
When one starts a `ValueObservation` in a `DatabasePool`, one would get a duplicate notification of the initial value.

Now this duplicate notification is avoided when we can prove that no transaction was committed, in the pool's writer connection, between the fetch of the initial value, and the first access to the writer connection (where the observation can really start by hooking on the SQLite commits).

A double notification will still happen if some writer commit is attempted during the ValueObservation start-up (even if the observed value is not impacted by the changes, and even if the commit fails).

As [documented](https://github.com/groue/GRDB.swift/blob/master/README.md#valueobservation-usage), ValueObservation users must be ready for duplicate notifications. This pull request produces *less* duplicate notifications, but does not remove all of them.

Fix #937
