### PR TITLE
Sugar for fetching only a few columns of associated records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,13 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **New**: [#1106](https://github.com/groue/GRDB.swift/pull/1106) by [@groue](https://github.com/groue): Sugar for fetching only a few columns of associated records
+- **Documentation Update**: The [Joining And Prefetching Associated Records](Documentation/AssociationsBasics.md#joining-and-prefetching-associated-records) chapter was fully rewritten. The joining methods `including(required:)` and others are much more detailed, with an exploration of frequent use cases.
+- **Documentation Update**: The [Joining And Prefetching Associated Records](Documentation/AssociationsBasics.md#joining-and-prefetching-associated-records) chapter introduces the new `annotated(withRequired:)` and `annotated(withOptional:)` joining methods.
+- **Documentation Update**: The new [Choosing a Joining Method Given the Shape of the Decoded Type](Documentation/AssociationsBasics.md#choosing-a-joining-method-given-the-shape-of-the-decoded-type) chapter helps choosing a joining method, given the shape of the fetched data.
+
 ## 5.15.0
 
 Released December 2, 2021 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v5.14.0...v5.15.0)

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -1630,7 +1630,7 @@ let teamInfos = try Team
 
 ## Columns Selected by an Association
 
-By default, associated records include all their columns:
+By default, associated records, like all records, include all their columns:
 
 ```swift
 // SELECT book.*, author.*
@@ -1641,7 +1641,9 @@ let request = Book.including(required: Book.author)
 
 **The selection can be changed for each individual request, or for all requests including a given type.**
 
-To specify the selection of an associated record in a specific request, use the `select` method:
+To specify the default selection for a given record type, see [Columns Selected by a Request](../README.md#columns-selected-by-a-request).
+
+To specify the selection in a specific request, use the `select` method:
 
 ```swift
 // SELECT book.*, author.id, author.name
@@ -1651,7 +1653,7 @@ let restrictedAuthor = Book.author.select(Column("id"), Column("name"))
 let request = Book.including(required: restrictedAuthor)
 ```
 
-To specify the default selection for all inclusions of a given type, see [Columns Selected by a Request](../README.md#columns-selected-by-a-request).
+In order to fetch from such requests of partial records, see the documentation of the [joining methods].
 
 
 ## Further Refinements to Associations

--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -870,7 +870,7 @@ let request = Book.including(required: Book.author)
 
 This method accepts any association. It has the base record fetched along with one associated record, which is "included" in the fetched results. When the associated record does not exist, records are not present in the fetched results: the associated record is "required".
 
-To fetch results from such a request, you define a dedicated record type:
+**To fetch results from such a request**, you define a dedicated record type:
 
 ```swift
 // Fetch all books along with their author
@@ -884,7 +884,7 @@ let bookInfos = try Book
     .fetchAll(db)
 ```
 
-The CodingKey for the `BookInfo.author` property must match the association key of the `Book.author` association. The association key is, by default, the name of the associated database table. This can be configured with the association `forKey(_:)` method:
+**The CodingKey for the `BookInfo.author` property must match the association key of the `Book.author` association.** The association key is, by default, the name of the associated database table. This can be configured with the association `forKey(_:)` method:
 
 ```swift
 struct Author: TableRecord {
@@ -906,7 +906,7 @@ let bookInfos = try Book
     .fetchAll(db)
 ```
 
-When you only need a few columns of the associated record, define a partial type with one property per selected column of the associated record:
+**When you only need a few columns of the associated record**, you can define a partial type with one property per selected column of the associated record:
 
 ```swift
 // Fetch all books along with the name and country of their author
@@ -951,7 +951,7 @@ let request = Book.including(optional: Book.author)
 
 This method accepts any association. It has the base record fetched along with one associated record, which is "included" in the fetched results. The associated record can be missing: it is "optional".
 
-To fetch results from such a request, you define a dedicated record type:
+**To fetch results from such a request**, you define a dedicated record type:
 
 ```swift
 // Fetch all books along with their eventual author
@@ -965,9 +965,9 @@ let bookInfos = try Book
     .fetchAll(db)
 ```
 
-The CodingKey for the `BookInfo.author` property must match the association key of the `Book.author` association. See [`including(required:)`] for more information.
+**The CodingKey for the `BookInfo.author` property must match the association key of the `Book.author` association.** See [`including(required:)`] for more information.
 
-When you only need a few columns of the associated record, define a partial type with one property per selected column of the associated record:
+**When you only need a few columns of the associated record**, you can define a partial type with one property per selected column of the associated record:
 
 ```swift
 // Fetch all books along with the name and country of their eventual author
@@ -1011,7 +1011,7 @@ let request = Author.including(all: Author.books)
 
 This method accepts any to-many association ([HasMany] or [HasManyThrough]). It has the base record fetched along with all its associated records, which are "included" in the fetched results.
 
-To fetch results from such a request, you define a dedicated record type:
+**To fetch results from such a request**, you define a dedicated record type:
 
 ```swift
 // Fetch all authors along with their books
@@ -1027,7 +1027,7 @@ let authorInfos = try Author
 
 The associated records can be stored into an Array as in the above example, but also a Set, and generally speaking any decodable Swift collection.
 
-The CodingKey for the `AuthorInfo.books` property must match the association key of the `Author.books` association. The association key is, by default, the pluralized name of the associated database table. This can be configured with the association `forKey(_:)` method:
+**The CodingKey for the `AuthorInfo.books` property must match the association key of the `Author.books` association.** The association key is, by default, the pluralized name of the associated database table. This can be configured with the association `forKey(_:)` method:
 
 ```swift
 struct Book: TableRecord {
@@ -1049,7 +1049,7 @@ let authorInfos = try Author
     .fetchAll(db)
 ```
 
-When you only need a few columns of the associated records, define a partial type with one property per selected column of the associated record:
+**When you only need a few columns of the associated records**, you can define a partial type with one property per selected column of the associated record:
 
 ```swift
 // Fetch all authors along with the titles and years of their books
@@ -1067,7 +1067,7 @@ let authorInfos = try Author
     .fetchAll(db)
 ```
 
-And when you need a single column of the associated records, use the association `forKey(_:)` method in order to match the name of the decoded property:
+When you need a single column of the associated records, avoid the extra partial type, and instead use the association `forKey(_:)` method in order to match the name of the decoded property:
 
 ```swift
 // Fetch all authors along with the titles of their books
@@ -1096,7 +1096,7 @@ let request = Book.annotated(withRequired: Book.author.select(Column("name"), Co
 
 This method accepts any association. The base record is annotated with the selected columns of one associated record. When the associated record does not exist, records are not present in the fetched results: the associated record is "required".
 
-To fetch results from such a request, you define a dedicated record type:
+**To fetch results from such a request**, you define a dedicated record type:
 
 ```swift
 // Fetch all books along with the name and country of their author
@@ -1138,7 +1138,7 @@ let request = Book.annotated(withOptional: Book.author.select(Column("name"), Co
 
 This method accepts any association. The base record is annotated with the selected columns of one associated record. When the associated record does not exist, the columns of the associated record are NULL: the associated record is "optional".
 
-To fetch results from such a request, you define a dedicated record type:
+**To fetch results from such a request**, you define a dedicated record type:
 
 ```swift
 // Fetch all books along with the name of their eventual author
@@ -1190,7 +1190,6 @@ let books = try Book
     .fetchAll(db)
 ```
 
-
 ### `joining(optional:)`
 
 ```swift
@@ -1203,6 +1202,7 @@ let request = Book.joining(optional: Book.author)
 This method accepts any association. It has the base record "joined" with one associated record, which is not included in the fetched results. The associated record can be missing: it is "optional".
 
 This method has no observable effect unless the associated record is used in a way or another. We'll see examples later in this documentation.
+
 
 ### Choosing a Joining Method Given the Shape of the Decoded Type
 

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -7,9 +7,9 @@ import Foundation
 public protocol TypedRequest {
     /// The type that can decode database rows.
     ///
-    /// In the request below, it is Book:
+    /// In the request below, it is Player:
     ///
-    ///     let request = Book.all()
+    ///     let request = Player.all()
     associatedtype RowDecoder
 }
 
@@ -825,20 +825,20 @@ extension DerivableRequest {
     
     /// Creates a request which appends *aggregates* to the current selection.
     ///
-    ///     // SELECT player.*, COUNT(DISTINCT book.id) AS bookCount
-    ///     // FROM player LEFT JOIN book ...
-    ///     var request = Player.all()
-    ///     request = request.annotated(with: Player.books.count)
+    ///     // SELECT team.*, COUNT(DISTINCT player.id) AS playerCount
+    ///     // FROM team LEFT JOIN player ...
+    ///     var request = Team.all()
+    ///     request = request.annotated(with: Team.players.count)
     public func annotated(with aggregates: AssociationAggregate<RowDecoder>...) -> Self {
         annotated(with: aggregates)
     }
     
     /// Creates a request which appends *aggregates* to the current selection.
     ///
-    ///     // SELECT player.*, COUNT(DISTINCT book.id) AS bookCount
-    ///     // FROM player LEFT JOIN book ...
-    ///     var request = Player.all()
-    ///     request = request.annotated(with: [Player.books.count])
+    ///     // SELECT team.*, COUNT(DISTINCT player.id) AS playerCount
+    ///     // FROM team LEFT JOIN player ...
+    ///     var request = team.all()
+    ///     request = request.annotated(with: [Team.players.count])
     public func annotated(with aggregates: [AssociationAggregate<RowDecoder>]) -> Self {
         aggregates.reduce(self) { request, aggregate in
             request.annotated(with: aggregate)
@@ -848,11 +848,11 @@ extension DerivableRequest {
     /// Creates a request which appends the provided aggregate *predicate* to
     /// the eventual set of already applied predicates.
     ///
-    ///     // SELECT player.*
-    ///     // FROM player LEFT JOIN book ...
-    ///     // HAVING COUNT(DISTINCT book.id) = 0
-    ///     var request = Player.all()
-    ///     request = request.having(Player.books.isEmpty)
+    ///     // SELECT team.*
+    ///     // FROM team LEFT JOIN player ...
+    ///     // HAVING COUNT(DISTINCT player.id) = 0
+    ///     var request = Team.all()
+    ///     request = request.having(Team.players.isEmpty)
     public func having(_ predicate: AssociationAggregate<RowDecoder>) -> Self {
         var request = self
         let expression = predicate.prepare(&request)

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -735,6 +735,7 @@ extension JoinableRequest where Self: SelectionRequest {
     ///         .annotated(with: teamAlias[Column("color")])
     ///         .joining(optional: Player.team.aliased(teamAlias))
     public func annotated<A: Association>(withOptional association: A) -> Self where A.OriginRowDecoder == RowDecoder {
+        // TODO: find a way to prefix the selection with the association key
         let alias = TableAlias()
         let selection = association._sqlAssociation.destination.relation.selectionPromise
         return self
@@ -777,6 +778,7 @@ extension JoinableRequest where Self: SelectionRequest {
     ///         .annotated(with: teamAlias[Column("color")])
     ///         .joining(required: Player.team.aliased(teamAlias))
     public func annotated<A: Association>(withRequired association: A) -> Self where A.OriginRowDecoder == RowDecoder {
+        // TODO: find a way to prefix the selection with the association key
         let selection = association._sqlAssociation.destination.relation.selectionPromise
         let alias = TableAlias()
         return self

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -703,6 +703,34 @@ extension JoinableRequest {
     }
 }
 
+extension JoinableRequest where Self: SelectionRequest {
+#warning("TODO: document")
+    public func annotated<A: Association>(withOptional association: A) -> Self where A.OriginRowDecoder == RowDecoder {
+        let alias = TableAlias()
+        let selection = association._sqlAssociation.destination.relation.selectionPromise
+        return self
+            .joining(optional: association.aliased(alias))
+            .annotated(with: { db in
+                try selection.resolve(db).map { selection in
+                    selection.qualified(with: alias)
+                }
+            })
+    }
+    
+#warning("TODO: document")
+    public func annotated<A: Association>(withRequired association: A) -> Self where A.OriginRowDecoder == RowDecoder {
+        let selection = association._sqlAssociation.destination.relation.selectionPromise
+        let alias = TableAlias()
+        return self
+            .joining(required: association.aliased(alias))
+            .annotated(with: { db in
+                try selection.resolve(db).map { selection in
+                    selection.qualified(with: alias)
+                }
+            })
+    }
+}
+
 // MARK: - DerivableRequest
 
 /// The base protocol for all requests that can be refined.

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -1187,7 +1187,40 @@ extension Table {
         all().joining(required: association)
     }
     
-#warning("TODO: document")
+    /// Creates a request which appends *columns of an associated record* to
+    /// the columns of the table.
+    ///
+    ///     let playerTable = Table("player")
+    ///     let teamTable = Table("team")
+    ///     let playerTeam = playerTable.belongsTo(teamTable)
+    ///
+    ///     // SELECT player.*, team.color
+    ///     // FROM player LEFT JOIN team ...
+    ///     let teamColor = playerTeam.select(Column("color")
+    ///     let request = playerTable.annotated(withOptional: teamColor))
+    ///
+    /// This method performs the same SQL request as `including(optional:)`.
+    /// The difference is in the shape of Decodable records that decode such
+    /// a request: the associated columns can be decoded at the same level as
+    /// the main record:
+    ///
+    ///     struct PlayerWithTeamColor: FetchableRecord, Decodable {
+    ///         var player: Player
+    ///         var color: String?
+    ///     }
+    ///     let players = try dbQueue.read { db in
+    ///         try request
+    ///             .asRequest(of: PlayerWithTeamColor.self)
+    ///             .fetchAll(db)
+    ///     }
+    ///
+    /// Note: this is a convenience method. You can build the same request with
+    /// `TableAlias`, `annotated(with:)`, and `joining(optional:)`:
+    ///
+    ///     let teamAlias = TableAlias()
+    ///     let request = playerTable
+    ///         .annotated(with: teamAlias[Column("color")])
+    ///         .joining(optional: playerTeam.aliased(teamAlias))
     public func annotated<A: Association>(withOptional association: A)
     -> QueryInterfaceRequest<RowDecoder>
     where A.OriginRowDecoder == RowDecoder
@@ -1195,7 +1228,40 @@ extension Table {
         all().annotated(withOptional: association)
     }
     
-#warning("TODO: document")
+    /// Creates a request which appends *columns of an associated record* to
+    /// the columns of the table.
+    ///
+    ///     let playerTable = Table("player")
+    ///     let teamTable = Table("team")
+    ///     let playerTeam = playerTable.belongsTo(teamTable)
+    ///
+    ///     // SELECT player.*, team.color
+    ///     // FROM player JOIN team ...
+    ///     let teamColor = playerTeam.select(Column("color")
+    ///     let request = playerTable.annotated(withRequired: teamColor))
+    ///
+    /// This method performs the same SQL request as `including(required:)`.
+    /// The difference is in the shape of Decodable records that decode such
+    /// a request: the associated columns can be decoded at the same level as
+    /// the main record:
+    ///
+    ///     struct PlayerWithTeamColor: FetchableRecord, Decodable {
+    ///         var player: Player
+    ///         var color: String
+    ///     }
+    ///     let players = try dbQueue.read { db in
+    ///         try request
+    ///             .asRequest(of: PlayerWithTeamColor.self)
+    ///             .fetchAll(db)
+    ///     }
+    ///
+    /// Note: this is a convenience method. You can build the same request with
+    /// `TableAlias`, `annotated(with:)`, and `joining(required:)`:
+    ///
+    ///     let teamAlias = TableAlias()
+    ///     let request = playerTable
+    ///         .annotated(with: teamAlias[Column("color")])
+    ///         .joining(required: playerTeam.aliased(teamAlias))
     public func annotated<A: Association>(withRequired association: A)
     -> QueryInterfaceRequest<RowDecoder>
     where A.OriginRowDecoder == RowDecoder

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -1186,6 +1186,22 @@ extension Table {
     {
         all().joining(required: association)
     }
+    
+#warning("TODO: document")
+    public func annotated<A: Association>(withOptional association: A)
+    -> QueryInterfaceRequest<RowDecoder>
+    where A.OriginRowDecoder == RowDecoder
+    {
+        all().annotated(withOptional: association)
+    }
+    
+#warning("TODO: document")
+    public func annotated<A: Association>(withRequired association: A)
+    -> QueryInterfaceRequest<RowDecoder>
+    where A.OriginRowDecoder == RowDecoder
+    {
+        all().annotated(withRequired: association)
+    }
 }
 
 // MARK: - Association Aggregates

--- a/GRDB/QueryInterface/TableRecord+Association.swift
+++ b/GRDB/QueryInterface/TableRecord+Association.swift
@@ -620,6 +620,22 @@ extension TableRecord {
     {
         all().joining(required: association)
     }
+    
+#warning("TODO: document")
+    public static func annotated<A: Association>(withOptional association: A)
+    -> QueryInterfaceRequest<Self>
+    where A.OriginRowDecoder == Self
+    {
+        all().annotated(withOptional: association)
+    }
+    
+#warning("TODO: document")
+    public static func annotated<A: Association>(withRequired association: A)
+    -> QueryInterfaceRequest<Self>
+    where A.OriginRowDecoder == Self
+    {
+        all().annotated(withRequired: association)
+    }
 }
 
 // MARK: - Aggregates

--- a/GRDB/QueryInterface/TableRecord+Association.swift
+++ b/GRDB/QueryInterface/TableRecord+Association.swift
@@ -621,7 +621,36 @@ extension TableRecord {
         all().joining(required: association)
     }
     
-#warning("TODO: document")
+    /// Creates a request which appends *columns of an associated record* to
+    /// the selection.
+    ///
+    ///     // SELECT player.*, team.color
+    ///     // FROM player LEFT JOIN team ...
+    ///     let teamColor = Player.team.select(Column("color"))
+    ///     let request = Player.annotated(withOptional: teamColor)
+    ///
+    /// This method performs the same SQL request as `including(optional:)`.
+    /// The difference is in the shape of Decodable records that decode such
+    /// a request: the associated columns can be decoded at the same level as
+    /// the main record:
+    ///
+    ///     struct PlayerWithTeamColor: FetchableRecord, Decodable {
+    ///         var player: Player
+    ///         var color: String?
+    ///     }
+    ///     let players = try dbQueue.read { db in
+    ///         try request
+    ///             .asRequest(of: PlayerWithTeamColor.self)
+    ///             .fetchAll(db)
+    ///     }
+    ///
+    /// Note: this is a convenience method. You can build the same request with
+    /// `TableAlias`, `annotated(with:)`, and `joining(optional:)`:
+    ///
+    ///     let teamAlias = TableAlias()
+    ///     let request = Player
+    ///         .annotated(with: teamAlias[Column("color")])
+    ///         .joining(optional: Player.team.aliased(teamAlias))
     public static func annotated<A: Association>(withOptional association: A)
     -> QueryInterfaceRequest<Self>
     where A.OriginRowDecoder == Self
@@ -629,7 +658,36 @@ extension TableRecord {
         all().annotated(withOptional: association)
     }
     
-#warning("TODO: document")
+    /// Creates a request which appends *columns of an associated record* to
+    /// the selection.
+    ///
+    ///     // SELECT player.*, team.color
+    ///     // FROM player JOIN team ...
+    ///     let teamColor = Player.team.select(Column("color"))
+    ///     let request = Player.annotated(withRequired: teamColor)
+    ///
+    /// This method performs the same SQL request as `including(required:)`.
+    /// The difference is in the shape of Decodable records that decode such
+    /// a request: the associated columns can be decoded at the same level as
+    /// the main record:
+    ///
+    ///     struct PlayerWithTeamColor: FetchableRecord, Decodable {
+    ///         var player: Player
+    ///         var color: String
+    ///     }
+    ///     let players = try dbQueue.read { db in
+    ///         try request
+    ///             .asRequest(of: PlayerWithTeamColor.self)
+    ///             .fetchAll(db)
+    ///     }
+    ///
+    /// Note: this is a convenience method. You can build the same request with
+    /// `TableAlias`, `annotated(with:)`, and `joining(required:)`:
+    ///
+    ///     let teamAlias = TableAlias()
+    ///     let request = Player
+    ///         .annotated(with: teamAlias[Column("color")])
+    ///         .joining(required: Player.team.aliased(teamAlias))
     public static func annotated<A: Association>(withRequired association: A)
     -> QueryInterfaceRequest<Self>
     where A.OriginRowDecoder == Self

--- a/README.md
+++ b/README.md
@@ -7824,11 +7824,9 @@ struct BookInfo: Decodable, FetchableRecord {
         // SELECT book.*, author.name AS authorName
         // FROM book
         // LEFT JOIN author ON author.id = book.authorID
-        let authorAlias = TableAlias()
-        let authorName = authorAlias[Author.Columns.name].forKey(CodingKeys.authorName)
+        let authorName = Author.Columns.name.forKey(CodingKeys.authorName)
         return Book
-            .annotated(with: authorName)
-            .joining(optional: Book.author.aliased(authorAlias))
+            .annotated(withOptional: Book.author.select(authorName))
             .asRequest(of: BookInfo.self)
     }
 }
@@ -7838,13 +7836,9 @@ let bookInfos: [BookInfo] = try dbQueue.read { db in
 }
 ```
 
-By using a TableAlias, you can refer to an author column from a request of books.
-
 By defining the request as a static method of BookInfo, you have access to the private `CodingKeys.authorName`, and a compiler-checked SQL column name.
 
-By using the `annotated(with:)` method, you append the author name to the top-level selection that can be decoded by the ad-hoc record.
-
-By using the `joining()` method, you make sure no author column is selected, but the one declared in `annotated(with:)`.
+By using the `annotated(withOptional:)` method, you append the author name to the top-level selection that can be decoded by the ad-hoc record.
 
 By using `asRequest(of:)`, you enhance the type-safety of your request.
 

--- a/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
@@ -66,6 +66,22 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
     }
     
+    func testDefaultScopeAnnotatedWithRequired() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withRequired: Player.defaultTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1, "name":"Reds"])
+    }
+    
+    func testDefaultScopeAnnotatedWithRequiredCustomSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withRequired: Player.defaultTeam.select(Column("name").forKey("teamName")))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
+    }
+    
     func testDefaultScopeIncludingOptional() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.including(optional: Player.defaultTeam)
