### PR TITLE
Allow access to Encoder from KeyedEncodingContainer

### DIFF
--- a/GRDB/Record/EncodableRecord+Encodable.swift
+++ b/GRDB/Record/EncodableRecord+Encodable.swift
@@ -111,11 +111,11 @@ private class RecordEncoder<Record: EncodableRecord>: Encoder {
         }
         
         func superEncoder() -> Encoder {
-            fatalError("Not implemented")
+            recordEncoder
         }
         
         func superEncoder(forKey key: Key) -> Encoder {
-            fatalError("Not implemented")
+            recordEncoder
         }
     }
     

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -229,12 +229,11 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
         }
         
         func superDecoder() throws -> Decoder {
-            // Not sure
-            return decoder
+            decoder
         }
         
         func superDecoder(forKey key: Key) throws -> Decoder {
-            fatalError("not implemented")
+            decoder
         }
         
         // Helper methods


### PR DESCRIPTION
While implementing a `propertyWrapper` to conditionally encode/decode properties only when stored to the database, I hit a snag where I couldn't access the parent `Encoder` which contains the custom [`userInfo`](https://github.com/groue/GRDB.swift#the-userinfo-dictionary) referenced here from the docs.

```swift
extension KeyedEncodingContainer {
    mutating func encode<T>(_ value: Local<T>, forKey key: K) throws {
        let encoder = superEncoder() // crashes here due to unimplemented fatalError
        if encoder.isDatabaseEncoder {
            try encodeIfPresent(value.wrappedValue, forKey: key)
        } else {
            // do nothing
        }
    }
}
```

The issue here is that there seems to be no way to access the `encoder` from a `KeyedEncodingContainer` (to then access the `userInfo` to see if we're the Database encoder) without calling `superEncoder()`.

Although the described usage of [`superEncoder`](https://developer.apple.com/documentation/swift/keyedencodingcontainerprotocol/2893423-superencoder) applies to another use case, there is no other way to access the parent `Encoder` from a `KeyedEncodingContainer`, or otherwise access the `userInfo` that we need. The only alternative I can see would be to make [`KeyedContainer<Key: CodingKey>: KeyedEncodingContainerProtocol`](https://github.com/groue/GRDB.swift/blob/0133ff9056f3f272a52c8f07d7f10de6b7518c23/GRDB/Record/EncodableRecord%2BEncodable.swift#L48) public, which seems a lot less ideal.

For parity I also included the same functionality on the `Decoder` side, in case others encounter this issue but in the reverse direction.

Cheers!

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
