### PR TITLE
Ensure Query can be updated

### DIFF
--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/project.pbxproj
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/project.pbxproj
@@ -731,7 +731,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"GRDBCombineDemo/Preview Content\"";
-				DEVELOPMENT_TEAM = AMD8W895CT;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = GRDBCombineDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -753,7 +753,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"GRDBCombineDemo/Preview Content\"";
-				DEVELOPMENT_TEAM = AMD8W895CT;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = GRDBCombineDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -772,7 +772,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Y5PE65HELJ;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = GRDBCombineDemoUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -792,7 +792,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = Y5PE65HELJ;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = GRDBCombineDemoUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/project.pbxproj
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		567C3E792520BB650011F6E9 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 567C3E752520BB650011F6E9 /* Localizable.stringsdict */; };
 		567C3E7A2520BB650011F6E9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 567C3E772520BB650011F6E9 /* LaunchScreen.storyboard */; };
 		56B6D1092619EC1B003CC455 /* PlayerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6D1082619EC1B003CC455 /* PlayerRequest.swift */; };
+		78E2F9E6261EEC22005D1F7F /* GRDBCombineDemoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E2F9E5261EEC22005D1F7F /* GRDBCombineDemoUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,6 +101,13 @@
 			remoteGlobalIDString = 56E5D7C91B4D3FED00430942;
 			remoteInfo = GRDBiOS;
 		};
+		78E2F9E8261EEC22005D1F7F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 567C3E0E2520B6DE0011F6E9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 567C3E152520B6DE0011F6E9;
+			remoteInfo = GRDBCombineDemo;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -140,6 +148,9 @@
 		567C3E762520BB650011F6E9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		567C3E782520BB650011F6E9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		56B6D1082619EC1B003CC455 /* PlayerRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerRequest.swift; sourceTree = "<group>"; };
+		78E2F9E3261EEC22005D1F7F /* GRDBCombineDemoUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GRDBCombineDemoUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		78E2F9E5261EEC22005D1F7F /* GRDBCombineDemoUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GRDBCombineDemoUITests.swift; sourceTree = "<group>"; };
+		78E2F9E7261EEC22005D1F7F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -155,6 +166,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				567C3E4E2520B70E0011F6E9 /* GRDB.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		78E2F9E0261EEC22005D1F7F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -196,6 +214,7 @@
 				567C3E292520B7000011F6E9 /* GRDB.xcodeproj */,
 				567C3E182520B6DE0011F6E9 /* GRDBCombineDemo */,
 				56026C9925B8A7D000D1DF3F /* GRDBCombineDemoTests */,
+				78E2F9E4261EEC22005D1F7F /* GRDBCombineDemoUITests */,
 				567C3E172520B6DE0011F6E9 /* Products */,
 				567C3E4D2520B70E0011F6E9 /* Frameworks */,
 			);
