### PR TITLE
Fix spelling succesful -> successful.

### DIFF
--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -70,7 +70,7 @@ public protocol MutablePersistableRecord: EncodableRecord, TableRecord {
     /// See https://www.sqlite.org/lang_conflict.html
     static var persistenceConflictPolicy: PersistenceConflictPolicy { get }
     
-    /// Notifies the record that it was succesfully inserted.
+    /// Notifies the record that it was successfully inserted.
     ///
     /// Do not call this method directly: it is called for you, in a protected
     /// dispatch queue, with the inserted RowID and the eventual
@@ -186,7 +186,7 @@ extension MutablePersistableRecord {
         PersistenceConflictPolicy(insert: .abort, update: .abort)
     }
     
-    /// Notifies the record that it was succesfully inserted.
+    /// Notifies the record that it was successfully inserted.
     ///
     /// The default implementation does nothing.
     public mutating func didInsert(with rowID: Int64, for column: String?) {
@@ -811,7 +811,7 @@ extension MutablePersistableRecord {
 /// are not mutating methods.
 public protocol PersistableRecord: MutablePersistableRecord {
     
-    /// Notifies the record that it was succesfully inserted.
+    /// Notifies the record that it was successfully inserted.
     ///
     /// Do not call this method directly: it is called for you, in a protected
     /// dispatch queue, with the inserted RowID and the eventual
@@ -869,7 +869,7 @@ public protocol PersistableRecord: MutablePersistableRecord {
 
 extension PersistableRecord {
     
-    /// Notifies the record that it was succesfully inserted.
+    /// Notifies the record that it was successfully inserted.
     ///
     /// The default implementation does nothing.
     public func didInsert(with rowID: Int64, for column: String?) {

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -116,7 +116,7 @@ open class Record: FetchableRecord, TableRecord, PersistableRecord {
     open func encode(to container: inout PersistenceContainer) {
     }
     
-    /// Notifies the record that it was succesfully inserted.
+    /// Notifies the record that it was successfully inserted.
     ///
     /// Do not call this method directly: it is called for you, in a protected
     /// dispatch queue, with the inserted RowID and the eventual

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -1064,9 +1064,9 @@ extension FetchableRecordDecodableTests {
         }
         
         // No error expected:
-        // - a is succesfully decoded because it consumes the one and unique
+        // - a is successfully decoded because it consumes the one and unique
         //   allowed missing key
-        // - b and c are succesfully decoded, because they are optionals, and
+        // - b and c are successfully decoded, because they are optionals, and
         //   all optionals decode missing keys are nil. This is because GRDB
         //   records accept rows with missing columns, and b and c may want to
         //   decode columns.

--- a/Tests/GRDBTests/RowTestCase.swift
+++ b/Tests/GRDBTests/RowTestCase.swift
@@ -15,7 +15,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[index] as? T {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -31,7 +31,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[name] as? T {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -47,7 +47,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[column] as? T {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -65,7 +65,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[index] as T? {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -83,7 +83,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[name] as T? {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -101,7 +101,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[column] as T? {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -119,7 +119,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[index] as T? {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -137,7 +137,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[name] as T? {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
     
@@ -155,7 +155,7 @@ class RowTestCase: GRDBTestCase {
         if let v = row[column] as T? {
             XCTAssertEqual(v, value)
         } else {
-            XCTFail("expected succesful extraction")
+            XCTFail("expected successful extraction")
         }
     }
 }


### PR DESCRIPTION
This fixes the spelling of the word `successful` and `successfully`. Perviously it was missing an `s`.

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
