### PR TITLE
Restore access to attached databases from record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
     let request = SQLRequest("SELECT ...")
     ```
 - **Fixed**: The `DerivableRequest.limit(_:offset:)` method was ill-designed, and removed from the documentation. It is unfortunately impossible to deprecate it without triggering warnings on the legit use cases (on `QueryInterfaceRequest`).
+- **Fixed**: [#973](https://github.com/groue/GRDB.swift/pull/973): Restore access to attached databases from record types
 - **Documentation Update**: A new [Query Interface Organization](Documentation/QueryInterfaceOrganization.md) document reveals the relationship between the various components of the GRDB query builder.
 
 ## 5.7.4

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -92,10 +92,9 @@ extension Database {
                 }
             }
         
-        // Temp schema shadows main and attached databases
+        // Temp schema shadows other schema: put it first
         if let tempIdx = schemaIdentifiers.firstIndex(of: .temp) {
-            schemaIdentifiers.remove(at: tempIdx)
-            schemaIdentifiers.insert(.temp, at: 0)
+            schemaIdentifiers.swapAt(tempIdx, 0)
         }
         
         schemaCache.schemaIdentifiers = schemaIdentifiers

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -7,14 +7,15 @@ extension Database {
         /// The temp database
         case temp
         
-        // Future support for attached database: https://sqlite.org/lang_attach.html
-        // case attached(String)
+        /// An attached database: https://sqlite.org/lang_attach.html
+        case attached(String)
         
         /// The name of the schema in SQL queries
         var sql: String {
             switch self {
             case .main: return "main"
             case .temp: return "temp"
+            case let .attached(name): return name
             }
         }
         
@@ -23,6 +24,7 @@ extension Database {
             switch self {
             case .main: return "sqlite_master"
             case .temp: return "sqlite_temp_master"
+            case let .attached(name): return "\(name).sqlite_master"
             }
         }
     }
@@ -73,9 +75,38 @@ extension Database {
         }
     }
     
+    /// The list of database schemas, in the order of SQLite resolution:
+    /// temp, main, then attached databases.
+    func schemaIdentifiers() throws -> [SchemaIdentifier] {
+        if let schemaIdentifiers = schemaCache.schemaIdentifiers {
+            return schemaIdentifiers
+        }
+        
+        var schemaIdentifiers = try Row
+            .fetchAll(self, sql: "PRAGMA database_list")
+            .map { row -> SchemaIdentifier in
+                switch row[1] as String {
+                case "main": return .main
+                case "temp": return .temp
+                case let other: return .attached(other)
+                }
+            }
+        
+        // Temp schema shadows main and attached databases
+        if let tempIdx = schemaIdentifiers.firstIndex(of: .temp) {
+            schemaIdentifiers.remove(at: tempIdx)
+            schemaIdentifiers.insert(.temp, at: 0)
+        }
+        
+        schemaCache.schemaIdentifiers = schemaIdentifiers
+        return schemaIdentifiers
+    }
+    
     /// Returns whether a table exists in the main or temp schema.
     public func tableExists(_ name: String) throws -> Bool {
-        try exists(type: .table, name: name, in: .main) || exists(type: .table, name: name, in: .temp)
+        try schemaIdentifiers().contains {
+            try exists(type: .table, name: name, in: $0)
+        }
     }
     
     private func tableExists(_ table: TableIdentifier) throws -> Bool {
@@ -124,12 +155,16 @@ extension Database {
     
     /// Returns whether a view exists in the main or temp schema.
     public func viewExists(_ name: String) throws -> Bool {
-        try exists(type: .view, name: name, in: .main) || exists(type: .view, name: name, in: .temp)
+        try schemaIdentifiers().contains {
+            try exists(type: .view, name: name, in: $0)
+        }
     }
     
     /// Returns whether a trigger exists in the main or temp schema.
     public func triggerExists(_ name: String) throws -> Bool {
-        try exists(type: .trigger, name: name, in: .main) || exists(type: .trigger, name: name, in: .temp)
+        try schemaIdentifiers().contains {
+            try exists(type: .trigger, name: name, in: $0)
+        }
     }
     
     private func exists(type: SchemaObjectType, name: String, in schemaID: SchemaIdentifier) throws -> Bool {
@@ -149,10 +184,12 @@ extension Database {
     ///
     /// - throws: A DatabaseError if table does not exist.
     public func primaryKey(_ tableName: String) throws -> PrimaryKeyInfo {
-        // SQLite has temporary tables shadow main ones
-        try primaryKey(TableIdentifier(schemaID: .temp, name: tableName))
-            ?? primaryKey(TableIdentifier(schemaID: .main, name: tableName))
-            ?? { throw DatabaseError.noSuchTable(tableName) }()
+        for schemaIdentifier in try schemaIdentifiers() {
+            if let result = try primaryKey(TableIdentifier(schemaID: schemaIdentifier, name: tableName)) {
+                return result
+            }
+        }
+        throw DatabaseError.noSuchTable(tableName)
     }
     
     /// Returns nil if table does not exist
@@ -281,10 +318,12 @@ extension Database {
     ///
     /// - throws: A DatabaseError if table does not exist.
     public func indexes(on tableName: String) throws -> [IndexInfo] {
-        // SQLite has temporary tables shadow main ones
-        try indexes(on: TableIdentifier(schemaID: .temp, name: tableName))
-            ?? indexes(on: TableIdentifier(schemaID: .main, name: tableName))
-            ?? { throw DatabaseError.noSuchTable(tableName) }()
+        for schemaIdentifier in try schemaIdentifiers() {
+            if let result = try indexes(on: TableIdentifier(schemaID: schemaIdentifier, name: tableName)) {
+                return result
+            }
+        }
+        throw DatabaseError.noSuchTable(tableName)
     }
     
     /// Returns nil if table does not exist
@@ -351,10 +390,12 @@ extension Database {
     ///
     /// - throws: A DatabaseError if table does not exist.
     public func foreignKeys(on tableName: String) throws -> [ForeignKeyInfo] {
-        // SQLite has temporary tables shadow main ones
-        try foreignKeys(on: TableIdentifier(schemaID: .temp, name: tableName))
-            ?? foreignKeys(on: TableIdentifier(schemaID: .main, name: tableName))
-            ?? { throw DatabaseError.noSuchTable(tableName) }()
+        for schemaIdentifier in try schemaIdentifiers() {
+            if let result = try foreignKeys(on: TableIdentifier(schemaID: schemaIdentifier, name: tableName)) {
+                return result
+            }
+        }
+        throw DatabaseError.noSuchTable(tableName)
     }
     
     /// Returns nil if table does not exist
@@ -426,9 +467,12 @@ extension Database {
     ///
     /// - throws: A DatabaseError if table does not exist.
     func canonicalTableName(_ tableName: String) throws -> String? {
-        // SQLite has temporary tables shadow main ones
-        try schema(.temp).canonicalName(tableName, ofType: .table)
-            ?? schema(.main).canonicalName(tableName, ofType: .table)
+        for schemaIdentifier in try schemaIdentifiers() {
+            if let result = try schema(schemaIdentifier).canonicalName(tableName, ofType: .table) {
+                return result
+            }
+        }
+        return nil
     }
     
     func schema(_ schemaID: SchemaIdentifier) throws -> SchemaInfo {
@@ -447,10 +491,12 @@ extension Database {
     ///
     /// - throws: A DatabaseError if table does not exist.
     public func columns(in tableName: String) throws -> [ColumnInfo] {
-        // SQLite has temporary tables shadow main ones
-        try columns(in: TableIdentifier(schemaID: .temp, name: tableName))
-            ?? columns(in: TableIdentifier(schemaID: .main, name: tableName))
-            ?? { throw DatabaseError.noSuchTable(tableName) }()
+        for schemaIdentifier in try schemaIdentifiers() {
+            if let result = try columns(in: TableIdentifier(schemaID: schemaIdentifier, name: tableName)) {
+                return result
+            }
+        }
+        throw DatabaseError.noSuchTable(tableName)
     }
     
     /// Returns nil if table does not exist

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -127,30 +127,21 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     // Caches
     struct SchemaCache {
-        /// The cache for the main schema
-        fileprivate var main = DatabaseSchemaCache()
-        
-        /// The cache for the temp schema
-        fileprivate var temp = DatabaseSchemaCache()
+        var schemaIdentifiers: [SchemaIdentifier]?
+        fileprivate var schemas: [SchemaIdentifier: DatabaseSchemaCache] = [:]
         
         subscript(schemaID: SchemaIdentifier) -> DatabaseSchemaCache { // internal so that it can be tested
             get {
-                switch schemaID {
-                case .main: return main
-                case .temp: return temp
-                }
+                schemas[schemaID] ?? DatabaseSchemaCache()
             }
             set {
-                switch schemaID {
-                case .main: main = newValue
-                case .temp: temp = newValue
-                }
+                schemas[schemaID] = newValue
             }
         }
         
         mutating func clear() {
-            main.clear()
-            temp.clear()
+            schemaIdentifiers = nil
+            schemas.removeAll()
         }
     }
     

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -55,7 +55,7 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
             invalidatesDatabaseSchemaCache = true
             return SQLITE_OK
             
-        case SQLITE_ALTER_TABLE, SQLITE_DETACH,
+        case SQLITE_ATTACH, SQLITE_DETACH, SQLITE_ALTER_TABLE,
              SQLITE_CREATE_INDEX, SQLITE_CREATE_TABLE,
              SQLITE_CREATE_TEMP_INDEX, SQLITE_CREATE_TEMP_TABLE,
              SQLITE_CREATE_TEMP_TRIGGER, SQLITE_CREATE_TEMP_VIEW,

--- a/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
@@ -106,7 +106,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
                 let primaryKey = try db.primaryKey("items")
                 XCTAssertEqual(primaryKey.rowIDColumn, "id")
                 XCTAssertTrue(db.schemaCache[.main].primaryKey("items")!.value != nil)
-                XCTAssertTrue(db.schemaCache[.temp].primaryKey("items")!.value == nil)
+                XCTAssertTrue(db.schemaCache[.temp].primaryKey("items") == nil)
                 try XCTAssertEqual(Int.fetchOne(db, sql: "SELECT id FROM items"), 1)
             }
             

--- a/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
@@ -155,7 +155,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
         }
         
         let main = try makeDatabaseQueue(filename: "main")
-        try main.write { db in
+        try main.writeWithoutTransaction { db in
             try XCTAssertFalse(db.tableExists("item"))
             
             try db.execute(literal: "ATTACH DATABASE \(attached1.path) AS attached1")
@@ -193,9 +193,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
             try XCTAssertEqual(Row.fetchOne(db, sql: "PRAGMA table_info(item)")?["name"], "attached1Column")
             try XCTAssertTrue(db.tableExists("item"))
             try XCTAssertEqual(db.columns(in: "item").first?.name, "attached1Column")
-        }
-        
-        try main.write { db in
+            
             // Attached1 no longer shadows attached2
             try db.execute(sql: "DETACH DATABASE attached1")
             try XCTAssertEqual(String.fetchOne(db, sql: "SELECT * FROM item"), "attached2")
@@ -203,9 +201,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
             try XCTAssertEqual(Row.fetchOne(db, sql: "PRAGMA table_info(item)")?["name"], "attached2Column")
             try XCTAssertTrue(db.tableExists("item"))
             try XCTAssertEqual(db.columns(in: "item").first?.name, "attached2Column")
-        }
-        
-        try main.write { db in
+            
             // Attached2 no longer shadows main
             try db.execute(sql: "DETACH DATABASE attached2")
             try XCTAssertFalse(db.tableExists("item"))

--- a/Tests/GRDBTests/TableRecordTests.swift
+++ b/Tests/GRDBTests/TableRecordTests.swift
@@ -125,4 +125,56 @@ class TableRecordTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT \"a\", \"b\" FROM \"t1\"")
         }
     }
+    
+    func testRecordInAttachedDatabase() throws {
+        struct Team: Codable, PersistableRecord, FetchableRecord, Equatable {
+            var id: Int64
+            var name: String
+        }
+        
+        struct Player: Codable, PersistableRecord, FetchableRecord, Equatable {
+            var id: Int64
+            var teamID: Int64
+            var name: String
+            var email: String
+        }
+        
+        struct PlayerInfo: Decodable, FetchableRecord, Equatable {
+            var player: Player
+            var team: Team
+        }
+        
+        let db1 = try makeDatabaseQueue(filename: "db1.sqlite")
+        try db1.write { db in
+            try db.create(table: "team") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("name", .text).notNull()
+            }
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("teamID", .integer).notNull().references("team")
+                t.column("name", .text).notNull()
+                t.column("email", .text).notNull().unique()
+            }
+        }
+        
+        let db2 = try makeDatabaseQueue(filename: "db2.sqlite")
+        try db2.write { db in
+            try db.execute(literal: "ATTACH DATABASE \(db1.path) AS db1")
+            try XCTAssertEqual(Player.fetchCount(db), 0)
+            let team = Team(id: 1, name: "Arthur")
+            let player = Player(id: 1, teamID: 1, name: "Arthur", email: "arthur@example.com")
+            
+            try team.insert(db)
+            try player.insert(db)
+            
+            try XCTAssertEqual(Player.orderByPrimaryKey().fetchOne(db)?.name, "Arthur")
+            try XCTAssertEqual(
+                Player
+                    .including(required: Player.belongsTo(Team.self))
+                    .asRequest(of: PlayerInfo.self)
+                    .fetchOne(db),
+                PlayerInfo(player: player, team: team))
+        }
+    }
 }

--- a/Tests/GRDBTests/TableRecordTests.swift
+++ b/Tests/GRDBTests/TableRecordTests.swift
@@ -177,4 +177,57 @@ class TableRecordTests: GRDBTestCase {
                 PlayerInfo(player: player, team: team))
         }
     }
+    
+    func testCrossAttachedDatabaseAssociation() throws {
+        struct Team: Codable, PersistableRecord, FetchableRecord, Equatable {
+            var id: Int64
+            var name: String
+        }
+        
+        struct Player: Codable, PersistableRecord, FetchableRecord, Equatable {
+            var id: Int64
+            var teamID: Int64
+            var name: String
+            var email: String
+        }
+        
+        struct PlayerInfo: Decodable, FetchableRecord, Equatable {
+            var player: Player
+            var team: Team
+        }
+        
+        let db1 = try makeDatabaseQueue(filename: "db1.sqlite")
+        try db1.write { db in
+            try db.create(table: "team") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("name", .text).notNull()
+            }
+        }
+        
+        let db2 = try makeDatabaseQueue(filename: "db2.sqlite")
+        try db2.write { db in
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("teamID", .integer).notNull()
+                t.column("name", .text).notNull()
+                t.column("email", .text).notNull().unique()
+            }
+            
+            try db.execute(literal: "ATTACH DATABASE \(db1.path) AS db1")
+            try XCTAssertEqual(Player.fetchCount(db), 0)
+            let team = Team(id: 1, name: "Arthur")
+            let player = Player(id: 1, teamID: 1, name: "Arthur", email: "arthur@example.com")
+            
+            try team.insert(db)
+            try player.insert(db)
+            
+            try XCTAssertEqual(Player.orderByPrimaryKey().fetchOne(db)?.name, "Arthur")
+            try XCTAssertEqual(
+                Player
+                    .including(required: Player.belongsTo(Team.self, using: ForeignKey(["teamID"])))
+                    .asRequest(of: PlayerInfo.self)
+                    .fetchOne(db),
+                PlayerInfo(player: player, team: team))
+        }
+    }
 }

--- a/Tests/GRDBTests/TableRecordTests.swift
+++ b/Tests/GRDBTests/TableRecordTests.swift
@@ -159,7 +159,7 @@ class TableRecordTests: GRDBTestCase {
         }
         
         let db2 = try makeDatabaseQueue(filename: "db2.sqlite")
-        try db2.write { db in
+        try db2.writeWithoutTransaction { db in
             try db.execute(literal: "ATTACH DATABASE \(db1.path) AS db1")
             try XCTAssertEqual(Player.fetchCount(db), 0)
             let team = Team(id: 1, name: "Arthur")
@@ -205,7 +205,7 @@ class TableRecordTests: GRDBTestCase {
         }
         
         let db2 = try makeDatabaseQueue(filename: "db2.sqlite")
-        try db2.write { db in
+        try db2.writeWithoutTransaction { db in
             try db.create(table: "player") { t in
                 t.autoIncrementedPrimaryKey("id")
                 t.column("teamID", .integer).notNull()


### PR DESCRIPTION
This pull request fixes #971, and restores access to attached databases from record types.

GRDB support for attached database is currently *implicit*. You can not, without writing raw SQL queries, instruct a record type to look into a specific attached database. But GRDB aims at honoring the [SQLite resolution rules for unqualified database tables](https://www.sqlite.org/lang_attach.html):

> Tables in an attached database can be referred to using the syntax `schema-name.table-name`. If the name of the table is unique across all attached databases and the main and temp databases, then the `schema-name` prefix is not required. If two or more tables in different databases have the same name and the `schema-name` prefix is not used on a table reference, then the table chosen is the one in the database that was least recently attached.

Thus a `Player` record type that looks into the `player` table should work regardless of the database that defines the `player` table: the main database, the temp database, or any attached database.

GRDB 5.7 has introduced a regression on this topic, due to the way GRDB would grab schema information about record tables (columns, primary key, secondary keys, indexes, etc.) This pull request restores the implicit support for attached database. We also have the ability, in the future, to define record types that target a specific attached database.

Thanks @mallman for reporting the issue!