@@ -79,6 +95,24 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[1].scopes["team"]!, ["id":nil, "name":nil])
     }
     
+    func testDefaultScopeAnnotatedWithOptional() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withOptional: Player.defaultTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1, "name":"Reds"])
+        XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "id":nil, "name":nil])
+    }
+    
+    func testDefaultScopeAnnotatedWithOptionalCustomSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withOptional: Player.defaultTeam.select(Column("name").forKey("teamName")))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
+        XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "teamName":nil])
+    }
+
     func testDefaultScopeJoiningRequired() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.joining(required: Player.defaultTeam)
@@ -118,7 +152,23 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(Set(rows[0].scopes.names), ["customTeam"])
         XCTAssertEqual(rows[0].scopes["customTeam"]!, ["id":1, "name":"Reds"])
     }
-
+    
+    func testCustomScopeAnnotatedWithRequired() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withRequired: Player.customTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1, "name":"Reds"])
+    }
+    
+    func testCustomScopeAnnotatedWithRequiredCustomSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withRequired: Player.customTeam.select(Column("name").forKey("teamName")))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
+    }
+    
     func testCustomScopeIncludingOptional() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.including(optional: Player.customTeam)
@@ -130,6 +180,24 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[1].unscoped, ["id":2, "teamId":nil, "name":"Barbara"])
         XCTAssertEqual(Set(rows[1].scopes.names), ["customTeam"])
         XCTAssertEqual(rows[1].scopes["customTeam"]!, ["id":nil, "name":nil])
