### PR TITLE
Prohibit observation of tables created WITHOUT ROWID

### DIFF
--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -169,6 +169,20 @@ public struct DatabaseRegion: CustomStringConvertible, Equatable {
         }
         return DatabaseRegion(tableRegions: filteredRegions)
     }
+
+    /// Returns an array containing the names of any tables in the region that
+    /// were created with WITHOUT ROWID.
+    func tablesWithoutRowid(_ db: Database) throws -> [String] {
+        guard let tableRegions = tableRegions else { return [] }
+        var tables: [String] = []
+        for (table, _) in tableRegions {
+            let pkInfo = try db.primaryKey(table)
+            if !pkInfo.tableHasRowID {
+                tables.append(table)
+            }
+        }
+        return tables
+    }
 }
 
 extension DatabaseRegion {

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -221,13 +221,15 @@ extension ValueObserver {
 
         let withoutRowid = try observedRegion?.tablesWithoutRowid(db) ?? []
         if !withoutRowid.isEmpty {
+            // https://www.sqlite.org/withoutrowid.html
+            // > The sqlite3_update_hook() interface does not fire callbacks for
+            // > changes to a WITHOUT ROWID table.
+            //
+            // This prevents us from observing those tables, and there is no
+            // workaround. It is thus a programmer error:
             fatalError("""
-                The sqlite3_update_hook() interface does not fire callbacks for changes to a WITHOUT ROWID table.
-                This observation contains the following tables that cannot be observed:
-                    \(withoutRowid.joined(separator: ", "))
-
-                See https://www.sqlite.org/withoutrowid.html for more information.
-            """)
+                Tracking WITHOUT ROWID table is not supported: \(withoutRowid.joined(separator: ", "))
+                """)
         }
 
         return result

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -218,7 +218,18 @@ extension ValueObserver {
         // TransactionObserver protocol. By removing them from the observed
         // region, we optimize our TransactionObserver conformance.
         observedRegion = try region.ignoringViews(db).ignoringInternalSQLiteTables()
-        
+
+        let withoutRowid = try observedRegion?.tablesWithoutRowid(db) ?? []
+        if !withoutRowid.isEmpty {
+            fatalError("""
+                The sqlite3_update_hook() interface does not fire callbacks for changes to a WITHOUT ROWID table.
+                This observation contains the following tables that cannot be observed:
+                    \(withoutRowid.joined(separator: ", "))
+
+                See https://www.sqlite.org/withoutrowid.html for more information.
+            """)
+        }
+
         return result
     }
 }

--- a/README.md
+++ b/README.md
@@ -5503,6 +5503,8 @@ Tracked changes include changes performed by the [query interface](#the-query-in
     
     </details>
     
+    > :point_up: **Note**: ValueObservation does not report changes to internal system tables (such as `sqlite_master`). Tracking [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables will raise a fatal error "Tracking WITHOUT ROWID table is not supported".
+    
 3. Start the observation in order to be notified of changes:
     
     ```swift

--- a/Tests/GRDBTests/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionTests.swift
@@ -824,4 +824,17 @@ class DatabaseRegionTests : GRDBTestCase {
             }
         }
     }
+
+    func testCheckingWithoutRowid() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE foo (name TEXT PRIMARY KEY) WITHOUT ROWID")
+            try db.execute(sql: "CREATE TABLE bar (id INTEGER PRIMARY KEY, name TEXT)")
+            do {
+                let statement = try db.makeSelectStatement(sql: "SELECT foo.name FROM foo JOIN bar ON foo.name == bar.name")
+                let tables = try statement.databaseRegion.tablesWithoutRowid(db)
+                XCTAssertEqual(tables, ["foo"])
+            }
+        }
+    }
 }


### PR DESCRIPTION
As discussed in #945 this PR adds a fatal error whenever a developer attempts to observe a table that lacks a rowid. Since SQLite does not report changes to these tables, notifying the developer of this makes sense.

The method on `DatabaseRegion` that performs the check loops all table regions and checks if those tables have a `rowid` and returns the names of tables that don't. First I had a variant that returned a `bool` as soon as a table without `rowid` was found. Thinking we don't need to check more than that. But it struck me that for valid regions the loop will always check every table anyway. So it felt better to instead gather up the names of the offending tables, if more than one, to provide better error reporting to the user.

I am not 100% confident that the single test case covers all bases.

I have not updated the README as I think maybe the documentation as is probably is enough together with this change.

And of course, let me know if you're not happy with the solution. You probably know if there are better ways to do it :)

### Pull Request Checklist

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested. **Two other tests in the suite failed, but they seemed unrelated to this change**
