### PR TITLE
Change init to fix Swift error

### DIFF
--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -84,8 +84,7 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
         guard let components = optionalComponents else {
             return nil
         }
-        self.dateComponents = components.dateComponents
-        self.format = components.format
+        self.init(components.dateComponents, format: components.format)
     }
     
     // MARK: - DatabaseValueConvertible adoption


### PR DESCRIPTION
I was getting the following error when building GRDB 5.11 through Cocoapods:

```
❌  Pods/GRDB.swift/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift:87:14: 'let' property 'dateComponents' may not be initialized directly; use "self.init(...)" or "self = ..." instead

        self.dateComponents = components.dateComponents
             ^



❌  Pods/GRDB.swift/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift:88:14: 'let' property 'format' may not be initialized directly; use "self.init(...)" or "self = ..." instead

        self.format = components.format
```

So I just changed it to use self.init as it suggested. Built with Xcode 12.5.1

### Pull Request Checklist

- [X] This pull request is submitted against the `development` branch.
- [N/A] Inline documentation has been updated.
- [N/A] README.md or another dedicated guide has been updated.
- [X] Changes are tested.