+    }
+    
+    func testCustomScopeAnnotatedWithOptional() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withOptional: Player.customTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1, "name":"Reds"])
+        XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "id":nil, "name":nil])
+    }
+    
+    func testCustomScopeAnnotatedWithOptionalCustomSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withOptional: Player.customTeam.select(Column("name").forKey("teamName")))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
+        XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "teamName":nil])
     }
     
     func testCustomPluralScopeIncludingRequired() throws {

--- a/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
@@ -61,6 +61,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."rowid" = "children"."parentId") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."rowid" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("rowid"))), """
+                    SELECT "children".*, "parents"."rowid" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
+                    """)
+                
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "rowid" = 1
                     """)
@@ -106,6 +122,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
@@ -182,6 +214,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -227,6 +275,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
@@ -301,6 +365,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -348,6 +428,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -393,6 +489,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parentId") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
@@ -472,6 +584,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -519,6 +647,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parent1Id") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
                     """)
@@ -566,6 +710,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 2
                     """)
@@ -611,6 +771,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."id" = "children"."parent2Id") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
                 
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
@@ -689,6 +865,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
@@ -784,6 +976,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -843,6 +1051,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
@@ -937,6 +1161,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -998,6 +1238,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -1057,6 +1313,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
                 
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
@@ -1160,6 +1432,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -1221,6 +1509,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
+                
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
                     """)
