### PR TITLE
Always add userInfo to databaseJSONDecoder and databaseJSONEncoder

### DIFF
--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -133,6 +133,7 @@ extension EncodableRecord {
             // guarantee some stability in order to ease record comparison
             encoder.outputFormatting = .sortedKeys
         }
+        encoder.userInfo = databaseEncodingUserInfo
         return encoder
     }
     

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -120,6 +120,7 @@ extension FetchableRecord {
         decoder.dataDecodingStrategy = .base64
         decoder.dateDecodingStrategy = .millisecondsSince1970
         decoder.nonConformingFloatDecodingStrategy = .throw
+        decoder.userInfo = databaseDecodingUserInfo
         return decoder
     }
     


### PR DESCRIPTION
We encountered an issue where `userInfo` was unexpectedly not containing our custom values from the `databaseEncodingUserInfo` and `databaseDecodingUserInfo` overrides. We were able to workaround the issue by completing overriding `databaseJSONEncoder` and `databaseJSONDecoder` in our local type's conformance to `EncodableRecord` and `FetchableRecord`, but I think this change would reduce the chance for others unexpectedly encountering this issue as well.

Cheers!

### Pull Request Checklist
- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