@@ -206,6 +225,7 @@
 			children = (
 				567C3E162520B6DE0011F6E9 /* GRDBCombineDemo.app */,
 				56026C9825B8A7D000D1DF3F /* GRDBCombineDemoTests.xctest */,
+				78E2F9E3261EEC22005D1F7F /* GRDBCombineDemoUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -269,6 +289,15 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		78E2F9E4261EEC22005D1F7F /* GRDBCombineDemoUITests */ = {
+			isa = PBXGroup;
+			children = (
+				78E2F9E5261EEC22005D1F7F /* GRDBCombineDemoUITests.swift */,
+				78E2F9E7261EEC22005D1F7F /* Info.plist */,
+			);
+			path = GRDBCombineDemoUITests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -309,13 +338,31 @@
 			productReference = 567C3E162520B6DE0011F6E9 /* GRDBCombineDemo.app */;
 			productType = "com.apple.product-type.application";
 		};
+		78E2F9E2261EEC22005D1F7F /* GRDBCombineDemoUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 78E2F9F3261EEC22005D1F7F /* Build configuration list for PBXNativeTarget "GRDBCombineDemoUITests" */;
+			buildPhases = (
+				78E2F9DF261EEC22005D1F7F /* Sources */,
+				78E2F9E0261EEC22005D1F7F /* Frameworks */,
+				78E2F9E1261EEC22005D1F7F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				78E2F9E9261EEC22005D1F7F /* PBXTargetDependency */,
+			);
+			name = GRDBCombineDemoUITests;
+			productName = GRDBCombineDemoUITests;
+			productReference = 78E2F9E3261EEC22005D1F7F /* GRDBCombineDemoUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		567C3E0E2520B6DE0011F6E9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1230;
+				LastSwiftUpdateCheck = 1250;
 				LastUpgradeCheck = 1200;
 				TargetAttributes = {
 					56026C9725B8A7D000D1DF3F = {
@@ -324,6 +371,10 @@
 					};
 					567C3E152520B6DE0011F6E9 = {
 						CreatedOnToolsVersion = 12.0;
+					};
+					78E2F9E2261EEC22005D1F7F = {
+						CreatedOnToolsVersion = 12.5;
+						TestTargetID = 567C3E152520B6DE0011F6E9;
 					};
 				};
 			};
@@ -348,6 +399,7 @@
 			targets = (
 				567C3E152520B6DE0011F6E9 /* GRDBCombineDemo */,
 				56026C9725B8A7D000D1DF3F /* GRDBCombineDemoTests */,
+				78E2F9E2261EEC22005D1F7F /* GRDBCombineDemoUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -430,6 +482,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		78E2F9E1261EEC22005D1F7F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -461,6 +520,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		78E2F9DF261EEC22005D1F7F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				78E2F9E6261EEC22005D1F7F /* GRDBCombineDemoUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -473,6 +540,11 @@
 			isa = PBXTargetDependency;
 			name = GRDBiOS;
 			targetProxy = 567C3E512520B71C0011F6E9 /* PBXContainerItemProxy */;
+		};
+		78E2F9E9261EEC22005D1F7F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 567C3E152520B6DE0011F6E9 /* GRDBCombineDemo */;
+			targetProxy = 78E2F9E8261EEC22005D1F7F /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -696,6 +768,46 @@
 			};
 			name = Release;
 		};
+		78E2F9EA261EEC22005D1F7F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = Y5PE65HELJ;
+				INFOPLIST_FILE = GRDBCombineDemoUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.groue.GRDBCombineDemoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = GRDBCombineDemo;
+			};
+			name = Debug;
+		};
+		78E2F9EB261EEC22005D1F7F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = Y5PE65HELJ;
+				INFOPLIST_FILE = GRDBCombineDemoUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.groue.GRDBCombineDemoUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = GRDBCombineDemo;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -722,6 +834,15 @@
 			buildConfigurations = (
 				567C3E262520B6DF0011F6E9 /* Debug */,
 				567C3E272520B6DF0011F6E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		78E2F9F3261EEC22005D1F7F /* Build configuration list for PBXNativeTarget "GRDBCombineDemoUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				78E2F9EA261EEC22005D1F7F /* Debug */,
+				78E2F9EB261EEC22005D1F7F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/project.pbxproj
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/project.pbxproj
@@ -774,7 +774,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = GRDBCombineDemoUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -794,7 +793,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = GRDBCombineDemoUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/xcshareddata/xcschemes/GRDBCombineDemo.xcscheme
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj/xcshareddata/xcschemes/GRDBCombineDemo.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:GRDBCombineDemo.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "78E2F9E2261EEC22005D1F7F"
+               BuildableName = "GRDBCombineDemoUITests.xctest"
+               BlueprintName = "GRDBCombineDemoUITests"
+               ReferencedContainer = "container:GRDBCombineDemo.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/AppDatabase.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/AppDatabase.swift
@@ -128,6 +128,25 @@ extension AppDatabase {
             }
         }
     }