@@ -1282,6 +1586,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B") AND ("parents"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 3) AND ("b" = 4)
                     """)
@@ -1341,6 +1661,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "children".* \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B") AND ("parents"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
+                    SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
                 
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
@@ -1470,6 +1806,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "PARENTS" ON ("PARENTS"."id" = "CHILDREN"."parentId") AND ("PARENTS"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "CHILDREN".*, "PARENTS".* \
+                    FROM "CHILDREN" \
+                    JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "CHILDREN".*, "PARENTS".* \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "CHILDREN".*, "PARENTS"."id" \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
+                
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "PARENTS" WHERE "id" = 1
                     """)
@@ -1517,6 +1869,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     LEFT JOIN "PARENTS" ON ("PARENTS"."id" = "CHILDREN"."parentId") AND ("PARENTS"."name" = 'foo')
                     """)
                 
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "CHILDREN".*, "PARENTS".* \
+                    FROM "CHILDREN" \
+                    JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "CHILDREN".*, "PARENTS".* \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "CHILDREN".*, "PARENTS"."id" \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
+                
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "PARENTS" WHERE "id" = 1
                     """)
@@ -1562,6 +1930,22 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     SELECT "CHILDREN".* \
                     FROM "CHILDREN" \
                     LEFT JOIN "PARENTS" ON ("PARENTS"."ID" = "CHILDREN"."PARENTID") AND ("PARENTS"."name" = 'foo')
