### PR TITLE
Allow parts of a multi-column primary key to be nil in PersistableRecord

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -7,9 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		223F6F3E26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
-		223F6F3F26BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
-		223F6F4026BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
+		22065EDF26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22065EDE26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
+		22065EE026C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22065EDE26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
+		22065EE126C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22065EDE26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
+		223F6F3E26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift */; };
+		223F6F3F26BC1202007A379C /* RecordPrimaryKeyNullableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift */; };
+		223F6F4026BC1202007A379C /* RecordPrimaryKeyNullableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift */; };
 		56012B552573EED000B4925B /* CommonTableExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56012B542573EED000B4925B /* CommonTableExpressionTests.swift */; };
 		56012B562573EED100B4925B /* CommonTableExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56012B542573EED000B4925B /* CommonTableExpressionTests.swift */; };
 		56012B572573EED100B4925B /* CommonTableExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56012B542573EED000B4925B /* CommonTableExpressionTests.swift */; };
@@ -1256,7 +1259,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordPrimaryKeyMultipleSomeNilTests.swift; sourceTree = "<group>"; };
+		22065EDE26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordPrimaryKeyMultipleSomeNilTests.swift; sourceTree = "<group>"; };
+		223F6F3D26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordPrimaryKeyNullableTests.swift; sourceTree = "<group>"; };
 		56012B542573EED000B4925B /* CommonTableExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTableExpressionTests.swift; sourceTree = "<group>"; };
 		56012B742574048B00B4925B /* CommonTableExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTableExpression.swift; sourceTree = "<group>"; };
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1840,7 +1844,8 @@
 				6340BF7F1E5E3F7900832805 /* RecordPersistenceConflictPolicy.swift */,
 				5698ACCD1DA8C2620056AF8C /* RecordPrimaryKeyHiddenRowIDTests.swift */,
 				56A238281B9C74A90082EB20 /* RecordPrimaryKeyMultipleTests.swift */,
-				223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */,
+				223F6F3D26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift */,
+				22065EDE26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift */,
 				56A238291B9C74A90082EB20 /* RecordPrimaryKeyNoneTests.swift */,
 				56A2382A1B9C74A90082EB20 /* RecordPrimaryKeyRowIDTests.swift */,
 				56A2382B1B9C74A90082EB20 /* RecordPrimaryKeySingleTests.swift */,
@@ -3287,6 +3292,7 @@
 				56419C7B24A51A39004967E1 /* RecordingError.swift in Sources */,
 				560A37AC1C90085D00949E71 /* DatabasePoolConcurrencyTests.swift in Sources */,
 				5607EFD41BB827FD00605DE3 /* TransactionObserverTests.swift in Sources */,
+				22065EE026C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
 				5690C33B1D23E7D200E59934 /* FoundationDateTests.swift in Sources */,
 				5653EAF320944B4F00F46237 /* AssociationBelongsToDecodableRecordTests.swift in Sources */,
 				565D5D721BBC694D00DC9BD4 /* Row+FoundationTests.swift in Sources */,
@@ -3390,7 +3396,7 @@
 				5653EAF520944B4F00F46237 /* AssociationParallelSQLTests.swift in Sources */,
 				563B06BE2185CCD300B38F35 /* ValueObservationTests.swift in Sources */,
 				56FF455A1D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift in Sources */,
-				223F6F3F26BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
+				223F6F3F26BC1202007A379C /* RecordPrimaryKeyNullableTests.swift in Sources */,
 				56419C7A24A51A39004967E1 /* Recorder.swift in Sources */,
 				56B7F42A1BE14A1900E39BBF /* CGFloatTests.swift in Sources */,
 				5605F1881C69111300235C62 /* DatabaseRegionTests.swift in Sources */,
@@ -3519,6 +3525,7 @@
 				56D496711D81309E008276D7 /* RecordPrimaryKeySingleTests.swift in Sources */,
 				56419C7924A51A38004967E1 /* RecordingError.swift in Sources */,
 				5665F85D203EE6030084C6C0 /* ColumnInfoTests.swift in Sources */,
+				22065EDF26C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
 				5698AC031D9B9FCF0056AF8C /* QueryInterfaceExtensibilityTests.swift in Sources */,
 				56D496611D81304E008276D7 /* Row+FoundationTests.swift in Sources */,
 				56D496C41D813767008276D7 /* DatabaseQueueTests.swift in Sources */,