+
+    static let uiTestPlayers = [
+        Player(id: nil, name: "Arthur", score: 5),
+        Player(id: nil, name: "Barbara", score: 6),
+        Player(id: nil, name: "Craig", score: 8),
+        Player(id: nil, name: "David", score: 4),
+        Player(id: nil, name: "Elena", score: 1),
+        Player(id: nil, name: "Frederik", score: 2),
+        Player(id: nil, name: "Gilbert", score: 7),
+        Player(id: nil, name: "Henriette", score: 3)]
+
+    func createPlayersForUITests() throws {
+        try dbWriter.write { db in
+            try AppDatabase.uiTestPlayers.forEach { player in
+                var mutablePlayer = player
+                try mutablePlayer.save(db)
+            }
+        }
+    }
     
     /// Support for `createRandomPlayersIfEmpty()` and `refreshPlayers()`.
     private func createRandomPlayers(_ db: Database) throws {

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/GRDBCombineDemoApp.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/GRDBCombineDemoApp.swift
@@ -3,9 +3,15 @@ import SwiftUI
 
 @main
 struct GRDBCombineDemoApp: App {
+    @State var initialOrdering: PlayerRequest.Ordering = .byName
+
     var body: some Scene {
         WindowGroup {
-            AppView().environment(\.appDatabase, AppDatabase.shared)
+            AppView(initialOrdering: initialOrdering)
+                .environment(\.appDatabase, AppDatabase.shared)
+                .onAppear {
+                    initialOrdering = .byScore
+                }
         }
     }
 }

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/GRDBCombineDemoApp.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/GRDBCombineDemoApp.swift
@@ -3,15 +3,9 @@ import SwiftUI
 
 @main
 struct GRDBCombineDemoApp: App {
-    @State var initialOrdering: PlayerRequest.Ordering = .byName
-
     var body: some Scene {
         WindowGroup {
-            AppView(initialOrdering: initialOrdering)
-                .environment(\.appDatabase, AppDatabase.shared)
-                .onAppear {
-                    initialOrdering = .byScore
-                }
+            AppView().environment(\.appDatabase, AppDatabase.shared)
         }
     }
 }

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Persistence.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Persistence.swift
@@ -6,35 +6,39 @@ extension AppDatabase {
     
     private static func makeShared() -> AppDatabase {
         do {
-            // Create a folder for storing the SQLite database, as well as
+            // Pick a folder for storing the SQLite database, as well as
             // the various temporary files created during normal database
             // operations (https://sqlite.org/tempfiles.html).
             let fileManager = FileManager()
             let folderURL = try fileManager
                 .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
                 .appendingPathComponent("database", isDirectory: true)
+
+            // Support for tests: delete the database if requested
+            if CommandLine.arguments.contains("-reset") {
+                try? fileManager.removeItem(at: folderURL)
+            }
+            
+            // Create the database folder if needed
             try fileManager.createDirectory(at: folderURL, withIntermediateDirectories: true)
             
             // Connect to a database on disk
             // See https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections
             let dbURL = folderURL.appendingPathComponent("db.sqlite")
-
-            if CommandLine.arguments.contains("-reset") {
-                try? fileManager.removeItem(at: dbURL)
-            }
-
             let dbPool = try DatabasePool(path: dbURL.path)
             
             // Create the AppDatabase
             let appDatabase = try AppDatabase(dbPool)
             
-            // Populate the database if it is empty, for better demo purpose.
+            // Prepare the database with test fixtures if requested
             if CommandLine.arguments.contains("-fixedTestData") {
                 try appDatabase.createPlayersForUITests()
             } else {
+                // Otherwise, populate the database if it is empty, for better
+                // demo purpose.
                 try appDatabase.createRandomPlayersIfEmpty()
             }
-
+            
             return appDatabase
         } catch {
             // Replace this implementation with code to handle the error appropriately.

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Persistence.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Persistence.swift
@@ -18,14 +18,23 @@ extension AppDatabase {
             // Connect to a database on disk
             // See https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections
             let dbURL = folderURL.appendingPathComponent("db.sqlite")
+
+            if CommandLine.arguments.contains("-reset") {
+                try? fileManager.removeItem(at: dbURL)
+            }
+
             let dbPool = try DatabasePool(path: dbURL.path)
             
             // Create the AppDatabase
             let appDatabase = try AppDatabase(dbPool)
             
             // Populate the database if it is empty, for better demo purpose.
-            try appDatabase.createRandomPlayersIfEmpty()
-            
+            if CommandLine.arguments.contains("-fixedTestData") {
+                try appDatabase.createPlayersForUITests()
+            } else {
+                try appDatabase.createRandomPlayersIfEmpty()
+            }
+
             return appDatabase
         } catch {
             // Replace this implementation with code to handle the error appropriately.

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Views/AppView.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Views/AppView.swift
@@ -6,15 +6,18 @@ struct AppView: View {
     @Environment(\.appDatabase) private var appDatabase
     
     /// The `players` property is kept up-to-date with the list of players.
-    @Query(PlayerRequest(ordering: .byName)) private var players: [Player]
+    @Query(PlayerRequest(ordering: .byScore)) private var players: [Player]
     
     /// Tracks the presentation of the player creation sheet.
     @State private var newPlayerIsPresented = false
 
-    init(initialOrdering: PlayerRequest.Ordering) {
-        // Example to update a query on init
-        _players = Query(PlayerRequest(ordering: initialOrdering))
-    }
+    // If you want to define the query on initialization, you will prefer:
+    //
+    // @Query<PlayerRequest> private var players: [Player]
+    //
+    // init(initialOrdering: PlayerRequest.Ordering) {
+    //     _players = Query(PlayerRequest(ordering: initialOrdering))
+    // }
     
     var body: some View {
         NavigationView {
@@ -89,10 +92,10 @@ struct AppView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             // Preview a database of random players
-            AppView(initialOrdering: .byScore).environment(\.appDatabase, .random())
+            AppView().environment(\.appDatabase, .random())
 
             // Preview an empty database
-            AppView(initialOrdering: .byScore).environment(\.appDatabase, .empty())
+            AppView().environment(\.appDatabase, .empty())
         }
     }
 }

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Views/AppView.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Views/AppView.swift
@@ -6,10 +6,15 @@ struct AppView: View {
     @Environment(\.appDatabase) private var appDatabase
     
     /// The `players` property is kept up-to-date with the list of players.
-    @Query(PlayerRequest(ordering: .byScore)) private var players: [Player]
+    @Query(PlayerRequest(ordering: .byName)) private var players: [Player]
     
     /// Tracks the presentation of the player creation sheet.
     @State private var newPlayerIsPresented = false
+
+    init(initialOrdering: PlayerRequest.Ordering) {
+        // Example to update a query on init
+        _players = Query(PlayerRequest(ordering: initialOrdering))
+    }
     
     var body: some View {
         NavigationView {
@@ -42,6 +47,7 @@ struct AppView: View {
         Button(
             action: { newPlayerIsPresented = true },
             label: { Image(systemName: "plus") })
+            .accessibility(label: Text("New Player"))
             .sheet(
                 isPresented: $newPlayerIsPresented,
                 content: {
@@ -83,10 +89,10 @@ struct AppView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             // Preview a database of random players
-            AppView().environment(\.appDatabase, .random())
+            AppView(initialOrdering: .byScore).environment(\.appDatabase, .random())
 
             // Preview an empty database
-            AppView().environment(\.appDatabase, .empty())
+            AppView(initialOrdering: .byScore).environment(\.appDatabase, .empty())
         }
     }
 }

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Views/PlayerFormView.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Views/PlayerFormView.swift
@@ -9,7 +9,9 @@ struct PlayerFormView: View {
     var body: some View {
         List {
             TextField("Name", text: $name)
+                .accessibility(label: Text("Player Name"))
             TextField("Score", text: $score).keyboardType(.numberPad)
+                .accessibility(label: Text("Player Score"))
         }
         .listStyle(InsetGroupedListStyle())
     }

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemoUITests/GRDBCombineDemoUITests.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemoUITests/GRDBCombineDemoUITests.swift
@@ -1,0 +1,66 @@
+//
+//  GRDBCombineDemoUITests.swift
+//  GRDBCombineDemoUITests
+//
+//  Created by Peter Steinberger on 08.04.21.
+//
+
+import XCTest
+
+class GRDBCombineDemoUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+    }
+
+    override func tearDownWithError() throws {
+    }
+
+    func runApp() -> XCUIApplication {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        // We enforce a fresh database to ensure 8 random players.
+        app.launchArguments = ["-reset", "-fixedTestData"]
+        app.launch()
+        return app
+    }
+
+    func testInitialSortingIsByScore() throws {
+        let app = runApp()
+
+        let getFirstCell = { () -> XCUIElement in
+            app.tables.element(boundBy: 0).cells.element(boundBy: 0)
+        }
+
+        // Given default sorting, Henriette must be on top
+        XCTAssertEqual(getFirstCell().label, "Craig, 8 points")
+
+        // Reverse sorting will bring Arthur on top (sort by name)
+        app.buttons["Score"].tap()
+        XCTAssertEqual(getFirstCell().label, "Arthur, 5 points")
+    }
+
+    func testListAndAddPlayer() throws {
+        let app = runApp()
+
+        // Ensure we have 8 players visible
+        XCTAssert(app.tables.cells.count == 8)
+
+        // add a player
+        app.buttons["New Player"].tap()
+
+        let playerNameField = app.textFields["Player Name"]
+        playerNameField.tap()
+        playerNameField.typeText("Tim Apple")
+
+        app.buttons["Save"].tap()
+
+        // This is suboptimal, but we need to wait for the animation to finish
+        // A better way could be to disable animations globally,
+        // and/or a hook to detect when the async fetch completes.
+        sleep(2)
+
+        XCTAssert(app.tables.cells.count == 9)
+    }
+}

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemoUITests/GRDBCombineDemoUITests.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemoUITests/GRDBCombineDemoUITests.swift
@@ -26,6 +26,21 @@ class GRDBCombineDemoUITests: XCTestCase {
         return app
     }
 
+    // This test, introduced in 481f6e93, tests the @Query fix added in
+    // 68874412. The fix expresses itself when a view defines an @Query
+    // property that is replaced in the view initializer, as in 481f6e93.
+    //
+    // It happens that I did not find that this particular view setup was suited
+    // for a demo app. The demo has to find a delicate balance, not too trivial,
+    // but without gratuitous complexity.
+    //
+    // I simplified the demo app in a5ffc52d, and we no longer have any view
+    // that defines an @Query property which is replaced in the view
+    // initializer. This means that this test no longer checks against
+    // 68874412 regressions!
+    //
+    // Whenever the @Query property wrapper ships with GRDB itself, make sure
+    // we test for those regressions!
     func testInitialSortingIsByScore() throws {
         let app = runApp()
 

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemoUITests/Info.plist
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemoUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
When a query is replaced in a view, the `@StateObject` keeps the `Core` class alive, and it might still use the previous query. This additional bool tracks this case and ensures the base query is updated.

Example where this caused issues:
<img width="728" alt="Screen Shot 2021-04-07 at 15 35 29" src="https://user-images.githubusercontent.com/58493/113875307-e8c50480-97b6-11eb-849b-9ee97760333c.png">

The query always ran with `userId = 0` (the early state while parent is resolving a suer) despite me updating the binding in init.