+                    """)
+                
+                try assertEqualSQL(db, Child.annotated(withRequired: association), """
+                    SELECT "CHILDREN".*, "PARENTS".* \
+                    FROM "CHILDREN" \
+                    JOIN "PARENTS" ON "PARENTS"."ID" = "CHILDREN"."PARENTID"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association), """
+                    SELECT "CHILDREN".*, "PARENTS".* \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."ID" = "CHILDREN"."PARENTID"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
+                    SELECT "CHILDREN".*, "PARENTS"."id" \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."ID" = "CHILDREN"."PARENTID"
                     """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLTests.swift
@@ -206,6 +206,25 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 JOIN "b" ON \(bCondition) \
                 JOIN "c" ON \(cCondition)
                 """)
+            
+            try assertEqualSQL(db, A.annotated(withOptional: ac), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.annotated(withRequired: ac), """
+                SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.annotated(withRequired: ac.select(Column.rowID)), """
+                SELECT "a".*, "c"."rowid" \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
         }
         do {
             try assertEqualSQL(db, A.including(optional: ac).including(optional: ab), """
@@ -228,6 +247,25 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 """)
             try assertEqualSQL(db, A.including(optional: ac).joining(required: ab), """
                 SELECT "a".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
+            
+            try assertEqualSQL(db, A.annotated(withOptional: ab).including(optional: ac), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                LEFT JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.including(optional: ac).annotated(withRequired: ab), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.including(optional: ac).annotated(withRequired: ab.select(Column.rowID)), """
+                SELECT "a".*, "b"."rowid", "c".* \
                 FROM "a" \
                 JOIN "b" ON \(bCondition) \
                 LEFT JOIN "c" ON \(cCondition)
@@ -258,6 +296,25 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 JOIN "b" ON \(bCondition) \
                 JOIN "c" ON \(cCondition)
                 """)