@@ -3622,7 +3629,7 @@
 				56677C19241D217F0050755D /* ValueObservationRecorderTests.swift in Sources */,
 				5653EAF420944B4F00F46237 /* AssociationParallelSQLTests.swift in Sources */,
 				563B06BD2185CCD300B38F35 /* ValueObservationTests.swift in Sources */,
-				223F6F3E26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
+				223F6F3E26BC1201007A379C /* RecordPrimaryKeyNullableTests.swift in Sources */,
 				56D496971D81317B008276D7 /* DatabaseReaderTests.swift in Sources */,
 				56419C7824A51A38004967E1 /* Recorder.swift in Sources */,
 				56D496911D81316E008276D7 /* RowFromStatementTests.swift in Sources */,
@@ -3884,6 +3891,7 @@
 				56419C7D24A51A3A004967E1 /* RecordingError.swift in Sources */,
 				AAA4DD69230F262000C74B15 /* DatabasePoolConcurrencyTests.swift in Sources */,
 				AAA4DD6A230F262000C74B15 /* TransactionObserverTests.swift in Sources */,
+				22065EE126C559FC004290C1 /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
 				AAA4DD6B230F262000C74B15 /* FoundationDateTests.swift in Sources */,
 				AAA4DD6C230F262000C74B15 /* AssociationBelongsToDecodableRecordTests.swift in Sources */,
 				AAA4DD6D230F262000C74B15 /* Row+FoundationTests.swift in Sources */,
@@ -3987,7 +3995,7 @@
 				AAA4DDC2230F262000C74B15 /* AssociationParallelSQLTests.swift in Sources */,
 				AAA4DDC3230F262000C74B15 /* ValueObservationTests.swift in Sources */,
 				AAA4DDC4230F262000C74B15 /* RecordUniqueIndexTests.swift in Sources */,
-				223F6F4026BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
+				223F6F4026BC1202007A379C /* RecordPrimaryKeyNullableTests.swift in Sources */,
 				56419C7C24A51A3A004967E1 /* Recorder.swift in Sources */,
 				AAA4DDC5230F262000C74B15 /* CGFloatTests.swift in Sources */,
 				AAA4DDC6230F262000C74B15 /* DatabaseRegionTests.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		223F6F3E26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
+		223F6F3F26BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
+		223F6F4026BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */; };
 		56012B552573EED000B4925B /* CommonTableExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56012B542573EED000B4925B /* CommonTableExpressionTests.swift */; };
 		56012B562573EED100B4925B /* CommonTableExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56012B542573EED000B4925B /* CommonTableExpressionTests.swift */; };
 		56012B572573EED100B4925B /* CommonTableExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56012B542573EED000B4925B /* CommonTableExpressionTests.swift */; };
@@ -1253,6 +1256,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordPrimaryKeyMultipleSomeNilTests.swift; sourceTree = "<group>"; };
 		56012B542573EED000B4925B /* CommonTableExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTableExpressionTests.swift; sourceTree = "<group>"; };
 		56012B742574048B00B4925B /* CommonTableExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonTableExpression.swift; sourceTree = "<group>"; };
 		56043299228F00C2009D3FE2 /* OrderedDictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderedDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1836,6 +1840,7 @@
 				6340BF7F1E5E3F7900832805 /* RecordPersistenceConflictPolicy.swift */,
 				5698ACCD1DA8C2620056AF8C /* RecordPrimaryKeyHiddenRowIDTests.swift */,
 				56A238281B9C74A90082EB20 /* RecordPrimaryKeyMultipleTests.swift */,
+				223F6F3D26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift */,
 				56A238291B9C74A90082EB20 /* RecordPrimaryKeyNoneTests.swift */,
 				56A2382A1B9C74A90082EB20 /* RecordPrimaryKeyRowIDTests.swift */,
 				56A2382B1B9C74A90082EB20 /* RecordPrimaryKeySingleTests.swift */,
@@ -3385,6 +3390,7 @@
 				5653EAF520944B4F00F46237 /* AssociationParallelSQLTests.swift in Sources */,
 				563B06BE2185CCD300B38F35 /* ValueObservationTests.swift in Sources */,
 				56FF455A1D2CDA5200F21EF9 /* RecordUniqueIndexTests.swift in Sources */,
+				223F6F3F26BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
 				56419C7A24A51A39004967E1 /* Recorder.swift in Sources */,
 				56B7F42A1BE14A1900E39BBF /* CGFloatTests.swift in Sources */,
 				5605F1881C69111300235C62 /* DatabaseRegionTests.swift in Sources */,
