### PR TITLE
Add drop column support

### DIFF
--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -685,6 +685,7 @@ public final class TableAlteration {
         case add(ColumnDefinition)
         case addColumnLiteral(SQL)
         case rename(old: String, new: String)
+        case drop(String)
     }
     
     private var alterations: [TableAlterationKind] = []
@@ -771,6 +772,21 @@ public final class TableAlteration {
         alterations.append(.rename(old: name, new: newName))
     }
     
+    
+    /// Drops a column from the table.
+    ///
+    ///     try db.alter(table: "player") { t in
+    ///         t.drop(column: "age")
+    ///     }
+    ///
+    /// See <https://www.sqlite.org/lang_altertable.html>
+    ///
+    /// - Parameter name: the column name to drop.
+    @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
+    public func drop(column name: String) {
+        alterations.append(.drop(name))
+    }
+    
     fileprivate func sql(_ db: Database) throws -> String {
         var statements: [String] = []
         
@@ -807,6 +823,15 @@ public final class TableAlteration {
                 chunks.append(oldName.quotedDatabaseIdentifier)
                 chunks.append("TO")
                 chunks.append(newName.quotedDatabaseIdentifier)
+                let statement = chunks.joined(separator: " ")
+                statements.append(statement)
+                
+            case let .drop(column):
+                var chunks: [String] = []
+                chunks.append("ALTER TABLE")
+                chunks.append(name.quotedDatabaseIdentifier)
+                chunks.append("DROP COLUMN")
+                chunks.append(column.quotedDatabaseIdentifier)
                 let statement = chunks.joined(separator: " ")
                 statements.append(statement)
             }

--- a/GRDB/QueryInterface/Schema/TableDefinition.swift
+++ b/GRDB/QueryInterface/Schema/TableDefinition.swift
@@ -751,6 +751,19 @@ public final class TableAlteration {
     public func rename(column name: String, to newName: String) {
         _rename(column: name, to: newName)
     }
+    
+    /// Drops a column from the table.
+    ///
+    ///     try db.alter(table: "player") { t in
+    ///         t.drop(column: "age")
+    ///     }
+    ///
+    /// See <https://www.sqlite.org/lang_altertable.html>
+    ///
+    /// - Parameter name: the column name to drop.
+    public func drop(column name: String) {
+        _drop(column: name)
+    }
     #else
     /// Renames a column in a table.
     ///
@@ -766,12 +779,6 @@ public final class TableAlteration {
     public func rename(column name: String, to newName: String) {
         _rename(column: name, to: newName)
     }
-    #endif
-    
-    private func _rename(column name: String, to newName: String) {
-        alterations.append(.rename(old: name, new: newName))
-    }
-    
     
     /// Drops a column from the table.
     ///
@@ -784,6 +791,15 @@ public final class TableAlteration {
     /// - Parameter name: the column name to drop.
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *)
     public func drop(column name: String) {
+        _drop(column: name)
+    }
+    #endif
+    
+    private func _rename(column name: String, to newName: String) {
+        alterations.append(.rename(old: name, new: newName))
+    }
+    
+    private func _drop(column name: String) {
         alterations.append(.drop(name))
     }
     

--- a/README.md
+++ b/README.md
@@ -4313,9 +4313,11 @@ try db.rename(table: "referer", to: "referrer")
 
 // ALTER TABLE player ADD COLUMN hasBonus BOOLEAN
 // ALTER TABLE player RENAME COLUMN url TO homeURL
+// ALTER TABLE player DROP COLUMN score
 try db.alter(table: "player") { t in
     t.add(column: "hasBonus", .boolean)
     t.rename(column: "url", to: "homeURL") // SQLite 3.25+
+    t.drop(column: "score") // SQLite 3.35+
 }
 ```
 

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -673,9 +673,14 @@ class TableDefinitionTests: GRDBTestCase {
     }
     
     func testAlterTableDropColumn() throws {
+        guard sqlite3_libversion_number() >= 3035000 else {
+            throw XCTSkip("ALTER TABLE DROP COLUMN is not available")
+        }
+        #if !GRDBCUSTOMSQLITE && !GRDBCIPHER
         guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) else {
             throw XCTSkip("ALTER TABLE DROP COLUMN is not available")
         }
+        #endif
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.create(table: "test") { t in
@@ -689,7 +694,6 @@ class TableDefinitionTests: GRDBTestCase {
             }
             assertEqualSQL(lastSQLQuery!, "ALTER TABLE \"test\" DROP COLUMN \"b\"")
         }
-
     }
     
     func testDropTable() throws {

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -672,6 +672,26 @@ class TableDefinitionTests: GRDBTestCase {
         #endif
     }
     
+    func testAlterTableDropColumn() throws {
+        guard #available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) else {
+            throw XCTSkip("ALTER TABLE DROP COLUMN is not available")
+        }
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(table: "test") { t in
+                t.column("a", .text)
+                t.column("b", .text)
+            }
+            
+            sqlQueries.removeAll()
+            try db.alter(table: "test") { t in
+                t.drop(column: "b")
+            }
+            assertEqualSQL(lastSQLQuery!, "ALTER TABLE \"test\" DROP COLUMN \"b\"")
+        }
+
+    }
+    
     func testDropTable() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in


### PR DESCRIPTION
Following on from #1138, This adds support for drop column. 

I did some poking and prodding with downloaded simulator versions and it would seem the first iOS version that shipped with >3.35 was iOS 15, was able to check against iOS 15.0 and iOS 14.5 (and those were the only simulator ranges available to download to check, i.e. couldn't check things like 14.6, 14.7 etc).

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.

```
...
Executed 2279 tests, with 6 tests skipped and 0 failures (0 unexpected) in 87.346 (88.464) seconds
...
Executed 2279 tests, with 6 tests skipped and 0 failures (0 unexpected) in 93.532 (94.811) seconds
...
```

> The `make smokeTest` terminal command runs without failure.

_Sort of. I don't have simulators older than iOS 14.5 installed so it failed when trying to test against 13.7, otherwise it passed. If you are able to test against that specific version, that would be great as my tiny hard drive suffers with every simulator I download to it_

PS: Please be kind, I use this repository heaps and just wanted to help and not sure if I've missed anything in making this PR :)