### PR TITLE
Improve performance of by-index row decoding

### DIFF
--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -166,6 +166,7 @@ extension Row {
     // MARK: - Extracting Values
     
     /// Fatal errors if index is out of bounds
+    @inline(__always)
     @usableFromInline
     /* private */ func _checkedIndex(_ index: Int, file: StaticString = #file, line: UInt = #line) -> Int {
         GRDBPrecondition(index >= 0 && index < count, "row index out of range", file: file, line: line)
@@ -241,6 +242,7 @@ extension Row {
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    @inline(__always)
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ index: Int) -> Value? {
         try! decodeIfPresent(Value.self, atIndex: index)
@@ -269,6 +271,7 @@ extension Row {
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    @inline(__always)
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ index: Int) -> Value {
         try! decode(Value.self, atIndex: index)
@@ -787,6 +790,7 @@ extension Row {
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    @inline(__always)
     @inlinable
     func decodeIfPresent<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -807,6 +811,7 @@ extension Row {
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    @inline(__always)
     @inlinable
     func decode<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -828,6 +833,7 @@ extension Row {
     /// This method exists as an optimization opportunity for types that adopt
     /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    @inline(__always)
     @inlinable
     func decodeIfPresent<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -168,9 +168,8 @@ extension Row {
     /// Fatal errors if index is out of bounds
     @inline(__always)
     @usableFromInline
-    /* private */ func _checkedIndex(_ index: Int, file: StaticString = #file, line: UInt = #line) -> Int {
+    /* private */ func _checkIndex(_ index: Int, file: StaticString = #file, line: UInt = #line) {
         GRDBPrecondition(index >= 0 && index < count, "row index out of range", file: file, line: line)
-        return index
     }
     
     /// Returns true if and only if one column contains a non-null value, or if
@@ -205,7 +204,8 @@ extension Row {
     /// in performance-critical code because it can avoid decoding database
     /// values.
     public func hasNull(atIndex index: Int) -> Bool {
-        impl.hasNull(atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return impl.hasNull(atUncheckedIndex: index)
     }
     
     /// Returns Int64, Double, String, Data or nil, depending on the value
@@ -214,7 +214,8 @@ extension Row {
     /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
     /// righmost column.
     public subscript(_ index: Int) -> DatabaseValueConvertible? {
-        impl.databaseValue(atUncheckedIndex: _checkedIndex(index)).storage.value
+        _checkIndex(index)
+        return impl.databaseValue(atUncheckedIndex: index).storage.value
     }
     
     /// Returns the value at given index, converted to the requested type.
@@ -715,7 +716,8 @@ extension Row {
         atIndex index: Int)
     throws -> Value?
     {
-        try Value.decodeIfPresent(fromRow: self, atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return try Value.decodeIfPresent(fromRow: self, atUncheckedIndex: index)
     }
     
     /// Returns the value at given index, converted to the requested type.
@@ -731,7 +733,8 @@ extension Row {
         atIndex index: Int)
     throws -> Value
     {
-        try Value.decode(fromRow: self, atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return try Value.decode(fromRow: self, atUncheckedIndex: index)
     }
     
     /// Returns the value at given column, converted to the requested type.
@@ -797,7 +800,8 @@ extension Row {
         atIndex index: Int)
     throws -> Value?
     {
-        try Value.fastDecodeIfPresent(fromRow: self, atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return try Value.fastDecodeIfPresent(fromRow: self, atUncheckedIndex: index)
     }
     
     /// Returns the value at given index, converted to the requested type.
@@ -818,7 +822,8 @@ extension Row {
         atIndex index: Int)
     throws -> Value
     {
-        try Value.fastDecode(fromRow: self, atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return try Value.fastDecode(fromRow: self, atUncheckedIndex: index)
     }
     
     /// Returns the value at given column, converted to the requested type.
@@ -905,7 +910,8 @@ extension Row {
     /// The returned data does not owns its bytes: it must not be used longer
     /// than the row's lifetime.
     func decodeDataNoCopyIfPresent(atIndex index: Int) throws -> Data? {
-        try impl.fastDecodeDataNoCopyIfPresent(atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return try impl.fastDecodeDataNoCopyIfPresent(atUncheckedIndex: index)
     }
     
     /// Returns the Data at given index.
@@ -919,7 +925,8 @@ extension Row {
     /// The returned data does not owns its bytes: it must not be used longer
     /// than the row's lifetime.
     func decodeDataNoCopy(atIndex index: Int) throws -> Data {
-        try impl.fastDecodeDataNoCopy(atUncheckedIndex: _checkedIndex(index))
+        _checkIndex(index)
+        return try impl.fastDecodeDataNoCopy(atUncheckedIndex: index)
     }
     
     /// Returns the optional Data at given column.
@@ -1663,7 +1670,8 @@ extension Row {
     
     /// Accesses the (ColumnName, DatabaseValue) pair at given index.
     public subscript(position: RowIndex) -> (String, DatabaseValue) {
-        let index = _checkedIndex(position.index)
+        let index = position.index
+        _checkIndex(index)
         return (
             impl.columnName(atUncheckedIndex: index),
             impl.databaseValue(atUncheckedIndex: index))

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -45,6 +45,7 @@ public protocol StatementColumnConvertible {
 // MARK: - Conversions
 
 extension DatabaseValueConvertible where Self: StatementColumnConvertible {
+    @inline(__always)
     @inlinable
     static func fastDecode(
         fromStatement sqliteStatement: SQLiteStatement,
@@ -64,6 +65,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         return value
     }
     
+    @inline(__always)
     @inlinable
     static func fastDecode(
         fromRow row: Row,
@@ -80,6 +82,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         return try row.fastDecode(Self.self, atUncheckedIndex: index)
     }
     
+    @inline(__always)
     @inlinable
     static func fastDecodeIfPresent(
         fromStatement sqliteStatement: SQLiteStatement,
@@ -100,6 +103,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         return value
     }
     
+    @inline(__always)
     @inlinable
     static func fastDecodeIfPresent(
         fromRow row: Row,

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -45,6 +45,20 @@ public protocol StatementColumnConvertible {
 // MARK: - Conversions
 
 extension DatabaseValueConvertible where Self: StatementColumnConvertible {
+    @usableFromInline
+    /* private */ static func _valueMismatch(
+        fromStatement sqliteStatement: SQLiteStatement,
+        atUncheckedIndex index: Int32,
+        context: @autoclosure () -> RowDecodingContext)
+    throws -> Never
+    {
+        throw RowDecodingError.valueMismatch(
+            Self.self,
+            sqliteStatement: sqliteStatement,
+            index: index,
+            context: context())
+    }
+    
     @inline(__always)
     @inlinable
     static func fastDecode(
@@ -56,11 +70,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         guard sqlite3_column_type(sqliteStatement, index) != SQLITE_NULL,
               let value = self.init(sqliteStatement: sqliteStatement, index: index)
         else {
-            throw RowDecodingError.valueMismatch(
-                Self.self,
-                sqliteStatement: sqliteStatement,
-                index: index,
-                context: context())
+            try _valueMismatch(fromStatement: sqliteStatement, atUncheckedIndex: index, context: context())
         }
         return value
     }
@@ -94,11 +104,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
             return nil
         }
         guard let value = self.init(sqliteStatement: sqliteStatement, index: index) else {
-            throw RowDecodingError.valueMismatch(
-                Self.self,
-                sqliteStatement: sqliteStatement,
-                index: index,
-                context: context())
+            try _valueMismatch(fromStatement: sqliteStatement, atUncheckedIndex: index, context: context())
         }
         return value
     }

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -69,6 +69,8 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         guard let cString = sqlite3_column_text(sqliteStatement, index) else {
             return nil

--- a/GRDB/Core/Support/Foundation/Date.swift
+++ b/GRDB/Core/Support/Foundation/Date.swift
@@ -58,6 +58,7 @@ extension Date: DatabaseValueConvertible {
         return nil
     }
     
+    @usableFromInline
     init?(databaseDateComponents: DatabaseDateComponents) {
         guard databaseDateComponents.format.hasYMDComponents else {
             // Refuse to turn hours without any date information into Date:
@@ -117,6 +118,8 @@ extension Date: StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         switch sqlite3_column_type(sqliteStatement, index) {
         case SQLITE_INTEGER, SQLITE_FLOAT:

--- a/GRDB/Core/Support/Foundation/Decimal.swift
+++ b/GRDB/Core/Support/Foundation/Decimal.swift
@@ -17,7 +17,7 @@ extension Decimal: DatabaseValueConvertible {
             return self.init(double)
         case let .string(string):
             // Must match NSNumber.fromDatabaseValue(_:)
-            return self.init(string: string, locale: posixLocale)
+            return self.init(string: string, locale: _posixLocale)
         default:
             return nil
         }
@@ -26,6 +26,8 @@ extension Decimal: DatabaseValueConvertible {
 
 /// Decimal adopts StatementColumnConvertible
 extension Decimal: StatementColumnConvertible {
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         switch sqlite3_column_type(sqliteStatement, index) {
         case SQLITE_INTEGER:
@@ -35,12 +37,13 @@ extension Decimal: StatementColumnConvertible {
         case SQLITE_TEXT:
             self.init(
                 string: String(cString: sqlite3_column_text(sqliteStatement, index)!),
-                locale: posixLocale)
+                locale: _posixLocale)
         default:
             return nil
         }
     }
 }
 
-private let posixLocale = Locale(identifier: "en_US_POSIX")
+@usableFromInline
+let _posixLocale = Locale(identifier: "en_US_POSIX")
 #endif

--- a/GRDB/Core/Support/Foundation/SQLiteDateParser.swift
+++ b/GRDB/Core/Support/Foundation/SQLiteDateParser.swift
@@ -2,13 +2,18 @@ import Foundation
 
 // inspired by: http://jordansmith.io/performant-date-parsing/
 
-final class SQLiteDateParser {
+@usableFromInline
+struct SQLiteDateParser {
+    @usableFromInline
+    init() { }
+    
     func components(from dateString: String) -> DatabaseDateComponents? {
         dateString.withCString { cString in
             components(cString: cString, length: strlen(cString))
         }
     }
     
+    @usableFromInline
     func components(cString: UnsafePointer<CChar>, length: Int) -> DatabaseDateComponents? {
         assert(strlen(cString) == length)
         

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -49,6 +49,8 @@ extension UUID: DatabaseValueConvertible {
 }
 
 extension UUID: StatementColumnConvertible {
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         switch sqlite3_column_type(sqliteStatement, index) {
         case SQLITE_TEXT:

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -98,6 +98,8 @@ extension Int: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int(exactly: int64) else { return nil }
@@ -127,6 +129,8 @@ extension Int8: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int8(exactly: int64) else { return nil }
@@ -156,6 +160,8 @@ extension Int16: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int16(exactly: int64) else { return nil }
@@ -185,6 +191,8 @@ extension Int32: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int32(exactly: int64) else { return nil }
@@ -250,6 +258,8 @@ extension UInt: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt(exactly: int64) else { return nil }
@@ -279,6 +289,8 @@ extension UInt8: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt8(exactly: int64) else { return nil }
@@ -308,6 +320,8 @@ extension UInt16: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt16(exactly: int64) else { return nil }
@@ -337,6 +351,8 @@ extension UInt32: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt32(exactly: int64) else { return nil }
@@ -366,6 +382,8 @@ extension UInt64: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    @inline(__always)
+    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt64(exactly: int64) else { return nil }

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -36,6 +36,7 @@ extension Optional: _OptionalProtocol { }
 // MARK: - Internal
 
 /// Reserved for GRDB: do not use.
+@inlinable
 func GRDBPrecondition(
     _ condition: @autoclosure() -> Bool,
     _ message: @autoclosure() -> String = "",

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -36,6 +36,7 @@ extension Optional: _OptionalProtocol { }
 // MARK: - Internal
 
 /// Reserved for GRDB: do not use.
+@inline(__always)
 @inlinable
 func GRDBPrecondition(
     _ condition: @autoclosure() -> Bool,

--- a/Tests/Performance/GRDBPerformance/FetchPositionalValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/FetchPositionalValuesTests.swift
@@ -15,7 +15,9 @@ class FetchPositionalValuesTests: XCTestCase {
         var connection: OpaquePointer? = nil
         sqlite3_open_v2(url.path, &connection, 0x00000004 /*SQLITE_OPEN_CREATE*/ | 0x00000002 /*SQLITE_OPEN_READWRITE*/, nil)
         
-        measure {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 50
+        measure(options: options) {
             var count = 0
             var statement: OpaquePointer? = nil
             sqlite3_prepare_v2(connection, "SELECT * FROM item", -1, &statement, nil)
@@ -56,7 +58,9 @@ class FetchPositionalValuesTests: XCTestCase {
         try generateSQLiteDatabaseIfMissing(at: url, insertedRowCount: expectedRowCount)
         let dbQueue = try DatabaseQueue(path: url.path)
         
-        measure {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 50
+        measure(options: options) {
             var count = 0
             
             try! dbQueue.inDatabase { db in

--- a/Tests/Performance/GRDBPerformance/FetchRecordOptimizedTests.swift
+++ b/Tests/Performance/GRDBPerformance/FetchRecordOptimizedTests.swift
@@ -50,7 +50,9 @@ class FetchRecordOptimizedTests: XCTestCase {
         try generateSQLiteDatabaseIfMissing(at: url, insertedRowCount: expectedRowCount)
         let dbQueue = try DatabaseQueue(path: url.path)
         
-        measure {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 50
+        measure(options: options) {
             let items = try! dbQueue.inDatabase { db in
                 try Item.fetchAll(db)
             }

--- a/Tests/Performance/GRDBPerformance/GRDBPerformance.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/Performance/GRDBPerformance/GRDBPerformance.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/realm/realm-cocoa.git",
         "state": {
           "branch": null,
-          "revision": "83a07f6a508c3427058d9e2c466208d0b6a960fa",
-          "version": "10.12.0"
+          "revision": "7a3e25994d4d917efe30fa4496775d3f024b71b6",
+          "version": "10.13.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/realm/realm-core",
         "state": {
           "branch": null,
-          "revision": "e72b3078bfc5c3f69a0b18f7a220be27e28c463f",
-          "version": "11.2.0"
+          "revision": "9a7d09994e85b7eda8e3553b444bcfef6ec3f9ea",
+          "version": "11.3.0"
         }
       },
       {
@@ -33,7 +33,7 @@
         "repositoryURL": "https://github.com/stephencelis/SQLite.swift.git",
         "state": {
           "branch": null,
-          "revision": "8096e9b9c5cc694f373d2176f96889d3e4afe053",
+          "revision": "9af51e2edf491c0ea632e369a6566e09b65aa333",
           "version": "0.13.0"
         }
       }

--- a/Tests/Performance/GRDBPerformance/InsertPositionalValuesTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertPositionalValuesTests.swift
@@ -22,7 +22,9 @@ class InsertPositionalValuesTests: XCTestCase {
             try! FileManager.default.removeItem(atPath: databasePath)
         }
         
-        measure {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 50
+        measure(options: options) {
             _ = try? FileManager.default.removeItem(atPath: databasePath)
             
             var connection: OpaquePointer? = nil
@@ -67,7 +69,9 @@ class InsertPositionalValuesTests: XCTestCase {
             }
             try! FileManager.default.removeItem(atPath: databasePath)
         }
-        measure {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 50
+        measure(options: options) {
             _ = try? FileManager.default.removeItem(atPath: databasePath)
             
             let dbQueue = try! DatabaseQueue(path: databasePath)

--- a/Tests/Performance/GRDBPerformance/InsertRecordOptimizedTests.swift
+++ b/Tests/Performance/GRDBPerformance/InsertRecordOptimizedTests.swift
@@ -64,7 +64,9 @@ class InsertRecordOptimizedTests: XCTestCase {
             try! FileManager.default.removeItem(atPath: databasePath)
         }
         
-        measure {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 50
+        measure(options: options) {
             _ = try? FileManager.default.removeItem(atPath: databasePath)
             
             let dbQueue = try! DatabaseQueue(path: databasePath)

--- a/Tests/parsePerformanceTests.rb
+++ b/Tests/parsePerformanceTests.rb
@@ -4,7 +4,7 @@ require 'json'
 
 tests = {}
 STDIN.each do |line|
-  if line =~ /\.([^ ]*) ([^ ]*)\]' measured \[Time, seconds\] average: ([\d.]+)/
+  if line =~ /\.([^ ]*) ([^ ]*)\]' measured \[.*\] average: ([\d.]+)/
     class_name = $1
     test_name = $2
     time = $3


### PR DESCRIPTION
This pull request fixes #1043.

In the latest perf report below, "Optimized Records" performance is roughly identical to "Column indexes" again, as it should.

|                                  | GRDB | Raw SQLite | FMDB | SQLite.swift | Core Data | Realm |
|:-------------------------------- | ----:| ----------:| ----:| ------------:| ---------:| -----:|
| **Column indexes**               |      |            |      |              |           |       |
| Fetch                            | 0.06 | 0.04 | 0.05 | 0.33 | ¹ | ¹ |
| Insert                           | 0.07 | 0.02 | 0.17 | 0.13 | ¹ | ¹ |
| **Column names**                 |      |            |      |              |           |       |
| Fetch                            | 0.13 | ¹ | 0.18 | 0.87 | ¹ | ¹ |
| Insert                           | 0.09 | ¹ | 0.88 | 0.62 | ¹ | ¹ |
| **Records**                      |      |            |      |              |           |       |
| Fetch                            | 0.12 | 0.04 | 1.68 | 0.66 | ¹ | ¹ |
| Insert                           | 0.19 | ¹ | ¹ | ¹ | ¹ | ¹ |
| **Codable Records**              |      |            |      |              |           |       |
| Fetch                            | 0.21 | ¹ | ¹ | ¹ | ¹ | ¹ |
| Insert                           | 0.23 | ¹ | ¹ | ¹ | ¹ | ¹ |
| **Optimized Records**            |      |            |      |              |           |       |
| Fetch                            | 0.07 | ¹ | ¹ | ¹ | ¹ | ¹ |
| Insert                           | 0.06 | ¹ | ¹ | ¹ | ¹ | ¹ |
| **Records with change tracking** |      |            |      |              |           |       |
| Fetch                            | 0.25 | ¹ | ¹ | ¹ | 0.43 | 0.09 |
| Insert                           | 0.22 | ¹ | ¹ | ¹ | 0.39 | 0.33 |

¹ Not applicable