@@ -3616,6 +3622,7 @@
 				56677C19241D217F0050755D /* ValueObservationRecorderTests.swift in Sources */,
 				5653EAF420944B4F00F46237 /* AssociationParallelSQLTests.swift in Sources */,
 				563B06BD2185CCD300B38F35 /* ValueObservationTests.swift in Sources */,
+				223F6F3E26BC1201007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
 				56D496971D81317B008276D7 /* DatabaseReaderTests.swift in Sources */,
 				56419C7824A51A38004967E1 /* Recorder.swift in Sources */,
 				56D496911D81316E008276D7 /* RowFromStatementTests.swift in Sources */,
@@ -3980,6 +3987,7 @@
 				AAA4DDC2230F262000C74B15 /* AssociationParallelSQLTests.swift in Sources */,
 				AAA4DDC3230F262000C74B15 /* ValueObservationTests.swift in Sources */,
 				AAA4DDC4230F262000C74B15 /* RecordUniqueIndexTests.swift in Sources */,
+				223F6F4026BC1202007A379C /* RecordPrimaryKeyMultipleSomeNilTests.swift in Sources */,
 				56419C7C24A51A3A004967E1 /* Recorder.swift in Sources */,
 				AAA4DDC5230F262000C74B15 /* CGFloatTests.swift in Sources */,
 				AAA4DDC6230F262000C74B15 /* DatabaseRegionTests.swift in Sources */,

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -871,12 +871,12 @@ extension UpdateQuery {
         if let sql = Self.sqlCache[self] {
             return sql
         }
-        let sql = uncachedSQL()
+        let sql = buildSQL()
         Self.sqlCache[self] = sql
         return sql
     }
     
