### PR TITLE
Add match operator in ColumnExpression for FTS5.

### DIFF
--- a/Documentation/FullTextSearch.md
+++ b/Documentation/FullTextSearch.md
@@ -540,7 +540,11 @@ let documents = try Document.fetchAll(db,
 Use them in the [query interface](../README.md#the-query-interface):
 
 ```swift
+// Search in all columns
 let documents = try Document.matching(pattern).fetchAll(db)
+
+// Search in a specific column:
+let documents = try Document.filter(Column("content").match(pattern)).fetchAll(db)
 ```
 
 

--- a/GRDB/QueryInterface/FTS5+QueryInterface.swift
+++ b/GRDB/QueryInterface/FTS5+QueryInterface.swift
@@ -48,11 +48,8 @@ extension ColumnExpression {
     ///
     ///     // content MATCH '...'
     ///     Column("content").match(pattern)
-    ///
-    /// If the search pattern is nil, SQLite will evaluate the expression
-    /// to false.
-    public func match(_ pattern: FTS5Pattern?) -> SQLExpression {
-        .binary(.match, sqlExpression, pattern?.sqlExpression ?? .null)
+    public func match(_ pattern: FTS5Pattern) -> SQLExpression {
+        .binary(.match, sqlExpression, pattern.sqlExpression)
     }
 }
 #endif

--- a/GRDB/QueryInterface/FTS5+QueryInterface.swift
+++ b/GRDB/QueryInterface/FTS5+QueryInterface.swift
@@ -41,4 +41,18 @@ extension TableRecord {
         all().matching(pattern)
     }
 }
+
+extension ColumnExpression {
+    
+    /// A matching SQL expression with the `MATCH` SQL operator.
+    ///
+    ///     // content MATCH '...'
+    ///     Column("content").match(pattern)
+    ///
+    /// If the search pattern is nil, SQLite will evaluate the expression
+    /// to false.
+    public func match(_ pattern: FTS5Pattern?) -> SQLExpression {
+        .binary(.match, sqlExpression, pattern?.sqlExpression ?? .null)
+    }
+}
 #endif

--- a/Tests/GRDBTests/FTS5RecordTests.swift
+++ b/Tests/GRDBTests/FTS5RecordTests.swift
@@ -72,6 +72,9 @@ class FTS5RecordTests: GRDBTestCase {
             
             let pattern = FTS5Pattern(matchingAllTokensIn: "Herman Melville")!
             XCTAssertEqual(try Book.matching(pattern).fetchCount(db), 1)
+            XCTAssertEqual(try Book.filter(Column("books").match(pattern)).fetchCount(db), 1)
+            XCTAssertEqual(try Book.filter(Column("author").match(pattern)).fetchCount(db), 1)
+            XCTAssertEqual(try Book.filter(Column("title").match(pattern)).fetchCount(db), 0)
         }
     }
 
@@ -86,6 +89,9 @@ class FTS5RecordTests: GRDBTestCase {
             let pattern = FTS5Pattern(matchingAllTokensIn: "")
             XCTAssertTrue(pattern == nil)
             XCTAssertEqual(try Book.matching(pattern).fetchCount(db), 0)
+            XCTAssertEqual(try Book.filter(Column("books").match(pattern)).fetchCount(db), 0)
+            XCTAssertEqual(try Book.filter(Column("author").match(pattern)).fetchCount(db), 0)
+            XCTAssertEqual(try Book.filter(Column("title").match(pattern)).fetchCount(db), 0)
         }
     }
 

--- a/Tests/GRDBTests/FTS5RecordTests.swift
+++ b/Tests/GRDBTests/FTS5RecordTests.swift
@@ -89,9 +89,6 @@ class FTS5RecordTests: GRDBTestCase {
             let pattern = FTS5Pattern(matchingAllTokensIn: "")
             XCTAssertTrue(pattern == nil)
             XCTAssertEqual(try Book.matching(pattern).fetchCount(db), 0)
-            XCTAssertEqual(try Book.filter(Column("books").match(pattern)).fetchCount(db), 0)
-            XCTAssertEqual(try Book.filter(Column("author").match(pattern)).fetchCount(db), 0)
-            XCTAssertEqual(try Book.filter(Column("title").match(pattern)).fetchCount(db), 0)
         }
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.

I'm using GRDB.swift with FTS5 support in my own project and found that in FTS5 query interface, there is no `match` operator for column expressions, which is found in FTS3.

This PR add this operator expression and related tests, making it aligned with FTS3 query interface API.