### PR TITLE
FTS: add support of ifNotExists in synchronize()

### DIFF
--- a/GRDB/FTS/FTS3.swift
+++ b/GRDB/FTS/FTS3.swift
@@ -45,10 +45,18 @@ public struct FTS3: VirtualTableModule {
     /// The virtual table module name
     public let moduleName = "fts3"
     
+    // TODO: remove when `makeTableDefinition()` is no longer a requirement
     /// Reserved; part of the VirtualTableModule protocol.
     ///
     /// See Database.create(virtualTable:using:)
     public func makeTableDefinition() -> FTS3TableDefinition {
+        preconditionFailure()
+    }
+    
+    /// Reserved; part of the VirtualTableModule protocol.
+    ///
+    /// See Database.create(virtualTable:using:)
+    public func makeTableDefinition(configuration: VirtualTableConfiguration) -> FTS3TableDefinition {
         FTS3TableDefinition()
     }
     

--- a/GRDB/QueryInterface/Schema/VirtualTableModule.swift
+++ b/GRDB/QueryInterface/Schema/VirtualTableModule.swift
@@ -21,13 +21,25 @@ public protocol VirtualTableModule {
     /// The name of the module.
     var moduleName: String { get }
     
+    // TODO: remove this requirement
     /// Returns a table definition that is passed as the closure argument in the
     /// `Database.create(virtualTable:using:)` method:
     ///
     ///     try db.create(virtualTable: "item", using: module) { t in
     ///         // t is the result of makeTableDefinition()
     ///     }
+    ///
+    /// - warning: This method is DEPRECATED. Define
+    ///   `makeTableDefinition(configuration:)` instead.
     func makeTableDefinition() -> TableDefinition
+    
+    /// Returns a table definition that is passed as the closure argument in the
+    /// `Database.create(virtualTable:using:)` method:
+    ///
+    ///     try db.create(virtualTable: "item", using: module) { t in
+    ///         // t is the result of makeTableDefinition(configuration:)
+    ///     }
+    func makeTableDefinition(configuration: VirtualTableConfiguration) -> TableDefinition
     
     /// Returns the module arguments for the `CREATE VIRTUAL TABLE` query.
     func moduleArguments(for definition: TableDefinition, in db: Database) throws -> [String]
@@ -35,6 +47,20 @@ public protocol VirtualTableModule {
     /// Execute any relevant database statement after the virtual table has
     /// been created.
     func database(_ db: Database, didCreate tableName: String, using definition: TableDefinition) throws
+}
+
+extension VirtualTableModule {
+    // Support for VirtualTableModule types defined by users
+    // TODO: remove when `makeTableDefinition()` is no longer a requirement
+    public func makeTableDefinition(configuration: VirtualTableConfiguration) -> TableDefinition {
+        makeTableDefinition()
+    }
+}
+
+public struct VirtualTableConfiguration {
+    /// If true, existing objects must not be replaced, or generate any error
+    /// (even if they do not match the objects that would be created otherwise.)
+    var ifNotExists: Bool
 }
 
 extension Database {
@@ -104,7 +130,8 @@ extension Database {
     throws
     {
         // Define virtual table
-        let definition = module.makeTableDefinition()
+        let configuration = VirtualTableConfiguration(ifNotExists: ifNotExists)
+        let definition = module.makeTableDefinition(configuration: configuration)
         if let body = body {
             body(definition)
         }


### PR DESCRIPTION
As mentioned in #988 , `synchronize()` does not take the `ifNotExists` flag from the table. Which may result in trigger creation errors, but they could already exists.

Attempt is made to extend the current protocol by adding another that add support of VirtualTableModule metadata. Which allows classes that implements it to read them when they are provided.

*Draft PR*: I am not fluent in Swift enough to figure out how to make the protocol `VirtualTableModuleWithMetadata` to dispatch and call the appropriate method the `makeTableDefinition`.

### Pull Request Checklist

- [x] This pull request is submitted against the `development` branch.
- [ ] Inline documentation has been updated.
- [ ] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