-    func uncachedSQL() -> String {
+    func buildSQL() -> String {
         let updateSQL = updatedColumns.map { "\($0.quotedDatabaseIdentifier)=?" }.joined(separator: ", ")
         var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }.joined(separator: " AND ")
         if nullConditionColumns.isEmpty == false {

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -692,10 +692,10 @@ final class DAO<Record: MutablePersistableRecord> {
     func updateStatement(columns: Set<String>, onConflict: Database.ConflictResolution) throws -> Statement? {
         let primaryKeysAndValues = groupedPrimaryKeysAndTheirValues()
 
-        // If there are no primary key columns at all, then return nil because we cannot proceed
-        if primaryKeysAndValues.notNullColumns.isEmpty {
-            return nil
-        }
+//        // If there are no primary key columns at all, then return nil because we cannot proceed
+//        if primaryKeysAndValues.notNullColumns.isEmpty {
+//            return nil
+//        }
         
         // Don't update columns not present in columns
         // Don't update columns not present in the persistenceContainer

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -878,11 +878,8 @@ extension UpdateQuery {
     
     func buildSQL() -> String {
         let updateSQL = updatedColumns.map { "\($0.quotedDatabaseIdentifier)=?" }.joined(separator: ", ")
-        var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }.joined(separator: " AND ")
-        if nullConditionColumns.isEmpty == false {
-            let nullConditions = nullConditionColumns.map { "\($0.quotedDatabaseIdentifier) IS NULL" }
-            whereSQL.append("AND \(nullConditions.joined(separator: " AND "))")
-        }
+        var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }
+        whereSQL.append(contentsOf: nullConditionColumns.map { "\($0.quotedDatabaseIdentifier) IS NULL" })
         
         let sql: String
         switch onConflict {
@@ -890,13 +887,13 @@ extension UpdateQuery {
             sql = """
                 UPDATE \(tableName.quotedDatabaseIdentifier) \
                 SET \(updateSQL) \
-                WHERE \(whereSQL)
+                WHERE \(whereSQL.joined(separator: " AND "))
                 """
         default:
             sql = """
                 UPDATE OR \(onConflict.rawValue) \(tableName.quotedDatabaseIdentifier) \
                 SET \(updateSQL) \
-                WHERE \(whereSQL)
+                WHERE \(whereSQL.joined(separator: " AND "))
                 """
         }
         Self.sqlCache[self] = sql
@@ -915,12 +912,9 @@ private struct DeleteQuery {
 
 extension DeleteQuery {
     var sql: String {
-        var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }.joined(separator: " AND ")
-        if nullConditionColumns.isEmpty == false {
-            let nullConditions = nullConditionColumns.map { "\($0.quotedDatabaseIdentifier) IS NULL" }
-            whereSQL.append("AND \(nullConditions.joined(separator: " AND "))")
-        }
-        return "DELETE FROM \(tableName.quotedDatabaseIdentifier) WHERE \(whereSQL)"
+        var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }
+        whereSQL.append(contentsOf: nullConditionColumns.map { "\($0.quotedDatabaseIdentifier) IS NULL" })
+        return "DELETE FROM \(tableName.quotedDatabaseIdentifier) WHERE \(whereSQL.joined(separator: " AND "))"
     }
 }
 
@@ -935,11 +929,8 @@ private struct ExistsQuery {
 
 extension ExistsQuery {
     var sql: String {
-        var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }.joined(separator: " AND ")
-        if nullConditionColumns.isEmpty == false {
-            let nullConditions = nullConditionColumns.map { "\($0.quotedDatabaseIdentifier) IS NULL" }
-            whereSQL.append("AND \(nullConditions.joined(separator: " AND "))")
-        }
-        return "SELECT 1 FROM \(tableName.quotedDatabaseIdentifier) WHERE \(whereSQL)"
+        var whereSQL = conditionColumns.map { "\($0.quotedDatabaseIdentifier)=?" }
+        whereSQL.append(contentsOf: nullConditionColumns.map { "\($0.quotedDatabaseIdentifier) IS NULL" })
+        return "SELECT 1 FROM \(tableName.quotedDatabaseIdentifier) WHERE \(whereSQL.joined(separator: " AND "))"
     }
 }

--- a/GRDB/Record/PersistableRecord.swift
+++ b/GRDB/Record/PersistableRecord.swift
@@ -806,7 +806,7 @@ final class DAO<Record: MutablePersistableRecord> {
             notNullValues: [])
  
         for column in result.allColumns {
-            if let value = persistenceContainer[caseInsensitive: column]?.databaseValue {
+            if let value = persistenceContainer[caseInsensitive: column]?.databaseValue, !value.isNull {
                 result.notNullColumns.append(column)
                 result.notNullValues.append(value)
             } else {

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleSomeNilTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleSomeNilTests.swift
@@ -1,10 +1,6 @@
 import XCTest
 import GRDB
 
-private enum MaybeRemoteMaybeLocalIdError: Error {
-    case mustHaveLocalIDorRemoteID
-}
-
 // MaybeRemoteMaybeLocalID is a record that might have a local id, or might have a remote id, or possibly both.
 // So its primary key is a combination of the local and remote ids,
 // permitting one or the other (but not both) to be null
@@ -13,7 +9,7 @@ private struct MaybeRemoteMaybeLocalID : Codable, MutablePersistableRecord, Fetc
     let remoteID: UInt64?
     var thing: String
     
-    init(localID: UInt64? = nil, remoteID: UInt64? = nil, thing: String) throws {
+    init(localID: UInt64? = nil, remoteID: UInt64? = nil, thing: String) {
         self.localID = localID
         self.remoteID = remoteID
         self.thing = thing
@@ -43,7 +39,7 @@ private struct MaybeRemoteMaybeLocalIDUsingNulls : MutablePersistableRecord {
     let remoteID: DatabaseValue
     var thing: String
     
-    init(localID: DatabaseValue, remoteID: DatabaseValue, thing: String) throws {
+    init(localID: DatabaseValue, remoteID: DatabaseValue, thing: String) {
         self.localID = localID
         self.remoteID = remoteID
         self.thing = thing
@@ -72,7 +68,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testInsert() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             try record.insert(db)
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM maybeRemoteMaybeLocalID WHERE localID = ?", arguments: [record.localID])!
@@ -89,7 +85,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testUpdate() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             try record.insert(db)
             record.thing = "Local One Updated"
             try record.update(db)
@@ -104,7 +100,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testUpdateUsingDatabaseValueNull() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalIDUsingNulls(localID: DatabaseValue(value: 1)!, remoteID: .null, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalIDUsingNulls(localID: DatabaseValue(value: 1)!, remoteID: .null, thing: "Local One")
             try record.insert(db)
             record.thing = "Local One Updated"
             try record.update(db)
@@ -119,7 +115,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testDelete() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             try record.insert(db)
             try record.delete(db)
             do {
@@ -139,7 +135,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testExistsFalse() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            let record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             XCTAssertFalse(try record.exists(db))
         }
     }
@@ -147,7 +143,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testExistsTrue() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             try record.insert(db)
             XCTAssertTrue(try record.exists(db))
         }
@@ -158,7 +154,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testSavesNew() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             try record.save(db)
             
             let row = try Row.fetchOne(db, sql: "SELECT * FROM maybeRemoteMaybeLocalID WHERE localID = ?", arguments: [record.localID])!
@@ -169,7 +165,7 @@ class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
     func testSavesUpdate() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            var record = MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
             try record.insert(db)
             record.thing = "Local One Updated"
             try record.save(db)

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleSomeNilTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleSomeNilTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+import GRDB
+
+private enum MaybeRemoteMaybeLocalIdError: Error {
+    case mustHaveLocalIDorRemoteID
+}
+
+// MaybeRemoteMaybeLocalID is a record that might have a local id, or might have a remote id, or possibly both.
+// So its primary key is a combination of the local and remote ids,
+// permitting one or the other (but not both) to be null
+private struct MaybeRemoteMaybeLocalID : Codable, MutablePersistableRecord, FetchableRecord {
+    let localID: UInt64?
+    let remoteID: UInt64?
+    var thing: String
+    
+    init(localID: UInt64? = nil, remoteID: UInt64? = nil, thing: String) throws {
+        guard localID != nil || remoteID != nil else { throw MaybeRemoteMaybeLocalIdError.mustHaveLocalIDorRemoteID }
+        self.localID = localID
+        self.remoteID = remoteID
+        self.thing = thing
+    }
+    
+    static func setup(inDatabase db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE maybeRemoteMaybeLocalID (
+                localID INT UNIQUE,
+                remoteID INT UNIQUE,
+                thing TEXT NOT NULL,
+                PRIMARY KEY (localID, remoteID),
+                CONSTRAINT check_primary CHECK (localID IS NOT NULL OR remoteID IS NOT NULL)
+            )
+            """)
+    }
+}
+
+
+class RecordPrimaryKeyMultipleSomeNilTests: GRDBTestCase {
+    
+    override func setup(_ dbWriter: DatabaseWriter) throws {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("createMaybeRemoteMaybeLocalID", migrate: MaybeRemoteMaybeLocalID.setup)
+        try migrator.migrate(dbWriter)
+    }
+    
+    
+    // MARK: - Insert
+    
+    // This works fine
+    func testInsert() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            try record.insert(db)
+            
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM maybeRemoteMaybeLocalID WHERE localID = ?", arguments: [record.localID])!
+            assert(record, isEncodedIn: row)
+        }
+    }
+    
+    // MARK: - Update
+    
+    /// This fails, because it generates the sql something like:
+    /// `UPDATE ... WHERE "localID"=1 AND "remoteID"=NULL`
+    /// where I was expecting it to be generating something like:
+    ///  `UPDATE ... WHERE "localID"=1 AND "remoteID" IS NULL`
+    func testUpdate() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = try MaybeRemoteMaybeLocalID(localID: 1, thing: "Local One")
+            try record.insert(db)
+            record.thing = "Local One Updated"
+            try record.update(db)
+            
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM maybeRemoteMaybeLocalID WHERE localID = ?", arguments: [record.localID])!
+            assert(record, isEncodedIn: row)
+        }
+    }
+}

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleSomeNilTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleSomeNilTests.swift
@@ -14,7 +14,6 @@ private struct MaybeRemoteMaybeLocalID : Codable, MutablePersistableRecord, Fetc
     var thing: String
     
     init(localID: UInt64? = nil, remoteID: UInt64? = nil, thing: String) throws {
-        guard localID != nil || remoteID != nil else { throw MaybeRemoteMaybeLocalIdError.mustHaveLocalIDorRemoteID }
         self.localID = localID
         self.remoteID = remoteID
         self.thing = thing

--- a/Tests/GRDBTests/RecordPrimaryKeyNullableTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyNullableTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+import GRDB
+
+// MaybeNullPrimaryKey is a record that might have a null primary key.
+//
+// From the [SQLite documentation](https://www.sqlite.org/lang_createtable.html#the_primary_key):
+// > According to the SQL standard, PRIMARY KEY should always imply NOT NULL. Unfortunately, due to a bug in some early versions, this is not the case in SQLite. Unless the column is an INTEGER PRIMARY KEY or the table is a WITHOUT ROWID table or the column is declared NOT NULL, SQLite allows NULL values in a PRIMARY KEY column. SQLite could be fixed to conform to the standard, but doing so might break legacy applications. Hence, it has been decided to merely document the fact that SQLite allows NULLs in most PRIMARY KEY columns.
+//
+// [According to @groue](https://github.com/groue/GRDB.swift/issues/1023#issuecomment-893504893):
+//
+// > Since SQLite itself _allows_ NULL in primary keys, GRDB should accept this non-standard practice as well. At least when it does not create problems.
+
+
+private struct PrimaryKeyNullable : Codable, MutablePersistableRecord, FetchableRecord {
+    let id: String?
+    var thing: String
+    
+    static func setup(inDatabase db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE primaryKeyNullable (
+                id PRIMARY KEY,
+                thing TEXT NOT NULL
+            )
+            """)
+    }
+}
+
+class RecordPrimaryKeyNullableTests: GRDBTestCase {
+    
+    override func setup(_ dbWriter: DatabaseWriter) throws {
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("createPrimaryKeyNullable", migrate: PrimaryKeyNullable.setup)
+        try migrator.migrate(dbWriter)
+    }
+    
+    
+    // MARK: - Insert
+    
+    func testInsert() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            try record.insert(db)
+            
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id = ?", arguments: [record.id])!
+            assert(record, isEncodedIn: row)
+        }
+    }
+    
+    func testInsertNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            try record.insert(db)
+            
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id IS NULL")!
+            assert(record, isEncodedIn: row)
+        }
+    }
+    
+    // MARK: - Update
+
+    func testUpdate() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            try record.insert(db)
+            record.thing = "Thing One Updated"
+            try record.update(db)
+
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id = ?", arguments: [record.id])!
+            assert(record, isEncodedIn: row)
+        }
+    }
+    
+    func testUpdateNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            try record.insert(db)
+            record.thing = "Thing One Updated"
+            try record.update(db)
+
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id IS NULL")!
+            assert(record, isEncodedIn: row)
+        }
+    }
+
+    // MARK: - Delete
+
+    func testDelete() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            try record.insert(db)
+            try record.delete(db)
+            do {
+                try record.update(db)
+                XCTFail("Expected PersistenceError.recordNotFound")
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "primaryKeyNullable")
+                XCTAssertEqual("One".databaseValue, key["id"])
+            }
+        }
+    }
+    
+    func testDeleteNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            try record.insert(db)
+            try record.delete(db)
+            do {
+                try record.update(db)
+                XCTFail("Expected PersistenceError.recordNotFound")
+            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected PersistenceError.recordNotFound
+                XCTAssertEqual(databaseTableName, "primaryKeyNullable")
+                XCTAssertEqual(DatabaseValue.null, key["id"])
+            }
+        }
+    }
+
+    // MARK: - Exists
+
+    func testExistsFalse() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            XCTAssertFalse(try record.exists(db))
+        }
+    }
+
+    func testExistsTrue() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            try record.insert(db)
+            XCTAssertTrue(try record.exists(db))
+        }
+    }
+    
+    func testExistsFalseNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            XCTAssertFalse(try record.exists(db))
+        }
+    }
+
+    func testExistsTrueNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            try record.insert(db)
+            XCTAssertTrue(try record.exists(db))
+        }
+    }
+
+    // MARK: - Save
+
+    func testSavesNew() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            try record.save(db)
+
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id = ?", arguments: [record.id])!
+            assert(record, isEncodedIn: row)
+        }
+    }
+
+    func testSavesUpdate() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: "One", thing: "Thing One")
+            try record.insert(db)
+            record.thing = "Thing One Updated"
+            try record.save(db)
+
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id = ?", arguments: [record.id])!
+            assert(record, isEncodedIn: row)
+        }
+    }
+    
+    func testSavesNewNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            try record.save(db)
+
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id IS NULL")!
+            assert(record, isEncodedIn: row)
+        }
+    }
+
+    func testSavesUpdateNullPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            var record = PrimaryKeyNullable(id: nil, thing: "Thing One")
+            try record.insert(db)
+            record.thing = "Thing One Updated"
+            try record.save(db)
+            let row = try Row.fetchOne(db, sql: "SELECT * FROM primaryKeyNullable WHERE id IS NULL")!
+            assert(record, isEncodedIn: row)
+        }
+    }
+    
+}


### PR DESCRIPTION
This pull request allow parts of a multi-column primary key to be nil in PersistableRecord. It relates to Issue #1023.

A first attempt, so grateful for feedback.

For others, please note what @groue [said](https://github.com/groue/GRDB.swift/issues/1023#issuecomment-893504893):

> Using NULL in primary keys is indeed begging for trouble

