### PR TITLE
Fix truncate optimization handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 ## Next Release
 
 - **Fixed**: Fixed a bug of `including(all:)` for composite foreign keys and limited requests.
+- **Fixed**: [#1162](https://github.com/groue/GRDB.swift/pull/1162) by [@groue](https://github.com/groue): Fix truncate optimization handling.
 - **New**: [#1160](https://github.com/groue/GRDB.swift/pull/1160) by [@groue](https://github.com/groue): Hide statement arguments by default.
 - **New**: [#1161](https://github.com/groue/GRDB.swift/pull/1160) by [@groue](https://github.com/groue): Target DispatchQueue for non-read-only database connections.
 - **Documentation Update**: The [Database Configuration](README.md#database-configuration) chapter explains how to opt in for public statement arguments in DEBUG builds.

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -639,7 +639,7 @@ struct StatementCache {
         statements.removeFirst { $0.value === statement }
     }
     
-    mutating func clear(where isDeleted: (Statement) -> Bool) {
-        statements = statements.filter { (_, statement) in !isDeleted(statement) }
+    mutating func removeAll(where shouldBeRemoved: (Statement) -> Bool) {
+        statements = statements.filter { (_, statement) in !shouldBeRemoved(statement) }
     }
 }

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -542,11 +542,9 @@ public class SQLStatementCursor: Cursor {
 }
 
 extension Database {
-    /// Returns the authorizer that should be used during statement execution
-    /// (this allows preventing the truncate optimization when there exists a
-    /// transaction observer for row deletion).
+    /// Makes sure statement can be executed, and prepares database observation.
     @usableFromInline
-    func statementWillExecute(_ statement: Statement) throws -> StatementAuthorizer? {
+    func statementWillExecute(_ statement: Statement) throws {
         // Two things must prevent the statement from executing: aborted
         // transactions, and database suspension.
         try checkForAbortedTransaction(sql: statement.sql, arguments: statement.arguments)

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -638,4 +638,8 @@ struct StatementCache {
     mutating func remove(_ statement: Statement) {
         statements.removeFirst { $0.value === statement }
     }
+    
+    mutating func clear(where isDeleted: (Statement) -> Bool) {
+        statements = statements.filter { (_, statement) in !isDeleted(statement) }
+    }
 }

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -87,24 +87,26 @@ public final class Statement {
     {
         SchedulingWatchdog.preconditionValidQueue(database)
         
-        let authorizer = StatementCompilationAuthorizer()
+        // Reset authorizer before preparing the statement
+        let authorizer = database.authorizer
+        authorizer.reset()
+        
         var sqliteStatement: SQLiteStatement? = nil
-        let code: Int32 = database.withAuthorizer(authorizer) {
-            // sqlite3_prepare_v3 was introduced in SQLite 3.20.0 http://www.sqlite.org/changes.html#version_3_20
-            #if GRDBCUSTOMSQLITE || GRDBCIPHER
-            return sqlite3_prepare_v3(
+        let code: Int32
+        // sqlite3_prepare_v3 was introduced in SQLite 3.20.0 http://www.sqlite.org/changes.html#version_3_20
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        code = sqlite3_prepare_v3(
+            database.sqliteConnection, statementStart, -1, UInt32(bitPattern: prepFlags),
+            &sqliteStatement, statementEnd)
+#else
+        if #available(iOS 12.0, OSX 10.14, tvOS 12.0, watchOS 5.0, *) {
+            code = sqlite3_prepare_v3(
                 database.sqliteConnection, statementStart, -1, UInt32(bitPattern: prepFlags),
                 &sqliteStatement, statementEnd)
-            #else
-            if #available(iOS 12.0, OSX 10.14, tvOS 12.0, watchOS 5.0, *) {
-                return sqlite3_prepare_v3(
-                    database.sqliteConnection, statementStart, -1, UInt32(bitPattern: prepFlags),
-                    &sqliteStatement, statementEnd)
-            } else {
-                return sqlite3_prepare_v2(database.sqliteConnection, statementStart, -1, &sqliteStatement, statementEnd)
-            }
-            #endif
+        } else {
+            code = sqlite3_prepare_v2(database.sqliteConnection, statementStart, -1, &sqliteStatement, statementEnd)
         }
+#endif
         
         guard code == SQLITE_OK else {
             throw DatabaseError(
@@ -296,43 +298,19 @@ public final class Statement {
     /// - throws: A DatabaseError whenever an SQLite error occurs.
     public func execute(arguments: StatementArguments? = nil) throws {
         try reset(withArguments: arguments)
-        try database.withAuthorizer(database.statementWillExecute(self)) {
-            // Iterate all rows, since they may execute side effects.
-            while true {
-                switch sqlite3_step(sqliteStatement) {
-                case SQLITE_DONE:
-                    try database.statementDidExecute(self)
-                    return
-                case SQLITE_ROW:
-                    break
-                case let code:
-                    try database.statementDidFail(self, withResultCode: code)
-                }
-            }
-        }
-    }
-    
-    /// Calls the given closure after one successful call to `sqlite3_step()`.
-    ///
-    /// This method is unable to deal with statements that need a specific
-    /// authorizer. See `forEachStep(_:)`.
-    @usableFromInline
-    func step<Element>(_ body: (SQLiteStatement) throws -> Element) throws -> Element? {
-        // This check takes 0 time when profiled. It is, practically speaking, free.
-        if sqlite3_stmt_busy(sqliteStatement) == 0 {
-            guard try database.statementWillExecute(self) == nil else {
-                fatalError("Can't execute step by step a statement that requires a customized authorizer.")
-            }
-        }
+        try database.statementWillExecute(self)
         
-        switch sqlite3_step(sqliteStatement) {
-        case SQLITE_DONE:
-            try database.statementDidExecute(self)
-            return nil
-        case SQLITE_ROW:
-            return try body(sqliteStatement)
-        case let code:
-            try database.statementDidFail(self, withResultCode: code)
+        // Iterate all rows, since they may execute side effects.
+        while true {
+            switch sqlite3_step(sqliteStatement) {
+            case SQLITE_DONE:
+                try database.statementDidExecute(self)
+                return
+            case SQLITE_ROW:
+                break
+            case let code:
+                try database.statementDidFail(self, withResultCode: code)
+            }
         }
     }
     
@@ -355,22 +333,40 @@ public final class Statement {
     @usableFromInline
     func forEachStep(_ body: (SQLiteStatement) throws -> Void) throws {
         SchedulingWatchdog.preconditionValidQueue(database)
-        guard sqlite3_stmt_busy(sqliteStatement) == 0 else {
-            // We can't deal with possible authorizer
-            fatalError("Statement is busy")
-        }
-        try database.withAuthorizer(database.statementWillExecute(self)) {
-            while true {
-                switch sqlite3_step(sqliteStatement) {
-                case SQLITE_DONE:
-                    try database.statementDidExecute(self)
-                    return
-                case SQLITE_ROW:
-                    try body(sqliteStatement)
-                case let code:
-                    try database.statementDidFail(self, withResultCode: code)
-                }
+        try database.statementWillExecute(self)
+        
+        while true {
+            switch sqlite3_step(sqliteStatement) {
+            case SQLITE_DONE:
+                try database.statementDidExecute(self)
+                return
+            case SQLITE_ROW:
+                try body(sqliteStatement)
+            case let code:
+                try database.statementDidFail(self, withResultCode: code)
             }
+        }
+    }
+    
+    /// Calls the given closure after one successful call to `sqlite3_step()`.
+    ///
+    /// This method is unable to deal with statements that need a specific
+    /// authorizer. See `forEachStep(_:)`.
+    @usableFromInline
+    func step<Element>(_ body: (SQLiteStatement) throws -> Element) throws -> Element? {
+        // This check takes 0 time when profiled. It is, practically speaking, free.
+        if sqlite3_stmt_busy(sqliteStatement) == 0 {
+            try database.statementWillExecute(self)
+        }
+        
+        switch sqlite3_step(sqliteStatement) {
+        case SQLITE_DONE:
+            try database.statementDidExecute(self)
+            return nil
+        case SQLITE_ROW:
+            return try body(sqliteStatement)
+        case let code:
+            try database.statementDidFail(self, withResultCode: code)
         }
     }
 }

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -2,20 +2,10 @@
 import Glibc
 #endif
 
-/// A protocol around sqlite3_set_authorizer
-@usableFromInline
-protocol StatementAuthorizer: AnyObject {
-    func authorize(
-        _ actionCode: Int32,
-        _ cString1: UnsafePointer<Int8>?,
-        _ cString2: UnsafePointer<Int8>?,
-        _ cString3: UnsafePointer<Int8>?,
-        _ cString4: UnsafePointer<Int8>?)
-    -> Int32
-}
-
 /// A class that gathers information about one statement during its compilation.
-final class StatementCompilationAuthorizer: StatementAuthorizer {
+final class StatementAuthorizer {
+    private unowned var database: Database
+    
     /// What this statements reads
     var selectedRegion = DatabaseRegion()
     
@@ -33,6 +23,19 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
     
     private var isDropStatement = false
     
+    init(_ database: Database) {
+        self.database = database
+    }
+    
+    /// Reset before compiling a new statement
+    func reset() {
+        selectedRegion = DatabaseRegion()
+        databaseEventKinds = []
+        invalidatesDatabaseSchemaCache = false
+        transactionEffect = nil
+        isDropStatement = false
+    }
+    
     func authorize(
         _ actionCode: Int32,
         _ cString1: UnsafePointer<Int8>?,
@@ -43,7 +46,7 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
     {
         // Uncomment when debugging
         // print("""
-        //     StatementCompilationAuthorizer: \
+        //     StatementAuthorizer: \
         //     \(AuthorizerActionCode(rawValue: actionCode)) \
         //     \([cString1, cString2, cString3, cString4].compactMap { $0.map(String.init) }.joined(separator: ", "))
         //     """)
@@ -94,10 +97,16 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
             guard strcmp(cString1, "sqlite_master") != 0 else { return SQLITE_OK }
             guard strcmp(cString1, "sqlite_temp_master") != 0 else { return SQLITE_OK }
             
+            let tableName = String(cString: cString1)
+            databaseEventKinds.append(.delete(tableName: tableName))
+            
             // Now we prevent the truncate optimization so that transaction
             // observers are notified of individual row deletions.
-            databaseEventKinds.append(.delete(tableName: String(cString: cString1)))
-            return SQLITE_IGNORE
+            if database.observationBroker.observesDeletions(on: tableName) {
+                return SQLITE_IGNORE
+            } else {
+                return SQLITE_OK
+            }
             
         case SQLITE_UPDATE:
             guard let tableName = cString1.map(String.init) else { return SQLITE_OK }
@@ -173,30 +182,6 @@ final class StatementCompilationAuthorizer: StatementAuthorizer {
             }
         }
         databaseEventKinds.append(.update(tableName: tableName, columnNames: [columnName]))
-    }
-}
-
-/// This authorizer prevents the [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt)
-/// which makes transaction observers unable to observe individual deletions
-/// when user runs `DELETE FROM t` statements.
-//
-/// Warning: to perform well, this authorizer must be used during statement
-/// execution, not during statement compilation.
-final class TruncateOptimizationBlocker: StatementAuthorizer {
-    func authorize(
-        _ actionCode: Int32,
-        _ cString1: UnsafePointer<Int8>?,
-        _ cString2: UnsafePointer<Int8>?,
-        _ cString3: UnsafePointer<Int8>?,
-        _ cString4: UnsafePointer<Int8>?)
-    -> Int32
-    {
-        // print("""
-        //     TruncateOptimizationBlocker: \
-        //     \(AuthorizerActionCode(rawValue: actionCode)) \
-        //     \([cString1, cString2, cString3, cString4].compactMap { $0.map(String.init) })
-        //     """)
-        return (actionCode == SQLITE_DELETE) ? SQLITE_IGNORE : SQLITE_OK
     }
 }
 

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -15,7 +15,7 @@ extension Database {
     {
         SchedulingWatchdog.preconditionValidQueue(self)
         
-        // Drop cached statements that delete, this the addition of an
+        // Drop cached statements that delete, because the addition of an
         // observer may change the need for truncate optimization prevention.
         publicStatementCache.removeAll { $0.databaseEventKinds.contains(where: \.isDelete) }
         internalStatementCache.removeAll{ $0.databaseEventKinds.contains(where: \.isDelete) }
@@ -27,7 +27,7 @@ extension Database {
     public func remove(transactionObserver: TransactionObserver) {
         SchedulingWatchdog.preconditionValidQueue(self)
         
-        // Drop cached statements that delete, this the removal of an
+        // Drop cached statements that delete, because the removal of an
         // observer may change the need for truncate optimization prevention.
         publicStatementCache.removeAll { $0.databaseEventKinds.contains(where: \.isDelete) }
         internalStatementCache.removeAll { $0.databaseEventKinds.contains(where: \.isDelete) }

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -17,8 +17,8 @@ extension Database {
         
         // Drop cached statements that delete, this the addition of an
         // observer may change the need for truncate optimization prevention.
-        publicStatementCache.clear(where: { $0.databaseEventKinds.contains(where: \.isDelete) })
-        internalStatementCache.clear(where: { $0.databaseEventKinds.contains(where: \.isDelete) })
+        publicStatementCache.removeAll { $0.databaseEventKinds.contains(where: \.isDelete) }
+        internalStatementCache.removeAll{ $0.databaseEventKinds.contains(where: \.isDelete) }
         
         observationBroker.add(transactionObserver: transactionObserver, extent: extent)
     }
@@ -29,8 +29,8 @@ extension Database {
         
         // Drop cached statements that delete, this the removal of an
         // observer may change the need for truncate optimization prevention.
-        publicStatementCache.clear(where: { $0.databaseEventKinds.contains(where: \.isDelete) })
-        internalStatementCache.clear(where: { $0.databaseEventKinds.contains(where: \.isDelete) })
+        publicStatementCache.removeAll { $0.databaseEventKinds.contains(where: \.isDelete) }
+        internalStatementCache.removeAll { $0.databaseEventKinds.contains(where: \.isDelete) }
         
         observationBroker.remove(transactionObserver: transactionObserver)
     }

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -198,16 +198,17 @@ class DatabaseObservationBroker {
     
     // MARK: - Statement execution
     
-    /// Setups observation of changes that are about to be performed by the
-    /// statement, and returns the authorizer that should be used during
-    /// statement execution (this allows preventing the truncate optimization
-    /// when there exists a transaction observer for row deletion).
-    func statementWillExecute(_ statement: Statement) -> StatementAuthorizer? {
+    /// Returns true if there exists some transaction observers interested in
+    /// deletions in the given table.
+    func observesDeletions(on table: String) -> Bool {
+        transactionObservations.contains { observation in
+            observation.observes(eventsOfKind: .delete(tableName: table))
+        }
+    }
+    
+    /// Prepares observation of changes that are about to be performed by the statement.
+    func statementWillExecute(_ statement: Statement) {
         // If any observer observes row deletions, we'll have to disable
-        // [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt)
-        // so that observers are notified.
-        var observesRowDeletion = false
-        
         if transactionObservations.isEmpty == false {
             // As statement executes, it may trigger database changes that will
             // be notified to transaction observers. As a consequence, observers
@@ -245,10 +246,6 @@ class DatabaseObservationBroker {
                         return nil
                     }
                     
-                    if case .delete = eventKind {
-                        observesRowDeletion = true
-                    }
-                    
                     // observation will be notified of all individual events
                     return (observation, DatabaseEventPredicate.true)
                 }
@@ -268,13 +265,6 @@ class DatabaseObservationBroker {
                         return nil
                     }
                     
-                    for eventKind in observedKinds {
-                        if case .delete = eventKind {
-                            observesRowDeletion = true
-                            break
-                        }
-                    }
-                    
                     // observation will only be notified of individual events that
                     // match one of the observed kinds.
                     return (
@@ -287,12 +277,6 @@ class DatabaseObservationBroker {
         }
         
         transactionState = .none
-        
-        if observesRowDeletion {
-            return TruncateOptimizationBlocker()
-        } else {
-            return nil
-        }
     }
     
     /// May throw a cancelled commit error, if a transaction observer cancels


### PR DESCRIPTION
This pull request fixes #1155 by cleaning up the relationship between database observation and the [truncate optimization](https://www.sqlite.org/lang_delete.html#truncateopt).

Thanks @mallman for the report!