### PR TITLE
Add brackets to urls in doc comments to make them clickable

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -62,3 +62,14 @@ opt_in_rules:
 vertical_whitespace:
   max_empty_lines: 2
 
+custom_rules:
+  # In doc comments (which start with ///), any link like http(s): must be wrapped in <angle brackets> to make it clickable in Xcode's rendered documentation.
+  angle_brackets_on_links_in_documentation:
+    name: "Angle brackets on links in documentation"
+    # exclude `](` to avoid triggering on Markdown URLs.
+    # exclude `<` so we don't trigger on URLs that are already bracketed.
+    # Note: does not catch missing `>` at the end of a URL; only missing `<` at the beginning.
+    regex: '^(\s+///.*[^<][^\]\(])(https?\:).+[^\n]'
+    capture_group: 2
+    message: "Links in documentation must be wrapped in <angle brackets>."
+    severity: warning

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/AppDatabase.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/AppDatabase.swift
@@ -4,7 +4,7 @@ import GRDB
 /// AppDatabase lets the application access the database.
 ///
 /// It applies the pratices recommended at
-/// https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md
+/// <https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md>
 struct AppDatabase {
     /// Creates an `AppDatabase`, and make sure the database schema is ready.
     init(_ dbWriter: DatabaseWriter) throws {
@@ -17,12 +17,12 @@ struct AppDatabase {
     /// Application can use a `DatabasePool`, while SwiftUI previews and tests
     /// can use a fast in-memory `DatabaseQueue`.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections
+    /// See <https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections>
     private let dbWriter: DatabaseWriter
     
     /// The DatabaseMigrator that defines the database schema.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/Documentation/Migrations.md
+    /// See <https://github.com/groue/GRDB.swift/blob/master/Documentation/Migrations.md>
     private var migrator: DatabaseMigrator {
         var migrator = DatabaseMigrator()
         

--- a/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Player.swift
+++ b/Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo/Player.swift
@@ -51,7 +51,7 @@ extension Player {
 
 /// Make Player a Codable Record.
 ///
-/// See https://github.com/groue/GRDB.swift/blob/master/README.md#records
+/// See <https://github.com/groue/GRDB.swift/blob/master/README.md#records>
 extension Player: Codable, FetchableRecord, MutablePersistableRecord {
     // Define database columns from CodingKeys
     fileprivate enum Columns {
@@ -69,8 +69,8 @@ extension Player: Codable, FetchableRecord, MutablePersistableRecord {
 
 /// Define some player requests used by the application.
 ///
-/// See https://github.com/groue/GRDB.swift/blob/master/README.md#requests
-/// See https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md
+/// See <https://github.com/groue/GRDB.swift/blob/master/README.md#requests>
+/// See <https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md>
 extension DerivableRequest where RowDecoder == Player {
     /// A request of players ordered by name.
     ///

--- a/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS/AppDatabase.swift
+++ b/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS/AppDatabase.swift
@@ -3,7 +3,7 @@ import GRDB
 /// AppDatabase lets the application access the database.
 ///
 /// It applies the pratices recommended at
-/// https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md
+/// <https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md>
 final class AppDatabase {
     /// Creates an `AppDatabase`, and make sure the database schema is ready.
     init(_ dbWriter: DatabaseWriter) throws {
@@ -16,12 +16,12 @@ final class AppDatabase {
     /// Application can use a `DatabasePool`, and tests can use a fast
     /// in-memory `DatabaseQueue`.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections
+    /// See <https://github.com/groue/GRDB.swift/blob/master/README.md#database-connections>
     private let dbWriter: DatabaseWriter
     
     /// The DatabaseMigrator that defines the database schema.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/Documentation/Migrations.md
+    /// See <https://github.com/groue/GRDB.swift/blob/master/Documentation/Migrations.md>
     private var migrator: DatabaseMigrator {
         var migrator = DatabaseMigrator()
         

--- a/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS/Player.swift
+++ b/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS/Player.swift
@@ -50,7 +50,7 @@ extension Player {
 
 /// Make Player a Codable Record.
 ///
-/// See https://github.com/groue/GRDB.swift/blob/master/README.md#records
+/// See <https://github.com/groue/GRDB.swift/blob/master/README.md#records>
 extension Player: Codable, FetchableRecord, MutablePersistableRecord {
     // Define database columns from CodingKeys
     fileprivate enum Columns {
@@ -68,8 +68,8 @@ extension Player: Codable, FetchableRecord, MutablePersistableRecord {
 
 /// Define some player requests used by the application.
 ///
-/// See https://github.com/groue/GRDB.swift/blob/master/README.md#requests
-/// See https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md
+/// See <https://github.com/groue/GRDB.swift/blob/master/README.md#requests>
+/// See <https://github.com/groue/GRDB.swift/blob/master/Documentation/GoodPracticesForDesigningRecordTypes.md>
 extension DerivableRequest where RowDecoder == Player {
     /// A request of players ordered by name.
     ///

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -179,7 +179,7 @@ public struct Configuration {
     
     // MARK: - Concurrency
     
-    /// The behavior in case of SQLITE_BUSY error. See https://www.sqlite.org/rescode.html#busy
+    /// The behavior in case of SQLITE_BUSY error. See <https://www.sqlite.org/rescode.html#busy>
     ///
     /// Default: immediateError
     public var busyMode: Database.BusyMode = .immediateError

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -1,5 +1,5 @@
 extension Database {
-    /// A SQLite schema. See https://sqlite.org/lang_naming.html
+    /// A SQLite schema. See <https://sqlite.org/lang_naming.html>
     enum SchemaIdentifier: Hashable {
         /// The main database
         case main
@@ -7,7 +7,7 @@ extension Database {
         /// The temp database
         case temp
         
-        /// An attached database: https://sqlite.org/lang_attach.html
+        /// An attached database: <https://sqlite.org/lang_attach.html>
         case attached(String)
         
         /// The name of the schema in SQL queries
@@ -116,7 +116,7 @@ extension Database {
     ///
     /// Those are tables whose name begins with `sqlite_` and `pragma_`.
     ///
-    /// For more information, see https://www.sqlite.org/fileformat2.html
+    /// For more information, see <https://www.sqlite.org/fileformat2.html>
     public static func isSQLiteInternalTable(_ tableName: String) -> Bool {
         // https://www.sqlite.org/fileformat2.html#internal_schema_objects
         // > The names of internal schema objects always begin with "sqlite_"
@@ -131,7 +131,7 @@ extension Database {
     ///
     /// Those are tables whose name begins with `sqlite_` and `pragma_`.
     ///
-    /// For more information, see https://www.sqlite.org/fileformat2.html
+    /// For more information, see <https://www.sqlite.org/fileformat2.html>
     @available(*, deprecated, message: "Use Database.isSQLiteInternalTable(_:) static method instead.")
     public func isSQLiteInternalTable(_ tableName: String) -> Bool {
         Self.isSQLiteInternalTable(tableName)
@@ -641,7 +641,7 @@ extension Database {
 ///     1       firstName   TEXT        0                       0      0
 ///     2       lastName    TEXT        0                       0      0
 ///
-/// See `Database.columns(in:)` and https://www.sqlite.org/pragma.html#pragma_table_info
+/// See `Database.columns(in:)` and <https://www.sqlite.org/pragma.html#pragma_table_info>
 public struct ColumnInfo: FetchableRecord {
     let cid: Int
     let hidden: Int?
@@ -689,8 +689,8 @@ public struct ColumnInfo: FetchableRecord {
     /// the primary key for columns that are part of the primary key.
     ///
     /// References:
-    /// - https://sqlite.org/releaselog/3_7_16.html
-    /// - http://mailinglists.sqlite.org/cgi-bin/mailman/private/sqlite-users/2013-April/046034.html
+    /// - <https://sqlite.org/releaselog/3_7_16.html>
+    /// - <http://mailinglists.sqlite.org/cgi-bin/mailman/private/sqlite-users/2013-April/046034.html>
     public let primaryKeyIndex: Int
     
     /// :nodoc:

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -56,7 +56,7 @@ extension Database {
     ///
     /// - parameter sql: An SQL query.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
-    ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
+    ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
     /// - returns: A SelectStatement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
     func makeSelectStatement(sql: String, prepFlags: Int32) throws -> SelectStatement {
@@ -169,7 +169,7 @@ extension Database {
     ///
     /// - parameter sql: An SQL query.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
-    ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
+    ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
     /// - returns: An UpdateStatement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
     func makeUpdateStatement(sql: String, prepFlags: Int32) throws -> UpdateStatement {

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -33,7 +33,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     /// The error logging function.
     ///
-    /// Quoting https://www.sqlite.org/errlog.html:
+    /// Quoting <https://www.sqlite.org/errlog.html>:
     ///
     /// > SQLite can be configured to invoke a callback function containing an
     /// > error code and a terse error message whenever anomalies occur. This
@@ -72,7 +72,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// If no row has ever been inserted using this database connection,
     /// returns zero.
     ///
-    /// For more detailed information, see https://www.sqlite.org/c3ref/last_insert_rowid.html
+    /// For more detailed information, see <https://www.sqlite.org/c3ref/last_insert_rowid.html>
     public var lastInsertedRowID: Int64 {
         SchedulingWatchdog.preconditionValidQueue(self)
         return sqlite3_last_insert_rowid(sqliteConnection)
@@ -81,7 +81,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// The number of rows modified, inserted or deleted by the most recent
     /// successful INSERT, UPDATE or DELETE statement.
     ///
-    /// For more detailed information, see https://www.sqlite.org/c3ref/changes.html
+    /// For more detailed information, see <https://www.sqlite.org/c3ref/changes.html>
     public var changesCount: Int {
         SchedulingWatchdog.preconditionValidQueue(self)
         return Int(sqlite3_changes(sqliteConnection))
@@ -91,7 +91,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// INSERT, UPDATE or DELETE statements since the database connection was
     /// opened.
     ///
-    /// For more detailed information, see https://www.sqlite.org/c3ref/total_changes.html
+    /// For more detailed information, see <https://www.sqlite.org/c3ref/total_changes.html>
     public var totalChangesCount: Int {
         SchedulingWatchdog.preconditionValidQueue(self)
         return Int(sqlite3_total_changes(sqliteConnection))
@@ -204,7 +204,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     // MARK: - Database Opening
     
     private static func openConnection(path: String, flags: Int32) throws -> SQLiteConnection {
-        // See https://www.sqlite.org/c3ref/open.html
+        // See <https://www.sqlite.org/c3ref/open.html>
         var sqliteConnection: SQLiteConnection? = nil
         let code = sqlite3_open_v2(path, &sqliteConnection, flags, nil)
         guard code == SQLITE_OK else {
@@ -415,7 +415,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     ///         try Player.deleteAll(db, keys: ids)
     ///     }
     ///
-    /// See https://www.sqlite.org/limits.html
+    /// See <https://www.sqlite.org/limits.html>
     /// and `SQLITE_LIMIT_VARIABLE_NUMBER`.
     public var maximumStatementArgumentCount: Int {
         Int(sqlite3_limit(sqliteConnection, SQLITE_LIMIT_VARIABLE_NUMBER, -1))
@@ -512,7 +512,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     #if SQLITE_ENABLE_SNAPSHOT
     /// Returns a snapshot that must be freed with `sqlite3_snapshot_free`.
     ///
-    /// See https://www.sqlite.org/c3ref/snapshot.html
+    /// See <https://www.sqlite.org/c3ref/snapshot.html>
     func takeVersionSnapshot() throws -> UnsafeMutablePointer<sqlite3_snapshot> {
         var snapshot: UnsafeMutablePointer<sqlite3_snapshot>?
         let code = withUnsafeMutablePointer(to: &snapshot) {
@@ -592,7 +592,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     ///     // Stop tracing
     ///     db.trace(options: [])
     ///
-    /// See https://www.sqlite.org/c3ref/trace_v2.html for more information.
+    /// See <https://www.sqlite.org/c3ref/trace_v2.html> for more information.
     ///
     /// - parameter options: The set of desired event kinds. Defaults to
     ///   `.statement`, which notifies all executed database statements.
@@ -700,8 +700,8 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     /// Runs a WAL checkpoint.
     ///
-    /// See https://www.sqlite.org/wal.html and
-    /// https://www.sqlite.org/c3ref/wal_checkpoint_v2.html for
+    /// See <https://www.sqlite.org/wal.html> and
+    /// <https://www.sqlite.org/c3ref/wal_checkpoint_v2.html> for
     /// more information.
     ///
     /// - parameter kind: The checkpoint mode (default passive)
@@ -731,7 +731,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     // MARK: - Interrupt
     
-    // See https://www.sqlite.org/c3ref/interrupt.html
+    // See <https://www.sqlite.org/c3ref/interrupt.html>
     func interrupt() {
         sqlite3_interrupt(sqliteConnection)
     }
@@ -773,7 +773,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
             
             // Interrupt the database because this may trigger an
             // SQLITE_INTERRUPT error which may itself abort a transaction and
-            // release a lock. See https://www.sqlite.org/c3ref/interrupt.html
+            // release a lock. See <https://www.sqlite.org/c3ref/interrupt.html>
             interrupt()
             
             // Now what about the eventual remaining lock? We'll issue a
@@ -910,7 +910,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// - parameters:
     ///     - kind: The transaction type (default nil). If nil, the transaction
     ///       type is configuration.defaultTransactionKind, which itself
-    ///       defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
+    ///       defaults to .deferred. See <https://www.sqlite.org/lang_transaction.html>
     ///       for more information.
     ///     - block: A block that executes SQL statements and return either
     ///       .commit or .rollback.
@@ -1077,7 +1077,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     ///
     /// - parameter kind: The transaction type (default nil). If nil, the
     ///   transaction type is configuration.defaultTransactionKind, which itself
-    ///   defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
+    ///   defaults to .deferred. See <https://www.sqlite.org/lang_transaction.html>
     ///   for more information.
     /// - throws: The error thrown by the block.
     public func beginTransaction(_ kind: TransactionKind? = nil) throws {
@@ -1311,7 +1311,7 @@ extension Database {
     
     // MARK: - Database-Related Types
     
-    /// See BusyMode and https://www.sqlite.org/c3ref/busy_handler.html
+    /// See BusyMode and <https://www.sqlite.org/c3ref/busy_handler.html>
     public typealias BusyCallback = (_ numberOfTries: Int) -> Bool
     
     /// When there are several connections to a database, a connection may try
@@ -1336,10 +1336,10 @@ extension Database {
     ///
     /// Relevant SQLite documentation:
     ///
-    /// - https://www.sqlite.org/c3ref/busy_timeout.html
-    /// - https://www.sqlite.org/c3ref/busy_handler.html
-    /// - https://www.sqlite.org/lang_transaction.html
-    /// - https://www.sqlite.org/wal.html
+    /// - <https://www.sqlite.org/c3ref/busy_timeout.html>
+    /// - <https://www.sqlite.org/c3ref/busy_handler.html>
+    /// - <https://www.sqlite.org/lang_transaction.html>
+    /// - <https://www.sqlite.org/wal.html>
     public enum BusyMode {
         /// The SQLITE_BUSY error is immediately returned to the connection that
         /// tries to access the locked database.
@@ -1350,7 +1350,7 @@ extension Database {
         case timeout(TimeInterval)
         
         /// A custom callback that is called when a database is locked.
-        /// See https://www.sqlite.org/c3ref/busy_handler.html
+        /// See <https://www.sqlite.org/c3ref/busy_handler.html>
         case callback(BusyCallback)
     }
     
@@ -1371,7 +1371,7 @@ extension Database {
     
     /// A built-in SQLite collation.
     ///
-    /// See https://www.sqlite.org/datatype3.html#collation
+    /// See <https://www.sqlite.org/datatype3.html#collation>
     public struct CollationName: RawRepresentable, Hashable {
         /// :nodoc:
         public let rawValue: String
@@ -1398,7 +1398,7 @@ extension Database {
     ///         t.column("title", .text)
     ///     }
     ///
-    /// See https://www.sqlite.org/datatype3.html
+    /// See <https://www.sqlite.org/datatype3.html>
     public struct ColumnType: RawRepresentable, Hashable {
         /// :nodoc:
         public let rawValue: String
@@ -1435,7 +1435,7 @@ extension Database {
     
     /// An SQLite conflict resolution.
     ///
-    /// See https://www.sqlite.org/lang_conflict.html
+    /// See <https://www.sqlite.org/lang_conflict.html>
     public enum ConflictResolution: String {
         /// The `ROLLBACK` conflict resolution
         case rollback = "ROLLBACK"
@@ -1455,7 +1455,7 @@ extension Database {
     
     /// A foreign key action.
     ///
-    /// See https://www.sqlite.org/foreignkeys.html
+    /// See <https://www.sqlite.org/foreignkeys.html>
     public enum ForeignKeyAction: String {
         /// The `CASCADE` foreign key action
         case cascade = "CASCADE"
@@ -1477,13 +1477,13 @@ extension Database {
     public struct TracingOptions: OptionSet {
         /// The raw "Trace Event Code".
         ///
-        /// See https://www.sqlite.org/c3ref/c_trace.html
+        /// See <https://www.sqlite.org/c3ref/c_trace.html>
         public let rawValue: CInt
         
         /// Creates a `TracingOptions` from a raw "Trace Event Code".
         ///
         /// See:
-        /// - https://www.sqlite.org/c3ref/c_trace.html
+        /// - <https://www.sqlite.org/c3ref/c_trace.html>
         /// - `Database.trace(options:_:)`
         public init(rawValue: CInt) {
             self.rawValue = rawValue
@@ -1607,7 +1607,7 @@ extension Database {
         case rollback
     }
     
-    /// An SQLite transaction kind. See https://www.sqlite.org/lang_transaction.html
+    /// An SQLite transaction kind. See <https://www.sqlite.org/lang_transaction.html>
     public enum TransactionKind: String {
         /// The `DEFERRED` transaction kind
         case deferred = "DEFERRED"
@@ -1619,7 +1619,7 @@ extension Database {
         case exclusive = "EXCLUSIVE"
     }
     
-    /// An SQLite threading mode. See https://www.sqlite.org/threadsafe.html.
+    /// An SQLite threading mode. See <https://www.sqlite.org/threadsafe.html>.
     enum ThreadingMode {
         case `default`
         case multiThread

--- a/GRDB/Core/DatabaseCollation.swift
+++ b/GRDB/Core/DatabaseCollation.swift
@@ -51,7 +51,7 @@ extension DatabaseCollation: Hashable {
     /// Two collations are equal if they share the same name (case insensitive)
     /// :nodoc:
     public static func == (lhs: DatabaseCollation, rhs: DatabaseCollation) -> Bool {
-        // See https://www.sqlite.org/c3ref/create_collation.html
+        // See <https://www.sqlite.org/c3ref/create_collation.html>
         return sqlite3_stricmp(lhs.name, rhs.name) == 0
     }
 }

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// An SQLite result code.
 ///
-/// See https://www.sqlite.org/rescode.html
+/// See <https://www.sqlite.org/rescode.html>
 public struct ResultCode: RawRepresentable, Equatable, CustomStringConvertible {
     /// The raw SQLite result code
     public let rawValue: CInt
@@ -13,7 +13,7 @@ public struct ResultCode: RawRepresentable, Equatable, CustomStringConvertible {
     }
     
     /// A result code limited to the least significant 8 bits of the receiver.
-    /// See https://www.sqlite.org/rescode.html for more information.
+    /// See <https://www.sqlite.org/rescode.html> for more information.
     ///
     ///     let resultCode = .SQLITE_CONSTRAINT_FOREIGNKEY
     ///     resultCode.primaryResultCode == .SQLITE_CONSTRAINT // true
@@ -193,7 +193,7 @@ extension ResultCode {
 public struct DatabaseError: Error, CustomStringConvertible, CustomNSError {
     
     /// The SQLite error code (see
-    /// https://www.sqlite.org/rescode.html#primary_result_code_list).
+    /// <https://www.sqlite.org/rescode.html#primary_result_code_list>).
     ///
     ///     do {
     ///         ...
@@ -203,7 +203,7 @@ public struct DatabaseError: Error, CustomStringConvertible, CustomNSError {
     ///
     /// This property returns a "primary result code", that is to say the least
     /// significant 8 bits of any SQLite result code. See
-    /// https://www.sqlite.org/rescode.html for more information.
+    /// <https://www.sqlite.org/rescode.html> for more information.
     ///
     /// See also `extendedResultCode`.
     public var resultCode: ResultCode {
@@ -211,7 +211,7 @@ public struct DatabaseError: Error, CustomStringConvertible, CustomNSError {
     }
     
     /// The SQLite extended error code (see
-    /// https://www.sqlite.org/rescode.html#extended_result_code_list).
+    /// <https://www.sqlite.org/rescode.html#extended_result_code_list>).
     ///
     ///     do {
     ///         ...

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -109,7 +109,7 @@ public final class DatabaseFunction: Hashable {
     
     /// Returns an SQL expression that applies the function.
     ///
-    /// See https://github.com/groue/GRDB.swift/#sql-functions
+    /// See <https://github.com/groue/GRDB.swift/#sql-functions>
     public func callAsFunction(_ arguments: SQLExpressible...) -> SQLExpression {
         switch kind {
         case .aggregate:
@@ -120,7 +120,7 @@ public final class DatabaseFunction: Hashable {
     }
 
     /// Calls sqlite3_create_function_v2
-    /// See https://sqlite.org/c3ref/create_function.html
+    /// See <https://sqlite.org/c3ref/create_function.html>
     func install(in db: Database) {
         // Retain the function definition
         let definition = kind.definition
@@ -147,7 +147,7 @@ public final class DatabaseFunction: Hashable {
     }
     
     /// Calls sqlite3_create_function_v2
-    /// See https://sqlite.org/c3ref/create_function.html
+    /// See <https://sqlite.org/c3ref/create_function.html>
     func uninstall(in db: Database) {
         let code = sqlite3_create_function_v2(
             db.sqliteConnection,
@@ -164,7 +164,7 @@ public final class DatabaseFunction: Hashable {
     
     /// The way to compute the result of a function.
     /// Feeds the `pApp` parameter of sqlite3_create_function_v2
-    /// http://sqlite.org/capi3ref.html#sqlite3_create_function
+    /// <http://sqlite.org/capi3ref.html#sqlite3_create_function>
     private class FunctionDefinition {
         let compute: (Int32, UnsafeMutablePointer<OpaquePointer?>?) throws -> DatabaseValueConvertible?
         init(compute: @escaping (Int32, UnsafeMutablePointer<OpaquePointer?>?) throws -> DatabaseValueConvertible?) {
@@ -174,7 +174,7 @@ public final class DatabaseFunction: Hashable {
     
     /// The way to start an aggregate.
     /// Feeds the `pApp` parameter of sqlite3_create_function_v2
-    /// http://sqlite.org/capi3ref.html#sqlite3_create_function
+    /// <http://sqlite.org/capi3ref.html#sqlite3_create_function>
     private class AggregateDefinition {
         let makeAggregate: () -> DatabaseAggregate
         init(makeAggregate: @escaping () -> DatabaseAggregate) {
@@ -192,7 +192,7 @@ public final class DatabaseFunction: Hashable {
     }
     
     /// A function kind: an "SQL function" or an "aggregate".
-    /// See http://sqlite.org/capi3ref.html#sqlite3_create_function
+    /// See <http://sqlite.org/capi3ref.html#sqlite3_create_function>
     private enum Kind {
         /// A regular function: SELECT f(1)
         case function((Int32, UnsafeMutablePointer<OpaquePointer?>?) throws -> DatabaseValueConvertible?)
@@ -201,7 +201,7 @@ public final class DatabaseFunction: Hashable {
         case aggregate(() -> DatabaseAggregate)
         
         /// Feeds the `pApp` parameter of sqlite3_create_function_v2
-        /// http://sqlite.org/capi3ref.html#sqlite3_create_function
+        /// <http://sqlite.org/capi3ref.html#sqlite3_create_function>
         var definition: AnyObject {
             switch self {
             case .function(let compute):
@@ -212,7 +212,7 @@ public final class DatabaseFunction: Hashable {
         }
         
         /// Feeds the `xFunc` parameter of sqlite3_create_function_v2
-        /// http://sqlite.org/capi3ref.html#sqlite3_create_function
+        /// <http://sqlite.org/capi3ref.html#sqlite3_create_function>
         var xFunc: (@convention(c) (OpaquePointer?, Int32, UnsafeMutablePointer<OpaquePointer?>?) -> Void)? {
             guard case .function = self else { return nil }
             return { (sqliteContext, argc, argv) in
@@ -230,7 +230,7 @@ public final class DatabaseFunction: Hashable {
         }
         
         /// Feeds the `xStep` parameter of sqlite3_create_function_v2
-        /// http://sqlite.org/capi3ref.html#sqlite3_create_function
+        /// <http://sqlite.org/capi3ref.html#sqlite3_create_function>
         var xStep: (@convention(c) (OpaquePointer?, Int32, UnsafeMutablePointer<OpaquePointer?>?) -> Void)? {
             guard case .aggregate = self else { return nil }
             return { (sqliteContext, argc, argv) in
@@ -250,7 +250,7 @@ public final class DatabaseFunction: Hashable {
         }
         
         /// Feeds the `xFinal` parameter of sqlite3_create_function_v2
-        /// http://sqlite.org/capi3ref.html#sqlite3_create_function
+        /// <http://sqlite.org/capi3ref.html#sqlite3_create_function>
         var xFinal: (@convention(c) (OpaquePointer?) -> Void)? {
             guard case .aggregate = self else { return nil }
             return { (sqliteContext) in
@@ -278,8 +278,8 @@ public final class DatabaseFunction: Hashable {
     ///
     /// The result must be released when the aggregate concludes.
     ///
-    /// See https://sqlite.org/c3ref/context.html
-    /// See https://sqlite.org/c3ref/aggregate_context.html
+    /// See <https://sqlite.org/c3ref/context.html>
+    /// See <https://sqlite.org/c3ref/aggregate_context.html>
     private static func unmanagedAggregateContext(_ sqliteContext: OpaquePointer?) -> Unmanaged<AggregateContext> {
         // > The first time the sqlite3_aggregate_context(C,N) routine is called
         // > for a particular aggregate function, SQLite allocates N of memory,

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -754,7 +754,7 @@ extension DatabasePool: DatabaseReader {
     /// - parameters:
     ///     - kind: The transaction type (default nil). If nil, the transaction
     ///       type is configuration.defaultTransactionKind, which itself
-    ///       defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
+    ///       defaults to .deferred. See <https://www.sqlite.org/lang_transaction.html>
     ///       for more information.
     ///     - updates: The updates to the database.
     /// - throws: The error thrown by the updates, or by the
@@ -1072,7 +1072,7 @@ extension DatabasePool {
     /// You can create as many snapshots as you need, regardless of the maximum
     /// number of reader connections in the pool.
     ///
-    /// For more information, read about "snapshot isolation" at https://sqlite.org/isolation.html
+    /// For more information, read about "snapshot isolation" at <https://sqlite.org/isolation.html>
     public func makeSnapshot() throws -> DatabaseSnapshot {
         // Sanity check
         if writer.onValidQueue {

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -361,7 +361,7 @@ extension DatabaseQueue {
     /// - parameters:
     ///     - kind: The transaction type (default nil). If nil, the transaction
     ///       type is configuration.defaultTransactionKind, which itself
-    ///       defaults to .deferred. See https://www.sqlite.org/lang_transaction.html
+    ///       defaults to .deferred. See <https://www.sqlite.org/lang_transaction.html>
     ///       for more information.
     ///     - updates: The updates to the database.
     /// - throws: The error thrown by the updates, or by the

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -5,7 +5,7 @@ import Dispatch
 ///
 /// See DatabasePool.makeSnapshot()
 ///
-/// For more information, read about "snapshot isolation" at https://sqlite.org/isolation.html
+/// For more information, read about "snapshot isolation" at <https://sqlite.org/isolation.html>
 public class DatabaseSnapshot: DatabaseReader {
     private var serializedDatabase: SerializedDatabase
     

--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// DatabaseValue is the intermediate type between SQLite and your values.
 ///
-/// See https://www.sqlite.org/datatype3.html
+/// See <https://www.sqlite.org/datatype3.html>
 public struct DatabaseValue: Hashable, CustomStringConvertible, DatabaseValueConvertible, SQLSpecificExpressible {
     /// The SQLite storage
     public let storage: Storage

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -315,7 +315,7 @@ extension DatabaseWriter {
     /// Rebuilds the database file, repacking it into a minimal amount of
     /// disk space.
     ///
-    /// See https://www.sqlite.org/lang_vacuum.html for more information.
+    /// See <https://www.sqlite.org/lang_vacuum.html> for more information.
     public func vacuum() throws {
         try writeWithoutTransaction { try $0.execute(sql: "VACUUM") }
     }
@@ -337,7 +337,7 @@ extension DatabaseWriter {
     /// Databases encrypted with SQLCipher are copied with the same password
     /// and configuration as the original database.
     ///
-    /// See https://www.sqlite.org/lang_vacuum.html#vacuuminto for more information.
+    /// See <https://www.sqlite.org/lang_vacuum.html#vacuuminto> for more information.
     ///
     /// - Parameter filePath: file path for new database
     public func vacuum(into filePath: String) throws {
@@ -348,7 +348,7 @@ extension DatabaseWriter {
     #else
     /// Creates a new database file at the specified path with a minimum
     /// amount of disk space.
-    /// See https://www.sqlite.org/lang_vacuum.html#vacuuminto for more information.
+    /// See <https://www.sqlite.org/lang_vacuum.html#vacuuminto> for more information.
     ///
     /// - Parameter filePath: file path for new database
     @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -239,7 +239,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ index: Int) -> Value? {
         try! decodeIfPresent(Value.self, atIndex: index)
@@ -267,7 +267,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ index: Int) -> Value {
         try! decode(Value.self, atIndex: index)
@@ -318,7 +318,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ columnName: String) -> Value? {
         try! decodeIfPresent(Value.self, forKey: columnName)
@@ -350,7 +350,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ columnName: String) -> Value {
         try! decode(Value.self, forKey: columnName)
@@ -392,7 +392,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     public subscript<Value, Column>(_ column: Column)
     -> Value?
@@ -429,7 +429,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     public subscript<Value, Column>(_ column: Column)
     -> Value
@@ -531,7 +531,7 @@ extension Row {
     /// A fatal error is raised if the scope is not available, or contains only
     /// null values.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
+    /// See <https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support>
     /// for more information.
     public subscript<Record: FetchableRecord>(_ scope: String) -> Record {
         try! decode(Record.self, forKey: scope)
@@ -566,7 +566,7 @@ extension Row {
     /// Nil is returned if the scope is not available, or contains only
     /// null values.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
+    /// See <https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support>
     /// for more information.
     public subscript<Record: FetchableRecord>(_ scope: String) -> Record? {
         try! decodeIfPresent(Record.self, forKey: scope)
@@ -786,7 +786,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     func decodeIfPresent<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -806,7 +806,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     func decode<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -827,7 +827,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     func decodeIfPresent<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -851,7 +851,7 @@ extension Row {
     ///
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
-    /// (see https://www.sqlite.org/datatype3.html).
+    /// (see <https://www.sqlite.org/datatype3.html>).
     @inlinable
     func decode<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -997,7 +997,7 @@ extension Row {
     /// Nil is returned if the scope is not available, or contains only
     /// null values.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
+    /// See <https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support>
     /// for more information.
     func decodeIfPresent<Record: FetchableRecord>(
         _ type: Record.Type = Record.self,
@@ -1039,7 +1039,7 @@ extension Row {
     /// A fatal error is raised if the scope is not available, or contains only
     /// null values.
     ///
-    /// See https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support
+    /// See <https://github.com/groue/GRDB.swift/blob/master/README.md#joined-queries-support>
     /// for more information.
     func decode<Record: FetchableRecord>(
         _ type: Record.Type = Record.self,

--- a/GRDB/Core/SchedulingWatchdog.swift
+++ b/GRDB/Core/SchedulingWatchdog.swift
@@ -6,7 +6,7 @@ import Dispatch
 ///
 /// Generally speaking, each connection has its own dispatch queue. But it's not
 /// enough: users need to use two database connections at the same time:
-/// https://github.com/groue/GRDB.swift/issues/55. To support this use case, a
+/// <https://github.com/groue/GRDB.swift/issues/55>. To support this use case, a
 /// single dispatch queue can be temporarily shared by two or more connections.
 ///
 /// - SchedulingWatchdog.makeSerializedQueue(allowingDatabase:) creates a

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -49,7 +49,7 @@ public class Statement {
     /// - parameter statementEnd: Upon success, the pointer to the next
     ///   statement in the C string.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
-    ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
+    ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
     /// - parameter authorizer: A StatementCompilationAuthorizer
     /// - throws: DatabaseError in case of compilation error.
     required init?(
@@ -332,7 +332,7 @@ public final class SelectStatement: Statement {
     /// - parameter statementEnd: Upon success, the pointer to the next
     ///   statement in the C string.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
-    ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
+    ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
     /// - parameter authorizer: A StatementCompilationAuthorizer
     /// - throws: DatabaseError in case of compilation error.
     required init?(
@@ -509,7 +509,7 @@ public final class UpdateStatement: Statement {
     /// - parameter statementEnd: Upon success, the pointer to the next
     ///   statement in the C string.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
-    ///   SQLite 3.20.0, see http://www.sqlite.org/c3ref/prepare.html)
+    ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
     /// - parameter authorizer: A StatementCompilationAuthorizer
     /// - throws: DatabaseError in case of compilation error.
     required init?(
@@ -561,7 +561,7 @@ public protocol StatementBinding {
 /// StatementArguments provide values to argument placeholders in raw
 /// SQL queries.
 ///
-/// Placeholders can take several forms (see https://www.sqlite.org/lang_expr.html#varparam
+/// Placeholders can take several forms (see <https://www.sqlite.org/lang_expr.html#varparam>
 /// for more information):
 ///
 /// - `?NNN` (e.g. `?2`): the NNN-th argument (starts at 1)

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -1,6 +1,6 @@
 /// The `StatementColumnConvertible` protocol grants access to the low-level C
 /// interface that extracts values from query results:
-/// https://www.sqlite.org/c3ref/column_blob.html. It can bring performance
+/// <https://www.sqlite.org/c3ref/column_blob.html>. It can bring performance
 /// improvements.
 ///
 /// To use it, have a value type adopt both `StatementColumnConvertible` and
@@ -34,7 +34,7 @@ public protocol StatementColumnConvertible {
     /// `nil` for failed conversions: GRDB will interpret a nil result as a
     /// decoding failure.
     ///
-    /// See https://www.sqlite.org/c3ref/column_blob.html for more information.
+    /// See <https://www.sqlite.org/c3ref/column_blob.html> for more information.
     ///
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.

--- a/GRDB/Core/Support/Foundation/Data.swift
+++ b/GRDB/Core/Support/Foundation/Data.swift
@@ -26,7 +26,7 @@ extension Data: DatabaseValueConvertible, StatementColumnConvertible {
             return data
         case .string(let string):
             // Implicit conversion from string to blob, just as SQLite does
-            // See https://www.sqlite.org/c3ref/column_blob.html
+            // See <https://www.sqlite.org/c3ref/column_blob.html>
             return string.data(using: .utf8)
         default:
             return nil

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -518,7 +518,7 @@ extension String: DatabaseValueConvertible, StatementColumnConvertible {
         switch dbValue.storage {
         case .blob(let data):
             // Implicit conversion from blob to string, just as SQLite does
-            // See https://www.sqlite.org/c3ref/column_blob.html
+            // See <https://www.sqlite.org/c3ref/column_blob.html>
             return String(data: data, encoding: .utf8)
         case .string(let string):
             return string

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -741,7 +741,7 @@ public protocol TransactionObserver: AnyObject {
     /// As of OSX 10.11.5, and iOS 9.3.2, the built-in SQLite library
     /// does not have this enabled, so you'll need to compile your own
     /// version of SQLite:
-    /// See https://github.com/groue/GRDB.swift/blob/master/Documentation/CustomSQLiteBuilds.md
+    /// See <https://github.com/groue/GRDB.swift/blob/master/Documentation/CustomSQLiteBuilds.md>
     ///
     /// The databaseDidChangeWithEvent callback is always available,
     /// and may provide most/all of what you need.
@@ -1350,7 +1350,7 @@ enum DatabaseEventPredicate {
 // MARK: - SavepointStack
 
 /// The SQLite savepoint stack is described at
-/// https://www.sqlite.org/lang_savepoint.html
+/// <https://www.sqlite.org/lang_savepoint.html>
 ///
 /// This class reimplements the SQLite stack, so that we can:
 ///

--- a/GRDB/FTS/FTS3.swift
+++ b/GRDB/FTS/FTS3.swift
@@ -8,7 +8,7 @@ public struct FTS3: VirtualTableModule {
     /// Options for Latin script characters. Matches the raw "remove_diacritics"
     /// tokenizer argument.
     ///
-    /// See https://www.sqlite.org/fts3.html
+    /// See <https://www.sqlite.org/fts3.html>
     public enum Diacritics {
         /// Do not remove diacritics from Latin script characters. This
         /// option matches the raw "remove_diacritics=0" tokenizer argument.
@@ -101,7 +101,7 @@ public final class FTS3TableDefinition {
     ///     try db.create(virtualTable: "document", using: FTS3()) { t in
     ///         t.tokenizer = .porter
     ///     }
-    /// See https://www.sqlite.org/fts3.html#creating_and_destroying_fts_tables
+    /// See <https://www.sqlite.org/fts3.html#creating_and_destroying_fts_tables>
     public var tokenizer: FTS3TokenizerDescriptor?
     
     /// Appends a table column.

--- a/GRDB/FTS/FTS3Pattern.swift
+++ b/GRDB/FTS/FTS3Pattern.swift
@@ -7,7 +7,7 @@ public struct FTS3Pattern {
     /// Creates a pattern from a raw pattern string; throws DatabaseError on
     /// invalid syntax.
     ///
-    /// The pattern syntax is documented at https://www.sqlite.org/fts3.html#full_text_index_queries
+    /// The pattern syntax is documented at <https://www.sqlite.org/fts3.html#full_text_index_queries>
     ///
     ///     try FTS3Pattern(rawPattern: "and") // OK
     ///     try FTS3Pattern(rawPattern: "AND") // malformed MATCH expression: [AND]

--- a/GRDB/FTS/FTS3TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS3TokenizerDescriptor.swift
@@ -4,7 +4,7 @@
 ///         t.tokenizer = .simple // FTS3TokenizerDescriptor
 ///     }
 ///
-/// See https://www.sqlite.org/fts3.html#tokenizer
+/// See <https://www.sqlite.org/fts3.html#tokenizer>
 public struct FTS3TokenizerDescriptor {
     let name: String
     let arguments: [String]
@@ -20,7 +20,7 @@ public struct FTS3TokenizerDescriptor {
     ///         t.tokenizer = .simple
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html#tokenizer
+    /// See <https://www.sqlite.org/fts3.html#tokenizer>
     public static let simple = FTS3TokenizerDescriptor("simple")
     
     /// The "porter" tokenizer.
@@ -29,7 +29,7 @@ public struct FTS3TokenizerDescriptor {
     ///         t.tokenizer = .porter
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html#tokenizer
+    /// See <https://www.sqlite.org/fts3.html#tokenizer>
     public static let porter = FTS3TokenizerDescriptor("porter")
     
     /// The "unicode61" tokenizer.
@@ -46,7 +46,7 @@ public struct FTS3TokenizerDescriptor {
     ///     - tokenCharacters: Unless empty (the default), SQLite will consider
     ///       these characters as token characters.
     ///
-    /// See https://www.sqlite.org/fts3.html#tokenizer
+    /// See <https://www.sqlite.org/fts3.html#tokenizer>
     public static func unicode61(
         diacritics: FTS3.Diacritics = .removeLegacy,
         separators: Set<Character> = [],

--- a/GRDB/FTS/FTS4.swift
+++ b/GRDB/FTS/FTS4.swift
@@ -5,7 +5,7 @@
 ///         t.column("content")
 ///     }
 ///
-/// See https://www.sqlite.org/fts3.html
+/// See <https://www.sqlite.org/fts3.html>
 public struct FTS4: VirtualTableModule {
     
     /// Creates a FTS4 module suitable for the Database
@@ -16,7 +16,7 @@ public struct FTS4: VirtualTableModule {
     ///         t.column("content")
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html
+    /// See <https://www.sqlite.org/fts3.html>
     public init() {
     }
     
@@ -158,7 +158,7 @@ public struct FTS4: VirtualTableModule {
 ///         t.column("content")
 ///     }
 ///
-/// See https://www.sqlite.org/fts3.html
+/// See <https://www.sqlite.org/fts3.html>
 public final class FTS4TableDefinition {
     enum ContentMode {
         case raw(content: String?)
@@ -175,7 +175,7 @@ public final class FTS4TableDefinition {
     ///         t.tokenizer = .porter
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html#creating_and_destroying_fts_tables
+    /// See <https://www.sqlite.org/fts3.html#creating_and_destroying_fts_tables>
     public var tokenizer: FTS3TokenizerDescriptor?
     
     /// The FTS4 `content` option
@@ -187,7 +187,7 @@ public final class FTS4TableDefinition {
     /// Setting this property invalidates any synchronization previously
     /// established with the `synchronize(withTable:)` method.
     ///
-    /// See https://www.sqlite.org/fts3.html#the_content_option_
+    /// See <https://www.sqlite.org/fts3.html#the_content_option_>
     public var content: String? {
         get {
             switch contentMode {
@@ -204,17 +204,17 @@ public final class FTS4TableDefinition {
     
     /// The FTS4 `compress` option
     ///
-    /// See https://www.sqlite.org/fts3.html#the_compress_and_uncompress_options
+    /// See <https://www.sqlite.org/fts3.html#the_compress_and_uncompress_options>
     public var compress: String?
     
     /// The FTS4 `uncompress` option
     ///
-    /// See https://www.sqlite.org/fts3.html#the_compress_and_uncompress_options
+    /// See <https://www.sqlite.org/fts3.html#the_compress_and_uncompress_options>
     public var uncompress: String?
     
     /// The FTS4 `matchinfo` option
     ///
-    /// See https://www.sqlite.org/fts3.html#the_matchinfo_option
+    /// See <https://www.sqlite.org/fts3.html#the_matchinfo_option>
     public var matchinfo: String?
     
     /// Support for the FTS5 `prefix` option
@@ -225,7 +225,7 @@ public final class FTS4TableDefinition {
     ///         t.column("content")
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html#the_prefix_option
+    /// See <https://www.sqlite.org/fts3.html#the_prefix_option>
     public var prefixes: Set<Int>?
     
     init(configuration: VirtualTableConfiguration) {
@@ -253,7 +253,7 @@ public final class FTS4TableDefinition {
     /// content in the external table. SQL triggers make sure that the
     /// full-text table is kept up to date with the external table.
     ///
-    /// See https://sqlite.org/fts5.html#external_content_tables
+    /// See <https://sqlite.org/fts5.html#external_content_tables>
     public func synchronize(withTable tableName: String) {
         contentMode = .synchronized(contentTable: tableName)
     }
@@ -268,7 +268,7 @@ public final class FTS4TableDefinition {
 ///         t.column("content")      // FTS4ColumnDefinition
 ///     }
 ///
-/// See https://www.sqlite.org/fts3.html
+/// See <https://www.sqlite.org/fts3.html>
 public final class FTS4ColumnDefinition {
     fileprivate let name: String
     fileprivate var isIndexed: Bool
@@ -287,7 +287,7 @@ public final class FTS4ColumnDefinition {
     ///         t.column("b").notIndexed()
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html#the_notindexed_option
+    /// See <https://www.sqlite.org/fts3.html#the_notindexed_option>
     ///
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
@@ -303,7 +303,7 @@ public final class FTS4ColumnDefinition {
     ///         t.column("lid").asLanguageId()
     ///     }
     ///
-    /// See https://www.sqlite.org/fts3.html#the_languageid_option
+    /// See <https://www.sqlite.org/fts3.html#the_languageid_option>
     ///
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -8,12 +8,12 @@ import Foundation
 ///         t.column("content")
 ///     }
 ///
-/// See https://www.sqlite.org/fts5.html
+/// See <https://www.sqlite.org/fts5.html>
 public struct FTS5: VirtualTableModule {
     /// Options for Latin script characters. Matches the raw "remove_diacritics"
     /// tokenizer argument.
     ///
-    /// See https://www.sqlite.org/fts5.html
+    /// See <https://www.sqlite.org/fts5.html>
     public enum Diacritics {
         /// Do not remove diacritics from Latin script characters. This
         /// option matches the raw "remove_diacritics=0" tokenizer argument.
@@ -43,7 +43,7 @@ public struct FTS5: VirtualTableModule {
     ///         t.column("content")
     ///     }
     ///
-    /// See https://www.sqlite.org/fts5.html
+    /// See <https://www.sqlite.org/fts5.html>
     public init() {
     }
     
@@ -259,7 +259,7 @@ public struct FTS5: VirtualTableModule {
 ///         t.column("content")
 ///     }
 ///
-/// See https://www.sqlite.org/fts5.html
+/// See <https://www.sqlite.org/fts5.html>
 public final class FTS5TableDefinition {
     enum ContentMode {
         case raw(content: String?, contentRowID: String?)
@@ -276,7 +276,7 @@ public final class FTS5TableDefinition {
     ///         t.tokenizer = .porter()
     ///     }
     ///
-    /// See https://www.sqlite.org/fts5.html#fts5_table_creation_and_initialization
+    /// See <https://www.sqlite.org/fts5.html#fts5_table_creation_and_initialization>
     public var tokenizer: FTS5TokenizerDescriptor?
     
     /// The FTS5 `content` option
@@ -288,7 +288,7 @@ public final class FTS5TableDefinition {
     /// Setting this property invalidates any synchronization previously
     /// established with the `synchronize(withTable:)` method.
     ///
-    /// See https://www.sqlite.org/fts5.html#external_content_and_contentless_tables
+    /// See <https://www.sqlite.org/fts5.html#external_content_and_contentless_tables>
     public var content: String? {
         get {
             switch contentMode {
@@ -317,7 +317,7 @@ public final class FTS5TableDefinition {
     /// Setting this property invalidates any synchronization previously
     /// established with the `synchronize(withTable:)` method.
     ///
-    /// See https://sqlite.org/fts5.html#external_content_tables
+    /// See <https://sqlite.org/fts5.html#external_content_tables>
     public var contentRowID: String? {
         get {
             switch contentMode {
@@ -339,17 +339,17 @@ public final class FTS5TableDefinition {
     
     /// Support for the FTS5 `prefix` option
     ///
-    /// See https://www.sqlite.org/fts5.html#prefix_indexes
+    /// See <https://www.sqlite.org/fts5.html#prefix_indexes>
     public var prefixes: Set<Int>?
     
     /// Support for the FTS5 `columnsize` option
     ///
-    /// https://www.sqlite.org/fts5.html#the_columnsize_option
+    /// <https://www.sqlite.org/fts5.html#the_columnsize_option>
     public var columnSize: Int?
     
     /// Support for the FTS5 `detail` option
     ///
-    /// https://www.sqlite.org/fts5.html#the_detail_option
+    /// <https://www.sqlite.org/fts5.html#the_detail_option>
     public var detail: String?
     
     init(configuration: VirtualTableConfiguration) {
@@ -377,7 +377,7 @@ public final class FTS5TableDefinition {
     /// content in the external table. SQL triggers make sure that the
     /// full-text table is kept up to date with the external table.
     ///
-    /// See https://sqlite.org/fts5.html#external_content_tables
+    /// See <https://sqlite.org/fts5.html#external_content_tables>
     public func synchronize(withTable tableName: String) {
         contentMode = .synchronized(contentTable: tableName)
     }
@@ -392,7 +392,7 @@ public final class FTS5TableDefinition {
 ///         t.column("content")      // FTS5ColumnDefinition
 ///     }
 ///
-/// See https://www.sqlite.org/fts5.html
+/// See <https://www.sqlite.org/fts5.html>
 public final class FTS5ColumnDefinition {
     fileprivate let name: String
     fileprivate var isIndexed: Bool
@@ -409,7 +409,7 @@ public final class FTS5ColumnDefinition {
     ///         t.column("b").notIndexed()
     ///     }
     ///
-    /// See https://www.sqlite.org/fts5.html#the_unindexed_column_option
+    /// See <https://www.sqlite.org/fts5.html#the_unindexed_column_option>
     ///
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult

--- a/GRDB/FTS/FTS5Pattern.swift
+++ b/GRDB/FTS/FTS5Pattern.swift
@@ -114,7 +114,7 @@ extension Database {
     /// Creates a pattern from a raw pattern string; throws DatabaseError on
     /// invalid syntax.
     ///
-    /// The pattern syntax is documented at https://www.sqlite.org/fts5.html#full_text_query_syntax
+    /// The pattern syntax is documented at <https://www.sqlite.org/fts5.html#full_text_query_syntax>
     ///
     ///     try db.makeFTS5Pattern(rawPattern: "and", forTable: "document") // OK
     ///     try db.makeFTS5Pattern(rawPattern: "AND", forTable: "document") // malformed MATCH expression: [AND]

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -15,7 +15,7 @@ public typealias FTS5TokenCallback = @convention(c) (
 
 /// The reason why FTS5 is requesting tokenization.
 ///
-/// See https://www.sqlite.org/fts5.html#custom_tokenizers
+/// See <https://www.sqlite.org/fts5.html#custom_tokenizers>
 public struct FTS5Tokenization: OptionSet {
     public let rawValue: Int32
     
@@ -41,7 +41,7 @@ public protocol FTS5Tokenizer: AnyObject {
     /// Tokenizes the text described by `pText` and `nText`, and
     /// notifies found tokens to the `tokenCallback` function.
     ///
-    /// It matches the `xTokenize` function documented at https://www.sqlite.org/fts5.html#custom_tokenizers
+    /// It matches the `xTokenize` function documented at <https://www.sqlite.org/fts5.html#custom_tokenizers>
     ///
     /// - parameters:
     ///     - context: An opaque pointer that is the first argument to
@@ -51,7 +51,7 @@ public protocol FTS5Tokenizer: AnyObject {
     ///       nul-terminated.
     ///     - nText: The number of bytes in the tokenized text.
     ///     - tokenCallback: The function to call for each found token.
-    ///       It matches the `xToken` callback at https://www.sqlite.org/fts5.html#custom_tokenizers
+    ///       It matches the `xToken` callback at <https://www.sqlite.org/fts5.html#custom_tokenizers>
     func tokenize(
         context: UnsafeMutableRawPointer?,
         tokenization: FTS5Tokenization,

--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -5,7 +5,7 @@
 ///         t.tokenizer = .unicode61() // FTS5TokenizerDescriptor
 ///     }
 ///
-/// See https://www.sqlite.org/fts5.html#tokenizers
+/// See <https://www.sqlite.org/fts5.html#tokenizers>
 public struct FTS5TokenizerDescriptor {
     /// The tokenizer components
     ///
@@ -55,7 +55,7 @@ public struct FTS5TokenizerDescriptor {
     ///     - tokenCharacters: Unless empty (the default), SQLite will
     ///       consider these characters as token characters.
     ///
-    /// See https://www.sqlite.org/fts5.html#ascii_tokenizer
+    /// See <https://www.sqlite.org/fts5.html#ascii_tokenizer>
     public static func ascii(
         separators: Set<Character> = [],
         tokenCharacters: Set<Character> = [])
@@ -108,7 +108,7 @@ public struct FTS5TokenizerDescriptor {
     ///     - base: An eventual wrapping tokenizer which replaces the
     //        default unicode61() base tokenizer.
     ///
-    /// See https://www.sqlite.org/fts5.html#porter_tokenizer
+    /// See <https://www.sqlite.org/fts5.html#porter_tokenizer>
     public static func porter(wrapping base: FTS5TokenizerDescriptor? = nil) -> FTS5TokenizerDescriptor {
         if let base = base {
             return FTS5TokenizerDescriptor(components: ["porter"] + base.components)
@@ -131,7 +131,7 @@ public struct FTS5TokenizerDescriptor {
     ///     - tokenCharacters: Unless empty (the default), SQLite will
     ///       consider these characters as token characters.
     ///
-    /// See https://www.sqlite.org/fts5.html#unicode61_tokenizer
+    /// See <https://www.sqlite.org/fts5.html#unicode61_tokenizer>
     public static func unicode61(
         diacritics: FTS5.Diacritics = .removeLegacy,
         separators: Set<Character> = [],

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Flags that tell SQLite how to register a token.
 ///
-/// See https://www.sqlite.org/fts5.html#custom_tokenizers
+/// See <https://www.sqlite.org/fts5.html#custom_tokenizers>
 public struct FTS5TokenFlags: OptionSet {
     public let rawValue: Int32
     
@@ -76,7 +76,7 @@ public protocol FTS5WrapperTokenizer: FTS5CustomTokenizer {
     /// 2. The input `flags` should be given unmodified to the tokenCallback
     /// function, unless you union it with the .colocated flag when the
     /// tokenizer produces synonyms (see
-    /// https://www.sqlite.org/fts5.html#synonym_support).
+    /// <https://www.sqlite.org/fts5.html#synonym_support>).
     ///
     /// - parameters:
     ///     - token: A token produced by the wrapped tokenizer

--- a/GRDB/QueryInterface/Request/Association/BelongsToAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/BelongsToAssociation.swift
@@ -44,7 +44,7 @@
 ///    SQLite guarantees that no book refers to a missing author. The
 ///    `onDelete: .cascade` option has SQLite automatically delete all of an
 ///    author's books when that author is deleted.
-///    See https://sqlite.org/foreignkeys.html#fk_actions for more information.
+///    See <https://sqlite.org/foreignkeys.html#fk_actions> for more information.
 ///
 /// The example above uses auto-incremented primary keys. But generally
 /// speaking, all primary keys are supported.

--- a/GRDB/QueryInterface/Request/Association/HasManyAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/HasManyAssociation.swift
@@ -44,7 +44,7 @@
 ///    SQLite guarantees that no book refers to a missing author. The
 ///    `onDelete: .cascade` option has SQLite automatically delete all of an
 ///    author's books when that author is deleted.
-///    See https://sqlite.org/foreignkeys.html#fk_actions for more information.
+///    See <https://sqlite.org/foreignkeys.html#fk_actions> for more information.
 ///
 /// The example above uses auto-incremented primary keys. But generally
 /// speaking, all primary keys are supported.

--- a/GRDB/QueryInterface/Request/Association/HasOneAssociation.swift
+++ b/GRDB/QueryInterface/Request/Association/HasOneAssociation.swift
@@ -46,7 +46,7 @@
 ///    country.code, so that SQLite guarantees that no profile refers to a
 ///    missing country. The `onDelete: .cascade` option has SQLite automatically
 ///    delete a profile when its country is deleted.
-///    See https://sqlite.org/foreignkeys.html#fk_actions for more information.
+///    See <https://sqlite.org/foreignkeys.html#fk_actions> for more information.
 ///
 /// The example above uses a string primary for the country table. But generally
 /// speaking, all primary keys are supported.

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -27,7 +27,7 @@
 ///         let players = try request.fetchAll(db) // [Player]
 ///     }
 ///
-/// See https://github.com/groue/GRDB.swift#the-query-interface
+/// See <https://github.com/groue/GRDB.swift#the-query-interface>
 public struct QueryInterfaceRequest<RowDecoder> {
     var relation: SQLRelation
 }

--- a/GRDB/QueryInterface/SQL/Column.swift
+++ b/GRDB/QueryInterface/SQL/Column.swift
@@ -16,7 +16,7 @@
 ///     let nameColumn = MyColumn(name: "name", sqlType: "VARCHAR")
 ///     let arthur = try Player.filter(nameColumn == "Arthur").fetchOne(db)
 ///
-/// See https://github.com/groue/GRDB.swift#the-query-interface
+/// See <https://github.com/groue/GRDB.swift#the-query-interface>
 public protocol ColumnExpression: SQLSpecificExpressible {
     /// The unqualified name of a database column.
     ///
@@ -35,7 +35,7 @@ extension ColumnExpression {
 /// When you need to introduce your own column type, don't wrap a Column.
 /// Instead, adopt the ColumnExpression protocol.
 ///
-/// See https://github.com/groue/GRDB.swift#the-query-interface
+/// See <https://github.com/groue/GRDB.swift#the-query-interface>
 public struct Column: ColumnExpression, Equatable {
     /// The hidden rowID column
     public static let rowID = Column("rowid")

--- a/GRDB/QueryInterface/SQL/SQLCollection.swift
+++ b/GRDB/QueryInterface/SQL/SQLCollection.swift
@@ -1,6 +1,6 @@
 /// The right-hand side of the `IN` or `NOT IN` SQL operators
 ///
-/// See https://sqlite.org/lang_expr.html#the_in_and_not_in_operators
+/// See <https://sqlite.org/lang_expr.html#the_in_and_not_in_operators>
 struct SQLCollection {
     private var impl: Impl
     

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -1,5 +1,5 @@
 /// SQLExpression is the type that represents an SQL expression, as
-/// described at https://www.sqlite.org/lang_expr.html
+/// described at <https://www.sqlite.org/lang_expr.html>
 public struct SQLExpression {
     private var impl: Impl
     
@@ -370,7 +370,7 @@ public typealias SQLAssociativeBinaryOperator = SQLExpression.AssociativeBinaryO
 extension SQLExpression {
     
     /// SQLite row values were shipped in SQLite 3.15:
-    /// https://www.sqlite.org/releaselog/3_15_0.html
+    /// <https://www.sqlite.org/releaselog/3_15_0.html>
     static let rowValuesAreAvailable = (sqlite3_libversion_number() >= 3015000)
     
     // MARK: Basic Expressions
@@ -1204,7 +1204,7 @@ extension SQLExpression {
     ///
     /// The `= 1` and `= 0` tests allow the SQLite query planner to
     /// optimize queries with indices on boolean columns and expressions.
-    /// See https://github.com/groue/GRDB.swift/issues/816
+    /// See <https://github.com/groue/GRDB.swift/issues/816>
     ///
     /// Some specific expressions can produce idiomatic SQL.
     ///
@@ -1559,7 +1559,7 @@ extension SQLExpression {
 /// It is adopted by protocols like `DatabaseValueConvertible`, and types
 /// like `Column`.
 ///
-/// See https://github.com/groue/GRDB.swift/#the-query-interface
+/// See <https://github.com/groue/GRDB.swift/#the-query-interface>
 public protocol SQLExpressible {
     /// Returns an SQL expression.
     var sqlExpression: SQLExpression { get }
@@ -1665,14 +1665,14 @@ extension SQLSpecificExpressible {
     
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// See <https://github.com/groue/GRDB.swift/#the-query-interface>
     public var asc: SQLOrdering {
         .asc(sqlExpression)
     }
     
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// See <https://github.com/groue/GRDB.swift/#the-query-interface>
     public var desc: SQLOrdering {
         .desc(sqlExpression)
     }
@@ -1680,21 +1680,21 @@ extension SQLSpecificExpressible {
     #if GRDBCUSTOMSQLITE
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// See <https://github.com/groue/GRDB.swift/#the-query-interface>
     public var ascNullsLast: SQLOrdering {
         .ascNullsLast(sqlExpression)
     }
     
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// See <https://github.com/groue/GRDB.swift/#the-query-interface>
     public var descNullsFirst: SQLOrdering {
         .descNullsFirst(sqlExpression)
     }
     #elseif !GRDBCIPHER
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// See <https://github.com/groue/GRDB.swift/#the-query-interface>
     @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
     public var ascNullsLast: SQLOrdering {
         .ascNullsLast(sqlExpression)
@@ -1702,7 +1702,7 @@ extension SQLSpecificExpressible {
     
     /// Returns a value that can be used as an argument to QueryInterfaceRequest.order()
     ///
-    /// See https://github.com/groue/GRDB.swift/#the-query-interface
+    /// See <https://github.com/groue/GRDB.swift/#the-query-interface>
     @available(OSX 10.16, iOS 14, tvOS 14, watchOS 7, *)
     public var descNullsFirst: SQLOrdering {
         .descNullsFirst(sqlExpression)

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -174,7 +174,7 @@ extension SQLSpecificExpressible {
 /// A date modifier for SQLite date functions such as `julianDay(_:_:)` and
 /// `dateTime(_:_:)`.
 ///
-/// For more information, see https://www.sqlite.org/lang_datefunc.html
+/// For more information, see <https://www.sqlite.org/lang_datefunc.html>
 public enum SQLDateModifier: SQLSpecificExpressible {
     /// Adds the specified amount of seconds
     case second(Double)
@@ -203,16 +203,16 @@ public enum SQLDateModifier: SQLSpecificExpressible {
     /// Shifts the date backwards to the beginning of the current year
     case startOfYear
     
-    /// See https://www.sqlite.org/lang_datefunc.html
+    /// See <https://www.sqlite.org/lang_datefunc.html>
     case weekday(Int)
     
-    /// See https://www.sqlite.org/lang_datefunc.html
+    /// See <https://www.sqlite.org/lang_datefunc.html>
     case unixEpoch
     
-    /// See https://www.sqlite.org/lang_datefunc.html
+    /// See <https://www.sqlite.org/lang_datefunc.html>
     case localTime
     
-    /// See https://www.sqlite.org/lang_datefunc.html
+    /// See <https://www.sqlite.org/lang_datefunc.html>
     case utc
     
     public var sqlExpression: SQLExpression {
@@ -261,7 +261,7 @@ public enum SQLDateModifier: SQLSpecificExpressible {
 ///     // JULIANDAY(date, '1 days')
 ///     julianDay(Column("date"), .day(1))
 ///
-/// For more information, see https://www.sqlite.org/lang_datefunc.html
+/// For more information, see <https://www.sqlite.org/lang_datefunc.html>
 public func julianDay(_ value: SQLSpecificExpressible, _ modifiers: SQLDateModifier...) -> SQLExpression {
     .function("JULIANDAY", [value.sqlExpression] + modifiers.map(\.sqlExpression))
 }
@@ -276,7 +276,7 @@ public func julianDay(_ value: SQLSpecificExpressible, _ modifiers: SQLDateModif
 ///     // DATETIME(date, '1 days')
 ///     dateTime(Column("date"), .day(1))
 ///
-/// For more information, see https://www.sqlite.org/lang_datefunc.html
+/// For more information, see <https://www.sqlite.org/lang_datefunc.html>
 public func dateTime(_ value: SQLSpecificExpressible, _ modifiers: SQLDateModifier...) -> SQLExpression {
     .function("DATETIME", [value.sqlExpression] + modifiers.map(\.sqlExpression))
 }

--- a/GRDB/QueryInterface/SQL/SQLOrdering.swift
+++ b/GRDB/QueryInterface/SQL/SQLOrdering.swift
@@ -1,5 +1,5 @@
 /// The type that can be used as an SQL ordering term, as described at
-/// https://www.sqlite.org/syntax/ordering-term.html
+/// <https://www.sqlite.org/syntax/ordering-term.html>
 public struct SQLOrdering {
     private var impl: Impl
     
@@ -117,7 +117,7 @@ extension SQLOrdering {
 // MARK: - SQLOrderingTerm
 
 /// The protocol for all types that can be used as an SQL ordering term, as
-/// described at https://www.sqlite.org/syntax/ordering-term.html
+/// described at <https://www.sqlite.org/syntax/ordering-term.html>
 public protocol SQLOrderingTerm {
     /// Returns an SQL ordering.
     var sqlOrdering: SQLOrdering { get }

--- a/GRDB/QueryInterface/SQL/SQLSelection.swift
+++ b/GRDB/QueryInterface/SQL/SQLSelection.swift
@@ -1,5 +1,5 @@
 /// The type that can be selected, as described at
-/// https://www.sqlite.org/syntax/result-column.html
+/// <https://www.sqlite.org/syntax/result-column.html>
 public struct SQLSelection {
     private var impl: Impl
     
@@ -175,7 +175,7 @@ extension SQLSelection {
     ///     COUNT(*)
     ///     (score + bonus) AS total
     ///
-    /// See https://sqlite.org/syntax/result-column.html
+    /// See <https://sqlite.org/syntax/result-column.html>
     ///
     /// - parameter context: An SQL generation context which accepts
     ///   statement arguments.
@@ -285,7 +285,7 @@ enum SQLCount {
 // MARK: - SQLSelectable
 
 /// SQLSelectable is the protocol for types that can be selected, as
-/// described at https://www.sqlite.org/syntax/result-column.html
+/// described at <https://www.sqlite.org/syntax/result-column.html>
 public protocol SQLSelectable {
     /// Returns an SQL selection.
     var sqlSelection: SQLSelection { get }

--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -12,8 +12,8 @@ extension Database {
     ///         t.column("latitude", .double).notNull()
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html and
-    /// https://www.sqlite.org/withoutrowid.html
+    /// See <https://www.sqlite.org/lang_createtable.html> and
+    /// <https://www.sqlite.org/withoutrowid.html>
     ///
     /// - parameters:
     ///     - name: The table name.
@@ -44,7 +44,7 @@ extension Database {
     
     /// Renames a database table.
     ///
-    /// See https://www.sqlite.org/lang_altertable.html
+    /// See <https://www.sqlite.org/lang_altertable.html>
     ///
     /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func rename(table name: String, to newName: String) throws {
@@ -57,7 +57,7 @@ extension Database {
     ///         t.add(column: "url", .text)
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_altertable.html
+    /// See <https://www.sqlite.org/lang_altertable.html>
     ///
     /// - parameters:
     ///     - name: The table name.
@@ -72,7 +72,7 @@ extension Database {
     
     /// Deletes a database table.
     ///
-    /// See https://www.sqlite.org/lang_droptable.html
+    /// See <https://www.sqlite.org/lang_droptable.html>
     ///
     /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func drop(table name: String) throws {
@@ -89,7 +89,7 @@ extension Database {
     ///
     ///     try db.execute(sql: "CREATE INDEX ...")
     ///
-    /// See https://www.sqlite.org/lang_createindex.html
+    /// See <https://www.sqlite.org/lang_createindex.html>
     ///
     /// - parameters:
     ///     - name: The index name.
@@ -98,7 +98,7 @@ extension Database {
     ///     - unique: If true, creates a unique index.
     ///     - ifNotExists: If false, no error is thrown if index already exists.
     ///     - condition: If not nil, creates a partial index
-    ///       (see https://www.sqlite.org/partialindex.html).
+    ///       (see <https://www.sqlite.org/partialindex.html>).
     public func create(
         index name: String,
         on table: String,
@@ -121,7 +121,7 @@ extension Database {
     
     /// Deletes a database index.
     ///
-    /// See https://www.sqlite.org/lang_dropindex.html
+    /// See <https://www.sqlite.org/lang_dropindex.html>
     ///
     /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func drop(index name: String) throws {
@@ -133,7 +133,7 @@ extension Database {
     /// This method is useful when the definition of a collation sequence
     /// has changed.
     ///
-    /// See https://www.sqlite.org/lang_reindex.html
+    /// See <https://www.sqlite.org/lang_reindex.html>
     ///
     /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func reindex(collation: Database.CollationName) throws {
@@ -145,7 +145,7 @@ extension Database {
     /// This method is useful when the definition of a collation sequence
     /// has changed.
     ///
-    /// See https://www.sqlite.org/lang_reindex.html
+    /// See <https://www.sqlite.org/lang_reindex.html>
     ///
     /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func reindex(collation: DatabaseCollation) throws {
@@ -162,7 +162,7 @@ extension Database {
 ///         t.column(...)
 ///     }
 ///
-/// See https://www.sqlite.org/lang_createtable.html
+/// See <https://www.sqlite.org/lang_createtable.html>
 public final class TableDefinition {
     private typealias KeyConstraint = (
         columns: [String],
@@ -238,11 +238,11 @@ public final class TableDefinition {
     /// asynchronous process, even if this row gets deleted and a new one is
     /// inserted in between.
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#primkeyconst and
-    /// https://www.sqlite.org/lang_createtable.html#rowid
+    /// See <https://www.sqlite.org/lang_createtable.html#primkeyconst> and
+    /// <https://www.sqlite.org/lang_createtable.html#rowid>
     ///
     /// - parameter conflictResolution: An optional conflict resolution
-    ///   (see https://www.sqlite.org/lang_conflict.html).
+    ///   (see <https://www.sqlite.org/lang_conflict.html>).
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func autoIncrementedPrimaryKey(
@@ -259,7 +259,7 @@ public final class TableDefinition {
     ///         t.column("name", .text)
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#tablecoldef
+    /// See <https://www.sqlite.org/lang_createtable.html#tablecoldef>
     ///
     /// - parameter name: the column name.
     /// - parameter type: the eventual column type.
@@ -305,12 +305,12 @@ public final class TableDefinition {
     ///         t.primaryKey(["citizenID", "countryCode"])
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#primkeyconst and
-    /// https://www.sqlite.org/lang_createtable.html#rowid
+    /// See <https://www.sqlite.org/lang_createtable.html#primkeyconst> and
+    /// <https://www.sqlite.org/lang_createtable.html#rowid>
     ///
     /// - parameter columns: The primary key columns.
     /// - parameter conflictResolution: An optional conflict resolution
-    ///   (see https://www.sqlite.org/lang_conflict.html).
+    ///   (see <https://www.sqlite.org/lang_conflict.html>).
     public func primaryKey(_ columns: [String], onConflict conflictResolution: Database.ConflictResolution? = nil) {
         guard primaryKeyConstraint == nil else {
             // Programmer error
@@ -327,11 +327,11 @@ public final class TableDefinition {
     ///         t.uniqueKey(["latitude", "longitude"])
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#uniqueconst
+    /// See <https://www.sqlite.org/lang_createtable.html#uniqueconst>
     ///
     /// - parameter columns: The unique key columns.
     /// - parameter conflictResolution: An optional conflict resolution
-    ///   (see https://www.sqlite.org/lang_conflict.html).
+    ///   (see <https://www.sqlite.org/lang_conflict.html>).
     public func uniqueKey(_ columns: [String], onConflict conflictResolution: Database.ConflictResolution? = nil) {
         uniqueKeyConstraints.append((columns: columns, conflictResolution: conflictResolution))
     }
@@ -345,7 +345,7 @@ public final class TableDefinition {
     ///         t.foreignKey(["citizenID", "countryCode"], references: "citizenship", onDelete: .cascade)
     ///     }
     ///
-    /// See https://www.sqlite.org/foreignkeys.html
+    /// See <https://www.sqlite.org/foreignkeys.html>
     ///
     /// - parameters:
     ///     - columns: The foreign key columns.
@@ -356,7 +356,7 @@ public final class TableDefinition {
     ///     - deleteAction: Optional action when the referenced row is deleted.
     ///     - updateAction: Optional action when the referenced row is updated.
     ///     - deferred: If true, defines a deferred foreign key constraint.
-    ///       See https://www.sqlite.org/foreignkeys.html#fk_deferred.
+    ///       See <https://www.sqlite.org/foreignkeys.html#fk_deferred>.
     public func foreignKey(
         _ columns: [String],
         references table: String,
@@ -384,7 +384,7 @@ public final class TableDefinition {
     ///         t.check(personalPhone != nil || workPhone != nil)
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    /// See <https://www.sqlite.org/lang_createtable.html#ckconst>
     ///
     /// - parameter condition: The checked condition
     public func check(_ condition: SQLExpressible) {
@@ -399,7 +399,7 @@ public final class TableDefinition {
     ///         t.check(sql: "personalPhone IS NOT NULL OR workPhone IS NOT NULL")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    /// See <https://www.sqlite.org/lang_createtable.html#ckconst>
     ///
     /// - parameter sql: An SQL snippet
     public func check(sql: String) {
@@ -572,7 +572,7 @@ public final class TableDefinition {
 ///         t.add(column: ...)
 ///     }
 ///
-/// See https://www.sqlite.org/lang_altertable.html
+/// See <https://www.sqlite.org/lang_altertable.html>
 public final class TableAlteration {
     private let name: String
     
@@ -594,7 +594,7 @@ public final class TableAlteration {
     ///         t.add(column: "url", .text)
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_altertable.html
+    /// See <https://www.sqlite.org/lang_altertable.html>
     ///
     /// - parameter name: the column name.
     /// - parameter type: the column type.
@@ -638,7 +638,7 @@ public final class TableAlteration {
     ///         t.rename(column: "url", to: "homeURL")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_altertable.html
+    /// See <https://www.sqlite.org/lang_altertable.html>
     ///
     /// - parameter name: the column name to rename.
     /// - parameter newName: the new name of the column.
@@ -652,7 +652,7 @@ public final class TableAlteration {
     ///         t.rename(column: "url", to: "homeURL")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_altertable.html
+    /// See <https://www.sqlite.org/lang_altertable.html>
     ///
     /// - parameter name: the column name to rename.
     /// - parameter newName: the new name of the column.
@@ -723,8 +723,8 @@ public final class TableAlteration {
 ///         t.add(column: ...) // ColumnDefinition
 ///     }
 ///
-/// See https://www.sqlite.org/lang_createtable.html and
-/// https://www.sqlite.org/lang_altertable.html
+/// See <https://www.sqlite.org/lang_createtable.html> and
+/// <https://www.sqlite.org/lang_altertable.html>
 public final class ColumnDefinition {
     enum Index {
         case none
@@ -743,7 +743,7 @@ public final class ColumnDefinition {
     /// The `GeneratedColumnQualification` enum defines whether a generated
     /// column sis virtual or stored.
     ///
-    /// See https://sqlite.org/gencol.html#virtual_versus_stored_columns
+    /// See <https://sqlite.org/gencol.html#virtual_versus_stored_columns>
     public enum GeneratedColumnQualification {
         case virtual
         case stored
@@ -776,12 +776,12 @@ public final class ColumnDefinition {
     ///         t.column("id", .integer).primaryKey()
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#primkeyconst and
-    /// https://www.sqlite.org/lang_createtable.html#rowid
+    /// See <https://www.sqlite.org/lang_createtable.html#primkeyconst> and
+    /// <https://www.sqlite.org/lang_createtable.html#rowid>
     ///
     /// - parameters:
     ///     - conflictResolution: An optional conflict resolution
-    ///       (see https://www.sqlite.org/lang_conflict.html).
+    ///       (see <https://www.sqlite.org/lang_conflict.html>).
     ///     - autoincrement: If true, the primary key is autoincremented.
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
@@ -800,10 +800,10 @@ public final class ColumnDefinition {
     ///         t.column("name", .text).notNull()
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#notnullconst
+    /// See <https://www.sqlite.org/lang_createtable.html#notnullconst>
     ///
     /// - parameter conflictResolution: An optional conflict resolution
-    ///   (see https://www.sqlite.org/lang_conflict.html).
+    ///   (see <https://www.sqlite.org/lang_conflict.html>).
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func notNull(onConflict conflictResolution: Database.ConflictResolution? = nil) -> Self {
@@ -817,10 +817,10 @@ public final class ColumnDefinition {
     ///         t.column("email", .text).unique()
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#uniqueconst
+    /// See <https://www.sqlite.org/lang_createtable.html#uniqueconst>
     ///
     /// - parameter conflictResolution: An optional conflict resolution
-    ///   (see https://www.sqlite.org/lang_conflict.html).
+    ///   (see <https://www.sqlite.org/lang_conflict.html>).
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func unique(onConflict conflictResolution: Database.ConflictResolution? = nil) -> Self {
@@ -834,7 +834,7 @@ public final class ColumnDefinition {
     ///         t.column("email", .text).indexed()
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#uniqueconst
+    /// See <https://www.sqlite.org/lang_createtable.html#uniqueconst>
     ///
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
@@ -851,7 +851,7 @@ public final class ColumnDefinition {
     ///         t.column("name", .text).check { length($0) > 0 }
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    /// See <https://www.sqlite.org/lang_createtable.html#ckconst>
     ///
     /// - parameter condition: A closure whose argument is an Column that
     ///   represents the defined column, and returns the expression to check.
@@ -868,7 +868,7 @@ public final class ColumnDefinition {
     ///         t.column("name", .text).check(sql: "LENGTH(name) > 0")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#ckconst
+    /// See <https://www.sqlite.org/lang_createtable.html#ckconst>
     ///
     /// - parameter sql: An SQL snippet.
     /// - returns: Self so that you can further refine the column definition.
@@ -884,7 +884,7 @@ public final class ColumnDefinition {
     ///         t.column("name", .text).defaults(to: "Anonymous")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#dfltval
+    /// See <https://www.sqlite.org/lang_createtable.html#dfltval>
     ///
     /// - parameter value: A DatabaseValueConvertible value.
     /// - returns: Self so that you can further refine the column definition.
@@ -900,7 +900,7 @@ public final class ColumnDefinition {
     ///         t.column("creationDate", .DateTime).defaults(sql: "CURRENT_TIMESTAMP")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html#dfltval
+    /// See <https://www.sqlite.org/lang_createtable.html#dfltval>
     ///
     /// - parameter sql: An SQL snippet.
     /// - returns: Self so that you can further refine the column definition.
@@ -916,7 +916,7 @@ public final class ColumnDefinition {
     ///         t.column("email", .text).collate(.nocase)
     ///     }
     ///
-    /// See https://www.sqlite.org/datatype3.html#collation
+    /// See <https://www.sqlite.org/datatype3.html#collation>
     ///
     /// - parameter collation: An Database.CollationName.
     /// - returns: Self so that you can further refine the column definition.
@@ -932,7 +932,7 @@ public final class ColumnDefinition {
     ///         t.column("name", .text).collate(.localizedCaseInsensitiveCompare)
     ///     }
     ///
-    /// See https://www.sqlite.org/datatype3.html#collation
+    /// See <https://www.sqlite.org/datatype3.html#collation>
     ///
     /// - parameter collation: A custom DatabaseCollation.
     /// - returns: Self so that you can further refine the column definition.
@@ -952,7 +952,7 @@ public final class ColumnDefinition {
     ///         t.column("totalScore", .integer).generatedAs(sql: "score + bonus", .stored)
     ///     }
     ///
-    /// See https://sqlite.org/gencol.html. Note particularly the limitations of
+    /// See <https://sqlite.org/gencol.html>. Note particularly the limitations of
     /// generated columns, e.g. they may not have a default value.
     ///
     /// - parameters:
@@ -982,7 +982,7 @@ public final class ColumnDefinition {
     ///         t.column("totalScore", .integer).generatedAs(Column("score") + Column("bonus"), .stored)
     ///     }
     ///
-    /// See https://sqlite.org/gencol.html. Note particularly the limitations of
+    /// See <https://sqlite.org/gencol.html>. Note particularly the limitations of
     /// generated columns, e.g. they may not have a default value.
     ///
     /// - parameters:
@@ -1009,7 +1009,7 @@ public final class ColumnDefinition {
     ///         t.column("authorId", .integer).references("author", onDelete: .cascade)
     ///     }
     ///
-    /// See https://www.sqlite.org/foreignkeys.html
+    /// See <https://www.sqlite.org/foreignkeys.html>
     ///
     /// - parameters
     ///     - table: The referenced table.
@@ -1018,7 +1018,7 @@ public final class ColumnDefinition {
     ///     - deleteAction: Optional action when the referenced row is deleted.
     ///     - updateAction: Optional action when the referenced row is updated.
     ///     - deferred: If true, defines a deferred foreign key constraint.
-    ///       See https://www.sqlite.org/foreignkeys.html#fk_deferred.
+    ///       See <https://www.sqlite.org/foreignkeys.html#fk_deferred>.
     /// - returns: Self so that you can further refine the column definition.
     @discardableResult
     public func references(

--- a/GRDB/QueryInterface/Schema/VirtualTableModule.swift
+++ b/GRDB/QueryInterface/Schema/VirtualTableModule.swift
@@ -71,7 +71,7 @@ extension Database {
     ///
     ///     try db.create(virtualTable: "vocabulary", using: "spellfix1")
     ///
-    /// See https://www.sqlite.org/lang_createtable.html
+    /// See <https://www.sqlite.org/lang_createtable.html>
     ///
     /// - parameters:
     ///     - name: The table name.
@@ -112,7 +112,7 @@ extension Database {
     ///         t.column("body")
     ///     }
     ///
-    /// See https://www.sqlite.org/lang_createtable.html
+    /// See <https://www.sqlite.org/lang_createtable.html>
     ///
     /// - parameters:
     ///     - name: The table name.

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -38,7 +38,7 @@ extension PersistenceError {
 ///
 /// See `MutablePersistableRecord.persistenceConflictPolicy`.
 ///
-/// See https://www.sqlite.org/lang_conflict.html
+/// See <https://www.sqlite.org/lang_conflict.html>
 public struct PersistenceConflictPolicy {
     /// The conflict resolution algorithm for insertions
     public let conflictResolutionForInsert: Database.ConflictResolution
@@ -67,7 +67,7 @@ public protocol MutablePersistableRecord: EncodableRecord, TableRecord {
     /// `didInsert(with:for:)` method is not called upon successful insertion,
     /// even if a row was actually inserted without any conflict.
     ///
-    /// See https://www.sqlite.org/lang_conflict.html
+    /// See <https://www.sqlite.org/lang_conflict.html>
     static var persistenceConflictPolicy: PersistenceConflictPolicy { get }
     
     /// Notifies the record that it was successfully inserted.

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -55,7 +55,7 @@ open class Record: FetchableRecord, TableRecord, PersistableRecord {
     /// `didInsert(with:for:)` method is not called upon successful insertion,
     /// even if a row was actually inserted without any conflict.
     ///
-    /// See https://www.sqlite.org/lang_conflict.html
+    /// See <https://www.sqlite.org/lang_conflict.html>
     open class var persistenceConflictPolicy: PersistenceConflictPolicy {
         PersistenceConflictPolicy(insert: .abort, update: .abort)
     }

--- a/GRDB/Utils/ReceiveValuesOn.swift
+++ b/GRDB/Utils/ReceiveValuesOn.swift
@@ -10,7 +10,7 @@ import Foundation
 ///
 /// This scheduling guarantee is used by GRDB in order to be able
 /// to make promises on the scheduling of database values without surprising
-/// the users as in https://forums.swift.org/t/28631.
+/// the users as in <https://forums.swift.org/t/28631>.
 @available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct ReceiveValuesOn<Upstream: Publisher, Context: Scheduler>: Publisher {
     typealias Output = Upstream.Output

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -8,7 +8,7 @@ extension String {
     ///
     ///     db.execute(sql: "SELECT * FROM \(tableName.quotedDatabaseIdentifier)")
     @inlinable public var quotedDatabaseIdentifier: String {
-        // See https://www.sqlite.org/lang_keywords.html
+        // See <https://www.sqlite.org/lang_keywords.html>
         return "\"\(self)\""
     }
 }
@@ -45,8 +45,8 @@ func GRDBPrecondition(
     line: UInt = #line)
 {
     /// Custom precondition function which aims at solving
-    /// https://bugs.swift.org/browse/SR-905 and
-    /// https://github.com/groue/GRDB.swift/issues/37
+    /// <https://bugs.swift.org/browse/SR-905> and
+    /// <https://github.com/groue/GRDB.swift/issues/37>
     if !condition() {
         fatalError(message(), file: file, line: line)
     }


### PR DESCRIPTION
Adds angle brackets around all URLs in doc comments, which makes them clickable in Xcode's rendered documentation views. Also adds a lint rule to ensure that this style is maintained throughout the code base.

Note: the regex is slightly lazy in that does not look at the end of the URL. It's probably possible to make such a regex, but it might be ungainly enough that it's not worth it. Happy to take a crack at it if you think it's necessary.

Before:

<img width="261" alt="A screenshot of some documentation rendered in Xcode's Quick Help Inspector. There is a URL, but it is not styled differently than the rest of the text." src="https://user-images.githubusercontent.com/464574/126414886-a39059f2-6f76-4610-839b-6ab5f1eddfb8.png">

After:

<img width="263" alt="A screenshot of some documentation rendered in Xcode's Quick Help Inspector. There is a URL, and it is rendered in blue, indicating that it is clickable." src="https://user-images.githubusercontent.com/464574/126414892-0b855533-0b5f-4232-baa6-f07874157196.png">

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.