+            
+            try assertEqualSQL(db, A.annotated(withOptional: ab).including(required: ac), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.including(required: ac).annotated(withRequired: ab), """
+                SELECT "a".*, "b".*, "c".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.including(required: ac).annotated(withRequired: ab.select(Column.rowID)), """
+                SELECT "a".*, "b"."rowid", "c".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
         }
         do {
             try assertEqualSQL(db, A.joining(optional: ac).including(optional: ab), """
@@ -284,6 +341,25 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 JOIN "b" ON \(bCondition) \
                 LEFT JOIN "c" ON \(cCondition)
                 """)
+            
+            try assertEqualSQL(db, A.annotated(withOptional: ab).joining(optional: ac), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                LEFT JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.joining(optional: ac).annotated(withRequired: ab), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.joining(optional: ac).annotated(withRequired: ab.select(Column.rowID)), """
+                SELECT "a".*, "b"."rowid" \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                LEFT JOIN "c" ON \(cCondition)
+                """)
         }
         do {
             try assertEqualSQL(db, A.joining(required: ac).including(optional: ab), """
@@ -306,6 +382,25 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 """)
             try assertEqualSQL(db, A.joining(required: ac).joining(required: ab), """
                 SELECT "a".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
+            
+            try assertEqualSQL(db, A.annotated(withOptional: ab).joining(required: ac), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.joining(required: ac).annotated(withRequired: ab), """
+                SELECT "a".*, "b".* \
+                FROM "a" \
+                JOIN "b" ON \(bCondition) \
+                JOIN "c" ON \(cCondition)
+                """)
+            try assertEqualSQL(db, A.joining(required: ac).annotated(withRequired: ab.select(Column.rowID)), """
+                SELECT "a".*, "b"."rowid" \
                 FROM "a" \
                 JOIN "b" ON \(bCondition) \
                 JOIN "c" ON \(cCondition)
@@ -841,6 +936,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                     JOIN "d" ON \(dCondition)
                     """)
             }
+            
+            for request in [
+                A.annotated(withOptional: dThroughC),
+                A.annotated(withOptional: dThroughB)]
+            {
+                try assertEqualSQL(db, request, """
+                    SELECT "a".*, "d".* \
+                    FROM "a" \
+                    LEFT JOIN "b" ON \(bCondition) \
+                    LEFT JOIN "c" ON \(cCondition) \
+                    LEFT JOIN "d" ON \(dCondition)
+                    """)
+            }
+            for request in [
+                A.annotated(withRequired: dThroughC),
+                A.annotated(withRequired: dThroughB)]
+            {
+                try assertEqualSQL(db, request, """
+                    SELECT "a".*, "d".* \
+                    FROM "a" \
+                    JOIN "b" ON \(bCondition) \
+                    JOIN "c" ON \(cCondition) \
+                    JOIN "d" ON \(dCondition)
+                    """)
+            }
+            for request in [
+                A.annotated(withRequired: dThroughC.select(Column.rowID)),
+                A.annotated(withRequired: dThroughB.select(Column.rowID))]
+            {
+                try assertEqualSQL(db, request, """
+                    SELECT "a".*, "d"."rowid" \
+                    FROM "a" \
+                    JOIN "b" ON \(bCondition) \
+                    JOIN "c" ON \(cCondition) \
+                    JOIN "d" ON \(dCondition)
+                    """)
+            }
         }
         
         do {
@@ -887,6 +1019,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 {
                     try assertEqualSQL(db, request, """
                         SELECT "a".*, "b".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                
+                for request in [
+                    A.including(optional: b).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).including(optional: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "b".* \
+                        FROM "a" \
+                        LEFT JOIN "b" ON \(bCondition) \
+                        LEFT JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(optional: b).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).including(optional: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "b".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(optional: b).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).including(optional: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid", "b".* \
                         FROM "a" \
                         JOIN "b" ON \(bCondition) \
                         JOIN "c" ON \(cCondition) \
@@ -944,6 +1113,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                         JOIN "d" ON \(dCondition)
                         """)
                 }
+                
+                for request in [
+                    A.including(required: b).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).including(required: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "b".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        LEFT JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(required: b).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).including(required: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "b".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(required: b).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).including(required: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid", "b".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
             }
             
             do {
@@ -995,6 +1201,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                         JOIN "d" ON \(dCondition)
                         """)
                 }
+                
+                for request in [
+                    A.joining(optional: b).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).joining(optional: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        LEFT JOIN "b" ON \(bCondition) \
+                        LEFT JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(optional: b).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).joining(optional: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(optional: b).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).joining(optional: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid" \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
             }
             
             do {
@@ -1040,6 +1283,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 {
                     try assertEqualSQL(db, request, """
                         SELECT "a".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                
+                for request in [
+                    A.joining(required: b).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).joining(required: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        LEFT JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(required: b).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).joining(required: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(required: b).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).joining(required: b)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid" \
                         FROM "a" \
                         JOIN "b" ON \(bCondition) \
                         JOIN "c" ON \(cCondition) \
@@ -1099,6 +1379,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                         JOIN "d" ON \(dCondition)
                         """)
                 }
+                
+                for request in [
+                    A.including(optional: c).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).including(optional: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "c".* \
+                        FROM "a" \
+                        LEFT JOIN "b" ON \(bCondition) \
+                        LEFT JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(optional: c).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).including(optional: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "c".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(optional: c).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).including(optional: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid", "c".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
             }
             
             do {
@@ -1144,6 +1461,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 {
                     try assertEqualSQL(db, request, """
                         SELECT "a".*, "c".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                
+                for request in [
+                    A.including(required: c).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).including(required: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "c".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(required: c).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).including(required: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".*, "c".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.including(required: c).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).including(required: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid", "c".* \
                         FROM "a" \
                         JOIN "b" ON \(bCondition) \
                         JOIN "c" ON \(cCondition) \
@@ -1201,6 +1555,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                         JOIN "d" ON \(dCondition)
                         """)
                 }
+                
+                for request in [
+                    A.joining(optional: c).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).joining(optional: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        LEFT JOIN "b" ON \(bCondition) \
+                        LEFT JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(optional: c).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).joining(optional: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(optional: c).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).joining(optional: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid" \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
             }
             
             do {
@@ -1246,6 +1637,43 @@ class AssociationHasOneThroughSQLTests: GRDBTestCase {
                 {
                     try assertEqualSQL(db, request, """
                         SELECT "a".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                
+                for request in [
+                    A.joining(required: c).annotated(withOptional: dThroughC),
+                    A.annotated(withOptional: dThroughB).joining(required: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        LEFT JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(required: c).annotated(withRequired: dThroughC),
+                    A.annotated(withRequired: dThroughB).joining(required: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d".* \
+                        FROM "a" \
+                        JOIN "b" ON \(bCondition) \
+                        JOIN "c" ON \(cCondition) \
+                        JOIN "d" ON \(dCondition)
+                        """)
+                }
+                for request in [
+                    A.joining(required: c).annotated(withRequired: dThroughC.select(Column.rowID)),
+                    A.annotated(withRequired: dThroughB.select(Column.rowID)).joining(required: c)]
+                {
+                    try assertEqualSQL(db, request, """
+                        SELECT "a".*, "d"."rowid" \
                         FROM "a" \
                         JOIN "b" ON \(bCondition) \
                         JOIN "c" ON \(cCondition) \

--- a/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingCodableRecordTests.swift
@@ -130,6 +130,46 @@ class AssociationPrefetchingCodableRecordTests: GRDBTestCase {
                     }
                 }
                 
+                // ContiguousArray
+                do {
+                    struct Record: FetchableRecord, Decodable, Equatable {
+                        var a: A
+                        var bs: ContiguousArray<B>
+                    }
+                    
+                    // Record.fetchAll
+                    do {
+                        let records = try Record.fetchAll(db, request)
+                        XCTAssertEqual(records, [
+                            Record(
+                                a: A(row: ["cola1": 1, "cola2": "a1"]),
+                                bs: [
+                                    B(row: ["colb1": 4, "colb2": 1, "colb3": "b1"]),
+                                    B(row: ["colb1": 5, "colb2": 1, "colb3": "b2"]),
+                                ]),
+                            Record(
+                                a: A(row: ["cola1": 2, "cola2": "a2"]),
+                                bs: [
+                                    B(row: ["colb1": 6, "colb2": 2, "colb3": "b3"]),
+                                ]),
+                            Record(
+                                a: A(row: ["cola1": 3, "cola2": "a3"]),
+                                bs: []),
+                            ])
+                    }
+                    
+                    // Record.fetchOne
+                    do {
+                        let record = try Record.fetchOne(db, request)!
+                        XCTAssertEqual(record, Record(
+                            a: A(row: ["cola1": 1, "cola2": "a1"]),
+                            bs: [
+                                B(row: ["colb1": 4, "colb2": 1, "colb3": "b1"]),
+                                B(row: ["colb1": 5, "colb2": 1, "colb3": "b2"]),
+                            ]))
+                    }
+                }
+
                 // Set
                 do {
                     struct Record: FetchableRecord, Decodable, Equatable {


### PR DESCRIPTION
This pull request introduces two convenience methods `annotated(withRequired:)` and `annotated(withOptional:)` that help fetching and decoding only a few columns of an associated record.

For example:

```swift
// Fetch all books with their respective author country
struct BookInfo: FetchableRecord, Decodable {
    var book: Book
    var country: String // Note: scalar property, not a record type
}

let request = Book.annotated(withRequired: Book.author.select(Column("country")))
let bookInfos = try BookInfo.fetchAll(db, request)
```

Those convenience methods are equivalent to the older technique described below. Fetching and decoding a subset of columns ought to be an [easy](https://signalvnoise.com/posts/3047-the-obvious-the-easy-and-the-possible) task, and before the new methods were introduced, the user had to use a difficult technique based on `TableAlias`:

```swift
// Before this PR
let authorAlias = TableAlias()
let request = Book
    .annotated(with: authorAlias[Column("country")])
    .joining(required: Book.author.aliased(authorAlias))
let bookInfos = try BookInfo.fetchAll(db, request)
```
