### PR TITLE
Precise foreign key checks for migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,12 +84,14 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 - **Breaking Change**: [#1076](https://github.com/groue/GRDB.swift/pull/1076) by [@groue](https://github.com/groue): Require Swift 5.3
 - **New**: [#1078](https://github.com/groue/GRDB.swift/pull/1078) by [@groue](https://github.com/groue): More convenience methods (non-mutating persistence methods, and existence-checking methods)
 - **New**: [#1088](https://github.com/groue/GRDB.swift/pull/1088) by [@groue](https://github.com/groue): Shared ValueObservation
+- **New**: [#1095](https://github.com/groue/GRDB.swift/pull/1095) by [@groue](https://github.com/groue): Precise foreign key checks for migrations
 - **New**: `DatabasePool.erase()` prevents concurrent reads until it has completed.
 - **New**: A new `close()` method allows precise closing of database connections.
 - **Fixed**: Filtering records by primary key now properly encodes dates and uuids according to the customized strategies (`filter(id:)`, `deleteAll(_:keys:)`, etc.)
 - **Documentation Update**: The [Date and UUID Coding Strategies](README.md#date-and-uuid-coding-strategies) was updated for the new support for customized date and uuid primary key coding.
 - **Documentation Update**: A new [Testing for Record Existence](README.md#testing-for-record-existence) chapter describes the new `request.isEmpty(_:)`, `Record.exists(_:id:)` and `Record.exists(_:key:)` methods.
 - **Documentation Update**: A new [ValueObservation Sharing](README.md#valueobservation-sharing) chapter describes how to share database observations and spare database resources.
+- **Documentation Update**: The [Migrations](Documentation/Migrations.md) guide has a much more detailed description of how you can mitigate that difficulties that SQLite creates around foreign keys during schema changes.
 
 ## 5.12.0
 

--- a/Documentation/Migrations.md
+++ b/Documentation/Migrations.md
@@ -229,7 +229,7 @@ In order to check for foreign key violations, the `checkForeignKeyViolations()` 
 
 ```swift
 // SQLite error 19: foreign key constraint failed from player(teamId) to team(id),
-// in [id:1 teamId:2 name:"O'Brien" score: 1000]
+// in [id:1 teamId:2 name:"O'Brien" score:1000]
 try db.checkForeignKeyViolations()
 ```
 

--- a/Documentation/Migrations.md
+++ b/Documentation/Migrations.md
@@ -227,7 +227,7 @@ In order to prevent foreign key violations from being committed to disk, you can
 In order to check for foreign key violations, the `checkForeignKeys()` and `checkForeignKeys(in:)` methods are recommended over the raw use of the [`PRAGMA foreign_key_check`](https://www.sqlite.org/pragma.html#pragma_foreign_key_check). Those methods throw a nicely detailed DatabaseError that contains a lot of debugging information:
 
 ```swift
-// SQLite error 19: foreign key constraint failed from player(teamId) to team(id),
+// SQLite error 19: FOREIGN KEY constraint violation - from player(teamId) to team(id),
 // in [id:1 teamId:2 name:"O'Brien" score:1000]
 try db.checkForeignKeys()
 ```
@@ -257,7 +257,7 @@ while let violation = try violations.next() {
     String(describing: violation)
     
     // Rich description:
-    // "foreign key constraint failed from player(teamId) to team(id),
+    // "FOREIGN KEY constraint violation - from player(teamId) to team(id),
     //  in [id:1 teamId:2 name:"O'Brien" score:1000]"
     try violation.failureDescription(db)
 }

--- a/Documentation/Migrations.md
+++ b/Documentation/Migrations.md
@@ -185,7 +185,7 @@ You can ask the migrator to stop performing foreign key checks for all newly reg
 :warning: If you use this technique, your app becomes responsible for preventing foreign key violations from being committed to disk!
 
 ```swift
-migrator = migrator.unsafeWithoutDeferredForeignKeyChecks()
+migrator = migrator.disablingDeferredForeignKeyChecks()
 
 // From now on, migrations are unchecked!
 migrator.registerMigration("fast but unchecked") { db in ... }
@@ -196,7 +196,7 @@ In order to prevent foreign key violations from being committed to disk, you can
 - Run migrations with immediate foreign key check, as long as they do not require the technique described by [Making Other Kinds Of Table Schema Changes](https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes):
 
     ```swift
-    migrator = migrator.unsafeWithoutDeferredForeignKeyChecks()
+    migrator = migrator.disablingDeferredForeignKeyChecks()
     migrator.registerMigration("unchecked") { db in ... }
     migrator.registerMigration("checked", foreignKeyChecks: .immediate) { db in ... }
     ```
@@ -204,7 +204,7 @@ In order to prevent foreign key violations from being committed to disk, you can
 - Perform foreign key checks on some tables only:
 
     ```swift
-    migrator = migrator.unsafeWithoutDeferredForeignKeyChecks()
+    migrator = migrator.disablingDeferredForeignKeyChecks()
     migrator.registerMigration("partially checked") { db in
         ...
         

--- a/Documentation/Migrations.md
+++ b/Documentation/Migrations.md
@@ -162,7 +162,7 @@ The detailed sequence of operations is described below, some of them are perform
 
 SQLite makes it [difficult](https://www.sqlite.org/lang_altertable.html) to perform some schema changes, and this creates very undesired churn w.r.t. foreign keys. GRDB makes its best to hide those problems to you, but you might have to deal with them one day, especially if your database becomes *very big*:
 
-You'll need to read this chapter if you are looking for a mitigation to the time spent by migrations performing foreign key checks. You'll know this by instrumenting your migrations, and looking for the time spent in the `checkForeignKeyViolations` method. See [Advanced Database Schema Changes] right above to know what are those foreign key checks.
+You'll need to read this chapter if you are looking for a mitigation to the time spent by migrations performing foreign key checks. You'll know this by instrumenting your migrations, and looking for the time spent in the `checkForeignKeys` method. See [Advanced Database Schema Changes] right above to know what are those foreign key checks.
 
 **Your first mitigation technique is immediate foreign key checks.**
 
@@ -209,7 +209,7 @@ In order to prevent foreign key violations from being committed to disk, you can
         
         // Throws an error and stops migrations if there exists a
         // foreign key violation in the 'player' table.
-        try db.checkForeignKeyViolations(in: "player")
+        try db.checkForeignKeys(in: "player")
     }
     ```
 
@@ -220,16 +220,16 @@ In order to prevent foreign key violations from being committed to disk, you can
     
     // Throws an error if there exists any foreign key violation.
     try dbQueue.read { db in
-        try db.checkForeignKeyViolations()
+        try db.checkForeignKeys()
     }
     ```
 
-In order to check for foreign key violations, the `checkForeignKeyViolations()` and `checkForeignKeyViolations(in:)` methods are recommended over the raw use of the [`PRAGMA foreign_key_check`](https://www.sqlite.org/pragma.html#pragma_foreign_key_check). Those methods throw a nicely detailed DatabaseError that contains a lot of debugging information:
+In order to check for foreign key violations, the `checkForeignKeys()` and `checkForeignKeys(in:)` methods are recommended over the raw use of the [`PRAGMA foreign_key_check`](https://www.sqlite.org/pragma.html#pragma_foreign_key_check). Those methods throw a nicely detailed DatabaseError that contains a lot of debugging information:
 
 ```swift
 // SQLite error 19: foreign key constraint failed from player(teamId) to team(id),
 // in [id:1 teamId:2 name:"O'Brien" score:1000]
-try db.checkForeignKeyViolations()
+try db.checkForeignKeys()
 ```
 
 You can also iterate a lazy [cursor](../README.md#cursors) of all individual foreign key violations found in the database:

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -808,7 +808,7 @@ public struct ForeignKeyViolation: FetchableRecord, CustomStringConvertible {
     
     /// Returns a precise description of the foreign key violation.
     ///
-    /// For example: 'foreign key constraint failed from player(teamId) to team(id),
+    /// For example: 'FOREIGN KEY constraint violation - from player(teamId) to team(id),
     /// in [id:1 teamId:2 name:"O'Brien" score: 1000]'
     public func failureDescription(_ db: Database) throws -> String {
         // Grab detailed information, if possible, for better error message
@@ -822,12 +822,12 @@ public struct ForeignKeyViolation: FetchableRecord, CustomStringConvertible {
         var description: String
         if let foreignKey = foreignKey {
             description = """
-                foreign key constraint failed \
+                FOREIGN KEY constraint violation - \
                 from \(originTable)(\(foreignKey.originColumns.joined(separator: ", "))) \
                 to \(destinationTable)(\(foreignKey.destinationColumns.joined(separator: ", ")))
                 """
         } else {
-            description = "foreign key constraint failed from \(originTable) to \(destinationTable)"
+            description = "FOREIGN KEY constraint violation - from \(originTable) to \(destinationTable)"
         }
         
         if let originRow = originRow {

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -479,14 +479,14 @@ extension Database {
     
     /// Throws a DatabaseError of extended code `SQLITE_CONSTRAINT_FOREIGNKEY`
     /// if there exists a foreign key violation in the database.
-    public func checkForeignKeyViolations() throws {
-        try checkForeignKeyViolations(from: foreignKeyViolations())
+    public func checkForeignKeys() throws {
+        try checkForeignKeys(from: foreignKeyViolations())
     }
     
     /// Throws a DatabaseError of extended code `SQLITE_CONSTRAINT_FOREIGNKEY`
     /// if there exists a foreign key violation in the table.
-    public func checkForeignKeyViolations(in tableName: String) throws {
-        try checkForeignKeyViolations(from: foreignKeyViolations(in: tableName))
+    public func checkForeignKeys(in tableName: String) throws {
+        try checkForeignKeys(from: foreignKeyViolations(in: tableName))
     }
     
     private func foreignKeyViolations(in table: TableIdentifier) throws -> RecordCursor<ForeignKeyViolation> {
@@ -495,7 +495,7 @@ extension Database {
             """)
     }
     
-    private func checkForeignKeyViolations(from violations: RecordCursor<ForeignKeyViolation>) throws {
+    private func checkForeignKeys(from violations: RecordCursor<ForeignKeyViolation>) throws {
         guard let violation = try violations.next() else {
             return
         }

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -175,7 +175,7 @@ extension Database {
             .contains { $0.lowercased() == name }
     }
     
-    /// The primary key for table named `tableName`, in the main or temp schema.
+    /// The primary key for table named `tableName`.
     ///
     /// All tables have a primary key, even when it is not explicit. When a
     /// table has no explicit primary key, the result is the hidden
@@ -304,7 +304,7 @@ extension Database {
         }
     }
     
-    /// The indexes on table named `tableName`, in the main or temp schema.
+    /// The indexes on table named `tableName`.
     ///
     /// Only indexes on columns are returned. Indexes on expressions are
     /// not returned.
@@ -385,7 +385,7 @@ extension Database {
         try columnsForUniqueKey(Array(columns), in: tableName) != nil
     }
     
-    /// The foreign keys defined on table named `tableName`, in the main or temp schema.
+    /// The foreign keys defined on table named `tableName`.
     ///
     /// - throws: A DatabaseError if table does not exist.
     public func foreignKeys(on tableName: String) throws -> [ForeignKeyInfo] {
@@ -404,6 +404,7 @@ extension Database {
         }
         
         var rawForeignKeys: [(
+            id: Int,
             destinationTable: String,
             mapping: [(origin: String, destination: String?, seq: Int)])] = []
         var previousId: Int? = nil
@@ -424,7 +425,7 @@ extension Database {
                     .append((origin: origin, destination: destination, seq: seq))
             } else {
                 let mapping = [(origin: origin, destination: destination, seq: seq)]
-                rawForeignKeys.append((destinationTable: table, mapping: mapping))
+                rawForeignKeys.append((id: id, destinationTable: table, mapping: mapping))
                 previousId = id
             }
         }
@@ -438,7 +439,7 @@ extension Database {
             }
         }
         
-        let foreignKeys = try rawForeignKeys.map { (destinationTable, columnMapping) -> ForeignKeyInfo in
+        let foreignKeys = try rawForeignKeys.map { (id, destinationTable, columnMapping) -> ForeignKeyInfo in
             let orderedMapping = columnMapping
                 .sorted { $0.seq < $1.seq }
                 .map { (origin: $0.origin, destination: $0 .destination) }
@@ -454,11 +455,57 @@ extension Database {
                     (origin: origin, destination: destination!)
                 }
             }
-            return ForeignKeyInfo(destinationTable: destinationTable, mapping: completeMapping)
+            return ForeignKeyInfo(id: id, destinationTable: destinationTable, mapping: completeMapping)
         }
         
         schemaCache[table.schemaID].set(foreignKeys: .value(foreignKeys), forTable: table.name)
         return foreignKeys
+    }
+    
+    /// Returns a cursor over foreign key violations in the database.
+    public func foreignKeyViolations() throws -> RecordCursor<ForeignKeyViolation> {
+        try ForeignKeyViolation.fetchCursor(self, sql: "PRAGMA foreign_key_check")
+    }
+    
+    /// Returns a cursor over foreign key violations in the table.
+    public func foreignKeyViolations(in tableName: String) throws -> RecordCursor<ForeignKeyViolation> {
+        for schemaIdentifier in try schemaIdentifiers() {
+            if try exists(type: .table, name: tableName, in: schemaIdentifier) {
+                return try foreignKeyViolations(in: TableIdentifier(schemaID: schemaIdentifier, name: tableName))
+            }
+        }
+        throw DatabaseError.noSuchTable(tableName)
+    }
+    
+    /// Throws a DatabaseError of extended code `SQLITE_CONSTRAINT_FOREIGNKEY`
+    /// if there exists a foreign key violation in the database.
+    public func checkForeignKeyViolations() throws {
+        try checkForeignKeyViolations(from: foreignKeyViolations())
+    }
+    
+    /// Throws a DatabaseError of extended code `SQLITE_CONSTRAINT_FOREIGNKEY`
+    /// if there exists a foreign key violation in the table.
+    public func checkForeignKeyViolations(in tableName: String) throws {
+        try checkForeignKeyViolations(from: foreignKeyViolations(in: tableName))
+    }
+    
+    private func foreignKeyViolations(in table: TableIdentifier) throws -> RecordCursor<ForeignKeyViolation> {
+        try ForeignKeyViolation.fetchCursor(self, sql: """
+            PRAGMA \(table.schemaID.sql).foreign_key_check(\(table.name.quotedDatabaseIdentifier))
+            """)
+    }
+    
+    private func checkForeignKeyViolations(from violations: RecordCursor<ForeignKeyViolation>) throws {
+        guard let violation = try violations.next() else {
+            return
+        }
+        
+        // Grab detailed information, if possible, for better error message.
+        // If detailed information is not available, fallback to plain description.
+        let message = (try? violation.failureDescription(self)) ?? String(describing: violation)
+        throw DatabaseError(
+            resultCode: .SQLITE_CONSTRAINT_FOREIGNKEY,
+            message: message)
     }
     
     /// Returns the actual name of the database table, in the main or temp
@@ -486,7 +533,7 @@ extension Database {
 
 extension Database {
     
-    /// The columns in the table named `tableName`, in the main or temp schema.
+    /// The columns in the table named `tableName`.
     ///
     /// - throws: A DatabaseError if table does not exist.
     public func columns(in tableName: String) throws -> [ColumnInfo] {
@@ -725,6 +772,74 @@ public struct IndexInfo {
     }
 }
 
+/// A foreign key violation produced by PRAGMA foreign_key_check
+///
+/// See <https://www.sqlite.org/pragma.html#pragma_foreign_key_check>
+public struct ForeignKeyViolation: FetchableRecord, CustomStringConvertible {
+    /// The name of the table that contains the `REFERENCES` clause
+    var originTable: String
+    
+    /// The rowid of the row that contains the invalid `REFERENCES` clause, or
+    /// nil if the origin table is a `WITHOUT ROWID` table.
+    var originRowID: Int64?
+    
+    /// The name of the table that is referred to.
+    var destinationTable: String
+    
+    /// The id of the specific foreign key constraint that failed. This id
+    /// matches `ForeignKeyInfo.id`. See `Database.foreignKeys(on:)` for more
+    /// information.
+    var foreignKeyId: Int
+    
+    public init(row: Row) {
+        originTable = row[0]
+        originRowID = row[1]
+        destinationTable = row[2]
+        foreignKeyId = row[3]
+    }
+    
+    public var description: String {
+        if let originRowID = originRowID {
+            return "Foreign key violation from \(originTable) to \(destinationTable), in rowid \(originRowID)"
+        } else {
+            return "Foreign key violation from \(originTable) to \(destinationTable)"
+        }
+    }
+    
+    /// Returns a precise description of the foreign key violation.
+    ///
+    /// For example: 'foreign key constraint failed from player(teamId) to team(id),
+    /// in [id:1 teamId:2 name:"O'Brien" score: 1000]'
+    public func failureDescription(_ db: Database) throws -> String {
+        // Grab detailed information, if possible, for better error message
+        let originRow = try originRowID.flatMap { rowid in
+            try Row.fetchOne(db, sql: "SELECT * FROM \(originTable) WHERE rowid = \(rowid)")
+        }
+        let foreignKey = try db.foreignKeys(on: originTable).first(where: { foreignKey in
+            foreignKey.id == foreignKeyId
+        })
+        
+        var description: String
+        if let foreignKey = foreignKey {
+            description = """
+                foreign key constraint failed \
+                from \(originTable)(\(foreignKey.originColumns.joined(separator: ", "))) \
+                to \(destinationTable)(\(foreignKey.destinationColumns.joined(separator: ", ")))
+                """
+        } else {
+            description = "foreign key constraint failed from \(originTable) to \(destinationTable)"
+        }
+        
+        if let originRow = originRow {
+            description += ", in \(String(describing: originRow))"
+        } else if let originRowID = originRowID {
+            description += ", in rowid \(originRowID)"
+        }
+        
+        return description
+    }
+}
+
 /// Primary keys are returned from the Database.primaryKey(_:) method.
 ///
 /// When the table's primary key is the rowid:
@@ -861,6 +976,9 @@ public struct PrimaryKeyInfo {
 /// You get foreign keys from table names, with the
 /// `foreignKeys(on:)` method.
 public struct ForeignKeyInfo {
+    /// The first column in the output of the `foreign_key_list` pragma
+    public var id: Int
+    
     /// The name of the destination table
     public let destinationTable: String
     

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -53,7 +53,7 @@ public struct DatabaseMigrator {
         /// are checked right before changes are committed on disk.
         ///
         /// These deferred checks are not executed if the migrator comes
-        /// from `unsafeWithoutDeferredForeignKeyChecks()`.
+        /// from `disablingDeferredForeignKeyChecks()`.
         ///
         /// Deferred foreign key checks are necessary for migrations that
         /// perform schema changes as described in
@@ -122,7 +122,7 @@ public struct DatabaseMigrator {
     ///         // Runs with immediate foreign key checks
     ///     }
     ///
-    ///     migrator = migrator.unsafeWithoutDeferredForeignKeyChecks()
+    ///     migrator = migrator.disablingDeferredForeignKeyChecks()
     ///     migrator.registerMigration("C") { db in
     ///         // Runs with disabled foreign key checks
     ///     }
@@ -133,7 +133,7 @@ public struct DatabaseMigrator {
     /// - warning: Before using this unsafe method, try to run your migrations with
     /// `.immediate` foreign key checks, if possible. This may enhance migration
     /// performances, while preserving the database integrity guarantee.
-    public func unsafeWithoutDeferredForeignKeyChecks() -> DatabaseMigrator {
+    public func disablingDeferredForeignKeyChecks() -> DatabaseMigrator {
         with { $0.defersForeignKeyChecks = false }
     }
     
@@ -158,7 +158,7 @@ public struct DatabaseMigrator {
     ///       disabled foreign keys, until foreign keys are checked right before
     ///       changes are committed on disk. These deferred checks are not
     ///       executed if the migrator comes
-    ///       from `unsafeWithoutDeferredForeignKeyChecks()`.
+    ///       from `disablingDeferredForeignKeyChecks()`.
     ///
     ///       The `.immediate` checks have the migration run with foreign
     ///       keys enabled.

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -47,6 +47,27 @@ import Foundation
 ///
 ///     try migrator.migrate(dbQueue)
 public struct DatabaseMigrator {
+    /// Controls how migrations handle foreign keys constraints.
+    public enum ForeignKeyChecks {
+        /// The migration runs with disabled foreign keys, until foreign keys
+        /// are checked right before changes are committed on disk.
+        ///
+        /// These deferred checks are not executed if the migrator comes
+        /// from `unsafeWithoutDeferredForeignKeyChecks()`.
+        ///
+        /// Deferred foreign key checks are necessary for migrations that
+        /// perform schema changes as described in
+        /// <https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes>
+        case deferred
+        
+        /// The migration runs for foreign keys on.
+        ///
+        /// Immediate foreign key checks are not compatible with migrations that
+        /// perform schema changes as described in
+        /// <https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes>
+        case immediate
+    }
+    
     /// When the `eraseDatabaseOnSchemaChange` flag is true, the migrator will
     /// automatically wipe out the full database content, and recreate the whole
     /// database from scratch, if it detects that a migration has changed its
@@ -72,10 +93,48 @@ public struct DatabaseMigrator {
     /// 2. When the database content can easily be recreated, such as a cache
     ///     for some downloaded data.
     public var eraseDatabaseOnSchemaChange = false
+    private var defersForeignKeyChecks = true
     private var _migrations: [Migration] = []
     
     /// A new migrator.
     public init() {
+    }
+    
+    // MARK: - Disabling Foreign Key Checks
+    
+    /// Returns a migrator that will not perform deferred foreign key checks in
+    /// all newly registered migrations.
+    ///
+    /// The returned migrator is _unsafe_, because it no longer guarantees the
+    /// integrity of the database. It is your responsibility to register
+    /// migrations that do not break foreign key constraints.
+    ///
+    /// Running migrations without foreign key checks can improve migration
+    /// performance on huge databases.
+    ///
+    /// Example:
+    ///
+    ///     var migrator = DatabaseMigrator()
+    ///     migrator.registerMigration("A") { db in
+    ///         // Runs with deferred foreign key checks
+    ///     }
+    ///     migrator.registerMigration("B", foreignKeyChecks: .immediate) { db in
+    ///         // Runs with immediate foreign key checks
+    ///     }
+    ///
+    ///     migrator = migrator.unsafeWithoutDeferredForeignKeyChecks()
+    ///     migrator.registerMigration("C") { db in
+    ///         // Runs with disabled foreign key checks
+    ///     }
+    ///     migrator.registerMigration("D", foreignKeyChecks: .immediate) { db in
+    ///         // Runs with immediate foreign key checks
+    ///     }
+    ///
+    /// - warning: Before using this unsafe method, try to run your migrations with
+    /// `.immediate` foreign key checks, if possible. This may enhance migration
+    /// performances, while preserving the database integrity guarantee.
+    public func unsafeWithoutDeferredForeignKeyChecks() -> DatabaseMigrator {
+        with { $0.defersForeignKeyChecks = false }
     }
     
     // MARK: - Registering Migrations
@@ -92,10 +151,40 @@ public struct DatabaseMigrator {
     ///
     /// - parameters:
     ///     - identifier: The migration identifier.
+    ///     - foreignKeyChecks: This parameter is ignored if the database has
+    ///       not enabled foreign keys.
+    ///
+    ///       The default `.deferred` checks have the migration run with
+    ///       disabled foreign keys, until foreign keys are checked right before
+    ///       changes are committed on disk. These deferred checks are not
+    ///       executed if the migrator comes
+    ///       from `unsafeWithoutDeferredForeignKeyChecks()`.
+    ///
+    ///       The `.immediate` checks have the migration run with foreign
+    ///       keys enabled.
+    ///
+    ///       Only use `.immediate` if you are sure that the migration does not
+    ///       perform schema changes described in
+    ///       <https://www.sqlite.org/lang_altertable.html#making_other_kinds_of_table_schema_changes>
     ///     - block: The migration block that performs SQL statements.
     /// - precondition: No migration with the same same as already been registered.
-    public mutating func registerMigration(_ identifier: String, migrate: @escaping (Database) throws -> Void) {
-        registerMigration(Migration(identifier: identifier, migrate: migrate))
+    public mutating func registerMigration(
+        _ identifier: String,
+        foreignKeyChecks: ForeignKeyChecks = .deferred,
+        migrate: @escaping (Database) throws -> Void)
+    {
+        let migrationChecks: Migration.ForeignKeyChecks
+        switch foreignKeyChecks {
+        case .deferred:
+            if defersForeignKeyChecks {
+                migrationChecks = .deferred
+            } else {
+                migrationChecks = .disabled
+            }
+        case .immediate:
+            migrationChecks = .immediate
+        }
+        registerMigration(Migration(identifier: identifier, foreignKeyChecks: migrationChecks, migrate: migrate))
     }
     
     // MARK: - Applying Migrations
@@ -346,6 +435,8 @@ public struct DatabaseMigrator {
         try runMigrations(db, upTo: targetIdentifier)
     }
 }
+
+extension DatabaseMigrator: Refinable { }
 
 #if canImport(Combine)
 extension DatabaseMigrator {

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -67,7 +67,7 @@ struct Migration {
                     // > then run PRAGMA foreign_key_check to verify that the
                     // > schema change did not break any foreign
                     // > key constraints.
-                    try db.checkForeignKeyViolations()
+                    try db.checkForeignKeys()
                     
                     // > 11. Commit the transaction started in step 2.
                     return .commit

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -67,23 +67,7 @@ struct Migration {
                     // > then run PRAGMA foreign_key_check to verify that the
                     // > schema change did not break any foreign
                     // > key constraints.
-                    if try db
-                        .makeStatement(sql: "PRAGMA foreign_key_check")
-                        .makeCursor()
-                        .isEmpty() == false
-                    {
-                        // https://www.sqlite.org/pragma.html#pragma_foreign_key_check
-                        //
-                        // PRAGMA foreign_key_check does not return an error,
-                        // but the list of violated foreign key constraints.
-                        //
-                        // Let's turn any violation into an
-                        // SQLITE_CONSTRAINT_FOREIGNKEY error, and rollback
-                        // the transaction.
-                        throw DatabaseError(
-                            resultCode: .SQLITE_CONSTRAINT_FOREIGNKEY,
-                            message: "FOREIGN KEY constraint failed")
-                    }
+                    try db.checkForeignKeyViolations()
                     
                     // > 11. Commit the transaction started in step 2.
                     return .commit

--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -1,17 +1,31 @@
 /// An internal struct that defines a migration.
 struct Migration {
+    public enum ForeignKeyChecks {
+        case deferred
+        case immediate
+        case disabled
+    }
+    
     let identifier: String
+    var foreignKeyChecks: ForeignKeyChecks
     let migrate: (Database) throws -> Void
     
     func run(_ db: Database) throws {
         if try Bool.fetchOne(db, sql: "PRAGMA foreign_keys") ?? false {
-            try runWithDeferredForeignKeysChecks(db)
+            switch foreignKeyChecks {
+            case .deferred:
+                try runWithDeferredForeignKeysChecks(db)
+            case .immediate:
+                try runWithImmediateForeignKeysChecks(db)
+            case .disabled:
+                try runWithDisabledForeignKeysChecks(db)
+            }
         } else {
-            try runWithoutDisabledForeignKeys(db)
+            try runWithImmediateForeignKeysChecks(db)
         }
     }
     
-    private func runWithoutDisabledForeignKeys(_ db: Database) throws {
+    private func runWithImmediateForeignKeysChecks(_ db: Database) throws {
         try db.inTransaction(.immediate) {
             try migrate(db)
             try insertAppliedIdentifier(db)
@@ -19,6 +33,21 @@ struct Migration {
         }
     }
     
+    private func runWithDisabledForeignKeysChecks(_ db: Database) throws {
+        try db.execute(sql: "PRAGMA foreign_keys = OFF")
+        try throwingFirstError(
+            execute: {
+                try db.inTransaction(.immediate) {
+                    try migrate(db)
+                    try insertAppliedIdentifier(db)
+                    return .commit
+                }
+            },
+            finally: {
+                try db.execute(sql: "PRAGMA foreign_keys = ON")
+            })
+    }
+
     private func runWithDeferredForeignKeysChecks(_ db: Database) throws {
         // Support for database alterations described at
         // https://www.sqlite.org/lang_altertable.html#otheralter

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -398,9 +398,9 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // The first migration should be committed.
                 // The second migration should be rollbacked.
                 
-                XCTAssert(error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY)
+                XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
-                XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
+                XCTAssertEqual(error.message, #"foreign key constraint failed from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
                 
                 let names = try dbQueue.inDatabase { db in
                     try String.fetchAll(db, sql: "SELECT name FROM persons")
@@ -418,9 +418,9 @@ class DatabaseMigratorTests : GRDBTestCase {
                 // The second migration should be rollbacked.
                 
                 let error = error as! DatabaseError
-                XCTAssert(error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY)
+                XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
-                XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
+                XCTAssertEqual(error.message, #"foreign key constraint failed from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
                 
                 let names = try! String.fetchAll(db, sql: "SELECT name FROM persons")
                 XCTAssertEqual(names, ["Arthur"])
@@ -461,9 +461,9 @@ class DatabaseMigratorTests : GRDBTestCase {
             // Migration 1 and 2 should be committed.
             // Migration 3 should not be committed.
             
-            XCTAssert((error.resultCode == error.extendedResultCode) || error.extendedResultCode == .SQLITE_CONSTRAINT_FOREIGNKEY)
+            XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
             XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
-            XCTAssertEqual(error.message!.lowercased(), "foreign key constraint failed") // lowercased: accept multiple SQLite version
+            XCTAssertEqual(error.message, #"foreign key constraint failed from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
             
             try dbQueue.inDatabase { db in
                 // Arthur inserted (migration 1), Barbara (migration 3) not inserted.
@@ -872,7 +872,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             do {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
-            } catch DatabaseError.SQLITE_CONSTRAINT { }
+            } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
             try dbQueue.read { db in
                 try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
             }
@@ -886,7 +886,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             do {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
-            } catch DatabaseError.SQLITE_CONSTRAINT { }
+            } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
             try dbQueue.read { db in
                 try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
             }
@@ -913,7 +913,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             do {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
-            } catch DatabaseError.SQLITE_CONSTRAINT { }
+            } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
             try dbQueue.read { db in
                 try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
             }
@@ -955,7 +955,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             do {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
-            } catch DatabaseError.SQLITE_CONSTRAINT { }
+            } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
             try dbQueue.read { db in
                 try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
             }
@@ -982,7 +982,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             do {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
-            } catch DatabaseError.SQLITE_CONSTRAINT { }
+            } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
             try dbQueue.read { db in
                 try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
             }
@@ -1008,6 +1008,6 @@ class DatabaseMigratorTests : GRDBTestCase {
         do {
             try migrator.migrate(dbQueue)
             XCTFail("Expected error")
-        } catch DatabaseError.SQLITE_CONSTRAINT { }
+        } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
     }
 }

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -400,7 +400,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
-                XCTAssertEqual(error.message, #"foreign key constraint failed from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
+                XCTAssertEqual(error.message, #"FOREIGN KEY constraint violation - from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
                 
                 let names = try dbQueue.inDatabase { db in
                     try String.fetchAll(db, sql: "SELECT name FROM persons")
@@ -420,7 +420,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 let error = error as! DatabaseError
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
-                XCTAssertEqual(error.message, #"foreign key constraint failed from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
+                XCTAssertEqual(error.message, #"FOREIGN KEY constraint violation - from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
                 
                 let names = try! String.fetchAll(db, sql: "SELECT name FROM persons")
                 XCTAssertEqual(names, ["Arthur"])
@@ -463,7 +463,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             
             XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
             XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
-            XCTAssertEqual(error.message, #"foreign key constraint failed from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
+            XCTAssertEqual(error.message, #"FOREIGN KEY constraint violation - from pets(masterId) to persons(id), in [masterId:123 name:"Bobby"]"#)
             
             try dbQueue.inDatabase { db in
                 // Arthur inserted (migration 1), Barbara (migration 3) not inserted.

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -873,7 +873,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
         do {
             var migrator = DatabaseMigrator()
@@ -885,7 +885,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
         
         // Transient foreign key violation
@@ -896,7 +896,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
             let dbQueue = try makeDatabaseQueue()
             try migrator.migrate(dbQueue)
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
         do {
             var migrator = DatabaseMigrator()
@@ -908,7 +908,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
     }
     
@@ -935,7 +935,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             try migrator.migrate(dbQueue)
             do {
                 // The unique opportunity for corrupt data!
-                try dbQueue.read { try $0.checkForeignKeyViolations() }
+                try dbQueue.read { try $0.checkForeignKeys() }
                 XCTFail("Expected foreign key violation")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
         }
@@ -949,7 +949,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
         
         // Transient foreign key violation
@@ -960,7 +960,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
             let dbQueue = try makeDatabaseQueue()
             try migrator.migrate(dbQueue)
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
         do {
             var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
@@ -972,7 +972,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { try $0.checkForeignKeyViolations() }
+            try dbQueue.read { try $0.checkForeignKeys() }
         }
     }
     

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -873,9 +873,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
         do {
             var migrator = DatabaseMigrator()
@@ -887,9 +885,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
         
         // Transient foreign key violation
@@ -900,9 +896,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
             let dbQueue = try makeDatabaseQueue()
             try migrator.migrate(dbQueue)
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
         do {
             var migrator = DatabaseMigrator()
@@ -914,9 +908,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
     }
     
@@ -941,10 +933,11 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
             let dbQueue = try makeDatabaseQueue()
             try migrator.migrate(dbQueue)
-            try dbQueue.read { db in
-                // The unique opportunity for corrupt data
-                try XCTAssertFalse(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            do {
+                // The unique opportunity for corrupt data!
+                try dbQueue.read { try $0.checkForeignKeyViolations() }
+                XCTFail("Expected foreign key violation")
+            } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
         }
         do {
             var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
@@ -956,9 +949,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
         
         // Transient foreign key violation
@@ -969,9 +960,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
             let dbQueue = try makeDatabaseQueue()
             try migrator.migrate(dbQueue)
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
         do {
             var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
@@ -983,9 +972,7 @@ class DatabaseMigratorTests : GRDBTestCase {
                 try migrator.migrate(dbQueue)
                 XCTFail("Expected error")
             } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
-            try dbQueue.read { db in
-                try XCTAssertTrue(Row.fetchCursor(db, sql: "PRAGMA foreign_key_check").isEmpty())
-            }
+            try dbQueue.read { try $0.checkForeignKeyViolations() }
         }
     }
     

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -920,7 +920,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         }
     }
     
-    func testUnsafeWithoutDeferredForeignKeyChecks() throws {
+    func testDisablingDeferredForeignKeyChecks() throws {
         let foreignKeyViolation = """
             CREATE TABLE parent(id INTEGER NOT NULL PRIMARY KEY);
             CREATE TABLE child(parentId INTEGER REFERENCES parent(id));
@@ -935,7 +935,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // Foreign key violation
         do {
-            var migrator = DatabaseMigrator().unsafeWithoutDeferredForeignKeyChecks()
+            var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
             migrator.registerMigration("A") { db in
                 try db.execute(sql: foreignKeyViolation)
             }
@@ -947,7 +947,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
         }
         do {
-            var migrator = DatabaseMigrator().unsafeWithoutDeferredForeignKeyChecks()
+            var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
             migrator.registerMigration("A", foreignKeyChecks: .immediate) { db in
                 try db.execute(sql: foreignKeyViolation)
             }
@@ -963,7 +963,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         
         // Transient foreign key violation
         do {
-            var migrator = DatabaseMigrator().unsafeWithoutDeferredForeignKeyChecks()
+            var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
             migrator.registerMigration("A") { db in
                 try db.execute(sql: transientForeignKeyViolation)
             }
@@ -974,7 +974,7 @@ class DatabaseMigratorTests : GRDBTestCase {
             }
         }
         do {
-            var migrator = DatabaseMigrator().unsafeWithoutDeferredForeignKeyChecks()
+            var migrator = DatabaseMigrator().disablingDeferredForeignKeyChecks()
             migrator.registerMigration("A", foreignKeyChecks: .immediate) { db in
                 try db.execute(sql: transientForeignKeyViolation)
             }
@@ -989,7 +989,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         }
     }
     
-    func testUnsafeWithoutDeferredForeignKeyChecks_applies_to_newly_registered_migrations() throws {
+    func test_disablingDeferredForeignKeyChecks_applies_to_newly_registered_migrations_only() throws {
         let foreignKeyViolation = """
             CREATE TABLE parent(id INTEGER NOT NULL PRIMARY KEY);
             CREATE TABLE child(parentId INTEGER REFERENCES parent(id));
@@ -1000,7 +1000,7 @@ class DatabaseMigratorTests : GRDBTestCase {
         migrator.registerMigration("A") { db in
             try db.execute(sql: foreignKeyViolation)
         }
-        migrator = migrator.unsafeWithoutDeferredForeignKeyChecks()
+        migrator = migrator.disablingDeferredForeignKeyChecks()
         migrator.registerMigration("B") { db in
             XCTFail("Should not run")
         }

--- a/Tests/GRDBTests/ForeignKeyInfoTests.swift
+++ b/Tests/GRDBTests/ForeignKeyInfoTests.swift
@@ -177,7 +177,7 @@ class ForeignKeyInfoTests: GRDBTestCase {
         }
     }
     
-    func testCheckForeignKeyViolations() throws {
+    func testCheckForeignKeys() throws {
         try makeDatabaseQueue().writeWithoutTransaction { db in
             try db.execute(sql: """
                 CREATE TABLE parent(id TEXT NOT NULL PRIMARY KEY);
@@ -187,7 +187,7 @@ class ForeignKeyInfoTests: GRDBTestCase {
                 """)
             
             do {
-                try db.checkForeignKeyViolations()
+                try db.checkForeignKeys()
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
@@ -205,7 +205,7 @@ class ForeignKeyInfoTests: GRDBTestCase {
                 """)
             
             do {
-                try db.checkForeignKeyViolations()
+                try db.checkForeignKeys()
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
@@ -223,7 +223,7 @@ class ForeignKeyInfoTests: GRDBTestCase {
                 """)
             
             do {
-                try db.checkForeignKeyViolations()
+                try db.checkForeignKeys()
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)

--- a/Tests/GRDBTests/ForeignKeyInfoTests.swift
+++ b/Tests/GRDBTests/ForeignKeyInfoTests.swift
@@ -191,8 +191,8 @@ class ForeignKeyInfoTests: GRDBTestCase {
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
-                XCTAssertEqual(error.message, #"foreign key constraint failed from child(parentId) to parent(id), in [id:13 parentId:"1"]"#)
-                XCTAssertEqual(error.description, #"SQLite error 19: foreign key constraint failed from child(parentId) to parent(id), in [id:13 parentId:"1"]"#)
+                XCTAssertEqual(error.message, #"FOREIGN KEY constraint violation - from child(parentId) to parent(id), in [id:13 parentId:"1"]"#)
+                XCTAssertEqual(error.description, #"SQLite error 19: FOREIGN KEY constraint violation - from child(parentId) to parent(id), in [id:13 parentId:"1"]"#)
             }
         }
         
@@ -209,8 +209,8 @@ class ForeignKeyInfoTests: GRDBTestCase {
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
-                XCTAssertEqual(error.message, #"foreign key constraint failed from child(parentA, parentB) to parent(a, b), in [id:13 parentA:"foo" parentB:"bar"]"#)
-                XCTAssertEqual(error.description, #"SQLite error 19: foreign key constraint failed from child(parentA, parentB) to parent(a, b), in [id:13 parentA:"foo" parentB:"bar"]"#)
+                XCTAssertEqual(error.message, #"FOREIGN KEY constraint violation - from child(parentA, parentB) to parent(a, b), in [id:13 parentA:"foo" parentB:"bar"]"#)
+                XCTAssertEqual(error.description, #"SQLite error 19: FOREIGN KEY constraint violation - from child(parentA, parentB) to parent(a, b), in [id:13 parentA:"foo" parentB:"bar"]"#)
             }
         }
         
@@ -227,8 +227,8 @@ class ForeignKeyInfoTests: GRDBTestCase {
             } catch let error as DatabaseError {
                 XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
                 XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
-                XCTAssertEqual(error.message, "foreign key constraint failed from child(parentA, parentB) to parent(a, b)")
-                XCTAssertEqual(error.description, "SQLite error 19: foreign key constraint failed from child(parentA, parentB) to parent(a, b)")
+                XCTAssertEqual(error.message, "FOREIGN KEY constraint violation - from child(parentA, parentB) to parent(a, b)")
+                XCTAssertEqual(error.description, "SQLite error 19: FOREIGN KEY constraint violation - from child(parentA, parentB) to parent(a, b)")
             }
         }
     }

--- a/Tests/GRDBTests/ForeignKeyInfoTests.swift
+++ b/Tests/GRDBTests/ForeignKeyInfoTests.swift
@@ -54,27 +54,181 @@ class ForeignKeyInfoTests: GRDBTestCase {
             do {
                 let foreignKeys = try db.foreignKeys(on: "children1")
                 XCTAssertEqual(foreignKeys.count, 1)
-                assertEqual(foreignKeys[0], ForeignKeyInfo(destinationTable: "parents1", mapping: [(origin: "parentId", destination: "id")]))
+                assertEqual(foreignKeys[0], ForeignKeyInfo(id: foreignKeys[0].id, destinationTable: "parents1", mapping: [(origin: "parentId", destination: "id")]))
             }
             
             do {
                 let foreignKeys = try db.foreignKeys(on: "children2")
                 XCTAssertEqual(foreignKeys.count, 2)
-                assertEqual(foreignKeys[0], ForeignKeyInfo(destinationTable: "parents1", mapping: [(origin: "parentId2", destination: "id")]))
-                assertEqual(foreignKeys[1], ForeignKeyInfo(destinationTable: "parents1", mapping: [(origin: "parentId1", destination: "id")]))
+                assertEqual(foreignKeys[0], ForeignKeyInfo(id: foreignKeys[0].id, destinationTable: "parents1", mapping: [(origin: "parentId2", destination: "id")]))
+                assertEqual(foreignKeys[1], ForeignKeyInfo(id: foreignKeys[1].id, destinationTable: "parents1", mapping: [(origin: "parentId1", destination: "id")]))
             }
             
             do {
                 let foreignKeys = try db.foreignKeys(on: "children3")
                 XCTAssertEqual(foreignKeys.count, 1)
-                assertEqual(foreignKeys[0], ForeignKeyInfo(destinationTable: "parents2", mapping: [(origin: "parentA", destination: "a"), (origin: "parentB", destination: "b")]))
+                assertEqual(foreignKeys[0], ForeignKeyInfo(id: foreignKeys[0].id, destinationTable: "parents2", mapping: [(origin: "parentA", destination: "a"), (origin: "parentB", destination: "b")]))
             }
             
             do {
                 let foreignKeys = try db.foreignKeys(on: "children4")
                 XCTAssertEqual(foreignKeys.count, 2)
-                assertEqual(foreignKeys[0], ForeignKeyInfo(destinationTable: "parents2", mapping: [(origin: "parentA2", destination: "b"), (origin: "parentB2", destination: "a")]))
-                assertEqual(foreignKeys[1], ForeignKeyInfo(destinationTable: "parents2", mapping: [(origin: "parentA1", destination: "a"), (origin: "parentB1", destination: "b")]))
+                assertEqual(foreignKeys[0], ForeignKeyInfo(id: foreignKeys[0].id, destinationTable: "parents2", mapping: [(origin: "parentA2", destination: "b"), (origin: "parentB2", destination: "a")]))
+                assertEqual(foreignKeys[1], ForeignKeyInfo(id: foreignKeys[1].id, destinationTable: "parents2", mapping: [(origin: "parentA1", destination: "a"), (origin: "parentB1", destination: "b")]))
+            }
+        }
+    }
+    
+    func testForeignKeyViolations() throws {
+        try makeDatabaseQueue().writeWithoutTransaction { db in
+            try db.execute(sql: """
+                CREATE TABLE parent(id TEXT NOT NULL PRIMARY KEY);
+                CREATE TABLE child1(id INTEGER NOT NULL PRIMARY KEY, parentId TEXT REFERENCES parent(id));
+                CREATE TABLE child2(id INTEGER NOT NULL PRIMARY KEY, parentId TEXT REFERENCES parent(id));
+                PRAGMA foreign_keys = OFF;
+                INSERT INTO child1 (id, parentId) VALUES (13, '1');
+                INSERT INTO child1 (id, parentId) VALUES (42, '2');
+                INSERT INTO child2 (id, parentId) VALUES (17, '3');
+                """)
+            
+            let violations = try Array(db.foreignKeyViolations())
+            XCTAssertEqual(violations.count, 3)
+            
+            if let violation = violations.first(where: { $0.originTable == "child1" && $0.originRowID == 13 }) {
+                XCTAssertEqual(violation.destinationTable, "parent")
+            } else {
+                XCTFail("Missing violation")
+            }
+            
+            if let violation = violations.first(where: { $0.originTable == "child1" && $0.originRowID == 42 }) {
+                XCTAssertEqual(violation.destinationTable, "parent")
+            } else {
+                XCTFail("Missing violation")
+            }
+            
+            if let violation = violations.first(where: { $0.originTable == "child2" && $0.originRowID == 17 }) {
+                XCTAssertEqual(violation.destinationTable, "parent")
+            } else {
+                XCTFail("Missing violation")
+            }
+        }
+    }
+    
+    func testForeignKeyViolationsInTable() throws {
+        try makeDatabaseQueue().writeWithoutTransaction { db in
+            try db.execute(sql: """
+                CREATE TABLE parent(id TEXT NOT NULL PRIMARY KEY);
+                CREATE TABLE child1(id INTEGER NOT NULL PRIMARY KEY, parentId TEXT REFERENCES parent(id));
+                CREATE TABLE child2(id INTEGER NOT NULL PRIMARY KEY, parentId TEXT REFERENCES parent(id));
+                PRAGMA foreign_keys = OFF;
+                INSERT INTO child1 (id, parentId) VALUES (13, '1');
+                INSERT INTO child1 (id, parentId) VALUES (42, '2');
+                INSERT INTO child2 (id, parentId) VALUES (17, '3');
+                """)
+            
+            do {
+                let violations = try Array(db.foreignKeyViolations(in: "child1"))
+                XCTAssertEqual(violations.count, 2)
+                
+                if let violation = violations.first(where: { $0.originRowID == 13 }) {
+                    XCTAssertEqual(violation.originTable, "child1")
+                    XCTAssertEqual(violation.destinationTable, "parent")
+                } else {
+                    XCTFail("Missing violation")
+                }
+                
+                if let violation = violations.first(where: { $0.originRowID == 42 }) {
+                    XCTAssertEqual(violation.originTable, "child1")
+                    XCTAssertEqual(violation.destinationTable, "parent")
+                } else {
+                    XCTFail("Missing violation")
+                }
+            }
+            
+            do {
+                let violations = try Array(db.foreignKeyViolations(in: "child2"))
+                XCTAssertEqual(violations.count, 1)
+                
+                if let violation = violations.first(where: { $0.originRowID == 17 }) {
+                    XCTAssertEqual(violation.originTable, "child2")
+                    XCTAssertEqual(violation.destinationTable, "parent")
+                } else {
+                    XCTFail("Missing violation")
+                }
+            }
+            
+            // Case insensitivity
+            do {
+                let violations = try Array(db.foreignKeyViolations(in: "cHiLd2"))
+                XCTAssertEqual(violations.count, 1)
+                
+                if let violation = violations.first(where: { $0.originRowID == 17 }) {
+                    XCTAssertEqual(violation.originTable, "child2")
+                    XCTAssertEqual(violation.destinationTable, "parent")
+                } else {
+                    XCTFail("Missing violation")
+                }
+            }
+            
+            // Missing table
+            do {
+                _ = try db.foreignKeyViolations(in: "missing")
+            } catch DatabaseError.SQLITE_ERROR { }
+        }
+    }
+    
+    func testCheckForeignKeyViolations() throws {
+        try makeDatabaseQueue().writeWithoutTransaction { db in
+            try db.execute(sql: """
+                CREATE TABLE parent(id TEXT NOT NULL PRIMARY KEY);
+                CREATE TABLE child(id INTEGER NOT NULL PRIMARY KEY, parentId TEXT REFERENCES parent(id));
+                PRAGMA foreign_keys = OFF;
+                INSERT INTO child (id, parentId) VALUES (13, '1');
+                """)
+            
+            do {
+                try db.checkForeignKeyViolations()
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
+                XCTAssertEqual(error.message, #"foreign key constraint failed from child(parentId) to parent(id), in [id:13 parentId:"1"]"#)
+                XCTAssertEqual(error.description, #"SQLite error 19: foreign key constraint failed from child(parentId) to parent(id), in [id:13 parentId:"1"]"#)
+            }
+        }
+        
+        try makeDatabaseQueue().writeWithoutTransaction { db in
+            try db.execute(sql: """
+                CREATE TABLE parent(a TEXT NOT NULL, b TEXT NOT NULL, PRIMARY KEY (a, b));
+                CREATE TABLE child(id INTEGER NOT NULL PRIMARY KEY, parentA, parentB, FOREIGN KEY (parentA, parentB) REFERENCES parent(a, b));
+                PRAGMA foreign_keys = OFF;
+                INSERT INTO child (id, parentA, parentB) VALUES (13, 'foo', 'bar');
+                """)
+            
+            do {
+                try db.checkForeignKeyViolations()
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
+                XCTAssertEqual(error.message, #"foreign key constraint failed from child(parentA, parentB) to parent(a, b), in [id:13 parentA:"foo" parentB:"bar"]"#)
+                XCTAssertEqual(error.description, #"SQLite error 19: foreign key constraint failed from child(parentA, parentB) to parent(a, b), in [id:13 parentA:"foo" parentB:"bar"]"#)
+            }
+        }
+        
+        try makeDatabaseQueue().writeWithoutTransaction { db in
+            try db.execute(sql: """
+                CREATE TABLE parent(a TEXT NOT NULL, b TEXT NOT NULL, PRIMARY KEY (a, b));
+                CREATE TABLE child(id INTEGER NOT NULL PRIMARY KEY, parentA, parentB, FOREIGN KEY (parentA, parentB) REFERENCES parent(a, b)) WITHOUT ROWID;
+                PRAGMA foreign_keys = OFF;
+                INSERT INTO child (id, parentA, parentB) VALUES (13, 'foo', 'bar');
+                """)
+            
+            do {
+                try db.checkForeignKeyViolations()
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_CONSTRAINT)
+                XCTAssertEqual(error.extendedResultCode, .SQLITE_CONSTRAINT_FOREIGNKEY)
+                XCTAssertEqual(error.message, "foreign key constraint failed from child(parentA, parentB) to parent(a, b)")
+                XCTAssertEqual(error.description, "SQLite error 19: foreign key constraint failed from child(parentA, parentB) to parent(a, b)")
             }
         }
     }


### PR DESCRIPTION
This pull request aims at helping applications enhance the performance of their migrations, when they notice that a lot of time is spent checking for foreign key violations.

The updated migrations guide explains what this is all about.

```swift
var migrator = DatabaseMigrator()

// New: migrations with immediate foreign key checks
migrator.registerMigration("...", foreignKeyChecks: .immediate) { db in ... }

// New: disable automatic deferred foreign key checks
migrator = migrator.disablingDeferredForeignKeyChecks()

// New: explicit foreign key checks
migrator.registerMigration("...") { db in
    ...
    try db.checkForeignKeyViolations()
    try db.checkForeignKeyViolations(in: "player")
}

// New: explicit iteration of foreign key violations
migrator.registerMigration("...") { db in
    ...
    let violations = try db.foreignKeyViolations()
    while let violation = try violations.next() {
        // inspect & handle violation
    }
}
```

Bonus: foreign key errors reported by migrations now contain much more debugging information (the involved tables and columns, as well as the faulty row):

```
SQLite error 19: FOREIGN KEY constraint violation - from player(teamId) to team(id),
in [id:1 teamId:2 name:"O'Brien" score:1000]
```

Fix #1087
