### PR TITLE
Support for archiving GRDB for xcframeworks

### DIFF
--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -85,8 +85,6 @@ public struct DatabaseValue: Hashable, CustomStringConvertible, DatabaseValueCon
     }
     
     // MARK: - Not Public
-    
-    @inlinable
     init(storage: Storage) {
         self.storage = storage
     }

--- a/GRDB/Core/Support/Foundation/Data.swift
+++ b/GRDB/Core/Support/Foundation/Data.swift
@@ -13,7 +13,6 @@ extension Data: DatabaseValueConvertible, StatementColumnConvertible {
     }
     
     /// Returns a value that can be stored in the database.
-    @inlinable
     public var databaseValue: DatabaseValue {
         DatabaseValue(storage: .blob(self))
     }

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -235,7 +235,6 @@ extension Int64: DatabaseValueConvertible, StatementColumnConvertible {
     }
     
     /// Returns a value that can be stored in the database.
-    @inlinable
     public var databaseValue: DatabaseValue {
         DatabaseValue(storage: .int64(self))
     }
@@ -434,7 +433,6 @@ extension Double: DatabaseValueConvertible, StatementColumnConvertible {
     }
     
     /// Returns a value that can be stored in the database.
-    @inlinable
     public var databaseValue: DatabaseValue {
         DatabaseValue(storage: .double(self))
     }
@@ -508,7 +506,6 @@ extension String: DatabaseValueConvertible, StatementColumnConvertible {
     }
     
     /// Returns a value that can be stored in the database.
-    @inlinable
     public var databaseValue: DatabaseValue {
         DatabaseValue(storage: .string(self))
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR should help resolve #964 and #972.

Opening this PR as a draft PR to get feedback from library maintainers/authors.

I am not entirely sure, why removing `@inlinable` leads to a green build while building with `SKIP_INSTALL=NO` and `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [ ] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [ ] Changes are tested.
   - Facing failures on these tests on my local machine (only when BUILD_LIBRARY_FOR_DISTRIBUTION=YES is enabled in build settings for GRDBiOS) (Will dig deeper, but would appreciate any pointers)
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/4892875/119542093-c7db6180-bdac-11eb-8179-9a762e777892.png">


### Testing Environment
Xcode  12.5, iOS 14.5 simulator, macOS 11.4