### PR TITLE
Provide access to included associations when root table is not selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
     let request = SQLRequest("SELECT ...")
     ```
 - **Fixed**: The `DerivableRequest.limit(_:offset:)` method was ill-designed, and removed from the documentation. It is unfortunately impossible to deprecate it without triggering warnings on the legit use cases (on `QueryInterfaceRequest`).
+- **Fixed**: [#974](https://github.com/groue/GRDB.swift/pull/974): Provide access to included associations when root table is not selected
 - **Documentation Update**: A new [Query Interface Organization](Documentation/QueryInterfaceOrganization.md) document reveals the relationship between the various components of the GRDB query builder.
 
 ## 5.7.4

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -589,9 +589,9 @@ private struct SQLQualifiedRelation {
     /// See SQLQueryGenerator.rowAdapter(_:)
     ///
     /// - parameter startIndex: The index of the leftmost selected column of
-    ///   this relation in a full SQL query. `startIndex` is 0 for the relation
-    ///   at the root of a SQLQueryGenerator (as opposed to the
-    ///   joined relations).
+    ///   this relation in a full SQL query.
+    /// - parameter rootRelation: True iff the relation is at the root of a
+    ///   SQLQueryGenerator (as opposed to the joined relations).
     /// - returns: An optional tuple made of a RowAdapter and the index past the
     ///   rightmost selected column of this relation. Nil is returned if this
     ///   relations does not need any row adapter.

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -468,7 +468,7 @@ struct SQLQueryGenerator: Refinable {
     ///         let author: Author = row["author"]
     ///     }
     private func rowAdapter(_ context: SQLGenerationContext) throws -> RowAdapter? {
-        try relation.rowAdapter(context, fromIndex: 0)?.adapter
+        try relation.rowAdapter(context, fromIndex: 0, rootRelation: true)?.adapter
     }
 }
 
@@ -597,11 +597,12 @@ private struct SQLQualifiedRelation {
     ///   relations does not need any row adapter.
     func rowAdapter(
         _ context: SQLGenerationContext,
-        fromIndex startIndex: Int) throws
+        fromIndex startIndex: Int,
+        rootRelation: Bool) throws
     -> (adapter: RowAdapter, endIndex: Int)?
     {
         // Root relation && no join => no need for any adapter
-        if startIndex == 0 && joins.isEmpty {
+        if rootRelation && joins.isEmpty {
             return nil
         }
         
@@ -614,14 +615,17 @@ private struct SQLQualifiedRelation {
         var endIndex = startIndex + sourceSelectionWidth
         var scopes: [String: RowAdapter] = [:]
         for (key, join) in joins {
-            if let (joinAdapter, joinEndIndex) = try join.relation.rowAdapter(context, fromIndex: endIndex) {
+            if let (joinAdapter, joinEndIndex) = try join
+                .relation
+                .rowAdapter(context, fromIndex: endIndex, rootRelation: false)
+            {
                 scopes[key] = joinAdapter
                 endIndex = joinEndIndex
             }
         }
         
         // (Root relation || empty selection) && no included relation => no need for any adapter
-        if (startIndex == 0 || sourceSelectionWidth == 0) && scopes.isEmpty {
+        if (rootRelation || sourceSelectionWidth == 0) && scopes.isEmpty {
             return nil
         }
         

--- a/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
@@ -56,6 +56,16 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
     }
     
+    func testDefaultScopeIncludingRequiredEmptySelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.select([]).including(required: Player.defaultTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].unscoped, [:])
+        XCTAssertEqual(Set(rows[0].scopes.names), ["team"])
+        XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
+    }
+    
     func testDefaultScopeIncludingOptional() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.including(optional: Player.defaultTeam)
@@ -99,6 +109,16 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[0].scopes["customTeam"]!, ["id":1, "name":"Reds"])
     }
     
+    func testCustomScopeIncludingRequiredEmptySelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.select([]).including(required: Player.customTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].unscoped, [:])
+        XCTAssertEqual(Set(rows[0].scopes.names), ["customTeam"])
+        XCTAssertEqual(rows[0].scopes["customTeam"]!, ["id":1, "name":"Reds"])
+    }
+
     func testCustomScopeIncludingOptional() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.including(optional: Player.customTeam)


### PR DESCRIPTION
This pull request fixes #965.

Requests like the following would incorrectly make associated records unavailable to Decodable records, or row scopes::

```swift
// SELECT team.*, ...
// FROM player
// JOIN team ON team.id = player.teamID
// ...
let request = Player
    .select([])
    .including(required: Player.team)
    .including(...)
```

The problem was an incorrect handling of the `select([])`.