### PR TITLE
Add conditional modifier to build requests

### DIFF
--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -777,3 +777,31 @@ extension DerivableRequest {
         return request.having(expression)
     }
 }
+
+extension DerivableRequest {
+    /// Conditional request modifier to conveniently build a request by chaining methods.
+    /// - Parameters:
+    ///   - condition: The condition that needs to return true for transform to be called
+    ///   - transform: Code that modifies a request
+    /// - Returns: Modified request if condition returns true, or unmodified request.
+    public func `if`(_ condition: @autoclosure () -> Bool, transform: (Self) -> Self) -> Self {
+        if condition() {
+            return transform(self)
+        } else {
+            return self
+        }
+    }
+
+    /// Conditional request modifier to conveniently build a request by chaining methods with an optional.
+    /// - Parameters:
+    ///   - item: Optional to resolve
+    ///   - content: Code that modifies a request
+    /// - Returns: Modified request if optional is not nil, or unmodified request.
+    public func modifier<Item>(`let` item: Item?, then content: (Self, Item) -> Self) -> Self {
+        if let item = item {
+            return content(self, item)
+        } else {
+            return self
+        }
+    }
+}


### PR DESCRIPTION
Consider following statement. These two new conditionals make request building FAR more convenient. Everything can be done without the need for inline variables. This follows the trend to structure ViewModifiers in SwiftUI.

```swift
public static func get(userId: Int64, tweetUserId: Int64? = nil, limit: Int = 100, db: Database) throws -> [TweetInfo] {
try TweetUserFavorite
    .filter(TweetUserFavorite.Columns.userId == userId)
    .including(required: TweetUserFavorite.tweet
                .if(tweetUserId != nil) { request in
                    request.filter(Tweet.Columns.userId == tweetUserId!)
                }
                .order(Tweet.Columns.createdAt).reversed())
    .including(required: TweetUserFavorite.user)
    .asRequest(of: TweetInfo.self)
    .limit(limit)
    .fetchAll(db)
}
```

Even more convenient, we can use `modifier` to automatically resolve the optional:

```swift
public static func get(userId: Int64, tweetUserId: Int64? = nil, limit: Int = 100, db: Database) throws -> [TweetInfo] {
try TweetUserFavorite
    .filter(TweetUserFavorite.Columns.userId == userId)
    .including(required: TweetUserFavorite.tweet
                    .modifier(let: tweetUserId) { request, tweetUserId in
                        request.filter(Tweet.Columns.userId == tweetUserId)
                    }
                .order(Tweet.Columns.createdAt).reversed())
    .including(required: TweetUserFavorite.user)
    .asRequest(of: TweetInfo.self)
    .limit(limit)
    .fetchAll(db)
}
```

Both are valid and useful, even though this particular example only needs let. Another common use for this in my codebase is sorting and optional limit-settings.

TODO: I feel that this should be mentioned in the Documentation, I hope @groue can take this over, as I'm not familiar enough yet to know where to best put it.