### PR TITLE
Merge prepared statement types, and introduce statement cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - **New**: Types that adopt both `DatabaseValueConvertible` and `Codable` now profit from automatic JSON encoding and decoding.
 - **New**: [#1010](https://github.com/groue/GRDB.swift/pull/1010) by [@tternes](https://github.com/tternes): Add VACUUM INTO Support
 - **New**: [#1012](https://github.com/groue/GRDB.swift/pull/1012) by [@ZevEisenberg](https://github.com/ZevEisenberg): Add brackets to urls in doc comments to make them clickable
+- **New**: [#1019](https://github.com/groue/GRDB.swift/pull/1019) by [@groue](https://github.com/groue): Merge prepared statement types, and introduce statement cursor
 - **Documentation Update**: The [Requests](README.md#requests) chapter was updated for the new `Table` type that can build requests without any record type.
 - **Documentation Update**: The [Custom Value Types](README.md#custom-value-types) chapter was extended about the new support for codable value types encoded as JSON arrays or objects.
+- **Documentation Update**: The [Fetching Methods](README.md#fetching-methods) and [Prepared Statements](README.md#prepared-statements) chapters have been updated for the unique `Statement` class, and the new `Database.allStatements()` method.
 
 
 ## 5.8.0

--- a/Documentation/Playgrounds/CustomizedDecodingOfDatabaseRows.playground/Contents.swift
+++ b/Documentation/Playgrounds/CustomizedDecodingOfDatabaseRows.playground/Contents.swift
@@ -212,30 +212,30 @@ extension Base: MyDatabaseDecoder {
 //: **prepared statement**:
 //:
 //:     try dbQueue.read { db in
-//:         let statement = try db.makeSelectStatement(sql: "SELECT ...")
+//:         let statement = try db.makeStatement(sql: "SELECT ...")
 //:         try Base.fetchCursor(statement) // Cursor of Base
 //:         try Base.fetchAll(statement)    // [Base]
 //:         try Base.fetchOne(statement)    // Base?
 //:     }
 
 extension MyDatabaseDecoder {
-    // MARK: - Fetch from SelectStatement
+    // MARK: - Fetch from Prepared Statement
     
-    // SelectStatement, StatementArguments, and RowAdapter are the fundamental
+    // Statement, StatementArguments, and RowAdapter are the fundamental
     // fetching parameters of GRDB. Make sure to accept them all:
-    static func fetchCursor(_ statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> MapCursor<RowCursor, DecodedType> {
+    static func fetchCursor(_ statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> MapCursor<RowCursor, DecodedType> {
         // Turn the cursor of raw rows into a cursor of decoded rows
         return try Row.fetchCursor(statement, arguments: arguments, adapter: adapter).map {
             self.decode(row: $0)
         }
     }
     
-    static func fetchAll(_ statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> [DecodedType] {
+    static func fetchAll(_ statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> [DecodedType] {
         // Turn the cursor into an Array
         return try Array(fetchCursor(statement, arguments: arguments, adapter: adapter))
     }
     
-    static func fetchOne(_ statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> DecodedType? {
+    static func fetchOne(_ statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws -> DecodedType? {
         // Consume the first value of the cursor
         return try fetchCursor(statement, arguments: arguments, adapter: adapter).next()
     }
@@ -243,7 +243,7 @@ extension MyDatabaseDecoder {
 
 try dbQueue.read { db in
     print("> Fetch from prepared statement")
-    let statement = try db.makeSelectStatement(sql: "SELECT * FROM base")
+    let statement = try db.makeStatement(sql: "SELECT * FROM base")
     let bases = try Base.fetchAll(statement)
     for base in bases {
         print(base.description)
@@ -422,7 +422,7 @@ protocol ContextFetchableRecord {
 
 extension ContextFetchableRecord {
     static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil,
         context: Context)
@@ -454,7 +454,7 @@ protocol FailableFetchableRecord {
 
 extension FailableFetchableRecord {
     static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
         throws -> MapCursor<RowCursor, Self>

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -57,8 +57,8 @@ extension Database {
         SchedulingWatchdog.preconditionValidQueue(self)
         schemaCache.clear()
         
-        // We also clear updateStatementCache and selectStatementCache despite
-        // the automatic statement recompilation (see https://www.sqlite.org/c3ref/prepare.html)
+        // We also clear statement cache despite the automatic statement
+        // recompilation (see https://www.sqlite.org/c3ref/prepare.html)
         // because the automatic statement recompilation only happens a
         // limited number of times.
         internalStatementCache.clear()
@@ -68,7 +68,7 @@ extension Database {
     /// Clears the database schema cache if the database schema has changed
     /// since this method was last called.
     func clearSchemaCacheIfNeeded() throws {
-        let schemaVersion = try Int32.fetchOne(internalCachedSelectStatement(sql: "PRAGMA schema_version"))
+        let schemaVersion = try Int32.fetchOne(internalCachedStatement(sql: "PRAGMA schema_version"))
         if _lastSchemaVersion != schemaVersion {
             _lastSchemaVersion = schemaVersion
             clearSchemaCache()
@@ -295,7 +295,7 @@ extension Database {
             //
             // TODO: find a way to know if a table is WITHOUT ROWID without
             // generating an error.
-            _ = try makeSelectStatement(sql: """
+            _ = try makeStatement(sql: """
                 SELECT rowid AS checkWithoutRowidOptimization FROM \(table.quotedDatabaseIdentifier)
                 """)
             return true

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -6,21 +6,78 @@ extension Database {
     
     /// Returns a new prepared statement that can be reused.
     ///
+    ///     let statement = try db.makeStatement(sql: "SELECT * FROM player WHERE id = ?")
+    ///     let player1 = try Player.fetchOne(statement, arguments: [1])!
+    ///     let player2 = try Player.fetchOne(statement, arguments: [2])!
+    ///
+    ///     let statement = try db.makeStatement(sql: "INSERT INTO player (name) VALUES (?)")
+    ///     try statement.execute(arguments: ["Arthur"])
+    ///     try statement.execute(arguments: ["Barbara"])
+    ///
+    /// - parameter sql: An SQL query.
+    /// - returns: A Statement.
+    /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
+    public func makeStatement(sql: String) throws -> Statement {
+        try makeStatement(sql: sql, prepFlags: 0)
+    }
+    
+    /// Returns a new prepared statement that can be reused.
+    ///
+    ///     let statement = try db.makeStatement(literal: "SELECT * FROM player WHERE id = ?")
+    ///     let player1 = try Player.fetchOne(statement, arguments: [1])!
+    ///     let player2 = try Player.fetchOne(statement, arguments: [2])!
+    ///
+    ///     let statement = try db.makeStatement(literal: "INSERT INTO player (name) VALUES (?)")
+    ///     try statement.execute(arguments: ["Arthur"])
+    ///     try statement.execute(arguments: ["Barbara"])
+    ///
+    /// - parameter sqlLiteral: An `SQL` literal.
+    /// - returns: A Statement.
+    /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
+    /// - precondition: No argument must be set, or all arguments must be set.
+    ///   A fatal error is raised otherwise.
+    ///
+    ///         // OK
+    ///         try makeStatement(literal: """
+    ///             SELECT COUNT(*) FROM player WHERE score > ?
+    ///             """)
+    ///         try makeStatement(literal: """
+    ///             SELECT COUNT(*) FROM player WHERE score > \(1000)
+    ///             """)
+    ///
+    ///         // NOT OK
+    ///         try makeStatement(literal: """
+    ///             SELECT COUNT(*) FROM player
+    ///             WHERE color = ? AND score > \(1000)
+    ///             """)
+    public func makeStatement(literal sqlLiteral: SQL) throws -> Statement {
+        let (sql, arguments) = try sqlLiteral.build(self)
+        let statement = try makeStatement(sql: sql)
+        if arguments.isEmpty == false {
+            // Crash if arguments do not match
+            statement.arguments = arguments
+        }
+        return statement
+    }
+    
+    /// Returns a new prepared statement that can be reused.
+    ///
     ///     let statement = try db.makeSelectStatement(sql: "SELECT * FROM player WHERE id = ?")
     ///     let player1 = try Player.fetchOne(statement, arguments: [1])!
     ///     let player2 = try Player.fetchOne(statement, arguments: [2])!
     ///
     /// - parameter sql: An SQL query.
-    /// - returns: A SelectStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
-    public func makeSelectStatement(sql: String) throws -> SelectStatement {
-        try makeSelectStatement(sql: sql, prepFlags: 0)
+    @available(*, deprecated, renamed: "makeStatement(sql:)")
+    public func makeSelectStatement(sql: String) throws -> Statement {
+        try makeStatement(sql: sql)
     }
     
     /// Returns a new prepared statement that can be reused.
     ///
     /// - parameter sqlLiteral: An `SQL` literal.
-    /// - returns: A SelectStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
     /// - precondition: No argument must be set, or all arguments must be set.
     ///   A fatal error is raised otherwise.
@@ -38,29 +95,83 @@ extension Database {
     ///             SELECT COUNT(*) FROM player
     ///             WHERE color = ? AND score > \(1000)
     ///             """)
-    public func makeSelectStatement(literal sqlLiteral: SQL) throws -> SelectStatement {
-        let (sql, arguments) = try sqlLiteral.build(self)
-        let statement = try makeSelectStatement(sql: sql)
-        if arguments.isEmpty == false {
-            // Crash if arguments do not match
-            statement.arguments = arguments
-        }
-        return statement
+    @available(*, deprecated, renamed: "makeStatement(literal:)")
+    public func makeSelectStatement(literal sqlLiteral: SQL) throws -> Statement {
+        try makeStatement(literal: sqlLiteral)
     }
     
     /// Returns a new prepared statement that can be reused.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM player WHERE score > ?", prepFlags: 0)
+    ///     let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM player WHERE score > ?", prepFlags: 0)
     ///     let moreThanTwentyCount = try Int.fetchOne(statement, arguments: [20])!
     ///     let moreThanThirtyCount = try Int.fetchOne(statement, arguments: [30])!
     ///
     /// - parameter sql: An SQL query.
     /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
     ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
-    /// - returns: A SelectStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
-    func makeSelectStatement(sql: String, prepFlags: Int32) throws -> SelectStatement {
-        try SelectStatement.prepare(self, sql: sql, prepFlags: prepFlags)
+    func makeStatement(sql: String, prepFlags: Int32) throws -> Statement {
+        try Statement.prepare(self, sql: sql, prepFlags: prepFlags)
+    }
+    
+    /// Returns a prepared statement that can be reused.
+    ///
+    ///     let statement = try db.cachedStatement(sql: "SELECT * FROM player WHERE id = ?")
+    ///     let player1 = try Player.fetchOne(statement, arguments: [1])!
+    ///     let player2 = try Player.fetchOne(statement, arguments: [2])!
+    ///
+    ///     let statement = try db.cachedStatement(sql: "INSERT INTO player (name) VALUES (?)")
+    ///     try statement.execute(arguments: ["Arthur"])
+    ///     try statement.execute(arguments: ["Barbara"])
+    ///
+    /// The returned statement may have already been used: it may or may not
+    /// contain values for its eventual arguments.
+    ///
+    /// - parameter sql: An SQL query.
+    /// - returns: A Statement.
+    /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
+    public func cachedStatement(sql: String) throws -> Statement {
+        try publicStatementCache.statement(sql)
+    }
+    
+    /// Returns a prepared statement that can be reused.
+    ///
+    ///     let statement = try db.cachedStatement(literal: "SELECT * FROM player WHERE id = ?")
+    ///     let player1 = try Player.fetchOne(statement, arguments: [1])!
+    ///     let player2 = try Player.fetchOne(statement, arguments: [2])!
+    ///
+    ///     let statement = try db.cachedStatement(literal: "INSERT INTO player (name) VALUES (?)")
+    ///     try statement.execute(arguments: ["Arthur"])
+    ///     try statement.execute(arguments: ["Barbara"])
+    ///
+    /// - parameter sqlLiteral: An `SQL` literal.
+    /// - returns: A Statement.
+    /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
+    /// - precondition: No argument must be set, or all arguments must be set.
+    ///   A fatal error is raised otherwise.
+    ///
+    ///         // OK
+    ///         try cachedStatement(literal: """
+    ///             SELECT COUNT(*) FROM player WHERE score > ?
+    ///             """)
+    ///         try cachedStatement(literal: """
+    ///             SELECT COUNT(*) FROM player WHERE score > \(1000)
+    ///             """)
+    ///
+    ///         // NOT OK
+    ///         try cachedStatement(literal: """
+    ///             SELECT COUNT(*) FROM player
+    ///             WHERE color = ? AND score > \(1000)
+    ///             """)
+    public func cachedStatement(literal sqlLiteral: SQL) throws -> Statement {
+        let (sql, arguments) = try sqlLiteral.build(self)
+        let statement = try cachedStatement(sql: sql)
+        if arguments.isEmpty == false {
+            // Crash if arguments do not match
+            statement.arguments = arguments
+        }
+        return statement
     }
     
     /// Returns a prepared statement that can be reused.
@@ -73,10 +184,11 @@ extension Database {
     /// contain values for its eventual arguments.
     ///
     /// - parameter sql: An SQL query.
-    /// - returns: An UpdateStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
-    public func cachedSelectStatement(sql: String) throws -> SelectStatement {
-        try publicStatementCache.selectStatement(sql)
+    @available(*, deprecated, renamed: "cachedStatement(sql:)")
+    public func cachedSelectStatement(sql: String) throws -> Statement {
+        try cachedStatement(sql: sql)
     }
     
     /// Returns a prepared statement that can be reused.
@@ -85,7 +197,7 @@ extension Database {
     ///     let moreThanTwentyCount = try Int.fetchOne(statement)!
     ///
     /// - parameter sqlLiteral: An `SQL` literal.
-    /// - returns: A SelectStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
     /// - precondition: No argument must be set, or all arguments must be set.
     ///   A fatal error is raised otherwise.
@@ -103,19 +215,14 @@ extension Database {
     ///             SELECT COUNT(*) FROM player
     ///             WHERE color = ? AND score > \(1000)
     ///             """)
-    public func cachedSelectStatement(literal sqlLiteral: SQL) throws -> SelectStatement {
-        let (sql, arguments) = try sqlLiteral.build(self)
-        let statement = try cachedSelectStatement(sql: sql)
-        if arguments.isEmpty == false {
-            // Crash if arguments do not match
-            statement.arguments = arguments
-        }
-        return statement
+    @available(*, deprecated, renamed: "cachedStatement(literal:)")
+    public func cachedSelectStatement(literal sqlLiteral: SQL) throws -> Statement {
+        try cachedStatement(literal: sqlLiteral)
     }
     
     /// Returns a cached statement that does not conflict with user's cached statements.
-    func internalCachedSelectStatement(sql: String) throws -> SelectStatement {
-        try internalStatementCache.selectStatement(sql)
+    func internalCachedStatement(sql: String) throws -> Statement {
+        try internalStatementCache.statement(sql)
     }
     
     /// Returns a new prepared statement that can be reused.
@@ -127,14 +234,15 @@ extension Database {
     /// - parameter sql: An SQL query.
     /// - returns: An UpdateStatement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
-    public func makeUpdateStatement(sql: String) throws -> UpdateStatement {
-        try makeUpdateStatement(sql: sql, prepFlags: 0)
+    @available(*, deprecated, renamed: "makeStatement(sql:)")
+    public func makeUpdateStatement(sql: String) throws -> Statement {
+        try makeStatement(sql: sql)
     }
     
     /// Returns a new prepared statement that can be reused.
     ///
     /// - parameter sqlLiteral: An `SQL` literal.
-    /// - returns: An UpdateStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
     /// - precondition: No argument must be set, or all arguments must be set.
     ///   A fatal error is raised otherwise.
@@ -151,29 +259,9 @@ extension Database {
     ///         try makeUpdateStatement(literal: """
     ///             UPDATE player SET name = ?, score = \(10)
     ///             """)
-    public func makeUpdateStatement(literal sqlLiteral: SQL) throws -> UpdateStatement {
-        let (sql, arguments) = try sqlLiteral.build(self)
-        let statement = try makeUpdateStatement(sql: sql)
-        if arguments.isEmpty == false {
-            // Crash if arguments do not match
-            statement.arguments = arguments
-        }
-        return statement
-    }
-    
-    /// Returns a new prepared statement that can be reused.
-    ///
-    ///     let statement = try db.makeUpdateStatement(sql: "INSERT INTO player (name) VALUES (?)", prepFlags: 0)
-    ///     try statement.execute(arguments: ["Arthur"])
-    ///     try statement.execute(arguments: ["Barbara"])
-    ///
-    /// - parameter sql: An SQL query.
-    /// - parameter prepFlags: Flags for sqlite3_prepare_v3 (available from
-    ///   SQLite 3.20.0, see <http://www.sqlite.org/c3ref/prepare.html>)
-    /// - returns: An UpdateStatement.
-    /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
-    func makeUpdateStatement(sql: String, prepFlags: Int32) throws -> UpdateStatement {
-        try UpdateStatement.prepare(self, sql: sql, prepFlags: prepFlags)
+    @available(*, deprecated, renamed: "makeStatement(literal:)")
+    public func makeUpdateStatement(literal sqlLiteral: SQL) throws -> Statement {
+        try makeStatement(literal: sqlLiteral)
     }
     
     /// Returns a prepared statement that can be reused.
@@ -186,16 +274,17 @@ extension Database {
     /// contain values for its eventual arguments.
     ///
     /// - parameter sql: An SQL query.
-    /// - returns: An UpdateStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
-    public func cachedUpdateStatement(sql: String) throws -> UpdateStatement {
-        try publicStatementCache.updateStatement(sql)
+    @available(*, deprecated, renamed: "cachedStatement(sql:)")
+    public func cachedUpdateStatement(sql: String) throws -> Statement {
+        try cachedStatement(sql: sql)
     }
     
     /// Returns a new prepared statement that can be reused.
     ///
     /// - parameter sqlLiteral: An `SQL` literal.
-    /// - returns: An UpdateStatement.
+    /// - returns: A Statement.
     /// - throws: A DatabaseError whenever SQLite could not parse the sql query.
     /// - precondition: No argument must be set, or all arguments must be set.
     ///   A fatal error is raised otherwise.
@@ -212,19 +301,9 @@ extension Database {
     ///         try cachedUpdateStatement(literal: """
     ///             UPDATE player SET name = ?, score = \(10)
     ///             """)
-    public func cachedUpdateStatement(literal sqlLiteral: SQL) throws -> UpdateStatement {
-        let (sql, arguments) = try sqlLiteral.build(self)
-        let statement = try cachedUpdateStatement(sql: sql)
-        if arguments.isEmpty == false {
-            // Crash if arguments do not match
-            statement.arguments = arguments
-        }
-        return statement
-    }
-    
-    /// Returns a cached statement that does not conflict with user's cached statements.
-    func internalCachedUpdateStatement(sql: String) throws -> UpdateStatement {
-        try internalStatementCache.updateStatement(sql)
+    @available(*, deprecated, renamed: "cachedStatement(sql:)")
+    public func cachedUpdateStatement(literal sqlLiteral: SQL) throws -> Statement {
+        try cachedStatement(literal: sqlLiteral)
     }
     
     /// Executes one or several SQL statements, separated by semi-colons.
@@ -290,13 +369,13 @@ extension Database {
             var statementStart = sqlStart
             while statementStart < sqlEnd {
                 var statementEnd: UnsafePointer<Int8>? = nil
-                let nextStatement: UpdateStatement?
+                let nextStatement: Statement?
                 
                 // Compile
                 do {
                     let authorizer = StatementCompilationAuthorizer()
                     nextStatement = try withAuthorizer(authorizer) {
-                        try UpdateStatement(
+                        try Statement(
                             database: self,
                             statementStart: statementStart,
                             statementEnd: &statementEnd,
@@ -334,18 +413,10 @@ extension Database {
 }
 
 extension Database {
-    func executeUpdateStatement(_ statement: UpdateStatement) throws {
-        // Two things must prevent the statement from executing: aborted
-        // transactions, and database suspension.
-        try checkForAbortedTransaction(sql: statement.sql, arguments: statement.arguments)
-        try checkForSuspensionViolation(from: statement)
-        
-        if _isRecordingSelectedRegion {
-            _selectedRegion.formUnion(statement.databaseRegion)
-        }
-        
-        let authorizer = observationBroker.updateStatementWillExecute(statement)
+    func executeStatement(_ statement: Statement) throws {
+        let authorizer = try statementWillExecute(statement)
         let sqliteStatement = statement.sqliteStatement
+        
         var code: Int32 = SQLITE_OK
         withAuthorizer(authorizer) {
             while true {
@@ -378,40 +449,18 @@ extension Database {
         // We can now move on further tasks.
         
         if code == SQLITE_DONE {
-            try updateStatementDidExecute(statement)
+            try statementDidExecute(statement)
         } else {
             assert(code != SQLITE_ROW)
-            try updateStatementDidFail(statement)
-            throw DatabaseError(
-                resultCode: code,
-                message: lastErrorMessage,
-                sql: statement.sql,
-                arguments: statement.arguments)
+            try statementDidFail(statement, withResultCode: code)
         }
     }
     
-    private func updateStatementDidExecute(_ statement: UpdateStatement) throws {
-        if statement.invalidatesDatabaseSchemaCache {
-            clearSchemaCache()
-        }
-        
-        try observationBroker.updateStatementDidExecute(statement)
-    }
-    
-    private func updateStatementDidFail(_ statement: UpdateStatement) throws {
-        // Failed statements can not be reused, because sqlite3_reset won't
-        // be able to restore the statement to its initial state:
-        // https://www.sqlite.org/c3ref/reset.html
-        //
-        // So make sure we clear this statement from the cache.
-        internalStatementCache.remove(statement)
-        publicStatementCache.remove(statement)
-        
-        try observationBroker.updateStatementDidFail(statement)
-    }
-    
-    @inline(__always)
-    func selectStatementWillExecute(_ statement: SelectStatement) throws {
+    /// Returns the authorizer that should be used during statement execution
+    /// (this allows preventing the truncate optimization when there exists a
+    /// transaction observer for row deletion).
+    @usableFromInline
+    func statementWillExecute(_ statement: Statement) throws -> StatementAuthorizer? {
         // Two things must prevent the statement from executing: aborted
         // transactions, and database suspension.
         try checkForAbortedTransaction(sql: statement.sql, arguments: statement.arguments)
@@ -420,9 +469,24 @@ extension Database {
         if _isRecordingSelectedRegion {
             _selectedRegion.formUnion(statement.databaseRegion)
         }
+        
+        return observationBroker.statementWillExecute(statement)
     }
     
-    func selectStatementDidFail(_ statement: SelectStatement) {
+    /// May throw a cancelled commit error, if a transaction observer cancels
+    /// an empty transaction.
+    @usableFromInline
+    func statementDidExecute(_ statement: Statement) throws {
+        if statement.invalidatesDatabaseSchemaCache {
+            clearSchemaCache()
+        }
+        
+        try observationBroker.statementDidExecute(statement)
+    }
+    
+    /// Always throws an error
+    @usableFromInline
+    func statementDidFail(_ statement: Statement, withResultCode resultCode: Int32) throws -> Never {
         // Failed statements can not be reused, because sqlite3_reset won't
         // be able to restore the statement to its initial state:
         // https://www.sqlite.org/c3ref/reset.html
@@ -430,21 +494,30 @@ extension Database {
         // So make sure we clear this statement from the cache.
         internalStatementCache.remove(statement)
         publicStatementCache.remove(statement)
+        
+        /// Exposes the user-provided cancelled commit error, if a transaction
+        /// observer has cancelled a transaction.
+        try observationBroker.statementDidFail(statement)
+        
+        throw DatabaseError(
+            resultCode: resultCode,
+            message: lastErrorMessage,
+            sql: statement.sql,
+            arguments: statement.arguments)
     }
 }
 
 /// A thread-unsafe statement cache
 struct StatementCache {
     unowned let db: Database
-    private var selectStatements: [String: SelectStatement] = [:]
-    private var updateStatements: [String: UpdateStatement] = [:]
+    private var statements: [String: Statement] = [:]
     
     init(database: Database) {
         self.db = database
     }
     
-    mutating func selectStatement(_ sql: String) throws -> SelectStatement {
-        if let statement = selectStatements[sql] {
+    mutating func statement(_ sql: String) throws -> Statement {
+        if let statement = statements[sql] {
             return statement
         }
         
@@ -458,61 +531,26 @@ struct StatementCache {
         // However SQLITE_PREPARE_PERSISTENT was only introduced in
         // SQLite 3.20.0 http://www.sqlite.org/changes.html#version_3_20
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        let statement = try db.makeSelectStatement(sql: sql, prepFlags: SQLITE_PREPARE_PERSISTENT)
+        let statement = try db.makeStatement(sql: sql, prepFlags: SQLITE_PREPARE_PERSISTENT)
         #else
-        let statement: SelectStatement
+        let statement: Statement
         if #available(iOS 12.0, OSX 10.14, watchOS 5.0, *) {
             // SQLite 3.24.0 or more
-            statement = try db.makeSelectStatement(sql: sql, prepFlags: SQLITE_PREPARE_PERSISTENT)
+            statement = try db.makeStatement(sql: sql, prepFlags: SQLITE_PREPARE_PERSISTENT)
         } else {
             // SQLite 3.19.3 or less
-            statement = try db.makeSelectStatement(sql: sql)
+            statement = try db.makeStatement(sql: sql)
         }
         #endif
-        selectStatements[sql] = statement
-        return statement
-    }
-    
-    mutating func updateStatement(_ sql: String) throws -> UpdateStatement {
-        if let statement = updateStatements[sql] {
-            return statement
-        }
-        
-        // http://www.sqlite.org/c3ref/c_prepare_persistent.html#sqlitepreparepersistent
-        // > The SQLITE_PREPARE_PERSISTENT flag is a hint to the query
-        // > planner that the prepared statement will be retained for a long
-        // > time and probably reused many times.
-        //
-        // This looks like a perfect match for cached statements.
-        //
-        // However SQLITE_PREPARE_PERSISTENT was only introduced in
-        // SQLite 3.20.0 http://www.sqlite.org/changes.html#version_3_20
-        #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        let statement = try db.makeUpdateStatement(sql: sql, prepFlags: SQLITE_PREPARE_PERSISTENT)
-        #else
-        let statement: UpdateStatement
-        if #available(iOS 12.0, OSX 10.14, watchOS 5.0, *) {
-            // SQLite 3.24.0 or more
-            statement = try db.makeUpdateStatement(sql: sql, prepFlags: SQLITE_PREPARE_PERSISTENT)
-        } else {
-            // SQLite 3.19.3 or less
-            statement = try db.makeUpdateStatement(sql: sql)
-        }
-        #endif
-        updateStatements[sql] = statement
+        statements[sql] = statement
         return statement
     }
     
     mutating func clear() {
-        updateStatements = [:]
-        selectStatements = [:]
+        statements = [:]
     }
     
-    mutating func remove(_ statement: SelectStatement) {
-        selectStatements.removeFirst { $0.value === statement }
-    }
-    
-    mutating func remove(_ statement: UpdateStatement) {
-        updateStatements.removeFirst { $0.value === statement }
+    mutating func remove(_ statement: Statement) {
+        statements.removeFirst { $0.value === statement }
     }
 }

--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -20,9 +20,9 @@
 ///
 /// - `DatabaseRegion(table:)`: the region that covers one database table.
 ///
-/// - `SelectStatement.databaseRegion`:
+/// - `Statement.databaseRegion`:
 ///
-///         let statement = try db.makeSelectStatement(sql: "SELECT name, score FROM player")
+///         let statement = try db.makeStatement(sql: "SELECT name, score FROM player")
 ///         let region = statement.databaseRegion
 ///
 /// - `FetchRequest.databaseRegion(_:)`

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -40,7 +40,7 @@ public class DatabaseSnapshot: DatabaseReader {
             try db.beginTransaction(.deferred)
             
             // Acquire snapshot isolation
-            try db.internalCachedSelectStatement(sql: "SELECT rootpage FROM sqlite_master LIMIT 1").makeCursor().next()
+            try db.internalCachedStatement(sql: "SELECT rootpage FROM sqlite_master LIMIT 1").makeCursor().next()
             
             #if SQLITE_ENABLE_SNAPSHOT
             // We must expect an error: https://www.sqlite.org/c3ref/snapshot_get.html

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -8,7 +8,7 @@
 ///     try String.fetchAll(db, sql: "SELECT name FROM ...", arguments:...)    // [String]
 ///     try String.fetchOne(db, sql: "SELECT name FROM ...", arguments:...)    // String?
 ///
-///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
 ///     try String.fetchCursor(statement, arguments:...) // Cursor of String
 ///     try String.fetchAll(statement, arguments:...)    // [String]
 ///     try String.fetchOne(statement, arguments:...)    // String?
@@ -58,7 +58,7 @@ extension DatabaseValueConvertible {
         let dbValue = DatabaseValue(sqliteStatement: sqliteStatement, index: index)
         return try decode(fromDatabaseValue: dbValue, context: context())
     }
-
+    
     @usableFromInline
     static func decode(fromRow row: Row, atUncheckedIndex index: Int) throws -> Self {
         if let sqliteStatement = row.sqliteStatement {
@@ -71,7 +71,7 @@ extension DatabaseValueConvertible {
             fromDatabaseValue: row.impl.databaseValue(atUncheckedIndex: index),
             context: RowDecodingContext(row: row, key: .columnIndex(index)))
     }
-
+    
     static func decodeIfPresent(
         fromDatabaseValue dbValue: DatabaseValue,
         context: @autoclosure () -> RowDecodingContext)
@@ -86,7 +86,7 @@ extension DatabaseValueConvertible {
             throw RowDecodingError.valueMismatch(Self.self, context: context(), databaseValue: dbValue)
         }
     }
-
+    
     @usableFromInline
     static func decodeIfPresent(
         fromStatement sqliteStatement: SQLiteStatement,
@@ -103,7 +103,7 @@ extension DatabaseValueConvertible {
             throw RowDecodingError.valueMismatch(Self.self, context: context(), databaseValue: dbValue)
         }
     }
-
+    
     @usableFromInline
     static func decodeIfPresent(fromRow row: Row, atUncheckedIndex index: Int) throws -> Self? {
         if let sqliteStatement = row.sqliteStatement {
@@ -130,12 +130,16 @@ extension DatabaseValueConvertible {
 ///         }
 ///     }
 public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor {
-    @usableFromInline let _statement: SelectStatement
+    @usableFromInline enum _State {
+        case idle, busy, done, failed
+    }
+    
+    @usableFromInline let _statement: Statement
     @usableFromInline let _sqliteStatement: SQLiteStatement
     @usableFromInline let _columnIndex: Int32
-    @usableFromInline var _done = false
+    @usableFromInline var _state = _State.idle
     
-    init(statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
+    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
         _statement = statement
         _sqliteStatement = statement.sqliteStatement
         if let adapter = adapter {
@@ -144,13 +148,16 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor 
         } else {
             _columnIndex = 0
         }
-        _statement.reset(withArguments: arguments)
         
-        // Assume cursor is created for iteration
-        try statement.database.selectStatementWillExecute(statement)
+        // Assume cursor is created for immediate iteration: reset and set arguments
+        statement.reset(withArguments: arguments)
     }
     
     deinit {
+        if _state == .busy {
+            try? _statement.database.statementDidExecute(_statement)
+        }
+        
         // Statement reset fails when sqlite3_step has previously failed.
         // Just ignore reset error.
         try? _statement.reset()
@@ -158,14 +165,28 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor 
     
     @inlinable
     public func next() throws -> Value? {
-        if _done {
+        switch _state {
+        case .done:
             // make sure this instance never yields a value again, even if the
             // statement is reset by another cursor.
             return nil
+        case .idle:
+            guard try _statement.database.statementWillExecute(_statement) == nil else {
+                throw DatabaseError(
+                    resultCode: SQLITE_MISUSE,
+                    message: "Can't run statement that requires a customized authorizer from a cursor",
+                    sql: _statement.sql,
+                    arguments: _statement.arguments)
+            }
+            _state = .busy
+        default:
+            break
         }
+        
         switch sqlite3_step(_sqliteStatement) {
         case SQLITE_DONE:
-            _done = true
+            _state = .done
+            try _statement.database.statementDidExecute(_statement)
             return nil
         case SQLITE_ROW:
             // TODO GRDB6: don't crash on decoding errors
@@ -174,7 +195,8 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor 
                 atUncheckedIndex: _columnIndex,
                 context: RowDecodingContext(statement: _statement, index: Int(_columnIndex)))
         case let code:
-            try _statement.didFail(withResultCode: code)
+            _state = .failed
+            try _statement.database.statementDidFail(_statement, withResultCode: code)
         }
     }
 }
@@ -189,12 +211,16 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor 
 ///         }
 ///     }
 public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>: Cursor {
-    @usableFromInline let _statement: SelectStatement
+    @usableFromInline enum _State {
+        case idle, busy, done, failed
+    }
+    
+    @usableFromInline let _statement: Statement
     @usableFromInline let _sqliteStatement: SQLiteStatement
     @usableFromInline let _columnIndex: Int32
-    @usableFromInline var _done = false
+    @usableFromInline var _state = _State.idle
     
-    init(statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
+    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
         _statement = statement
         _sqliteStatement = statement.sqliteStatement
         if let adapter = adapter {
@@ -203,13 +229,16 @@ public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>:
         } else {
             _columnIndex = 0
         }
-        _statement.reset(withArguments: arguments)
         
-        // Assume cursor is created for iteration
-        try statement.database.selectStatementWillExecute(statement)
+        // Assume cursor is created for immediate iteration: reset and set arguments
+        statement.reset(withArguments: arguments)
     }
     
     deinit {
+        if _state == .busy {
+            try? _statement.database.statementDidExecute(_statement)
+        }
+        
         // Statement reset fails when sqlite3_step has previously failed.
         // Just ignore reset error.
         try? _statement.reset()
@@ -217,14 +246,28 @@ public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>:
     
     @inlinable
     public func next() throws -> Value?? {
-        if _done {
+        switch _state {
+        case .done:
             // make sure this instance never yields a value again, even if the
             // statement is reset by another cursor.
             return nil
+        case .idle:
+            guard try _statement.database.statementWillExecute(_statement) == nil else {
+                throw DatabaseError(
+                    resultCode: SQLITE_MISUSE,
+                    message: "Can't run statement that requires a customized authorizer from a cursor",
+                    sql: _statement.sql,
+                    arguments: _statement.arguments)
+            }
+            _state = .busy
+        default:
+            break
         }
+        
         switch sqlite3_step(_sqliteStatement) {
         case SQLITE_DONE:
-            _done = true
+            _state = .done
+            try _statement.database.statementDidExecute(_statement)
             return nil
         case SQLITE_ROW:
             // TODO GRDB6: don't crash on decoding errors
@@ -233,7 +276,8 @@ public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>:
                 atUncheckedIndex: _columnIndex,
                 context: RowDecodingContext(statement: _statement, index: Int(_columnIndex)))
         case let code:
-            try _statement.didFail(withResultCode: code)
+            _state = .failed
+            try _statement.database.statementDidFail(_statement, withResultCode: code)
         }
     }
 }
@@ -245,7 +289,7 @@ public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>:
 ///     try String.fetchAll(db, sql: "SELECT name FROM ...", arguments:...)    // [String]
 ///     try String.fetchOne(db, sql: "SELECT name FROM ...", arguments:...)    // String?
 ///
-///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
 ///     try String.fetchCursor(statement, arguments:...) // Cursor of String
 ///     try String.fetchAll(statement, arguments:...)    // [String]
 ///     try String.fetchOne(statement, arguments:...)    // String
@@ -253,11 +297,11 @@ public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>:
 /// DatabaseValueConvertible is adopted by Bool, Int, String, etc.
 extension DatabaseValueConvertible {
     
-    // MARK: Fetching From SelectStatement
+    // MARK: Fetching From Prepared Statement
     
     /// Returns a cursor over values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try String.fetchCursor(statement) // Cursor of String
     ///     while let name = try names.next() { // String
     ///         ...
@@ -275,7 +319,7 @@ extension DatabaseValueConvertible {
     /// - returns: A cursor over fetched values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> DatabaseValueCursor<Self>
@@ -285,7 +329,7 @@ extension DatabaseValueConvertible {
     
     /// Returns an array of values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try String.fetchAll(statement)  // [String]
     ///
     /// - parameters:
@@ -295,7 +339,7 @@ extension DatabaseValueConvertible {
     /// - returns: An array.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchAll(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> [Self]
@@ -308,7 +352,7 @@ extension DatabaseValueConvertible {
     /// The result is nil if the query returns no row, or if no value can be
     /// extracted from the first row.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let name = try String.fetchOne(statement)   // String?
     ///
     /// - parameters:
@@ -318,7 +362,7 @@ extension DatabaseValueConvertible {
     /// - returns: An optional value.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchOne(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Self?
@@ -332,7 +376,7 @@ extension DatabaseValueConvertible {
 extension DatabaseValueConvertible where Self: Hashable {
     /// Returns a set of values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try String.fetchSet(statement)  // Set<String>
     ///
     /// - parameters:
@@ -342,7 +386,7 @@ extension DatabaseValueConvertible where Self: Hashable {
     /// - returns: A set.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchSet(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Set<Self>
@@ -603,18 +647,18 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & Hashable {
 ///     try Optional<String>.fetchCursor(db, sql: "SELECT name FROM ...", arguments:...) // Cursor of String?
 ///     try Optional<String>.fetchAll(db, sql: "SELECT name FROM ...", arguments:...)    // [String?]
 ///
-///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
 ///     try Optional<String>.fetchCursor(statement, arguments:...) // Cursor of String?
 ///     try Optional<String>.fetchAll(statement, arguments:...)    // [String?]
 ///
 /// DatabaseValueConvertible is adopted by Bool, Int, String, etc.
 extension Optional where Wrapped: DatabaseValueConvertible {
     
-    // MARK: Fetching From SelectStatement
+    // MARK: Fetching From Prepared Statement
     
     /// Returns a cursor over optional values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try Optional<String>.fetchCursor(statement) // Cursor of String?
     ///     while let name = try names.next() { // String?
     ///         ...
@@ -632,7 +676,7 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     /// - returns: A cursor over fetched optional values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> NullableDatabaseValueCursor<Wrapped>
@@ -642,7 +686,7 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     
     /// Returns an array of optional values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try Optional<String>.fetchAll(statement)  // [String?]
     ///
     /// - parameters:
@@ -652,7 +696,7 @@ extension Optional where Wrapped: DatabaseValueConvertible {
     /// - returns: An array of optional values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchAll(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> [Wrapped?]
@@ -664,7 +708,7 @@ extension Optional where Wrapped: DatabaseValueConvertible {
 extension Optional where Wrapped: DatabaseValueConvertible & Hashable {
     /// Returns a set of optional values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try Optional<String>.fetchSet(statement)  // Set<String?>
     ///
     /// - parameters:
@@ -674,7 +718,7 @@ extension Optional where Wrapped: DatabaseValueConvertible & Hashable {
     /// - returns: A set of optional values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchSet(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Set<Wrapped?>

--- a/GRDB/Core/FetchRequest.swift
+++ b/GRDB/Core/FetchRequest.swift
@@ -49,7 +49,7 @@ extension FetchRequest {
 /// A PreparedRequest is a request that is ready to be executed.
 public struct PreparedRequest {
     /// A prepared statement
-    public var statement: SelectStatement
+    public var statement: Statement
     
     /// An eventual adapter for rows fetched by the select statement
     public var adapter: RowAdapter?
@@ -58,7 +58,7 @@ public struct PreparedRequest {
     var supplementaryFetch: ((Database, [Row]) throws -> Void)?
     
     init(
-        statement: SelectStatement,
+        statement: Statement,
         adapter: RowAdapter?,
         supplementaryFetch: ((Database, [Row]) throws -> Void)? = nil)
     {

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -14,7 +14,7 @@ public final class Row: Equatable, Hashable, RandomAccessCollection,
     ///
     ///     let rows = try Row.fetchCursor(db, sql: "SELECT ...")
     ///     let players = try Player.fetchAll(db, sql: "SELECT ...")
-    @usableFromInline let statement: SelectStatement?
+    @usableFromInline let statement: Statement?
     @usableFromInline let sqliteStatement: SQLiteStatement?
     
     /// The number of columns in the row.
@@ -96,7 +96,7 @@ public final class Row: Equatable, Hashable, RandomAccessCollection,
     /// The row is implemented on top of StatementRowImpl, which grants *direct*
     /// access to the SQLite statement. Iteration of the statement does modify
     /// the row.
-    init(statement: SelectStatement) {
+    init(statement: Statement) {
         self.statement = statement
         self.sqliteStatement = statement.sqliteStatement
         self.impl = StatementRowImpl(sqliteStatement: statement.sqliteStatement, statement: statement)
@@ -120,7 +120,7 @@ public final class Row: Equatable, Hashable, RandomAccessCollection,
     /// statement does not modify the row.
     convenience init(
         copiedFromSQLiteStatement sqliteStatement: SQLiteStatement,
-        statement: SelectStatement)
+        statement: Statement)
     {
         self.init(impl: StatementCopyRowImpl(
                     sqliteStatement: sqliteStatement,
@@ -1189,23 +1189,30 @@ extension Row {
 ///         let rows: RowCursor = try Row.fetchCursor(db, sql: "SELECT * FROM player")
 ///     }
 public final class RowCursor: Cursor {
+    @usableFromInline enum _State {
+        case idle, busy, done, failed
+    }
+    
     /// The statement iterated by this cursor
-    public let statement: SelectStatement
+    public let statement: Statement
     @usableFromInline let _sqliteStatement: SQLiteStatement
     @usableFromInline let _row: Row // Reused for performance
-    @usableFromInline var _done = false
+    @usableFromInline var _state = _State.idle
     
-    init(statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
+    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
         self.statement = statement
         self._row = try Row(statement: statement).adapted(with: adapter, layout: statement)
         self._sqliteStatement = statement.sqliteStatement
-        statement.reset(withArguments: arguments)
         
-        // Assume cursor is created for iteration
-        try statement.database.selectStatementWillExecute(statement)
+        // Assume cursor is created for immediate iteration: reset and set arguments
+        statement.reset(withArguments: arguments)
     }
     
     deinit {
+        if _state == .busy {
+            try? statement.database.statementDidExecute(statement)
+        }
+        
         // Statement reset fails when sqlite3_step has previously failed.
         // Just ignore reset error.
         try? statement.reset()
@@ -1213,30 +1220,45 @@ public final class RowCursor: Cursor {
     
     @inlinable
     public func next() throws -> Row? {
-        if _done {
+        switch _state {
+        case .done:
             // make sure this instance never yields a value again, even if the
             // statement is reset by another cursor.
             return nil
+        case .idle:
+            guard try statement.database.statementWillExecute(statement) == nil else {
+                throw DatabaseError(
+                    resultCode: SQLITE_MISUSE,
+                    message: "Can't run statement that requires a customized authorizer from a cursor",
+                    sql: statement.sql,
+                    arguments: statement.arguments)
+            }
+            _state = .busy
+        default:
+            break
         }
+        
         switch sqlite3_step(_sqliteStatement) {
         case SQLITE_DONE:
-            _done = true
+            _state = .done
+            try statement.database.statementDidExecute(statement)
             return nil
         case SQLITE_ROW:
             return _row
         case let code:
-            try statement.didFail(withResultCode: code)
+            _state = .failed
+            try statement.database.statementDidFail(statement, withResultCode: code)
         }
     }
 }
 
 extension Row {
     
-    // MARK: - Fetching From SelectStatement
+    // MARK: - Fetching From Prepared Statement
     
     /// Returns a cursor over rows fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT ...")
     ///     let rows = try Row.fetchCursor(statement) // RowCursor
     ///     while let row = try rows.next() { // Row
     ///         let id: Int64 = row[0]
@@ -1264,7 +1286,7 @@ extension Row {
     /// - returns: A cursor over fetched rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> RowCursor
@@ -1274,7 +1296,7 @@ extension Row {
     
     /// Returns an array of rows fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT ...")
     ///     let rows = try Row.fetchAll(statement)
     ///
     /// - parameters:
@@ -1284,7 +1306,7 @@ extension Row {
     /// - returns: An array of rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchAll(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> [Row]
@@ -1295,7 +1317,7 @@ extension Row {
     
     /// Returns a set of rows fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT ...")
     ///     let rows = try Row.fetchSet(statement)
     ///
     /// - parameters:
@@ -1305,7 +1327,7 @@ extension Row {
     /// - returns: A set of rows.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchSet(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Set<Row>
@@ -1316,7 +1338,7 @@ extension Row {
     
     /// Returns a single row fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT ...")
     ///     let row = try Row.fetchOne(statement)
     ///
     /// - parameters:
@@ -1326,7 +1348,7 @@ extension Row {
     /// - returns: An optional row.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchOne(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Row?
@@ -2225,11 +2247,11 @@ private struct StatementCopyRowImpl: RowImpl {
 
 /// See Row.init(statement:)
 private struct StatementRowImpl: RowImpl {
-    let statement: SelectStatement
+    let statement: Statement
     let sqliteStatement: SQLiteStatement
     let lowercaseColumnIndexes: [String: Int]
     
-    init(sqliteStatement: SQLiteStatement, statement: SelectStatement) {
+    init(sqliteStatement: SQLiteStatement, statement: Statement) {
         self.statement = statement
         self.sqliteStatement = sqliteStatement
         // Optimize row[columnName]

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -141,7 +141,7 @@ public protocol _RowLayout {
     func _layoutIndex(ofColumn name: String) -> Int?
 }
 
-extension SelectStatement: _RowLayout {
+extension Statement: _RowLayout {
     /// :nodoc:
     public var _layoutColumns: [(Int, String)] {
         Array(columnNames.enumerated())

--- a/GRDB/Core/RowDecodingError.swift
+++ b/GRDB/Core/RowDecodingError.swift
@@ -92,7 +92,7 @@ enum RowDecodingError: Error {
     @usableFromInline
     static func valueMismatch(
         _ type: Any.Type,
-        statement: SelectStatement,
+        statement: Statement,
         index: Int)
     -> Self
     {
@@ -149,7 +149,7 @@ struct RowDecodingContext {
     
     /// Convenience initializer
     @usableFromInline
-    init(statement: SelectStatement, index: Int) {
+    init(statement: Statement, index: Int) {
         self.key = .columnIndex(index)
         self.row = Row(copiedFromSQLiteStatement: statement.sqliteStatement, statement: statement)
         self.sql = statement.sql
@@ -171,7 +171,7 @@ extension RowDecodingError: CustomStringConvertible {
                 let columnName = row.columnNames[rowIndex]
                 chunks.append("column: \(String(reflecting: columnName))")
                 chunks.append("column index: \(columnIndex)")
-
+                
             case let .columnName(columnName):
                 if let columnIndex = row.index(forColumn: columnName) {
                     chunks.append("column: \(String(reflecting: columnName))")

--- a/GRDB/Core/SQLRequest.swift
+++ b/GRDB/Core/SQLRequest.swift
@@ -155,14 +155,14 @@ extension SQLRequest: FetchRequest {
     {
         let context = SQLGenerationContext(db)
         let sql = try sqlLiteral.sql(context)
-        let statement: SelectStatement
+        let statement: Statement
         switch cache {
         case .none:
-            statement = try db.makeSelectStatement(sql: sql)
+            statement = try db.makeStatement(sql: sql)
         case .public?:
-            statement = try db.cachedSelectStatement(sql: sql)
+            statement = try db.cachedStatement(sql: sql)
         case .internal?:
-            statement = try db.internalCachedSelectStatement(sql: sql)
+            statement = try db.internalCachedStatement(sql: sql)
         }
         try statement.setArguments(context.arguments)
         return PreparedRequest(statement: statement, adapter: adapter)

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -3,6 +3,7 @@ import Glibc
 #endif
 
 /// A protocol around sqlite3_set_authorizer
+@usableFromInline
 protocol StatementAuthorizer: AnyObject {
     func authorize(
         _ actionCode: Int32,
@@ -28,7 +29,7 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
     
     /// Not nil if a statement is a BEGIN/COMMIT/ROLLBACK/RELEASE transaction or
     /// savepoint statement.
-    var transactionEffect: UpdateStatement.TransactionEffect?
+    var transactionEffect: Statement.TransactionEffect?
     
     private var isDropStatement = false
     

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -63,7 +63,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         }
         return value
     }
-
+    
     @inlinable
     static func fastDecode(
         fromRow row: Row,
@@ -79,7 +79,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         // Support for fast decoding from adapted rows
         return try row.fastDecode(Self.self, atUncheckedIndex: index)
     }
-
+    
     @inlinable
     static func fastDecodeIfPresent(
         fromStatement sqliteStatement: SQLiteStatement,
@@ -99,7 +99,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         }
         return value
     }
-
+    
     @inlinable
     static func fastDecodeIfPresent(
         fromRow row: Row,
@@ -129,12 +129,16 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
 ///         }
 ///     }
 public final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & StatementColumnConvertible> : Cursor {
-    @usableFromInline let _statement: SelectStatement
+    @usableFromInline enum _State {
+        case idle, busy, done, failed
+    }
+    
+    @usableFromInline let _statement: Statement
     @usableFromInline let _columnIndex: Int32
     @usableFromInline let _sqliteStatement: SQLiteStatement
-    @usableFromInline var _done = false
+    @usableFromInline var _state = _State.idle
     
-    init(statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
+    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
         _statement = statement
         _sqliteStatement = statement.sqliteStatement
         if let adapter = adapter {
@@ -143,13 +147,16 @@ public final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & Sta
         } else {
             _columnIndex = 0
         }
-        _statement.reset(withArguments: arguments)
         
-        // Assume cursor is created for iteration
-        try statement.database.selectStatementWillExecute(statement)
+        // Assume cursor is created for immediate iteration: reset and set arguments
+        statement.reset(withArguments: arguments)
     }
     
     deinit {
+        if _state == .busy {
+            try? _statement.database.statementDidExecute(_statement)
+        }
+        
         // Statement reset fails when sqlite3_step has previously failed.
         // Just ignore reset error.
         try? _statement.reset()
@@ -157,14 +164,28 @@ public final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & Sta
     
     @inlinable
     public func next() throws -> Value? {
-        if _done {
+        switch _state {
+        case .done:
             // make sure this instance never yields a value again, even if the
             // statement is reset by another cursor.
             return nil
+        case .idle:
+            guard try _statement.database.statementWillExecute(_statement) == nil else {
+                throw DatabaseError(
+                    resultCode: SQLITE_MISUSE,
+                    message: "Can't run statement that requires a customized authorizer from a cursor",
+                    sql: _statement.sql,
+                    arguments: _statement.arguments)
+            }
+            _state = .busy
+        default:
+            break
         }
+        
         switch sqlite3_step(_sqliteStatement) {
         case SQLITE_DONE:
-            _done = true
+            _state = .done
+            try _statement.database.statementDidExecute(_statement)
             return nil
         case SQLITE_ROW:
             // TODO GRDB6: don't crash on decoding errors
@@ -173,7 +194,8 @@ public final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & Sta
                 atUncheckedIndex: _columnIndex,
                 context: RowDecodingContext(statement: _statement, index: Int(_columnIndex)))
         case let code:
-            try _statement.didFail(withResultCode: code)
+            _state = .failed
+            try _statement.database.statementDidFail(_statement, withResultCode: code)
         }
     }
 }
@@ -191,12 +213,16 @@ public final class FastDatabaseValueCursor<Value: DatabaseValueConvertible & Sta
 public final class FastNullableDatabaseValueCursor<Value>: Cursor
 where Value: DatabaseValueConvertible & StatementColumnConvertible
 {
-    @usableFromInline let _statement: SelectStatement
+    @usableFromInline enum _State {
+        case idle, busy, done, failed
+    }
+    
+    @usableFromInline let _statement: Statement
     @usableFromInline let _columnIndex: Int32
     @usableFromInline let _sqliteStatement: SQLiteStatement
-    @usableFromInline var _done = false
+    @usableFromInline var _state = _State.idle
     
-    init(statement: SelectStatement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
+    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
         _statement = statement
         _sqliteStatement = statement.sqliteStatement
         if let adapter = adapter {
@@ -205,13 +231,16 @@ where Value: DatabaseValueConvertible & StatementColumnConvertible
         } else {
             _columnIndex = 0
         }
-        _statement.reset(withArguments: arguments)
         
-        // Assume cursor is created for iteration
-        try statement.database.selectStatementWillExecute(statement)
+        // Assume cursor is created for immediate iteration: reset and set arguments
+        statement.reset(withArguments: arguments)
     }
     
     deinit {
+        if _state == .busy {
+            try? _statement.database.statementDidExecute(_statement)
+        }
+        
         // Statement reset fails when sqlite3_step has previously failed.
         // Just ignore reset error.
         try? _statement.reset()
@@ -219,14 +248,28 @@ where Value: DatabaseValueConvertible & StatementColumnConvertible
     
     @inlinable
     public func next() throws -> Value?? {
-        if _done {
+        switch _state {
+        case .done:
             // make sure this instance never yields a value again, even if the
             // statement is reset by another cursor.
             return nil
+        case .idle:
+            guard try _statement.database.statementWillExecute(_statement) == nil else {
+                throw DatabaseError(
+                    resultCode: SQLITE_MISUSE,
+                    message: "Can't run statement that requires a customized authorizer from a cursor",
+                    sql: _statement.sql,
+                    arguments: _statement.arguments)
+            }
+            _state = .busy
+        default:
+            break
         }
+        
         switch sqlite3_step(_sqliteStatement) {
         case SQLITE_DONE:
-            _done = true
+            _state = .done
+            try _statement.database.statementDidExecute(_statement)
             return nil
         case SQLITE_ROW:
             // TODO GRDB6: don't crash on decoding errors
@@ -235,7 +278,8 @@ where Value: DatabaseValueConvertible & StatementColumnConvertible
                 atUncheckedIndex: _columnIndex,
                 context: RowDecodingContext(statement: _statement, index: Int(_columnIndex)))
         case let code:
-            try _statement.didFail(withResultCode: code)
+            _state = .failed
+            try _statement.database.statementDidFail(_statement, withResultCode: code)
         }
     }
 }
@@ -247,11 +291,11 @@ where Value: DatabaseValueConvertible & StatementColumnConvertible
 /// See DatabaseValueConvertible for more information.
 extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     
-    // MARK: Fetching From SelectStatement
+    // MARK: Fetching From Prepared Statement
     
     /// Returns a cursor over values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try String.fetchCursor(statement) // Cursor of String
     ///     while let name = try names.next() { // String
     ///         ...
@@ -269,7 +313,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     /// - returns: A cursor over fetched values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> FastDatabaseValueCursor<Self>
@@ -279,7 +323,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     
     /// Returns an array of values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try String.fetchAll(statement)  // [String]
     ///
     /// - parameters:
@@ -289,7 +333,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     /// - returns: An array of values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchAll(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> [Self]
@@ -299,7 +343,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     
     /// Returns a single value fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let name = try String.fetchOne(statement)   // String?
     ///
     /// - parameters:
@@ -309,7 +353,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     /// - returns: An optional value.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchOne(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Self?
@@ -326,7 +370,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
 extension DatabaseValueConvertible where Self: StatementColumnConvertible & Hashable {
     /// Returns a set of values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try String.fetchSet(statement)  // Set<String>
     ///
     /// - parameters:
@@ -336,7 +380,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible & Hash
     /// - returns: A set of values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchSet(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Set<Self>
@@ -593,18 +637,18 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & StatementCol
 ///     try Optional<String>.fetchCursor(db, sql: "SELECT name FROM ...", arguments:...) // Cursor of String?
 ///     try Optional<String>.fetchAll(db, sql: "SELECT name FROM ...", arguments:...)    // [String?]
 ///
-///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
 ///     try Optional<String>.fetchCursor(statement, arguments:...) // Cursor of String?
 ///     try Optional<String>.fetchAll(statement, arguments:...)    // [String?]
 ///
 /// DatabaseValueConvertible is adopted by Bool, Int, String, etc.
 extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible {
     
-    // MARK: Fetching From SelectStatement
+    // MARK: Fetching From Prepared Statement
     
     /// Returns a cursor over optional values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try Optional<String>.fetchCursor(statement) // Cursor of String?
     ///     while let name = try names.next() { // String?
     ///         ...
@@ -622,7 +666,7 @@ extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConv
     /// - returns: A cursor over fetched optional values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchCursor(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> FastNullableDatabaseValueCursor<Wrapped>
@@ -632,7 +676,7 @@ extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConv
     
     /// Returns an array of optional values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try Optional<String>.fetchAll(statement)  // [String?]
     ///
     /// - parameters:
@@ -642,7 +686,7 @@ extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConv
     /// - returns: An array of optional values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchAll(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> [Wrapped?]
@@ -654,7 +698,7 @@ extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConv
 extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible & Hashable {
     /// Returns a set of optional values fetched from a prepared statement.
     ///
-    ///     let statement = try db.makeSelectStatement(sql: "SELECT name FROM ...")
+    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
     ///     let names = try Optional<String>.fetchSet(statement)  // Set<String?>
     ///
     /// - parameters:
@@ -664,7 +708,7 @@ extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConv
     /// - returns: A set of optional values.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public static func fetchSet(
-        _ statement: SelectStatement,
+        _ statement: Statement,
         arguments: StatementArguments? = nil,
         adapter: RowAdapter? = nil)
     throws -> Set<Wrapped?>

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -200,8 +200,9 @@ class DatabaseObservationBroker {
     
     /// Setups observation of changes that are about to be performed by the
     /// statement, and returns the authorizer that should be used during
-    /// statement execution.
-    func updateStatementWillExecute(_ statement: UpdateStatement) -> StatementAuthorizer? {
+    /// statement execution (this allows preventing the truncate optimization
+    /// when there exists a transaction observer for row deletion).
+    func statementWillExecute(_ statement: Statement) -> StatementAuthorizer? {
         // If any observer observes row deletions, we'll have to disable
         // [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt)
         // so that observers are notified.
@@ -285,16 +286,7 @@ class DatabaseObservationBroker {
             }
         }
         
-        switch transactionState {
-        case .none:
-            break
-        default:
-            // May happen after "PRAGMA journal_mode = WAL" executed with a
-            // SelectStatement.
-            // TODO: Maybe this state machine should be run for *all* statements,
-            // not ony update statements.
-            transactionState = .none
-        }
+        transactionState = .none
         
         if observesRowDeletion {
             return TruncateOptimizationBlocker()
@@ -303,8 +295,10 @@ class DatabaseObservationBroker {
         }
     }
     
-    func updateStatementDidFail(_ statement: UpdateStatement) throws {
-        // Undo updateStatementWillExecute
+    /// May throw a cancelled commit error, if a transaction observer cancels
+    /// a transaction.
+    func statementDidFail(_ statement: Statement) throws {
+        // Undo statementWillExecute
         statementObservations = []
         SchedulingWatchdog.current!.databaseObservationBroker = nil
         
@@ -327,8 +321,10 @@ class DatabaseObservationBroker {
         }
     }
     
-    func updateStatementDidExecute(_ statement: UpdateStatement) throws {
-        // Undo updateStatementWillExecute
+    /// May throw a cancelled commit error, if a transaction observer cancels
+    /// an empty transaction.
+    func statementDidExecute(_ statement: Statement) throws {
+        // Undo statementWillExecute
         if transactionObservations.isEmpty == false {
             statementObservations = []
             SchedulingWatchdog.current!.databaseObservationBroker = nil
@@ -443,7 +439,7 @@ class DatabaseObservationBroker {
         }
     }
     
-    // Called from updateStatementDidExecute
+    // Called from statementDidExecute
     private func databaseDidCommit() {
         savepointStack.clear()
         
@@ -453,7 +449,9 @@ class DatabaseObservationBroker {
         databaseDidEndTransaction()
     }
     
-    // Called from updateStatementDidExecute
+    // Called from statementDidExecute
+    /// May throw a cancelled commit error, if a transaction observer cancels
+    /// the empty transaction.
     private func databaseDidCommitEmptyDeferredTransaction() throws {
         // A statement that ends a transaction has been executed. But for
         // SQLite, no transaction at all has started, and sqlite3_commit_hook
@@ -496,7 +494,7 @@ class DatabaseObservationBroker {
         }
     }
     
-    // Called from updateStatementDidExecute or updateStatementDidFails
+    // Called from statementDidExecute or statementDidFail
     private func databaseDidRollback(notifyTransactionObservers: Bool) {
         savepointStack.clear()
         
@@ -531,7 +529,7 @@ class DatabaseObservationBroker {
         //
         // Normally, notifyBufferedEvents() is called as part of statement
         // execution, and the current broker has been set in
-        // updateStatementWillExecute(). An assertion should be enough:
+        // statementWillExecute(). An assertion should be enough:
         //
         //      assert(SchedulingWatchdog.current?.databaseObservationBroker != nil)
         //
@@ -539,10 +537,8 @@ class DatabaseObservationBroker {
         //
         //      let journalMode = String.fetchOne(db, sql: "PRAGMA journal_mode = wal")
         //
-        // It runs a SelectStatement, not an UpdateStatement. But this not why
-        // this case is particular. What is unexpected is that it triggers
-        // the commit hook when the "PRAGMA journal_mode = wal" statement is
-        // finalized, long after it has executed:
+        // It triggers the commit hook when the "PRAGMA journal_mode = wal"
+        // statement is finalized, long after it has executed:
         //
         // 1. Statement.deinit()
         // 2. sqlite3_finalize()
@@ -555,7 +551,7 @@ class DatabaseObservationBroker {
         // journal mode would trigger the commit hook in sqlite3_step(),
         // not in sqlite3_finalize().
         //
-        // Anyway: in this scenario, updateStatementWillExecute() has not been
+        // Anyway: in this scenario, statementWillExecute() has not been
         // called, and the current broker is nil.
         //
         // Let's not try to outsmart SQLite, and build a complex state machine.
@@ -590,7 +586,7 @@ class DatabaseObservationBroker {
             do {
                 try broker.databaseWillCommit()
                 broker.transactionState = .commit
-                // Next step: updateStatementDidExecute()
+                // Next step: statementDidExecute()
                 return 0
             } catch {
                 broker.transactionState = .cancelledCommit(error)
@@ -603,11 +599,11 @@ class DatabaseObservationBroker {
             let broker = Unmanaged<DatabaseObservationBroker>.fromOpaque(brokerPointer!).takeUnretainedValue()
             switch broker.transactionState {
             case .cancelledCommit:
-                // Next step: updateStatementDidFail()
+                // Next step: statementDidFail()
                 break
             default:
                 broker.transactionState = .rollback
-            // Next step: updateStatementDidExecute()
+            // Next step: statementDidExecute()
             }
         }, brokerPointer)
     }

--- a/GRDB/FTS/FTS5Pattern.swift
+++ b/GRDB/FTS/FTS5Pattern.swift
@@ -93,7 +93,7 @@ public struct FTS5Pattern {
                         }
                     }
                 }
-                try db.makeSelectStatement(sql: "SELECT * FROM document WHERE document MATCH ?")
+                try db.makeStatement(sql: "SELECT * FROM document WHERE document MATCH ?")
                     .makeCursor(arguments: [rawPattern])
                     .next() // error on next() for invalid patterns
             }

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -15,7 +15,7 @@ extension AnyFetchRequest {
     { preconditionFailure() }
     
     @available(*, unavailable, message: "Define your own FetchRequest type instead.")
-    public init(_ prepare: @escaping (Database, _ singleResult: Bool) throws -> (SelectStatement, RowAdapter?))
+    public init(_ prepare: @escaping (Database, _ singleResult: Bool) throws -> (Statement, RowAdapter?))
     { preconditionFailure() }
 }
 
@@ -129,7 +129,7 @@ extension DatabaseReader {
 
 extension FetchRequest {
     @available(*, unavailable, message: "Use makePreparedRequest(_:forSingleResult:) instead.")
-    func prepare(_ db: Database, forSingleResult singleResult: Bool) throws -> (SelectStatement, RowAdapter?)
+    func prepare(_ db: Database, forSingleResult singleResult: Bool) throws -> (Statement, RowAdapter?)
     { preconditionFailure() }
     
     @available(*, unavailable, message: "Use ValueObservation.tracking(request.fetchCount) instead")

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -39,7 +39,7 @@ struct Migration {
                     // > schema change did not break any foreign
                     // > key constraints.
                     if try db
-                        .makeSelectStatement(sql: "PRAGMA foreign_key_check")
+                        .makeStatement(sql: "PRAGMA foreign_key_check")
                         .makeCursor()
                         .isEmpty() == false
                     {

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -812,7 +812,7 @@ throws -> DatabaseRegion
         .destinationRelation()
     
     return try SQLQueryGenerator(relation: prefetchRelation)
-        .makeSelectStatement(db)
+        .makeStatement(db)
         .databaseRegion // contains region of nested associations
 }
 

--- a/GRDB/QueryInterface/SQL/SQLSubquery.swift
+++ b/GRDB/QueryInterface/SQL/SQLSubquery.swift
@@ -45,7 +45,7 @@ extension SQLSubquery {
             // do not execute the statement or modify its arguments.
             let context = SQLGenerationContext(db)
             let sql = try sqlLiteral.sql(context)
-            let statement = try db.cachedSelectStatement(sql: sql)
+            let statement = try db.cachedStatement(sql: sql)
             return statement.columnCount
             
         case let .relation(relation):

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -677,19 +677,19 @@ final class DAO<Record: MutablePersistableRecord> {
     }
     
     @usableFromInline
-    func insertStatement(onConflict: Database.ConflictResolution) throws -> UpdateStatement {
+    func insertStatement(onConflict: Database.ConflictResolution) throws -> Statement {
         let query = InsertQuery(
             onConflict: onConflict,
             tableName: databaseTableName,
             insertedColumns: persistenceContainer.columns)
-        let statement = try db.internalCachedUpdateStatement(sql: query.sql)
+        let statement = try db.internalCachedStatement(sql: query.sql)
         statement.setUncheckedArguments(StatementArguments(persistenceContainer.values))
         return statement
     }
     
     /// Returns nil if and only if primary key is nil
     @usableFromInline
-    func updateStatement(columns: Set<String>, onConflict: Database.ConflictResolution) throws -> UpdateStatement? {
+    func updateStatement(columns: Set<String>, onConflict: Database.ConflictResolution) throws -> Statement? {
         // Fail early if primary key does not resolve to a database row.
         let primaryKeyColumns = primaryKey.columns
         let primaryKeyValues = primaryKeyColumns.map {
@@ -732,14 +732,14 @@ final class DAO<Record: MutablePersistableRecord> {
             tableName: databaseTableName,
             updatedColumns: updatedColumns,
             conditionColumns: primaryKeyColumns)
-        let statement = try db.internalCachedUpdateStatement(sql: query.sql)
+        let statement = try db.internalCachedStatement(sql: query.sql)
         statement.setUncheckedArguments(StatementArguments(updatedValues + primaryKeyValues))
         return statement
     }
     
     /// Returns nil if and only if primary key is nil
     @usableFromInline
-    func deleteStatement() throws -> UpdateStatement? {
+    func deleteStatement() throws -> Statement? {
         // Fail early if primary key does not resolve to a database row.
         let primaryKeyColumns = primaryKey.columns
         let primaryKeyValues = primaryKeyColumns.map {
@@ -752,14 +752,14 @@ final class DAO<Record: MutablePersistableRecord> {
         let query = DeleteQuery(
             tableName: databaseTableName,
             conditionColumns: primaryKeyColumns)
-        let statement = try db.internalCachedUpdateStatement(sql: query.sql)
+        let statement = try db.internalCachedStatement(sql: query.sql)
         statement.setUncheckedArguments(StatementArguments(primaryKeyValues))
         return statement
     }
     
     /// Returns nil if and only if primary key is nil
     @usableFromInline
-    func existsStatement() throws -> SelectStatement? {
+    func existsStatement() throws -> Statement? {
         // Fail early if primary key does not resolve to a database row.
         let primaryKeyColumns = primaryKey.columns
         let primaryKeyValues = primaryKeyColumns.map {
@@ -772,7 +772,7 @@ final class DAO<Record: MutablePersistableRecord> {
         let query = ExistsQuery(
             tableName: databaseTableName,
             conditionColumns: primaryKeyColumns)
-        let statement = try db.internalCachedSelectStatement(sql: query.sql)
+        let statement = try db.internalCachedStatement(sql: query.sql)
         statement.setUncheckedArguments(StatementArguments(primaryKeyValues))
         return statement
     }

--- a/README.md
+++ b/README.md
@@ -1843,7 +1843,7 @@ Alternatively, you can create a prepared statement with [SQL Interpolation]:
 ```swift
 let insertStatement = try db.makeStatement(literal: "INSERT ...")
 let selectStatement = try db.makeStatement(literal: "SELECT ...")
-//                                               ~~~~~~~
+//                                         ~~~~~~~
 ```
 
 Statements can be executed:

--- a/README.md
+++ b/README.md
@@ -1798,40 +1798,38 @@ dbQueue.inTransaction(.exclusive) { db in ... }
 
 **Prepared Statements** let you prepare an SQL query and execute it later, several times if you need, with different arguments.
 
-There are two kinds of prepared statements: **select statements**, and **update statements**:
-
 ```swift
 try dbQueue.write { db in
-    let updateSQL = "INSERT INTO player (name, score) VALUES (:name, :score)"
-    let updateStatement = try db.makeUpdateStatement(sql: updateSQL)
+    let insertSQL = "INSERT INTO player (name, score) VALUES (:name, :score)"
+    let insertStatement = try db.makeStatement(sql: insertSQL)
     
     let selectSQL = "SELECT * FROM player WHERE name = ?"
-    let selectStatement = try db.makeSelectStatement(sql: selectSQL)
+    let selectStatement = try db.makeStatement(sql: selectSQL)
 }
 ```
 
 The `?` and colon-prefixed keys like `:name` in the SQL query are the statement arguments. You set them with arrays or dictionaries (arguments are actually of type [StatementArguments](http://groue.github.io/GRDB.swift/docs/5.8/Structs/StatementArguments.html), which happens to adopt the ExpressibleByArrayLiteral and ExpressibleByDictionaryLiteral protocols).
 
 ```swift
-updateStatement.arguments = ["name": "Arthur", "score": 1000]
+insertStatement.arguments = ["name": "Arthur", "score": 1000]
 selectStatement.arguments = ["Arthur"]
 ```
 
 Alternatively, you can create a prepared statement with [SQL Interpolation]:
 
 ```swift
-let updateStatement = try db.makeUpdateStatement(literal: "INSERT ...")
-let selectStatement = try db.makeSelectStatement(literal: "SELECT ...")
+let insertStatement = try db.makeStatement(literal: "INSERT ...")
+let selectStatement = try db.makeStatement(literal: "SELECT ...")
 //                                               ~~~~~~~
 ```
 
-Update statements can be executed:
+Statements can be executed:
 
 ```swift
-try updateStatement.execute()
+try insertStatement.execute()
 ```
 
-Select statements can be used wherever a raw SQL query string would fit (see [fetch queries](#fetch-queries)):
+Statements can be used wherever a raw SQL query string would fit (see [fetch queries](#fetch-queries)):
 
 ```swift
 let rows = try Row.fetchCursor(selectStatement)    // A Cursor of Row
@@ -1843,13 +1841,13 @@ let player = try Player.fetchOne(selectStatement)  // Player?
 You can set the arguments at the moment of the statement execution:
 
 ```swift
-try updateStatement.execute(arguments: ["name": "Arthur", "score": 1000])
+try insertStatement.execute(arguments: ["name": "Arthur", "score": 1000])
 let player = try Player.fetchOne(selectStatement, arguments: ["Arthur"])
 ```
 
 > :point_up: **Note**: it is a programmer error to reuse a prepared statement that has failed: GRDB may crash if you do so.
 
-See [row queries](#row-queries), [value queries](#value-queries), and [Records](#records) for more information.
+For more information about prepared statements, see the [Statement reference](http://groue.github.io/GRDB.swift/docs/5.8/Classes/Statement.html).
 
 
 ### Prepared Statements Cache
@@ -1860,19 +1858,17 @@ When the same query will be used several times in the lifetime of your applicati
 
 > :point_up: **Note**: This is because you don't have the necessary tools. Statements are tied to specific SQLite connections and dispatch queues which you don't manage yourself, especially when you use [database pools](#database-pools). A change in the database schema [may, or may not](https://www.sqlite.org/compile.html#max_schema_retry) invalidate a statement.
 
-Instead, use the `cachedUpdateStatement` and `cachedSelectStatement` methods. GRDB does all the hard caching and [memory management](#memory-management) stuff for you:
+Instead, use the `cachedStatement` method. GRDB does all the hard caching and [memory management](#memory-management) stuff for you:
 
 ```swift
-let updateStatement = try db.cachedUpdateStatement(sql: sql)
-let selectStatement = try db.cachedSelectStatement(sql: sql)
+let statement = try db.cachedStatement(sql: sql)
 ```
 
 Cached statements also support [SQL Interpolation]:
 
 ```swift
-let updateStatement = try db.cachedUpdateStatement(literal: "INSERT ...")
-let selectStatement = try db.cachedSelectStatement(literal: "SELECT ...")
-//                                                 ~~~~~~~
+let statement = try db.cachedStatement(literal: "INSERT ...")
+//                                     ~~~~~~~
 ```
 
 > :warning: **Warning**: Should a cached prepared statement throw an error, don't reuse it (it is a programmer error). Instead, reload one from the cache.
@@ -2288,7 +2284,7 @@ try dbQueue.read { db in
     let sqliteConnection = db.sqliteConnection
 
     // The raw pointer to a statement:
-    let statement = try db.makeSelectStatement(sql: "SELECT ...")
+    let statement = try db.makeStatement(sql: "SELECT ...")
     let sqliteStatement = statement.sqliteStatement
 }
 ```
@@ -3978,7 +3974,7 @@ let player = try Player.fetchOne(db, sql: "SELECT * FROM player WHERE id = ?", a
 <a name="list-of-record-methods-4">⁴</a> See [Prepared Statements](#prepared-statements):
 
 ```swift
-let statement = try db.makeSelectStatement(sql: "SELECT * FROM player WHERE id = ?")
+let statement = try db.makeStatement(sql: "SELECT * FROM player WHERE id = ?")
 let player = try Player.fetchOne(statement, arguments: [1])  // Player?
 ```
 
@@ -7087,7 +7083,7 @@ In such a situation, you can still avoid fatal errors by exposing and handling e
 ```swift
 // Untrusted arguments
 if let arguments = StatementArguments(arguments) {
-    let statement = try db.makeSelectStatement(sql: sql)
+    let statement = try db.makeStatement(sql: sql)
     try statement.setArguments(arguments)
     
     var cursor = try Row.fetchCursor(statement)

--- a/README.md
+++ b/README.md
@@ -817,10 +817,10 @@ This `allStatements` method allows you to iterate all rows from multiple stateme
 // A Cursor of all rows from all statements
 let rows = try db
     .allStatements(sql: "...")
-    .map { statement in try Row.fetchCursor(statement) }
-    .joined()
+    .flatMap { statement in try Row.fetchCursor(statement) }
 ```
 
+See [prepared statements](#prepared-statements) for more information about `allStatements()`.
 
 ### Cursors
 
@@ -1872,15 +1872,25 @@ When you want to build multiple statements joined with a semicolon, use the `all
 
 ```swift
 let statements = try db.allStatements(sql: """
-    INSERT ...;
-    SELECT ...; 
-    SELECT ...; 
-    """)
+    INSERT INTO player (name, score) VALUES (?, ?);
+    INSERT INTO player (name, score) VALUES (?, ?);
+    """, arguments: ["Arthur", 100, "O'Brien", 1000])
 while let statement = try statements.next() {
-    // Use statement
+    try statement.execute()
 }
 ```
 
+`allStatements` also supports [SQL Interpolation]:
+
+```swift
+let statements = try db.allStatements(literal: """
+    INSERT INTO player (name, score) VALUES (\("Arthur"), \(100));
+    INSERT INTO player (name, score) VALUES (\("O'Brien"), \(1000));
+    """)
+while let statement = try statements.next() {
+    try statement.execute()
+}
+```
 
 > :point_up: **Note**: it is a programmer error to reuse a prepared statement that has failed: GRDB may crash if you do so.
 

--- a/README.md
+++ b/README.md
@@ -1868,7 +1868,7 @@ try insertStatement.execute(arguments: ["name": "Arthur", "score": 1000])
 let player = try Player.fetchOne(selectStatement, arguments: ["Arthur"])
 ```
 
-When you want to build multiple statements joined with a semicolon, use the `allStatements` method:
+**When you want to build multiple statements joined with a semicolon**, use the `allStatements` method:
 
 ```swift
 let statements = try db.allStatements(sql: """
@@ -1891,6 +1891,19 @@ while let statement = try statements.next() {
     try statement.execute()
 }
 ```
+
+You can turn the [cursor](#cursors) returned from `allStatements` into a regular Swift array, but make sure all individual statements can compile even if the previous ones were not run:
+
+```swift
+// OK
+let statements = try Array(db.allStatements(sql: "SELECT ...; SELECT ...;"))
+let statements = try Array(db.allStatements(sql: "INSERT ...; UPDATE ...;"))
+
+// Will fail since the insert statement won't compile until the table is created
+let statements = try Array(db.allStatements(sql: "CREATE TABLE player ...; INSERT INTO player ...;"))
+```
+
+See also `Database.execute(sql:)` in the [Executing Updates](#executing-updates) chapter.
 
 > :point_up: **Note**: it is a programmer error to reuse a prepared statement that has failed: GRDB may crash if you do so.
 

--- a/README.md
+++ b/README.md
@@ -1892,12 +1892,11 @@ while let statement = try statements.next() {
 }
 ```
 
-You can turn the [cursor](#cursors) returned from `allStatements` into a regular Swift array, but make sure all individual statements can compile even if the previous ones were not run:
+You can turn the [cursor](#cursors) returned from `allStatements` into a regular Swift array, but in this case make sure all individual statements can compile even if the previous ones were not run:
 
 ```swift
 // OK
-let statements = try Array(db.allStatements(sql: "SELECT ...; SELECT ...;"))
-let statements = try Array(db.allStatements(sql: "INSERT ...; UPDATE ...;"))
+let statements = try Array(db.allStatements(sql: "INSERT ...; UPDATE ...; SELECT ...;"))
 
 // Will fail since the insert statement won't compile until the table is created
 let statements = try Array(db.allStatements(sql: "CREATE TABLE player ...; INSERT INTO player ...;"))

--- a/Tests/Crash/DatabasePoolCrashTests.swift
+++ b/Tests/Crash/DatabasePoolCrashTests.swift
@@ -6,7 +6,7 @@ class DatabasePoolCrashTests: GRDBCrashTestCase {
     func testReaderCanNotStartTransaction() {
         assertCrash("DatabasePool readers can not start transactions or savepoints.") {
             try dbPool.read { db in
-                let statement = try db.makeUpdateStatement(sql: "BEGIN TRANSACTION")
+                let statement = try db.makeStatement(sql: "BEGIN TRANSACTION")
             }
         }
     }
@@ -14,7 +14,7 @@ class DatabasePoolCrashTests: GRDBCrashTestCase {
     func testReaderCanNotStartSavepoint() {
         assertCrash("DatabasePool readers can not start transactions or savepoints.") {
             try dbPool.read { db in
-                let statement = try db.makeUpdateStatement(sql: "SAVEPOINT foo")
+                let statement = try db.makeStatement(sql: "SAVEPOINT foo")
             }
         }
     }

--- a/Tests/Crash/DatabaseValueConvertibleCrashTests.swift
+++ b/Tests/Crash/DatabaseValueConvertibleCrashTests.swift
@@ -25,7 +25,7 @@ class DatabaseValueConvertibleCrashTests: GRDBCrashTestCase {
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (1)")
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (NULL)")
                 
-                let statement = try db.makeSelectStatement(sql: "SELECT int FROM ints ORDER BY int")
+                let statement = try db.makeStatement(sql: "SELECT int FROM ints ORDER BY int")
                 let sequence = IntConvertible.fetch(statement)
                 for _ in sequence { }
             }
@@ -39,7 +39,7 @@ class DatabaseValueConvertibleCrashTests: GRDBCrashTestCase {
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (1)")
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (NULL)")
                 
-                let statement = try db.makeSelectStatement(sql: "SELECT int FROM ints ORDER BY int")
+                let statement = try db.makeStatement(sql: "SELECT int FROM ints ORDER BY int")
                 _ = IntConvertible.fetchAll(statement)
             }
         }

--- a/Tests/Crash/StatementColumnConvertibleCrashTests.swift
+++ b/Tests/Crash/StatementColumnConvertibleCrashTests.swift
@@ -10,7 +10,7 @@ class StatementColumnConvertibleCrashTests: GRDBCrashTestCase {
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (1)")
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (NULL)")
                 
-                let statement = try db.makeSelectStatement(sql: "SELECT int FROM ints ORDER BY int")
+                let statement = try db.makeStatement(sql: "SELECT int FROM ints ORDER BY int")
                 let sequence = try Int.fetch(statement)
                 for _ in sequence { }
             }
@@ -24,7 +24,7 @@ class StatementColumnConvertibleCrashTests: GRDBCrashTestCase {
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (1)")
                 try db.execute(sql: "INSERT INTO ints (int) VALUES (NULL)")
                 
-                let statement = try db.makeSelectStatement(sql: "SELECT int FROM ints ORDER BY int")
+                let statement = try db.makeStatement(sql: "SELECT int FROM ints ORDER BY int")
                 _ = try Int.fetchAll(statement)
             }
         }

--- a/Tests/GRDBTests/DatabaseErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseErrorTests.swift
@@ -88,7 +88,7 @@ class DatabaseErrorTests: GRDBTestCase {
         // statement.execute(arguments)
         try dbQueue.inDatabase { db in
             do {
-                let statement = try db.makeUpdateStatement(sql: "INSERT INTO pets (masterId, name) VALUES (?, ?)")
+                let statement = try db.makeStatement(sql: "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 try statement.execute(arguments: [1, "Bobby"])
                 XCTFail()
             } catch let error as DatabaseError {
@@ -103,7 +103,7 @@ class DatabaseErrorTests: GRDBTestCase {
         // statement.execute()
         try dbQueue.inDatabase { db in
             do {
-                let statement = try db.makeUpdateStatement(sql: "INSERT INTO pets (masterId, name) VALUES (?, ?)")
+                let statement = try db.makeStatement(sql: "INSERT INTO pets (masterId, name) VALUES (?, ?)")
                 statement.arguments = [1, "Bobby"]
                 try statement.execute()
                 XCTFail()

--- a/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
@@ -201,12 +201,12 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
                 s2.signal()
             }
             let block2 = { [weak dbPool] () in
-                var statement: UpdateStatement? = nil
+                var statement: Statement? = nil
                 do {
                     if let dbPool = dbPool {
                         do {
                             try dbPool.write { db in
-                                statement = try db.makeUpdateStatement(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
+                                statement = try db.makeStatement(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
                                 s1.signal()
                             }
                         } catch {

--- a/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabasePoolSchemaCacheTests.swift
@@ -115,7 +115,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
 //
 //        let block1 = { () in
 //            try! dbPool.read { db in
-//                let stmt = try! db.cachedSelectStatement(sql: "SELECT * FROM items")
+//                let stmt = try! db.cachedStatement(sql: "SELECT * FROM items")
 //                XCTAssertEqual(try Int.fetchOne(stmt)!, 1)
 //                s1.signal()
 //            }
@@ -123,7 +123,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
 //        let block2 = { () in
 //            try! dbPool.read { db in
 //                _ = s1.wait(timeout: .distantFuture)
-//                let stmt = try! db.cachedSelectStatement(sql: "SELECT * FROM items")
+//                let stmt = try! db.cachedStatement(sql: "SELECT * FROM items")
 //                XCTAssertEqual(try Int.fetchOne(stmt)!, 1)
 //            }
 //        }
@@ -177,7 +177,7 @@ class DatabasePoolSchemaCacheTests : GRDBTestCase {
             _ = s1.wait(timeout: .distantFuture)
             try! dbPool.read { db in
                 // activate snapshot isolation so that foo table is visible during the whole read. Any read is enough.
-                try db.makeSelectStatement(sql: "SELECT * FROM sqlite_master").makeCursor().next()
+                try db.makeStatement(sql: "SELECT * FROM sqlite_master").makeCursor().next()
                 // warm cache
                 _ = try db.primaryKey("foo")
                 // cache contains the primary key

--- a/Tests/GRDBTests/DatabaseQueueReadOnlyTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueReadOnlyTests.swift
@@ -22,7 +22,7 @@ class DatabaseQueueReadOnlyTests : GRDBTestCase {
         dbConfiguration.readonly = true
         let dbQueue = try makeDatabaseQueue(filename: "test.sqlite")
         let statement = try dbQueue.inDatabase { db in
-            try db.makeUpdateStatement(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
+            try db.makeStatement(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
         }
         do {
             try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/DatabaseQueueReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueReleaseMemoryTests.swift
@@ -116,12 +116,12 @@ class DatabaseQueueReleaseMemoryTests: GRDBTestCase {
                 s2.signal()
             }
             let block2 = { [weak dbQueue] () in
-                var statement: UpdateStatement? = nil
+                var statement: Statement? = nil
                 do {
                     if let dbQueue = dbQueue {
                         do {
                             try dbQueue.write { db in
-                                statement = try db.makeUpdateStatement(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
+                                statement = try db.makeStatement(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
                                 s1.signal()
                             }
                         } catch {

--- a/Tests/GRDBTests/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionTests.swift
@@ -265,13 +265,13 @@ class DatabaseRegionTests : GRDBTestCase {
             
             do {
                 // Select the rowid
-                let statement = try db.makeSelectStatement(sql: "SELECT id FROM foo")
+                let statement = try db.makeStatement(sql: "SELECT id FROM foo")
                 let expectedRegion = DatabaseRegion(table: "foo")
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(*)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT ID FROM FOO")
+                let statement = try db.makeStatement(sql: "SELECT ID FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo")
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(*)")
@@ -286,33 +286,33 @@ class DatabaseRegionTests : GRDBTestCase {
             try db.execute(sql: "CREATE TABLE bar (id INTEGER PRIMARY KEY, fooId INTEGER)")
             
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT name FROM foo")
+                let statement = try db.makeStatement(sql: "SELECT name FROM foo")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["name"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(name)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT NAME FROM FOO")
+                let statement = try db.makeStatement(sql: "SELECT NAME FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["name"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(name)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT foo.name FROM foo JOIN bar ON fooId = foo.id")
+                let statement = try db.makeStatement(sql: "SELECT foo.name FROM foo JOIN bar ON fooId = foo.id")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["name", "id"])
                     .union(DatabaseRegion(table: "bar", columns: ["fooId"]))
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "bar(fooId),foo(id,name)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT FOO.NAME FROM FOO JOIN BAR ON FOOID = FOO.ID")
+                let statement = try db.makeStatement(sql: "SELECT FOO.NAME FROM FOO JOIN BAR ON FOOID = FOO.ID")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["name", "id"])
                     .union(DatabaseRegion(table: "bar", columns: ["fooId"]))
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "bar(fooId),foo(id,name)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM foo")
+                let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM foo")
                 if sqlite3_libversion_number() < 3019000 {
                     let expectedRegion = DatabaseRegion.fullDatabase
                     XCTAssertEqual(statement.databaseRegion, expectedRegion)
@@ -324,7 +324,7 @@ class DatabaseRegionTests : GRDBTestCase {
                 }
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM FOO")
+                let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM FOO")
                 if sqlite3_libversion_number() < 3019000 {
                     let expectedRegion = DatabaseRegion.fullDatabase
                     XCTAssertEqual(statement.databaseRegion, expectedRegion)
@@ -542,7 +542,7 @@ class DatabaseRegionTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE foo (id INTEGER PRIMARY KEY, bar TEXT, baz TEXT, qux TEXT)")
             do {
-                let statement = try db.makeUpdateStatement(sql: "UPDATE foo SET bar = 'bar', baz = 'baz' WHERE id = 1")
+                let statement = try db.makeStatement(sql: "UPDATE foo SET bar = 'bar', baz = 'baz' WHERE id = 1")
                 XCTAssertFalse(statement.invalidatesDatabaseSchemaCache)
                 XCTAssertEqual(statement.databaseEventKinds.count, 1)
                 guard case .update(let tableName, let columnNames) = statement.databaseEventKinds[0] else {
@@ -553,7 +553,7 @@ class DatabaseRegionTests : GRDBTestCase {
                 XCTAssertEqual(columnNames, Set(["bar", "baz"]))
             }
             do {
-                let statement = try db.makeUpdateStatement(sql: "UPDATE FOO SET BAR = 'bar', BAZ = 'baz' WHERE ID = 1")
+                let statement = try db.makeStatement(sql: "UPDATE FOO SET BAR = 'bar', BAZ = 'baz' WHERE ID = 1")
                 XCTAssertFalse(statement.invalidatesDatabaseSchemaCache)
                 XCTAssertEqual(statement.databaseEventKinds.count, 1)
                 guard case .update(let tableName, let columnNames) = statement.databaseEventKinds[0] else {
@@ -582,19 +582,19 @@ class DatabaseRegionTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE foo (name TEXT)")
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT rowid FROM FOO")
+                let statement = try db.makeStatement(sql: "SELECT rowid FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["ROWID"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(ROWID)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT _ROWID_ FROM FOO")
+                let statement = try db.makeStatement(sql: "SELECT _ROWID_ FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["ROWID"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(ROWID)")
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT oID FROM FOO")
+                let statement = try db.makeStatement(sql: "SELECT oID FROM FOO")
                 let expectedRegion = DatabaseRegion(table: "foo", columns: ["ROWID"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
                 XCTAssertEqual(statement.databaseRegion.description, "foo(ROWID)")
@@ -611,7 +611,7 @@ class DatabaseRegionTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE foo (name TEXT)")
             do {
-                let statement = try db.makeUpdateStatement(sql: "UPDATE foo SET rowid = 1")
+                let statement = try db.makeStatement(sql: "UPDATE foo SET rowid = 1")
                 XCTAssertEqual(statement.databaseEventKinds.count, 1)
                 guard case .update(let tableName, let columnNames) = statement.databaseEventKinds[0] else {
                     XCTFail()
@@ -621,7 +621,7 @@ class DatabaseRegionTests : GRDBTestCase {
                 XCTAssertEqual(columnNames, ["ROWID"])
             }
             do {
-                let statement = try db.makeUpdateStatement(sql: "UPDATE foo SET _ROWID_ = 1")
+                let statement = try db.makeStatement(sql: "UPDATE foo SET _ROWID_ = 1")
                 XCTAssertEqual(statement.databaseEventKinds.count, 1)
                 guard case .update(let tableName, let columnNames) = statement.databaseEventKinds[0] else {
                     XCTFail()
@@ -631,7 +631,7 @@ class DatabaseRegionTests : GRDBTestCase {
                 XCTAssertEqual(columnNames, ["ROWID"])
             }
             do {
-                let statement = try db.makeUpdateStatement(sql: "UPDATE foo SET oID = 1")
+                let statement = try db.makeStatement(sql: "UPDATE foo SET oID = 1")
                 XCTAssertEqual(statement.databaseEventKinds.count, 1)
                 guard case .update(let tableName, let columnNames) = statement.databaseEventKinds[0] else {
                     XCTFail()
@@ -647,7 +647,7 @@ class DatabaseRegionTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE foo (id INTEGER, bar TEXT, baz TEXT, qux TEXT)")
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO foo (id, bar) VALUES (1, 'bar')")
+            let statement = try db.makeStatement(sql: "INSERT INTO foo (id, bar) VALUES (1, 'bar')")
             XCTAssertFalse(statement.invalidatesDatabaseSchemaCache)
             XCTAssertEqual(statement.databaseEventKinds.count, 1)
             guard case .insert(let tableName) = statement.databaseEventKinds[0] else {
@@ -662,7 +662,7 @@ class DatabaseRegionTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE foo (id INTEGER, bar TEXT, baz TEXT, qux TEXT)")
-            let statement = try db.makeUpdateStatement(sql: "DELETE FROM foo")
+            let statement = try db.makeStatement(sql: "DELETE FROM foo")
             XCTAssertFalse(statement.invalidatesDatabaseSchemaCache)
             XCTAssertEqual(statement.databaseEventKinds.count, 1)
             guard case .delete(let tableName) = statement.databaseEventKinds[0] else {
@@ -677,16 +677,16 @@ class DatabaseRegionTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             do {
-                let statement = try db.makeUpdateStatement(sql: "CREATE TABLE foo (id INTEGER)")
+                let statement = try db.makeStatement(sql: "CREATE TABLE foo (id INTEGER)")
                 XCTAssertTrue(statement.invalidatesDatabaseSchemaCache)
                 try statement.execute()
             }
             do {
-                let statement = try db.makeUpdateStatement(sql: "ALTER TABLE foo ADD COLUMN name TEXT")
+                let statement = try db.makeStatement(sql: "ALTER TABLE foo ADD COLUMN name TEXT")
                 XCTAssertTrue(statement.invalidatesDatabaseSchemaCache)
             }
             do {
-                let statement = try db.makeUpdateStatement(sql: "DROP TABLE foo")
+                let statement = try db.makeStatement(sql: "DROP TABLE foo")
                 XCTAssertTrue(statement.invalidatesDatabaseSchemaCache)
             }
         }
@@ -870,34 +870,34 @@ class DatabaseRegionTests : GRDBTestCase {
             // INTEGER PRIMARY KEY
             do {
                 // TODO: contact SQLite and ask if this test is expected to fail
-//                let statement = try db.makeSelectStatement(sql: "SELECT id FROM a")
+//                let statement = try db.makeStatement(sql: "SELECT id FROM a")
 //                let expectedRegion = DatabaseRegion(table: "a", columns: ["id"])
 //                XCTAssertEqual(statement.databaseRegion, expectedRegion)
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT name FROM a")
+                let statement = try db.makeStatement(sql: "SELECT name FROM a")
                 let expectedRegion = DatabaseRegion(table: "a", columns: ["name"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT id, name FROM a")
+                let statement = try db.makeStatement(sql: "SELECT id, name FROM a")
                 let expectedRegion = DatabaseRegion(table: "a", columns: ["id", "name"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
             }
             
             // TEXT primary key
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT id FROM b")
+                let statement = try db.makeStatement(sql: "SELECT id FROM b")
                 let expectedRegion = DatabaseRegion(table: "b", columns: ["id"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT name FROM b")
+                let statement = try db.makeStatement(sql: "SELECT name FROM b")
                 let expectedRegion = DatabaseRegion(table: "b", columns: ["name"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
             }
             do {
-                let statement = try db.makeSelectStatement(sql: "SELECT id, name FROM b")
+                let statement = try db.makeStatement(sql: "SELECT id, name FROM b")
                 let expectedRegion = DatabaseRegion(table: "b", columns: ["id", "name"])
                 XCTAssertEqual(statement.databaseRegion, expectedRegion)
             }

--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -51,7 +51,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
             // The tested function:
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES ('Arthur', 41)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES ('Arthur', 41)")
             try statement.execute()
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -65,7 +65,7 @@ class DatabaseTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
             try statement.execute(arguments: ["Arthur", 41])
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -79,7 +79,7 @@ class DatabaseTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
             try statement.execute(arguments: ["name": "Arthur", "age": 41])
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -94,7 +94,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
             // The tested function:
-            let statement = try db.makeUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES ('Arthur', 41)")
+            let statement = try db.makeStatement(literal: "INSERT INTO persons (name, age) VALUES ('Arthur', 41)")
             try statement.execute()
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -109,7 +109,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
             // The tested function:
-            let statement = try db.makeUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES (\("Arthur"), \(41))")
+            let statement = try db.makeStatement(literal: "INSERT INTO persons (name, age) VALUES (\("Arthur"), \(41))")
             try statement.execute()
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -123,7 +123,7 @@ class DatabaseTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
-            let statement = try db.makeUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES (?, ?)")
+            let statement = try db.makeStatement(literal: "INSERT INTO persons (name, age) VALUES (?, ?)")
             try statement.execute(arguments: ["Arthur", 41])
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -137,7 +137,7 @@ class DatabaseTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
-            let statement = try db.makeUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES (:name, :age)")
+            let statement = try db.makeStatement(literal: "INSERT INTO persons (name, age) VALUES (:name, :age)")
             try statement.execute(arguments: ["name": "Arthur", "age": 41])
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -152,7 +152,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
             // The tested function:
-            let statement = try db.cachedUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES ('Arthur', 41)")
+            let statement = try db.cachedStatement(literal: "INSERT INTO persons (name, age) VALUES ('Arthur', 41)")
             try statement.execute()
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -167,7 +167,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
             // The tested function:
-            let statement = try db.cachedUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES (\("Arthur"), \(41))")
+            let statement = try db.cachedStatement(literal: "INSERT INTO persons (name, age) VALUES (\("Arthur"), \(41))")
             try statement.execute()
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -181,7 +181,7 @@ class DatabaseTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
-            let statement = try db.cachedUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES (?, ?)")
+            let statement = try db.cachedStatement(literal: "INSERT INTO persons (name, age) VALUES (?, ?)")
             try statement.execute(arguments: ["Arthur", 41])
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -195,7 +195,7 @@ class DatabaseTests : GRDBTestCase {
         try dbQueue.inDatabase { db in
             try db.execute(sql: "CREATE TABLE persons (name TEXT, age INT)")
             
-            let statement = try db.cachedUpdateStatement(literal: "INSERT INTO persons (name, age) VALUES (:name, :age)")
+            let statement = try db.cachedStatement(literal: "INSERT INTO persons (name, age) VALUES (:name, :age)")
             try statement.execute(arguments: ["name": "Arthur", "age": 41])
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM persons")!
@@ -279,7 +279,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(sql: "SELECT * FROM persons")
+            let statement = try db.makeStatement(sql: "SELECT * FROM persons")
             let rows = try Row.fetchAll(statement)
             XCTAssertEqual(rows.count, 2)
         }
@@ -292,7 +292,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE name = ?")
+            let statement = try db.makeStatement(sql: "SELECT * FROM persons WHERE name = ?")
             let rows = try Row.fetchAll(statement, arguments: ["Arthur"])
             XCTAssertEqual(rows.count, 1)
         }
@@ -305,7 +305,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE name = :name")
+            let statement = try db.makeStatement(sql: "SELECT * FROM persons WHERE name = :name")
             let rows = try Row.fetchAll(statement, arguments: ["name": "Arthur"])
             XCTAssertEqual(rows.count, 1)
         }
@@ -318,7 +318,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(literal: "SELECT * FROM persons")
+            let statement = try db.makeStatement(literal: "SELECT * FROM persons")
             let rows = try Row.fetchAll(statement)
             XCTAssertEqual(rows.count, 2)
         }
@@ -331,7 +331,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(literal: "SELECT * FROM persons WHERE name = \("Arthur")")
+            let statement = try db.makeStatement(literal: "SELECT * FROM persons WHERE name = \("Arthur")")
             let rows = try Row.fetchAll(statement)
             XCTAssertEqual(rows.count, 1)
         }
@@ -344,7 +344,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(literal: "SELECT * FROM persons WHERE name = ?")
+            let statement = try db.makeStatement(literal: "SELECT * FROM persons WHERE name = ?")
             let rows = try Row.fetchAll(statement, arguments: ["Arthur"])
             XCTAssertEqual(rows.count, 1)
         }
@@ -357,7 +357,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.makeSelectStatement(literal: "SELECT * FROM persons WHERE name = :name")
+            let statement = try db.makeStatement(literal: "SELECT * FROM persons WHERE name = :name")
             let rows = try Row.fetchAll(statement, arguments: ["name": "Arthur"])
             XCTAssertEqual(rows.count, 1)
         }
@@ -370,7 +370,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.cachedSelectStatement(literal: "SELECT * FROM persons")
+            let statement = try db.cachedStatement(literal: "SELECT * FROM persons")
             let rows = try Row.fetchAll(statement)
             XCTAssertEqual(rows.count, 2)
         }
@@ -383,7 +383,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.cachedSelectStatement(literal: "SELECT * FROM persons WHERE name = \("Arthur")")
+            let statement = try db.cachedStatement(literal: "SELECT * FROM persons WHERE name = \("Arthur")")
             let rows = try Row.fetchAll(statement)
             XCTAssertEqual(rows.count, 1)
         }
@@ -396,7 +396,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.cachedSelectStatement(literal: "SELECT * FROM persons WHERE name = ?")
+            let statement = try db.cachedStatement(literal: "SELECT * FROM persons WHERE name = ?")
             let rows = try Row.fetchAll(statement, arguments: ["Arthur"])
             XCTAssertEqual(rows.count, 1)
         }
@@ -409,7 +409,7 @@ class DatabaseTests : GRDBTestCase {
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Arthur", "age": 41])
             try db.execute(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)", arguments: ["name": "Barbara", "age": nil])
             
-            let statement = try db.cachedSelectStatement(literal: "SELECT * FROM persons WHERE name = :name")
+            let statement = try db.cachedStatement(literal: "SELECT * FROM persons WHERE name = :name")
             let rows = try Row.fetchAll(statement, arguments: ["name": "Arthur"])
             XCTAssertEqual(rows.count, 1)
         }

--- a/Tests/GRDBTests/DatabaseValueConversionErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConversionErrorTests.swift
@@ -15,7 +15,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // conversion error
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS name")
+            let statement = try db.makeStatement(sql: "SELECT ? AS name")
             statement.arguments = [nil]
             
             do {
@@ -69,7 +69,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // missing column
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS unused")
+            let statement = try db.makeStatement(sql: "SELECT ? AS unused")
             statement.arguments = ["ignored"]
             
             do {
@@ -137,7 +137,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // conversion error
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT 1, ? AS value")
+            let statement = try db.makeStatement(sql: "SELECT 1, ? AS value")
             statement.arguments = ["invalid"]
             
             do {
@@ -191,7 +191,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // missing column
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS unused")
+            let statement = try db.makeStatement(sql: "SELECT ? AS unused")
             statement.arguments = ["ignored"]
             
             do {
@@ -252,7 +252,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // conversion error
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT NULL AS name, ? AS team")
+            let statement = try db.makeStatement(sql: "SELECT NULL AS name, ? AS team")
             statement.arguments = ["invalid"]
             
             do {
@@ -308,7 +308,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // missing column
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS unused")
+            let statement = try db.makeStatement(sql: "SELECT ? AS unused")
             statement.arguments = ["ignored"]
             
             do {
@@ -374,7 +374,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // conversion error
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT NULL AS name, ? AS value")
+            let statement = try db.makeStatement(sql: "SELECT NULL AS name, ? AS value")
             statement.arguments = ["invalid"]
             
             do {
@@ -430,7 +430,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // missing column
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS unused")
+            let statement = try db.makeStatement(sql: "SELECT ? AS unused")
             statement.arguments = ["ignored"]
             
             do {
@@ -496,7 +496,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // conversion error
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT NULL AS name, ? AS value")
+            let statement = try db.makeStatement(sql: "SELECT NULL AS name, ? AS value")
             statement.arguments = ["invalid"]
             
             do {
@@ -550,7 +550,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         // missing column
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS unused")
+            let statement = try db.makeStatement(sql: "SELECT ? AS unused")
             statement.arguments = ["ignored"]
             
             do {
@@ -606,7 +606,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
     func testStatementColumnConvertible1() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT NULL AS name, ? AS team")
+            let statement = try db.makeStatement(sql: "SELECT NULL AS name, ? AS team")
             statement.arguments = ["invalid"]
             
             do {
@@ -684,7 +684,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
     func testStatementColumnConvertible2() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT ? AS foo")
+            let statement = try db.makeStatement(sql: "SELECT ? AS foo")
             statement.arguments = [1000]
             
             do {
@@ -790,7 +790,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
         
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT NULL AS name, ? AS team")
+            let statement = try db.makeStatement(sql: "SELECT NULL AS name, ? AS team")
             statement.arguments = ["invalid"]
             
             do {

--- a/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
@@ -31,7 +31,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchCursor(db, sql: sql))
                 try test(Fetched.fetchCursor(statement))
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)))
@@ -39,7 +39,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchCursor(statement, adapter: adapter))
@@ -85,7 +85,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchCursor(db, sql: sql), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -93,7 +93,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -117,7 +117,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchCursor(db, sql: sql), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -125,7 +125,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -140,7 +140,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchAll(db, sql: sql))
                 try test(Fetched.fetchAll(statement))
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)))
@@ -148,7 +148,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchAll(statement, adapter: adapter))
@@ -186,7 +186,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchAll(db, sql: sql), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -194,7 +194,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -218,7 +218,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchAll(db, sql: sql), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -226,7 +226,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -241,7 +241,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchSet(db, sql: sql))
                 try test(Fetched.fetchSet(statement))
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)))
@@ -249,7 +249,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchSet(statement, adapter: adapter))
@@ -287,7 +287,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchSet(db, sql: sql), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -295,7 +295,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -319,7 +319,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchSet(db, sql: sql), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -327,7 +327,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -343,7 +343,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -351,7 +351,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -365,7 +365,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT NULL"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -373,7 +373,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, NULL"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -387,7 +387,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 1"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -395,7 +395,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, 1"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -434,7 +434,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchOne(db, sql: sql), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -442,7 +442,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
@@ -466,7 +466,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchOne(db, sql: sql), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -474,7 +474,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
@@ -494,7 +494,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql))
                 try test(Optional<Fetched>.fetchCursor(statement))
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql)))
@@ -502,7 +502,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql, adapter: adapter))
                 try test(Optional<Fetched>.fetchCursor(statement, adapter: adapter))
@@ -548,7 +548,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -556,7 +556,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -580,7 +580,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -588,7 +588,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -605,7 +605,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql))
                 try test(Optional<Fetched>.fetchAll(statement))
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql)))
@@ -613,7 +613,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql, adapter: adapter))
                 try test(Optional<Fetched>.fetchAll(statement, adapter: adapter))
@@ -651,7 +651,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Optional<Fetched>.fetchAll(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -659,7 +659,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -683,7 +683,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Optional<Fetched>.fetchAll(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -691,7 +691,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -706,7 +706,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql))
                 try test(Optional<Fetched>.fetchSet(statement))
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql)))
@@ -714,7 +714,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql, adapter: adapter))
                 try test(Optional<Fetched>.fetchSet(statement, adapter: adapter))
@@ -752,7 +752,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Optional<Fetched>.fetchSet(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -760,7 +760,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -784,7 +784,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Optional<Fetched>.fetchSet(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -792,7 +792,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -246,7 +246,7 @@ class DatabaseWriterTests : GRDBTestCase {
                 """)
         }
         try dbQueue.read { db in
-            _ = try Row.fetchCursor(db.cachedSelectStatement(sql: "SELECT * FROM t")).next()
+            _ = try Row.fetchCursor(db.cachedStatement(sql: "SELECT * FROM t")).next()
         }
         try dbQueue.erase()
     }
@@ -261,7 +261,7 @@ class DatabaseWriterTests : GRDBTestCase {
                 INSERT INTO t VALUES (1);
                 PRAGMA query_only = 1;
                 """)
-            _ = try Row.fetchCursor(db.cachedSelectStatement(sql: "SELECT * FROM t")).next()
+            _ = try Row.fetchCursor(db.cachedStatement(sql: "SELECT * FROM t")).next()
         }
         try DatabaseQueue().backup(to: dbQueue)
     }

--- a/Tests/GRDBTests/FetchableRecordTests.swift
+++ b/Tests/GRDBTests/FetchableRecordTests.swift
@@ -36,7 +36,7 @@ class FetchableRecordTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchCursor(db, sql: sql))
                 try test(Fetched.fetchCursor(statement))
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)))
@@ -44,7 +44,7 @@ class FetchableRecordTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 0, 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchCursor(statement, adapter: adapter))
@@ -94,7 +94,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw(), NULL"
                 try test(Fetched.fetchCursor(db, sql: sql), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -102,7 +102,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT 0, throw(), NULL"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -126,7 +126,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchCursor(db, sql: sql), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -134,7 +134,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -150,7 +150,7 @@ class FetchableRecordTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchAll(db, sql: sql))
                 try test(Fetched.fetchAll(statement))
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)))
@@ -158,7 +158,7 @@ class FetchableRecordTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 0, 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchAll(statement, adapter: adapter))
@@ -199,7 +199,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchAll(db, sql: sql), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -207,7 +207,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -231,7 +231,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchAll(db, sql: sql), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -239,7 +239,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -255,7 +255,7 @@ class FetchableRecordTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchSet(db, sql: sql))
                 try test(Fetched.fetchSet(statement))
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)))
@@ -263,7 +263,7 @@ class FetchableRecordTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 0, 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchSet(statement, adapter: adapter))
@@ -304,7 +304,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchSet(db, sql: sql), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -312,7 +312,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -336,7 +336,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchSet(db, sql: sql), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -344,7 +344,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -360,7 +360,7 @@ class FetchableRecordTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -368,7 +368,7 @@ class FetchableRecordTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -383,7 +383,7 @@ class FetchableRecordTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -391,7 +391,7 @@ class FetchableRecordTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -433,7 +433,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchOne(db, sql: sql), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -441,7 +441,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
@@ -465,7 +465,7 @@ class FetchableRecordTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchOne(db, sql: sql), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -473,7 +473,7 @@ class FetchableRecordTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -226,7 +226,7 @@ class GRDBTestCase: XCTestCase {
 
 extension FetchRequest {
     /// Turn request into a statement
-    func makeStatement(_ db: Database) throws -> SelectStatement {
+    func makeStatement(_ db: Database) throws -> Statement {
         try makePreparedRequest(db, forSingleResult: false).statement
     }
     

--- a/Tests/GRDBTests/RowFetchTests.swift
+++ b/Tests/GRDBTests/RowFetchTests.swift
@@ -21,7 +21,7 @@ class RowFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Row.fetchCursor(db, sql: sql))
                 try test(Row.fetchCursor(statement))
                 try test(Row.fetchCursor(db, SQLRequest<Void>(sql: sql)))
@@ -29,7 +29,7 @@ class RowFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 0, 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchCursor(db, sql: sql, adapter: adapter))
                 try test(Row.fetchCursor(statement, adapter: adapter))
@@ -75,7 +75,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw(), NULL"
                 try test(Row.fetchCursor(db, sql: sql), sql: sql)
-                try test(Row.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -83,7 +83,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw(), NULL"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -107,7 +107,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Row.fetchCursor(db, sql: sql), sql: sql)
-                try test(Row.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -115,7 +115,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -131,7 +131,7 @@ class RowFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Row.fetchAll(db, sql: sql))
                 try test(Row.fetchAll(statement))
                 try test(Row.fetchAll(db, SQLRequest<Void>(sql: sql)))
@@ -139,7 +139,7 @@ class RowFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 0, 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchAll(db, sql: sql, adapter: adapter))
                 try test(Row.fetchAll(statement, adapter: adapter))
@@ -177,7 +177,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Row.fetchAll(db, sql: sql), sql: sql)
-                try test(Row.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -185,7 +185,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -209,7 +209,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Row.fetchAll(db, sql: sql), sql: sql)
-                try test(Row.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -217,7 +217,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -233,7 +233,7 @@ class RowFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Row.fetchSet(db, sql: sql))
                 try test(Row.fetchSet(statement))
                 try test(Row.fetchSet(db, SQLRequest<Void>(sql: sql)))
@@ -241,7 +241,7 @@ class RowFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 0, 'Barbara', 'Gourde'"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchSet(db, sql: sql, adapter: adapter))
                 try test(Row.fetchSet(statement, adapter: adapter))
@@ -279,7 +279,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Row.fetchSet(db, sql: sql), sql: sql)
-                try test(Row.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -287,7 +287,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -311,7 +311,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Row.fetchSet(db, sql: sql), sql: sql)
-                try test(Row.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -319,7 +319,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -335,7 +335,7 @@ class RowFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Row.fetchOne(db, sql: sql))
                     try test(Row.fetchOne(statement))
                     try test(Row.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -343,7 +343,7 @@ class RowFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Row.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Row.fetchOne(statement, adapter: adapter))
@@ -358,7 +358,7 @@ class RowFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Row.fetchOne(db, sql: sql))
                     try test(Row.fetchOne(statement))
                     try test(Row.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -366,7 +366,7 @@ class RowFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0 AS firstName, 'Arthur' AS firstName, 'Martin' AS lastName"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Row.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Row.fetchOne(statement, adapter: adapter))
@@ -405,7 +405,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Row.fetchOne(db, sql: sql), sql: sql)
-                try test(Row.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -413,7 +413,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
@@ -437,7 +437,7 @@ class RowFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Row.fetchOne(db, sql: sql), sql: sql)
-                try test(Row.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Row.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Row.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -445,7 +445,7 @@ class RowFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Row.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Row.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Row.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Row.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Row>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }

--- a/Tests/GRDBTests/SelectStatementTests.swift
+++ b/Tests/GRDBTests/SelectStatementTests.swift
@@ -172,9 +172,7 @@ class SelectStatementTests : GRDBTestCase {
                     SELECT age FROM persons ORDER BY age;
                     SELECT age FROM persons ORDER BY age DESC;
                     """)
-                let ages = try Array(statements
-                                        .map { try Int.fetchCursor($0) }
-                                        .joined())
+                let ages = try Array(statements.flatMap { try Int.fetchCursor($0) })
                 XCTAssertEqual(ages, [13, 26, 41, 41, 26, 13])
             }
             do {

--- a/Tests/GRDBTests/SelectStatementTests.swift
+++ b/Tests/GRDBTests/SelectStatementTests.swift
@@ -25,7 +25,7 @@ class SelectStatementTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let sql = "SELECT 'Arthur' AS firstName, 'Martin' AS lastName UNION ALL SELECT 'Barbara', 'Gourde'"
-            let statement = try db.makeSelectStatement(sql: sql)
+            let statement = try db.makeStatement(sql: sql)
             let cursor = try statement.makeCursor()
             
             // Check that StatementCursor gives access to the raw SQLite API
@@ -62,15 +62,15 @@ class SelectStatementTests : GRDBTestCase {
                     // error. What we care about is that there is an error.
                 }
             }
-            try test(db.makeSelectStatement(sql: "SELECT throw(), NULL").makeCursor())
-            try test(db.makeSelectStatement(sql: "SELECT 0, throw(), NULL").makeCursor())
+            try test(db.makeStatement(sql: "SELECT throw(), NULL").makeCursor())
+            try test(db.makeStatement(sql: "SELECT 0, throw(), NULL").makeCursor())
         }
     }
     
     func testArrayStatementArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < ?")
+            let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < ?")
             let ages = [20, 30, 40, 50]
             let counts = try ages.map { try Int.fetchOne(statement, arguments: [$0])! }
             XCTAssertEqual(counts, [1,2,2,3])
@@ -80,7 +80,7 @@ class SelectStatementTests : GRDBTestCase {
     func testStatementArgumentsSetterWithArray() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < ?")
+            let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < ?")
             let ages = [20, 30, 40, 50]
             let counts = try ages.map { (age: Int) -> Int in
                 statement.arguments = [age]
@@ -93,7 +93,7 @@ class SelectStatementTests : GRDBTestCase {
     func testDictionaryStatementArguments() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < :age")
+            let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < :age")
             let ageDicts: [[String: DatabaseValueConvertible?]] = [["age": 20], ["age": 30], ["age": 40], ["age": 50]]
             let counts = try ageDicts.map { dic -> Int in
                 // Make sure we don't trigger a failible initializer
@@ -107,7 +107,7 @@ class SelectStatementTests : GRDBTestCase {
     func testStatementArgumentsSetterWithDictionary() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeSelectStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < :age")
+            let statement = try db.makeStatement(sql: "SELECT COUNT(*) FROM persons WHERE age < :age")
             let ageDicts: [[String: DatabaseValueConvertible?]] = [["age": 20], ["age": 30], ["age": 40], ["age": 50]]
             let counts = try ageDicts.map { ageDict -> Int in
                 statement.arguments = StatementArguments(ageDict)
@@ -121,7 +121,7 @@ class SelectStatementTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             do {
-                _ = try db.makeSelectStatement(sql: "SELECT * FROM blah")
+                _ = try db.makeStatement(sql: "SELECT * FROM blah")
                 XCTFail()
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
@@ -145,11 +145,11 @@ class SelectStatementTests : GRDBTestCase {
             let sql = "SELECT bomb()"
             
             needsThrow = false
-            XCTAssertEqual(try String.fetchAll(db.cachedSelectStatement(sql: sql)), ["success"])
+            XCTAssertEqual(try String.fetchAll(db.cachedStatement(sql: sql)), ["success"])
             
             do {
                 needsThrow = true
-                _ = try String.fetchAll(db.cachedSelectStatement(sql: sql))
+                _ = try String.fetchAll(db.cachedStatement(sql: sql))
                 XCTFail()
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
@@ -159,7 +159,7 @@ class SelectStatementTests : GRDBTestCase {
             }
             
             needsThrow = false
-            XCTAssertEqual(try String.fetchAll(db.cachedSelectStatement(sql: sql)), ["success"])
+            XCTAssertEqual(try String.fetchAll(db.cachedStatement(sql: sql)), ["success"])
         }
     }
     
@@ -217,16 +217,16 @@ class SelectStatementTests : GRDBTestCase {
             try db.execute(sql: "CREATE TRIGGER table5trigger AFTER INSERT ON table5 BEGIN INSERT INTO table1 (id3, id4, a, b) VALUES (NULL, NULL, 0, 0); END")
             
             let statements = try [
-                db.makeSelectStatement(sql: "SELECT * FROM table1"),
-                db.makeSelectStatement(sql: "SELECT id, id3, a FROM table1"),
-                db.makeSelectStatement(sql: "SELECT table1.id, table1.a, table2.a FROM table1 JOIN table2 ON table1.id = table2.id"),
+                db.makeStatement(sql: "SELECT * FROM table1"),
+                db.makeStatement(sql: "SELECT id, id3, a FROM table1"),
+                db.makeStatement(sql: "SELECT table1.id, table1.a, table2.a FROM table1 JOIN table2 ON table1.id = table2.id"),
                 
                 // This last request triggers its observer or not, depending on the SQLite version.
                 // Before SQLite 3.19.0, its region is doubtful, and every database change is deemed impactful.
                 // Starting SQLite 3.19.0, it knows that only table1 is involved.
                 //
                 // See doubtfulCountFunction below
-                db.makeSelectStatement(sql: "SELECT COUNT(*) FROM table1"),
+                db.makeStatement(sql: "SELECT COUNT(*) FROM table1"),
             ]
             
             let doubtfulCountFunction = (sqlite3_libversion_number() < 3019000)

--- a/Tests/GRDBTests/StatementArguments+FoundationTests.swift
+++ b/Tests/GRDBTests/StatementArguments+FoundationTests.swift
@@ -25,7 +25,7 @@ class StatementArgumentsFoundationTests: GRDBTestCase {
         
         try dbQueue.inTransaction { db in
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
             let persons: [[Any]] = [
                 ["Arthur", 41],
                 ["Barbara", 38],
@@ -63,7 +63,7 @@ class StatementArgumentsFoundationTests: GRDBTestCase {
         
         try dbQueue.inTransaction { db in
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
             let persons: [[AnyHashable: Any]] = [
                 ["name": "Arthur", "age": 41],
                 ["name": "Barbara", "age": 38],

--- a/Tests/GRDBTests/StatementArgumentsTests.swift
+++ b/Tests/GRDBTests/StatementArgumentsTests.swift
@@ -20,7 +20,7 @@ class StatementArgumentsTests: GRDBTestCase {
     func testPositionalStatementArgumentsValidation() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
             
             do {
                 // Correct number of arguments
@@ -83,11 +83,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments([name, age] as [DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
             updateStatement.arguments = arguments
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = ? AND age = ?")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = ? AND age = ?")
             selectStatement.arguments = arguments
             let row = try Row.fetchOne(selectStatement)!
             
@@ -103,11 +103,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments([name, age] as [DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
             try updateStatement.setArguments(arguments)
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = ? AND age = ?")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = ? AND age = ?")
             try selectStatement.setArguments(arguments)
             let row = try Row.fetchOne(selectStatement)!
             
@@ -141,11 +141,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments([name, age] as [DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (?, ?)")
             updateStatement.setUncheckedArguments(arguments)
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = ? AND age = ?")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = ? AND age = ?")
             selectStatement.setUncheckedArguments(arguments)
             let row = try Row.fetchOne(selectStatement)!
             
@@ -157,7 +157,7 @@ class StatementArgumentsTests: GRDBTestCase {
     func testNamedStatementArgumentsValidation() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:firstName, :age)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:firstName, :age)")
             
             do {
                 // Correct number of arguments
@@ -234,11 +234,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments(["name": name, "age": age] as [String: DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:name, :age)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:name, :age)")
             updateStatement.arguments = arguments
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND age = :age")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND age = :age")
             selectStatement.arguments = arguments
             let row = try Row.fetchOne(selectStatement)!
             
@@ -254,11 +254,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments(["name": name, "age": age] as [String: DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:name, :age)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:name, :age)")
             try updateStatement.setArguments(arguments)
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND age = :age")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND age = :age")
             try selectStatement.setArguments(arguments)
             let row = try Row.fetchOne(selectStatement)!
             
@@ -292,11 +292,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments(["name": name, "age": age] as [String: DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:name, :age)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, age) VALUES (:name, :age)")
             updateStatement.setUncheckedArguments(arguments)
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND age = :age")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND age = :age")
             selectStatement.setUncheckedArguments(arguments)
             let row = try Row.fetchOne(selectStatement)!
             
@@ -308,7 +308,7 @@ class StatementArgumentsTests: GRDBTestCase {
     func testReusedNamedStatementArgumentsValidation() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
             
             do {
                 try statement.execute(arguments: ["name": "foo", "age": 1])
@@ -394,11 +394,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments(["name": name, "age": age] as [String: DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
             updateStatement.arguments = arguments
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND lastName = :name AND age = :age")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND lastName = :name AND age = :age")
             selectStatement.arguments = arguments
             let row = try Row.fetchOne(selectStatement)!
             
@@ -414,11 +414,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments(["name": name, "age": age] as [String: DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
             try updateStatement.setArguments(arguments)
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND lastName = :name AND age = :age")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND lastName = :name AND age = :age")
             try selectStatement.setArguments(arguments)
             let row = try Row.fetchOne(selectStatement)!
             
@@ -452,11 +452,11 @@ class StatementArgumentsTests: GRDBTestCase {
             let age = 42
             let arguments = StatementArguments(["name": name, "age": age] as [String: DatabaseValueConvertible?])
             
-            let updateStatement = try db.makeUpdateStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
+            let updateStatement = try db.makeStatement(sql: "INSERT INTO persons (firstName, lastName, age) VALUES (:name, :name, :age)")
             updateStatement.setUncheckedArguments(arguments)
             try updateStatement.execute()
             
-            let selectStatement = try db.makeSelectStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND lastName = :name AND age = :age")
+            let selectStatement = try db.makeStatement(sql: "SELECT * FROM persons WHERE firstName = :name AND lastName = :name AND age = :age")
             selectStatement.setUncheckedArguments(arguments)
             let row = try Row.fetchOne(selectStatement)!
             

--- a/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
@@ -121,7 +121,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchCursor(db, sql: sql))
                 try test(Fetched.fetchCursor(statement))
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)))
@@ -129,7 +129,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchCursor(statement, adapter: adapter))
@@ -176,7 +176,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchCursor(db, sql: sql), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -184,7 +184,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -208,7 +208,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchCursor(db, sql: sql), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -216,7 +216,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -232,7 +232,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchAll(db, sql: sql))
                 try test(Fetched.fetchAll(statement))
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)))
@@ -240,7 +240,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchAll(statement, adapter: adapter))
@@ -279,7 +279,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchAll(db, sql: sql), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -287,7 +287,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -311,7 +311,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchAll(db, sql: sql), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -319,7 +319,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -335,7 +335,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Fetched.fetchSet(db, sql: sql))
                 try test(Fetched.fetchSet(statement))
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)))
@@ -343,7 +343,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, 2"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter))
                 try test(Fetched.fetchSet(statement, adapter: adapter))
@@ -382,7 +382,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchSet(db, sql: sql), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -390,7 +390,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -414,7 +414,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchSet(db, sql: sql), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -422,7 +422,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -438,7 +438,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -446,7 +446,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, 1 WHERE 0"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -460,7 +460,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT NULL"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -468,7 +468,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, NULL"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -482,7 +482,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 1"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     try test(Fetched.fetchOne(db, sql: sql))
                     try test(Fetched.fetchOne(statement))
                     try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)))
@@ -490,7 +490,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 }
                 do {
                     let sql = "SELECT 0, 1"
-                    let statement = try db.makeSelectStatement(sql: sql)
+                    let statement = try db.makeStatement(sql: sql)
                     let adapter = SuffixRowAdapter(fromIndex: 1)
                     try test(Fetched.fetchOne(db, sql: sql, adapter: adapter))
                     try test(Fetched.fetchOne(statement, adapter: adapter))
@@ -530,7 +530,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Fetched.fetchOne(db, sql: sql), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -538,7 +538,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
@@ -562,7 +562,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Fetched.fetchOne(db, sql: sql), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql)), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql).fetchOne(db), sql: sql)
             }
@@ -570,7 +570,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Fetched.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Fetched.fetchOne(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Fetched.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Fetched.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
@@ -592,7 +592,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql))
                 try test(Optional<Fetched>.fetchCursor(statement))
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql)))
@@ -600,7 +600,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql, adapter: adapter))
                 try test(Optional<Fetched>.fetchCursor(statement, adapter: adapter))
@@ -638,7 +638,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchCursor(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchCursor(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchCursor(db), sql: sql)
             }
@@ -646,7 +646,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchCursor(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchCursor(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchCursor(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchCursor(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchCursor(db), sql: sql)
             }
@@ -664,7 +664,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql))
                 try test(Optional<Fetched>.fetchAll(statement))
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql)))
@@ -672,7 +672,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql, adapter: adapter))
                 try test(Optional<Fetched>.fetchAll(statement, adapter: adapter))
@@ -711,7 +711,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Optional<Fetched>.fetchAll(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -719,7 +719,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -743,7 +743,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Optional<Fetched>.fetchAll(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchAll(db), sql: sql)
             }
@@ -751,7 +751,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchAll(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchAll(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchAll(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchAll(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchAll(db), sql: sql)
             }
@@ -767,7 +767,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 1 UNION ALL SELECT NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql))
                 try test(Optional<Fetched>.fetchSet(statement))
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql)))
@@ -775,7 +775,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             }
             do {
                 let sql = "SELECT 0, 1 UNION ALL SELECT 0, NULL"
-                let statement = try db.makeSelectStatement(sql: sql)
+                let statement = try db.makeStatement(sql: sql)
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql, adapter: adapter))
                 try test(Optional<Fetched>.fetchSet(statement, adapter: adapter))
@@ -814,7 +814,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT throw()"
                 try test(Optional<Fetched>.fetchSet(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -822,7 +822,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT 0, throw()"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }
@@ -846,7 +846,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 let sql = "SELECT * FROM nonExistingTable"
                 try test(Optional<Fetched>.fetchSet(db, sql: sql), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql)), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql).fetchSet(db), sql: sql)
             }
@@ -854,7 +854,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 let sql = "SELECT * FROM nonExistingTable"
                 let adapter = SuffixRowAdapter(fromIndex: 1)
                 try test(Optional<Fetched>.fetchSet(db, sql: sql, adapter: adapter), sql: sql)
-                try test(Optional<Fetched>.fetchSet(db.makeSelectStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
             }

--- a/Tests/GRDBTests/TransactionObserverTests.swift
+++ b/Tests/GRDBTests/TransactionObserverTests.swift
@@ -617,6 +617,38 @@ class TransactionObserverTests: GRDBTestCase {
         }
     }
 
+    func testInsertEventWithCursor() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try setupArtistDatabase(in: dbQueue)
+        let observer = Observer()
+        dbQueue.add(transactionObserver: observer)
+        
+        try dbQueue.writeWithoutTransaction { db in
+            let insertedName = "Gerhard Richter"
+            let statement = try db.makeStatement(literal: "INSERT INTO artists (name) VALUES (\(insertedName))")
+            _ = try Row.fetchCursor(statement).next()
+            let insertedId = db.lastInsertedRowID
+            
+            XCTAssertEqual(observer.lastCommittedEvents.count, 1)
+            let event = observer.lastCommittedEvents.filter { event in
+                self.match(event: event, kind: .insert, tableName: "artists", rowId: insertedId)
+            }.first
+            XCTAssertTrue(event != nil)
+            
+            #if SQLITE_ENABLE_PREUPDATE_HOOK
+            XCTAssertEqual(observer.lastCommittedPreUpdateEvents.count, 1)
+            let preUpdateEvent = observer.lastCommittedPreUpdateEvents.filter { event in
+                self.match(preUpdateEvent: event, kind: .insert, tableName: "artists", initialRowID: nil, finalRowID: insertedId, initialValues: nil,
+                           finalValues: [
+                            insertedId.databaseValue,
+                            insertedName.databaseValue
+                           ])
+            }.first
+            XCTAssertTrue(preUpdateEvent != nil)
+            #endif
+        }
+    }
+    
     func testUpdateEvent() throws {
         let dbQueue = try makeDatabaseQueue()
         try setupArtistDatabase(in: dbQueue)

--- a/Tests/GRDBTests/TruncateOptimizationTests.swift
+++ b/Tests/GRDBTests/TruncateOptimizationTests.swift
@@ -94,7 +94,7 @@ class TruncateOptimizationTests: GRDBTestCase {
         
         try dbQueue.writeWithoutTransaction { db in
             try db.execute(sql: "CREATE TABLE t(a)")
-            let deleteStatement = try db.makeUpdateStatement(sql: "DELETE FROM t")
+            let deleteStatement = try db.makeStatement(sql: "DELETE FROM t")
             
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
@@ -140,7 +140,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TABLE t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TABLE t") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TABLE t") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.tableExists("t"))
         }
@@ -153,7 +153,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TABLE t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TABLE t") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TABLE t") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.tableExists("t"))
         }
@@ -188,7 +188,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TEMPORARY TABLE t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TABLE t") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TABLE t") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.tableExists("t"))
         }
@@ -201,7 +201,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TEMPORARY TABLE t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TABLE t") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TABLE t") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.tableExists("t"))
         }
@@ -236,7 +236,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE VIRTUAL TABLE t USING fts3(a)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TABLE t") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TABLE t") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.tableExists("t"))
         }
@@ -249,7 +249,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE VIRTUAL TABLE t USING fts3(a)")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.tableExists("t"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TABLE t") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TABLE t") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.tableExists("t"))
         }
@@ -287,7 +287,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE VIEW v AS SELECT * FROM t")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.viewExists("v"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP VIEW v") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP VIEW v") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.viewExists("v"))
         }
@@ -301,7 +301,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE VIEW v AS SELECT * FROM t")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.viewExists("v"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP VIEW v") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP VIEW v") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.viewExists("v"))
         }
@@ -339,7 +339,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TEMPORARY VIEW v AS SELECT * FROM t")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.viewExists("v"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP VIEW v") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP VIEW v") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.viewExists("v"))
         }
@@ -353,7 +353,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TEMPORARY VIEW v AS SELECT * FROM t")
             try db.execute(sql: "INSERT INTO t VALUES (NULL)")
             try XCTAssertTrue(db.viewExists("v"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP VIEW v") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP VIEW v") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.viewExists("v"))
         }
@@ -389,7 +389,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE INDEX i ON t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (1)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP INDEX i") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP INDEX i") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertTrue(db.indexes(on: "t").isEmpty)
         }
@@ -403,7 +403,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE INDEX i ON t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (1)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP INDEX i") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP INDEX i") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertTrue(db.indexes(on: "t").isEmpty)
         }
@@ -439,7 +439,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE INDEX i ON t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (1)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP INDEX i") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP INDEX i") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertTrue(db.indexes(on: "t").isEmpty)
         }
@@ -453,7 +453,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE INDEX i ON t(a)")
             try db.execute(sql: "INSERT INTO t VALUES (1)")
             try XCTAssertFalse(db.indexes(on: "t").isEmpty)
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP INDEX i") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP INDEX i") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertTrue(db.indexes(on: "t").isEmpty)
         }
@@ -488,7 +488,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TABLE t(a)")
             try db.execute(sql: "CREATE TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TRIGGER r") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TRIGGER r") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.triggerExists("r"))
         }
@@ -501,7 +501,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TABLE t(a)")
             try db.execute(sql: "CREATE TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TRIGGER r") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TRIGGER r") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.triggerExists("r"))
         }
@@ -536,7 +536,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TABLE t(a)")
             try db.execute(sql: "CREATE TEMPORARY TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TRIGGER r") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TRIGGER r") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.triggerExists("r"))
         }
@@ -549,7 +549,7 @@ class TruncateOptimizationTests: GRDBTestCase {
             try db.execute(sql: "CREATE TABLE t(a)")
             try db.execute(sql: "CREATE TEMPORARY TRIGGER r INSERT ON t BEGIN DELETE FROM t; END")
             try XCTAssertTrue(db.triggerExists("r"))
-            let dropStatement = try db.makeUpdateStatement(sql: "DROP TRIGGER r") // compile...
+            let dropStatement = try db.makeStatement(sql: "DROP TRIGGER r") // compile...
             try dropStatement.execute() // ... then execute
             try XCTAssertFalse(db.triggerExists("r"))
         }

--- a/Tests/GRDBTests/UpdateStatementTests.swift
+++ b/Tests/GRDBTests/UpdateStatementTests.swift
@@ -372,9 +372,16 @@ class UpdateStatementTests : GRDBTestCase {
                 XCTFail("Expected error")
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
-                XCTAssertEqual(error.message!, "Multiple statements found. To execute multiple statements, use Database.execute(sql:) instead.")
+                XCTAssertEqual(error.message!, """
+                    Multiple statements found. To execute multiple statements, \
+                    use Database.execute(sql:) or Database.allStatements(sql:) instead.
+                    """)
                 XCTAssertEqual(error.sql!, "UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
-                XCTAssertEqual(error.description, "SQLite error 21: Multiple statements found. To execute multiple statements, use Database.execute(sql:) instead. - while executing `UPDATE persons SET age = 1; UPDATE persons SET age = 2;`")
+                XCTAssertEqual(error.description, """
+                    SQLite error 21: Multiple statements found. To execute multiple statements, \
+                    use Database.execute(sql:) or Database.allStatements(sql:) instead. \
+                    - while executing `UPDATE persons SET age = 1; UPDATE persons SET age = 2;`
+                    """)
             }
         }
     }
@@ -387,9 +394,16 @@ class UpdateStatementTests : GRDBTestCase {
                 XCTFail("Expected error")
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
-                XCTAssertEqual(error.message!, "Multiple statements found. To execute multiple statements, use Database.execute(sql:) instead.")
+                XCTAssertEqual(error.message!, """
+                    Multiple statements found. To execute multiple statements, \
+                    use Database.execute(sql:) or Database.allStatements(sql:) instead.
+                    """)
                 XCTAssertEqual(error.sql!, "UPDATE persons SET age = 1;x")
-                XCTAssertEqual(error.description, "SQLite error 21: Multiple statements found. To execute multiple statements, use Database.execute(sql:) instead. - while executing `UPDATE persons SET age = 1;x`")
+                XCTAssertEqual(error.description, """
+                    SQLite error 21: Multiple statements found. To execute multiple statements, \
+                    use Database.execute(sql:) or Database.allStatements(sql:) instead. \
+                    - while executing `UPDATE persons SET age = 1;x`
+                    """)
             }
         }
     }

--- a/Tests/GRDBTests/UpdateStatementTests.swift
+++ b/Tests/GRDBTests/UpdateStatementTests.swift
@@ -20,10 +20,10 @@ class UpdateStatementTests : GRDBTestCase {
     func testTrailingSemicolonAndWhiteSpaceIsAcceptedAndOptional() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inTransaction { db in
-            try db.makeUpdateStatement(sql: "INSERT INTO persons (name) VALUES ('Arthur');").execute()
-            try db.makeUpdateStatement(sql: "INSERT INTO persons (name) VALUES ('Barbara')\n \t").execute()
-            try db.makeUpdateStatement(sql: "INSERT INTO persons (name) VALUES ('Craig'); ; ;").execute()
-            try db.makeUpdateStatement(sql: "INSERT INTO persons (name) VALUES ('Daniel');\n \t").execute()
+            try db.makeStatement(sql: "INSERT INTO persons (name) VALUES ('Arthur');").execute()
+            try db.makeStatement(sql: "INSERT INTO persons (name) VALUES ('Barbara')\n \t").execute()
+            try db.makeStatement(sql: "INSERT INTO persons (name) VALUES ('Craig'); ; ;").execute()
+            try db.makeStatement(sql: "INSERT INTO persons (name) VALUES ('Daniel');\n \t").execute()
             return .commit
         }
         try dbQueue.inDatabase { db in
@@ -35,8 +35,8 @@ class UpdateStatementTests : GRDBTestCase {
     func testStatementSQL() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            try XCTAssertEqual(db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES ('Arthur', ?)").sql, "INSERT INTO persons (name, age) VALUES ('Arthur', ?)")
-            try XCTAssertEqual(db.makeUpdateStatement(sql: " INSERT INTO persons (name, age) VALUES ('Arthur', ?) ; ").sql, "INSERT INTO persons (name, age) VALUES ('Arthur', ?)")
+            try XCTAssertEqual(db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES ('Arthur', ?)").sql, "INSERT INTO persons (name, age) VALUES ('Arthur', ?)")
+            try XCTAssertEqual(db.makeStatement(sql: " INSERT INTO persons (name, age) VALUES ('Arthur', ?) ; ").sql, "INSERT INTO persons (name, age) VALUES ('Arthur', ?)")
         }
     }
 
@@ -45,7 +45,7 @@ class UpdateStatementTests : GRDBTestCase {
         
         try dbQueue.inTransaction { db in
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
             let persons: [[DatabaseValueConvertible?]] = [
                 ["Arthur", 41],
                 ["Barbara", nil],
@@ -72,7 +72,7 @@ class UpdateStatementTests : GRDBTestCase {
         
         try dbQueue.inTransaction { db in
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (?, ?)")
             let persons: [[DatabaseValueConvertible?]] = [
                 ["Arthur", 41],
                 ["Barbara", nil],
@@ -100,7 +100,7 @@ class UpdateStatementTests : GRDBTestCase {
         
         try dbQueue.inTransaction { db in
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
             let persons: [[String: DatabaseValueConvertible?]] = [
                 ["name": "Arthur", "age": 41],
                 ["name": "Barbara", "age": nil],
@@ -127,7 +127,7 @@ class UpdateStatementTests : GRDBTestCase {
         
         try dbQueue.inTransaction { db in
             
-            let statement = try db.makeUpdateStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
+            let statement = try db.makeStatement(sql: "INSERT INTO persons (name, age) VALUES (:name, :age)")
             let persons: [[String: DatabaseValueConvertible?]] = [
                 ["name": "Arthur", "age": 41],
                 ["name": "Barbara", "age": nil],
@@ -156,7 +156,7 @@ class UpdateStatementTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.execute(sql: "SELECT 1")
-            let statement = try db.makeUpdateStatement(sql: "SELECT 1")
+            let statement = try db.makeStatement(sql: "SELECT 1")
             try statement.execute()
         }
     }
@@ -170,7 +170,7 @@ class UpdateStatementTests : GRDBTestCase {
                 return index
             })
             try db.execute(sql: "SELECT seq() UNION ALL SELECT seq() UNION ALL SELECT seq()")
-            let statement = try db.makeUpdateStatement(sql: "SELECT seq() UNION ALL SELECT seq() UNION ALL SELECT seq()")
+            let statement = try db.makeStatement(sql: "SELECT seq() UNION ALL SELECT seq() UNION ALL SELECT seq()")
             try statement.execute()
         }
         XCTAssertEqual(index, 3 + 3)
@@ -310,7 +310,7 @@ class UpdateStatementTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             do {
-                _ = try db.makeUpdateStatement(sql: "UPDATE blah SET id = 12")
+                _ = try db.makeStatement(sql: "UPDATE blah SET id = 12")
                 XCTFail()
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
@@ -325,7 +325,7 @@ class UpdateStatementTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             do {
-                _ = try db.makeUpdateStatement(sql: "UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
+                _ = try db.makeStatement(sql: "UPDATE persons SET age = 1; UPDATE persons SET age = 2;")
                 XCTFail("Expected error")
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)
@@ -340,7 +340,7 @@ class UpdateStatementTests : GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             do {
-                _ = try db.makeUpdateStatement(sql: "UPDATE persons SET age = 1;x")
+                _ = try db.makeStatement(sql: "UPDATE persons SET age = 1;x")
                 XCTFail("Expected error")
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_MISUSE)

--- a/Tests/GRDBTests/ValueObservationPrintTests.swift
+++ b/Tests/GRDBTests/ValueObservationPrintTests.swift
@@ -14,7 +14,7 @@ class ValueObservationPrintTests: GRDBTestCase {
     private func region(sql: String, in dbReader: DatabaseReader) throws -> String {
         try dbReader.read { db in
             try db
-                .makeSelectStatement(sql: sql)
+                .makeStatement(sql: sql)
                 .databaseRegion
                 .description
         }

--- a/Tests/Performance/GRDBPerformance/Generation.swift
+++ b/Tests/Performance/GRDBPerformance/Generation.swift
@@ -18,7 +18,7 @@ func generateSQLiteDatabaseIfMissing(at url: URL, insertedRowCount: Int) throws 
         }
         try db.execute(sql: "CREATE TABLE item (i0 INT, i1 INT, i2 INT, i3 INT, i4 INT, i5 INT, i6 INT, i7 INT, i8 INT, i9 INT)")
         
-        let statement = try! db.makeUpdateStatement(sql: "INSERT INTO item (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (?,?,?,?,?,?,?,?,?,?)")
+        let statement = try! db.makeStatement(sql: "INSERT INTO item (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (?,?,?,?,?,?,?,?,?,?)")
         for i in 0..<insertedRowCount {
             try statement.execute(arguments: [i, i, i, i, i, i, i, i, i, i])
         }

--- a/Tests/Performance/GRDBPerformance/InsertNamedValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertNamedValuesTests.swift
@@ -31,7 +31,7 @@ class InsertNamedValuesTests: XCTestCase {
             }
             
             try! dbQueue.inTransaction { db in
-                let statement = try! db.makeUpdateStatement(sql: "INSERT INTO item (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (:i0, :i1, :i2, :i3, :i4, :i5, :i6, :i7, :i8, :i9)")
+                let statement = try! db.makeStatement(sql: "INSERT INTO item (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (:i0, :i1, :i2, :i3, :i4, :i5, :i6, :i7, :i8, :i9)")
                 for i in 0..<insertedRowCount {
                     try statement.execute(arguments: ["i0": i, "i1": i, "i2": i, "i3": i, "i4": i, "i5": i, "i6": i, "i7": i, "i8": i, "i9": i])
                 }

--- a/Tests/Performance/GRDBPerformance/InsertPositionalValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertPositionalValuesTests.swift
@@ -76,7 +76,7 @@ class InsertPositionalValuesTests: XCTestCase {
             }
             
             try! dbQueue.inTransaction { db in
-                let statement = try! db.makeUpdateStatement(sql: "INSERT INTO item (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (?,?,?,?,?,?,?,?,?,?)")
+                let statement = try! db.makeStatement(sql: "INSERT INTO item (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (?,?,?,?,?,?,?,?,?,?)")
                 for i in 0..<insertedRowCount {
                     statement.setUncheckedArguments([i, i, i, i, i, i, i, i, i, i])
                     try statement.execute()

--- a/Tests/Performance/GRDBPerformance/InsertRecordOptimizedTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertRecordOptimizedTests.swift
@@ -16,8 +16,8 @@ private struct Item: Codable, FetchableRecord, PersistableRecord {
     var i8: Int
     var i9: Int
     
-    static func optimizedInsertStatement(_ db: Database) throws -> UpdateStatement {
-        try db.makeUpdateStatement(literal: """
+    static func optimizedInsertStatement(_ db: Database) throws -> Statement {
+        try db.makeStatement(literal: """
             INSERT INTO \(self) (
               \(CodingKeys.i0),
               \(CodingKeys.i1),
@@ -33,7 +33,7 @@ private struct Item: Codable, FetchableRecord, PersistableRecord {
             """)
     }
     
-    func insert(with statement: UpdateStatement) throws {
+    func insert(with statement: Statement) throws {
         statement.setUncheckedArguments([
             i0,
             i1,

--- a/Tests/Performance/GRDBProfiling/GRDBProfiling/AppDelegate.swift
+++ b/Tests/Performance/GRDBProfiling/GRDBProfiling/AppDelegate.swift
@@ -211,7 +211,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func _insertPositionalValues(_ db: Database) throws {
-        let statement = try db.makeUpdateStatement(sql: "INSERT INTO items (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (?,?,?,?,?,?,?,?,?,?)")
+        let statement = try db.makeStatement(sql: "INSERT INTO items (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (?,?,?,?,?,?,?,?,?,?)")
         for i in 0..<insertedRowCount {
             try statement.execute(arguments: [i, i, i, i, i, i, i, i, i, i])
         }
@@ -240,7 +240,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func _insertNamedValues(_ db: Database) throws {
-        let statement = try db.makeUpdateStatement(sql: "INSERT INTO items (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (:i0, :i1, :i2, :i3, :i4, :i5, :i6, :i7, :i8, :i9)")
+        let statement = try db.makeStatement(sql: "INSERT INTO items (i0, i1, i2, i3, i4, i5, i6, i7, i8, i9) VALUES (:i0, :i1, :i2, :i3, :i4, :i5, :i6, :i7, :i8, :i9)")
         for i in 0..<insertedRowCount {
             try statement.execute(arguments: ["i0": i, "i1": i, "i2": i, "i3": i, "i4": i, "i5": i, "i6": i, "i7": i, "i8": i, "i9": i])
         }


### PR DESCRIPTION
This pull request addresses #1015.

The two `SelectStatement` and `UpdateStatement` classes are now deprecated. They have become type aliases to a unique `Statement` class.

A new method `Database.allStatements()` methods returns a cursor of all statements found in an SQL string:

```swift
try dbQueue.write { db in
    let statements = try db.allStatements(sql: """
        CREATE TABLE ...;
        INSERT ...;
        SELECT ...;
        SELECT ...;
        """)
    while let statement = try statements.next() {
        // You can execute each individual statement...
        try statement.execute();

        // ... or fetch
        let rows = try Row.fetchAll(statement)
    }
}
```

Just as the `Database.execute()` method, `allStatements()` accepts statement arguments, and supports [SQL Interpolation](https://github.com/groue/GRDB.swift/blob/master/Documentation/SQLInterpolation.md):

```swift
let statements = try db.allStatements(sql: """
    INSERT INTO player (name, score) VALUES (?, ?);
    INSERT INTO player (name, score) VALUES (?, ?);
    """, arguments: ["Arthur", 100, "Barbara", 1000])

let statements = try db.allStatements(literal: """
    INSERT INTO player (name, score) VALUES (\("Arthur"), \(100));
    INSERT INTO player (name, score) VALUES (\("Barbara"), \(1000));
    """)
```


The `allStatements` method makes it possible to fetch all rows from multiple statements, in a way similar to [`sqlite3_exec`](https://www.sqlite.org/c3ref/exec.html):

```swift
// A cursor of all rows fetched from all statements
let rows = try db
    .allStatements(sql: "...")
    .map { statement in try Row.fetchCursor(statement) }
    .joined()
while let row = try rows.next() {
    // use row
}
```

⚠️ Because `SelectStatement` and `UpdateStatement` are now identical classes, this pull request is, strictly speaking, a breaking change. Some apps that rely on runtime checks in order to distinguish the two statement class will have to be updated. It is expected that this is very unlikely to happen in the wild, though, and this breaking change will ship in the next minor version. However, in order to help dealing with eventual nasty cases, a new `Statement.isReadonly` property is introduced (see [`sqlite3_stmt_readonly`](https://www.sqlite.org/c3ref/stmt_readonly.html)).

cc @benrb