### PR TITLE
Target DispatchQueue for non-read-only database connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - **Fixed**: Fixed a bug of `including(all:)` for composite foreign keys and limited requests.
 - **New**: [#1160](https://github.com/groue/GRDB.swift/pull/1160) by [@groue](https://github.com/groue): Hide statement arguments by default.
+- **New**: [#1161](https://github.com/groue/GRDB.swift/pull/1160) by [@groue](https://github.com/groue): Target DispatchQueue for non-read-only database connections.
 - **Documentation Update**: The [Database Configuration](README.md#database-configuration) chapter explains how to opt in for public statement arguments in DEBUG builds.
 
 

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -336,7 +336,7 @@ extension DatabasePool: DatabaseReader {
             defaultLabel: "GRDB.DatabasePool",
             purpose: "asyncRead")
         configuration
-            .makeDispatchQueue(label: label)
+            .makeReaderDispatchQueue(label: label)
             .async {
                 do {
                     guard let readerPool = self.readerPool else {
@@ -374,7 +374,7 @@ extension DatabasePool: DatabaseReader {
             defaultLabel: "GRDB.DatabasePool",
             purpose: "asyncRead")
         configuration
-            .makeDispatchQueue(label: label)
+            .makeReaderDispatchQueue(label: label)
             .async { [weak self] in
                 guard let self = self else {
                     value(nil)
@@ -435,7 +435,7 @@ extension DatabasePool: DatabaseReader {
             defaultLabel: "GRDB.DatabasePool",
             purpose: "asyncUnsafeRead")
         configuration
-            .makeDispatchQueue(label: label)
+            .makeReaderDispatchQueue(label: label)
             .async {
                 do {
                     guard let readerPool = self.readerPool else {
@@ -802,7 +802,7 @@ extension DatabasePool: DatabaseReader {
             observation: observation,
             writer: self,
             scheduler: scheduler,
-            reduceQueue: configuration.makeDispatchQueue(label: reduceQueueLabel),
+            reduceQueue: configuration.makeReaderDispatchQueue(label: reduceQueueLabel),
             onChange: onChange)
         
         // Starting a concurrent observation means that we'll fetch the initial

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -382,7 +382,7 @@ extension DatabaseWriter {
             observation: observation,
             writer: self,
             scheduler: scheduler,
-            reduceQueue: configuration.makeDispatchQueue(label: reduceQueueLabel),
+            reduceQueue: configuration.makeWriterDispatchQueue(label: reduceQueueLabel),
             onChange: onChange)
         
         if scheduler.immediateInitialValue() {

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -47,7 +47,11 @@ final class SerializedDatabase {
             path: path,
             description: identifier,
             configuration: config)
-        self.queue = configuration.makeDispatchQueue(label: identifier)
+        if config.readonly {
+            self.queue = configuration.makeReaderDispatchQueue(label: identifier)
+        } else {
+            self.queue = configuration.makeWriterDispatchQueue(label: identifier)
+        }
         SchedulingWatchdog.allowDatabase(db, onQueue: queue)
         try queue.sync {
             do {

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -432,6 +432,7 @@ public struct DatabaseMigrator {
                         // just as the migrated database
                         var tmpConfig = db.configuration
                         tmpConfig.targetQueue = nil // Avoid deadlocks
+                        tmpConfig.writeTargetQueue = nil // Avoid deadlocks
                         tmpConfig.label = "GRDB.DatabaseMigrator.temporary"
                         
                         // Create the temporary database on disk, just in

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -772,8 +772,22 @@ class DatabaseMigratorTests : GRDBTestCase {
     }
     
     // Regression test for https://github.com/groue/GRDB.swift/issues/741
-    func testEraseDatabaseOnSchemaChangeDoesNotDeadLock() throws {
+    func testEraseDatabaseOnSchemaChangeDoesNotDeadLockOnTargetQueue() throws {
         dbConfiguration.targetQueue = DispatchQueue(label: "target")
+        let dbQueue = try makeDatabaseQueue()
+        
+        var migrator = DatabaseMigrator()
+        migrator.eraseDatabaseOnSchemaChange = true
+        migrator.registerMigration("1", migrate: { _ in })
+        try migrator.migrate(dbQueue)
+        
+        migrator.registerMigration("2", migrate: { _ in })
+        try migrator.migrate(dbQueue)
+    }
+    
+    // Regression test for https://github.com/groue/GRDB.swift/issues/741
+    func testEraseDatabaseOnSchemaChangeDoesNotDeadLockOnWriteTargetQueue() throws {
+        dbConfiguration.writeTargetQueue = DispatchQueue(label: "writerTarget")
         let dbQueue = try makeDatabaseQueue()
         
         var migrator = DatabaseMigrator()


### PR DESCRIPTION
The new `Configuration.writeTargetQueue` property makes it possible to control the dispatch of non-read-only database connections.