### PR TITLE
Fix memory consumption when encoding JSON columns

### DIFF
--- a/GRDB/Record/EncodableRecord+Encodable.swift
+++ b/GRDB/Record/EncodableRecord+Encodable.swift
@@ -148,16 +148,19 @@ private class RecordEncoder<Record: EncodableRecord>: Encoder {
                 }
             } catch is JSONRequiredError {
                 // Encode to JSON
-                let jsonData = try Record.databaseJSONEncoder(for: key.stringValue).encode(value)
-                
-                // Store JSON String in the database for easier debugging and
-                // database inspection. Thanks to SQLite weak typing, we won't
-                // have any trouble decoding this string into data when we
-                // eventually perform JSON decoding.
-                // TODO: possible optimization: avoid this conversion to string,
-                // and store raw data bytes as an SQLite string
-                let jsonString = String(data: jsonData, encoding: .utf8)!
-                persist(jsonString, forKey: key)
+                try autoreleasepool {
+
+                    let jsonData = try Record.databaseJSONEncoder(for: key.stringValue).encode(value)
+
+                    // Store JSON String in the database for easier debugging and
+                    // database inspection. Thanks to SQLite weak typing, we won't
+                    // have any trouble decoding this string into data when we
+                    // eventually perform JSON decoding.
+                    // TODO: possible optimization: avoid this conversion to string,
+                    // and store raw data bytes as an SQLite string
+                    let jsonString = String(data: jsonData, encoding: .utf8)!
+                    persist(jsonString, forKey: key)
+                }
             }
         }
     }


### PR DESCRIPTION
This PR is meant to fix the issue shown in #944 where encoding json columns leads to significant memory buildup.

What I found is that the memory buildup can be prevented by simply wrapping it into an autoreleasepool. However, I have not much experience with that mechanic, so please be the judge of whether or not this is the right way to go.

--- 

As a possible reason for the buildup I found that the a new JSONEncoder is initiated for every json column of every item being persisted: 
https://github.com/groue/GRDB.swift/blob/67892d7cdb7d16a56bd975a091e9b427d7115270/GRDB/Record/EncodableRecord.swift#L127-L137

Since `databaseJSONEncoder(for column: String)` doesn't seem to actually use its parameter `column` this could maybe actually be implemented as a lazy computed property (or maybe cache the encoder elsewhere?).

Sadly I couldn't directly see a way around this without changing the `EncodableRecord` protocol implementation since the extension doesn't allow stored properties.

Would be happy to hear your thoughts on this!

---

### Pull Request Checklist

- [x] This pull request is submitted against the `development` branch.
- [ ] Inline documentation has been updated.  
- [ ] README.md or another dedicated guide has been updated.
- [ ] Changes are tested.

Existing tests seem to run fine and it doesn't seem like any additional ones are necessary.
I also can't see if there's any need to change the documentation. I would like to leave that decision up to you.
