### PR TITLE
Explicit tracked region for ValueObservation

### DIFF
--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -21,9 +21,6 @@ extension AnyFetchRequest {
 
 @available(*, unavailable, message: "Custom reducers are no longer supported. See the \"Migrating From GRDB 4 to GRDB 5\" guide.")
 public struct AnyValueReducer<Fetched, Value>: ValueReducer {
-    public var _trackingMode: _ValueReducerTrackingMode
-    { preconditionFailure() }
-    
     public init(fetch: @escaping (Database) throws -> Fetched, value: @escaping (Fetched) -> Value?)
     { preconditionFailure() }
     
@@ -559,9 +556,6 @@ extension ValueObservation where Reducer.Value: Equatable {
 extension ValueReducers {
     @available(*, unavailable)
     public enum Unavailable<T>: ValueReducer {
-        public var _trackingMode: _ValueReducerTrackingMode
-        { preconditionFailure() }
-        
         public func _fetch(_ db: Database) throws -> Never
         { preconditionFailure() }
         

--- a/GRDB/Fixit/GRDB-5.0.swift
+++ b/GRDB/Fixit/GRDB-5.0.swift
@@ -21,7 +21,7 @@ extension AnyFetchRequest {
 
 @available(*, unavailable, message: "Custom reducers are no longer supported. See the \"Migrating From GRDB 4 to GRDB 5\" guide.")
 public struct AnyValueReducer<Fetched, Value>: ValueReducer {
-    public var _isSelectedRegionDeterministic: Bool
+    public var _trackingMode: _ValueReducerTrackingMode
     { preconditionFailure() }
     
     public init(fetch: @escaping (Database) throws -> Fetched, value: @escaping (Fetched) -> Value?)
@@ -559,7 +559,7 @@ extension ValueObservation where Reducer.Value: Equatable {
 extension ValueReducers {
     @available(*, unavailable)
     public enum Unavailable<T>: ValueReducer {
-        public var _isSelectedRegionDeterministic: Bool
+        public var _trackingMode: _ValueReducerTrackingMode
         { preconditionFailure() }
         
         public func _fetch(_ db: Database) throws -> Never

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -496,7 +496,97 @@ extension ValueObservation where Reducer == ValueReducers.Auto {
         _ fetch: @escaping (Database) throws -> Value)
     -> ValueObservation<ValueReducers.Fetch<Value>>
     {
-        .init(makeReducer: { .init(isSelectedRegionDeterministic: true, fetch: fetch) })
+        .init(makeReducer: { ValueReducers.Fetch(trackingMode: .constantRegionRecordedFromSelection, fetch: fetch) })
+    }
+    
+    /// Creates a `ValueObservation` that notifies the values returned by the
+    /// `fetch` function whenever a database transaction has an impact on the
+    /// given regions.
+    ///
+    /// The tracked region *is not* automatically inferred from the requests
+    /// performed in the `fetch` function.
+    ///
+    /// For example:
+    ///
+    ///     // Tracks the full database
+    ///     let observation = ValueObservation.tracking
+    ///         region: .fullDatabase,
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks the full 'player' table
+    ///     let observation = ValueObservation.tracking
+    ///         region: Player.all(),
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks the row with id 42 in the 'player' table
+    ///     let observation = ValueObservation.tracking
+    ///         region: Player.filter(id: 42),
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks the 'score' column in the 'player' table
+    ///     let observation = ValueObservation.tracking
+    ///         region: Player.select(max(Column("score")),
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks both the 'player' and 'team' tables
+    ///     let observation = ValueObservation.tracking
+    ///         region: Player.all(), Team.all(),
+    ///         fetch: { db in ... })
+    ///
+    /// - parameter region: A list of observed regions.
+    /// - parameter fetch: A function that fetches the observed value from
+    ///   the database.
+    public static func tracking<Value>(
+        region: DatabaseRegionConvertible...,
+        fetch: @escaping (Database) throws -> Value)
+    -> ValueObservation<ValueReducers.Fetch<Value>>
+    {
+        tracking(regions: region, fetch: fetch)
+    }
+    
+    /// Creates a `ValueObservation` that notifies the values returned by the
+    /// `fetch` function whenever a database transaction has an impact on the
+    /// given regions.
+    ///
+    /// The tracked region *is not* automatically inferred from the requests
+    /// performed in the `fetch` function.
+    ///
+    /// For example:
+    ///
+    ///     // Tracks the full database
+    ///     let observation = ValueObservation.tracking
+    ///         regions: [.fullDatabase],
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks the full 'player' table
+    ///     let observation = ValueObservation.tracking
+    ///         regions: [Player.all()],
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks the row with id 42 in the 'player' table
+    ///     let observation = ValueObservation.tracking
+    ///         regions: [Player.filter(id: 42)],
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks the 'score' column in the 'player' table
+    ///     let observation = ValueObservation.tracking
+    ///         regions: [Player.select(max(Column("score"))],
+    ///         fetch: { db in ... })
+    ///
+    ///     // Tracks both the 'player' and 'team' tables
+    ///     let observation = ValueObservation.tracking
+    ///         regions: [Player.all(), Team.all()],
+    ///         fetch: { db in ... })
+    ///
+    /// - parameter regions: A list of observed regions.
+    /// - parameter fetch: A function that fetches the observed value from
+    ///   the database.
+    public static func tracking<Value>(
+        regions: [DatabaseRegionConvertible],
+        fetch: @escaping (Database) throws -> Value)
+    -> ValueObservation<ValueReducers.Fetch<Value>>
+    {
+        .init(makeReducer: { ValueReducers.Fetch(trackingMode: .constantRegion(regions), fetch: fetch) })
     }
     
     /// Creates a `ValueObservation` that notifies the values returned by the
@@ -521,7 +611,7 @@ extension ValueObservation where Reducer == ValueReducers.Auto {
         _ fetch: @escaping (Database) throws -> Value)
     -> ValueObservation<ValueReducers.Fetch<Value>>
     {
-        .init(makeReducer: { .init(isSelectedRegionDeterministic: false, fetch: fetch) })
+        .init(makeReducer: { ValueReducers.Fetch(trackingMode: .nonConstantRegionRecordedFromSelection, fetch: fetch) })
     }
     
     /// Creates a `ValueObservation` that notifies the values returned by the

--- a/GRDB/ValueObservation/ValueObserver.swift
+++ b/GRDB/ValueObservation/ValueObserver.swift
@@ -5,7 +5,7 @@ import Foundation
 final class ValueObserver<Reducer: ValueReducer> {
     var isCompleted: Bool { synchronized { _isCompleted } }
     let events: ValueObservationEvents
-    let trackingMode: _ValueReducerTrackingMode
+    let trackingMode: ValueObservationTrackingMode
     private var observedRegion: DatabaseRegion? {
         didSet {
             if let willTrackRegion = events.willTrackRegion,
@@ -35,6 +35,7 @@ final class ValueObserver<Reducer: ValueReducer> {
         events: ValueObservationEvents,
         reducer: Reducer,
         requiresWriteAccess: Bool,
+        trackingMode: ValueObservationTrackingMode,
         writer: DatabaseWriter,
         scheduler: ValueObservationScheduler,
         reduceQueue: DispatchQueue,
@@ -43,11 +44,11 @@ final class ValueObserver<Reducer: ValueReducer> {
         self.events = events
         self.reducer = reducer
         self.requiresWriteAccess = requiresWriteAccess
+        self.trackingMode = trackingMode
         self.writer = writer
         self.scheduler = scheduler
         self.reduceQueue = reduceQueue
         self.onChange = onChange
-        self.trackingMode = reducer._trackingMode
     }
     
     convenience init(
@@ -61,6 +62,7 @@ final class ValueObserver<Reducer: ValueReducer> {
             events: observation.events,
             reducer: observation.makeReducer(),
             requiresWriteAccess: observation.requiresWriteAccess,
+            trackingMode: observation.trackingMode,
             writer: writer,
             scheduler: scheduler,
             reduceQueue: reduceQueue,

--- a/GRDB/ValueObservation/ValueReducer/Fetch.swift
+++ b/GRDB/ValueObservation/ValueReducer/Fetch.swift
@@ -2,12 +2,9 @@ extension ValueReducers {
     /// A reducer which passes raw fetched values through.
     public struct Fetch<Value>: ValueReducer {
         private let __fetch: (Database) throws -> Value
-        /// :nodoc:
-        public let _trackingMode: _ValueReducerTrackingMode
         
         /// Creates a reducer which passes raw fetched values through.
-        init(trackingMode: _ValueReducerTrackingMode, fetch: @escaping (Database) throws -> Value) {
-            self._trackingMode = trackingMode
+        init(fetch: @escaping (Database) throws -> Value) {
             self.__fetch = fetch
         }
         

--- a/GRDB/ValueObservation/ValueReducer/Fetch.swift
+++ b/GRDB/ValueObservation/ValueReducer/Fetch.swift
@@ -3,23 +3,11 @@ extension ValueReducers {
     public struct Fetch<Value>: ValueReducer {
         private let __fetch: (Database) throws -> Value
         /// :nodoc:
-        public let _isSelectedRegionDeterministic: Bool
+        public let _trackingMode: _ValueReducerTrackingMode
         
-        /// Creates a reducer, which passes raw fetched values through.
-        ///
-        /// - parameter isSelectedRegionDeterministic: When true, the fetching
-        ///   function is assumed to always fetch from the same database region.
-        ///   This information is used by ValueObserver, which can optimize the
-        ///   observation by computing the observed region only once, and
-        ///   performing concurrent fetches of fresh values.
-        ///
-        ///   When false, the ValueObserver always fetches fresh values from the
-        ///   writer dispatch queue, and updates its observed region on
-        ///   each fetch.
-        ///
-        /// - parameter fetch: A function that fetches the observed value.
-        init(isSelectedRegionDeterministic: Bool, fetch: @escaping (Database) throws -> Value) {
-            self._isSelectedRegionDeterministic = isSelectedRegionDeterministic
+        /// Creates a reducer which passes raw fetched values through.
+        init(trackingMode: _ValueReducerTrackingMode, fetch: @escaping (Database) throws -> Value) {
+            self._trackingMode = trackingMode
             self.__fetch = fetch
         }
         

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -18,7 +18,7 @@ extension ValueReducers {
         private var base: Base
         private let transform: (Base.Value) -> Value
         /// :nodoc:
-        public var _isSelectedRegionDeterministic: Bool { base._isSelectedRegionDeterministic }
+        public var _trackingMode: _ValueReducerTrackingMode { base._trackingMode }
         
         init(_ base: Base, _ transform: @escaping (Base.Value) -> Value) {
             self.base = base

--- a/GRDB/ValueObservation/ValueReducer/Map.swift
+++ b/GRDB/ValueObservation/ValueReducer/Map.swift
@@ -17,8 +17,6 @@ extension ValueReducers {
     public struct Map<Base: ValueReducer, Value>: ValueReducer {
         private var base: Base
         private let transform: (Base.Value) -> Value
-        /// :nodoc:
-        public var _trackingMode: _ValueReducerTrackingMode { base._trackingMode }
         
         init(_ base: Base, _ transform: @escaping (Base.Value) -> Value) {
             self.base = base

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -13,8 +13,6 @@ extension ValueReducers {
     public struct RemoveDuplicates<Base: ValueReducer>: ValueReducer where Base.Value: Equatable {
         private var base: Base
         private var previousValue: Base.Value?
-        /// :nodoc:
-        public var _trackingMode: _ValueReducerTrackingMode { base._trackingMode }
         
         init(_ base: Base) {
             self.base = base

--- a/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
+++ b/GRDB/ValueObservation/ValueReducer/RemoveDuplicates.swift
@@ -14,7 +14,7 @@ extension ValueReducers {
         private var base: Base
         private var previousValue: Base.Value?
         /// :nodoc:
-        public var _isSelectedRegionDeterministic: Bool { base._isSelectedRegionDeterministic }
+        public var _trackingMode: _ValueReducerTrackingMode { base._trackingMode }
         
         init(_ base: Base) {
             self.base = base

--- a/GRDB/ValueObservation/ValueReducer/Trace.swift
+++ b/GRDB/ValueObservation/ValueReducer/Trace.swift
@@ -4,8 +4,6 @@ extension ValueReducers {
         var base: Base
         let willFetch: () -> Void
         let didReceiveValue: (Base.Value) -> Void
-        /// :nodoc:
-        public var _trackingMode: _ValueReducerTrackingMode { base._trackingMode }
         
         /// :nodoc:
         public func _fetch(_ db: Database) throws -> Base.Fetched {

--- a/GRDB/ValueObservation/ValueReducer/Trace.swift
+++ b/GRDB/ValueObservation/ValueReducer/Trace.swift
@@ -5,7 +5,7 @@ extension ValueReducers {
         let willFetch: () -> Void
         let didReceiveValue: (Base.Value) -> Void
         /// :nodoc:
-        public var _isSelectedRegionDeterministic: Bool { base._isSelectedRegionDeterministic }
+        public var _trackingMode: _ValueReducerTrackingMode { base._trackingMode }
         
         /// :nodoc:
         public func _fetch(_ db: Database) throws -> Base.Fetched {

--- a/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
+++ b/GRDB/ValueObservation/ValueReducer/ValueReducer.swift
@@ -8,9 +8,6 @@ public protocol _ValueReducer {
     /// The type of observed values
     associatedtype Value
     
-    /// The tracked region
-    var _trackingMode: _ValueReducerTrackingMode { get }
-    
     /// Fetches database values upon changes in an observed database region.
     ///
     /// ValueReducer semantics require that this method does not depend on
@@ -32,38 +29,6 @@ public protocol _ValueReducer {
     mutating func _value(_ fetched: Fetched) -> Value?
 }
 
-/// Implementation details of `ValueReducer`.
-///
-/// :nodoc:
-public enum _ValueReducerTrackingMode {
-    /// The tracked region is constant and explicit.
-    ///
-    /// Use case:
-    ///
-    ///     // Tracked Region is always the full player table
-    ///     ValueObservation.trackingConstantRegion(Player.all()) { db in ... }
-    case constantRegion([DatabaseRegionConvertible])
-    
-    /// The tracked region is constant and inferred from the fetched values.
-    ///
-    /// Use case:
-    ///
-    ///     // Tracked Region is always the full player table
-    ///     ValueObservation.trackingConstantRegion { db in Player.fetchAll(db) }
-    case constantRegionRecordedFromSelection
-    
-    /// The tracked region is not constant, and inferred from the fetched values.
-    ///
-    /// Use case:
-    ///
-    ///     // Tracked Region is the one row of the table, and it changes on
-    ///     // each fetch.
-    ///     ValueObservation.tracking { db in
-    ///         try Player.fetchOne(db, id: Int.random(in: 1.1000))
-    ///     }
-    case nonConstantRegionRecordedFromSelection
-}
-
 /// The `ValueReducer` protocol supports `ValueObservation`.
 public protocol ValueReducer: _ValueReducer { }
 
@@ -81,8 +46,6 @@ public enum ValueReducers {
     // ValueObservation<ValueReducers.Auto>.tracking(_:).
     /// :nodoc:
     public enum Auto: ValueReducer {
-        /// :nodoc:
-        public var _trackingMode: _ValueReducerTrackingMode { preconditionFailure() }
         /// :nodoc:
         public func _fetch(_ db: Database) throws -> Never { preconditionFailure() }
         /// :nodoc:

--- a/README.md
+++ b/README.md
@@ -5935,6 +5935,8 @@ See the companion library [RxGRDB] for more information.
 **Generally speaking**:
 
 - ValueObservation notifies an initial value before the eventual changes.
+- ValueObservation only notifies changes committed to disk.
+- By default, ValueObservation notifies a fresh value whenever any of its component is modified (any fetched column, row, etc.). This can be [configured](#specifying-the-region-tracked-by-valueobservation).
 - By default, ValueObservation notifies the initial value, as well as eventual changes and errors, on the main thread, asynchronously. This can be [configured](#valueobservation-scheduling).
 - ValueObservation may coalesce subsequent changes into a single notification.
 - ValueObservation may notify consecutive identical values. You can filter out the undesired duplicates with the [removeDuplicates()](#valueobservationremoveduplicates) method.
@@ -5943,7 +5945,7 @@ See the companion library [RxGRDB] for more information.
     - An error occurs.
     - The database connection is closed.
 
-Take care that there are use cases that ValueObservation is unfit for. For example, your application may need to process absolutely all changes, and avoid any coalescing. It may also need to process changes before any further modifications are performed in the database file. In those cases, you need to track *individual transactions*, not values. See [DatabaseRegionObservation], and the low-level [TransactionObserver Protocol](#transactionobserver-protocol).
+Take care that there are use cases that ValueObservation is unfit for. For example, your application may need to process absolutely all changes, and avoid any coalescing. It may also need to process changes before any further modifications are performed in the database file. In those cases, you need to track *individual transactions*, not values. See [DatabaseRegionObservation]. If you need to process uncommitted changes, see [TransactionObserver](#transactionobserver-protocol).
 
 
 ### ValueObservation Scheduling

--- a/README.md
+++ b/README.md
@@ -6683,17 +6683,22 @@ After `stopObservingDatabaseChangesUntilNextTransaction()`, the `databaseDidChan
 
 ### DatabaseRegion
 
-**[DatabaseRegion](https://groue.github.io/GRDB.swift/docs/5.14/Structs/DatabaseRegion.html) is a type that helps observing changes in the results of a database [request](#requests)**.
+A `DatabaseRegion` is a reunion of database tables, and combination of columns and rows (identified by their rowid):
 
-A request knows which database modifications can impact its results. It can communicate this information to [transaction observers](#transactionobserver-protocol) by the way of a DatabaseRegion.
+    |Table1 |   |Table2 |   |Table3 |   |Table4 |   |Table5 |
+    |-------|   |-------|   |-------|   |-------|   |-------|
+    |x|x|x|x|   |x| | | |   |x|x|x|x|   |x|x| |x|   | | | | |
+    |x|x|x|x|   |x| | | |   | | | | |   | | | | |   | |x| | |
+    |x|x|x|x|   |x| | | |   | | | | |   |x|x| |x|   | | | | |
+    |x|x|x|x|   |x| | | |   | | | | |   | | | | |   | | | | |
 
-DatabaseRegion fuels, for example, [ValueObservation] and [DatabaseRegionObservation].
+DatabaseRegion helps [ValueObservation] and [DatabaseRegionObservation] track changes in the database through the [TransactionObserver](#transactionobserver-protocol) protocol.
 
-**A region notifies *potential* changes, not *actual* changes in the results of a request.** A change is notified if and only if a statement has actually modified the tracked tables and columns by inserting, updating, or deleting a row.
+**Note that observing a database region spots *potential* changes, not *actual* changes in the results of a request.** A change is notified if and only if a statement has actually modified the tracked tables and columns by inserting, updating, or deleting a row.
 
 For example, if you observe the region of `Player.select(max(Column("score")))`, then you'll get be notified of all changes performed on the `score` column of the `player` table (updates, insertions and deletions), even if they do not modify the value of the maximum score. However, you will not get any notification for changes performed on other database tables, or updates to other columns of the player table.
 
-For more details, see the [reference](http://groue.github.io/GRDB.swift/docs/5.14/Structs/DatabaseRegion.html#/s:4GRDB14DatabaseRegionV10isModified2bySbAA0B5EventV_tF).
+For more details, see the [reference](https://groue.github.io/GRDB.swift/docs/5.14/Structs/DatabaseRegion.html).
 
 
 #### The DatabaseRegionConvertible Protocol

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -242,8 +242,6 @@ public struct AnyValueReducer<Fetched, Value>: ValueReducer {
     private var __fetch: (Database) throws -> Fetched
     private var __value: (Fetched) -> Value?
     
-    public var _trackingMode: _ValueReducerTrackingMode { .nonConstantRegionRecordedFromSelection }
-    
     public init(
         fetch: @escaping (Database) throws -> Fetched,
         value: @escaping (Fetched) -> Value?)

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -242,7 +242,7 @@ public struct AnyValueReducer<Fetched, Value>: ValueReducer {
     private var __fetch: (Database) throws -> Fetched
     private var __value: (Fetched) -> Value?
     
-    public var _isSelectedRegionDeterministic: Bool { false }
+    public var _trackingMode: _ValueReducerTrackingMode { .nonConstantRegionRecordedFromSelection }
     
     public init(
         fetch: @escaping (Database) throws -> Fetched,

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -155,7 +155,7 @@ class ValueObservationTests: GRDBTestCase {
         do {
             try assertValueObservation(
                 ValueObservation
-                    .tracking(region: .fullDatabase, fetch: Table("t").fetchCount),
+                    .tracking(region: DatabaseRegion.fullDatabase, fetch: Table("t").fetchCount),
                 records: [0, 1, 1, 2, 3, 4],
                 setup: { db in
                     try db.execute(sql: """


### PR DESCRIPTION
This PR addresses #1101

ValueObservation has a new factory method, `ValueObservation.tracking(region:fetch:)`, which allows to entirely separate the **observed region** from the **fetched value** itself:

```swift
// Triggered by all transactions
ValueObservation.tracking(
    region: .fullDatabase,
    fetch: { db in ... })

// Triggered by all changes to player with rowid 1
ValueObservation.tracking(
    region: Player.filter(id: 1),
    fetch: { db in ... })

// Triggered by all changes to the score column of the player table
ValueObservation.tracking(
    region: SQLRequest("SELECT score FROM player"),
    fetch: { db in ... })

// Triggered by all changes to player or team tables
ValueObservation.tracking(
    region: Player.all(), Team.all(),
    fetch: { db in ... })
```
