### PR TITLE
Expose FTS5Pattern initializer for raw pattern.

### DIFF
--- a/Documentation/FullTextSearch.md
+++ b/Documentation/FullTextSearch.md
@@ -508,7 +508,16 @@ try db.makeFTS5Pattern(rawPattern: "AND", forTable: "book")
 try db.makeFTS5Pattern(rawPattern: "missing: sqlite", forTable: "book")
 ```
 
-The FTS5Pattern initializers don't throw. They build a valid pattern from any string, **including strings provided by users of your application**. They let you find documents that match all given words, any given word, or a full phrase, depending on the needs of your application:
+The first initializer validates your raw patterns against the query grammar, and may throw a [DatabaseError](../README.md#databaseerror):
+
+```swift
+// OK: FTS5Pattern
+let pattern = try FTS5Pattern(rawPattern: "sqlite", forTable: "book")
+// DatabaseError: syntax error near \"AND\"
+let pattern = try FTS5Pattern(rawPattern: "AND", forTable: "book")
+```
+
+The other four FTS5Pattern initializers don't throw. They build a valid pattern from any string, **including strings provided by users of your application**. They let you find documents that match all given words, any given word, or a full phrase, depending on the needs of your application:
 
 ```swift
 let query = "SQLite database"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Pull Request Checklist

<!--
Please verify that your pull request checks those boxes:
-->

- [x] This pull request is submitted against the `development` branch.
- [x] Inline documentation has been updated.
- [x] README.md or another dedicated guide has been updated.
- [x] Changes are tested.

`FTS3Pattern` as an initializer `public init(rawPattern: String) throws` that constructs it directly from raw pattern, while `FTS5Pattern` can be constructed using `Database` extensions, making `public init(rawPattern: String, allowedColumns: [String] = []) throws` publicly available helps make it constructed easier outside a database-agnostic context.

This PR also compared `FTS3Pattern.swift` with `FTS5Pattern.swift`, and made some minor adjustments  to make it easier to those APIs aligned up.