### PR TITLE
Drop async apis from DatabaseMigrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **Breaking Change**: [#1164](https://github.com/groue/GRDB.swift/pull/1164) by [@groue](https://github.com/groue): Drop async apis from DatabaseMigrator
+
+
 ## 5.20.0
 
 Released February 1, 2022 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v5.19.0...v5.20.0)

--- a/Documentation/Migrations.md
+++ b/Documentation/Migrations.md
@@ -268,13 +268,7 @@ while let violation = try violations.next() {
 
 ## Asynchronous Migrations
 
-`DatabaseMigrator` provides three ways to migrate a database in an asynchronous way.
-
-The async `migrate()` method:
-
-```swift
-try await migrator.migrate(dbQueue)
-```
+`DatabaseMigrator` provides the following ways to migrate a database in an asynchronous way.
 
 The `asyncMigrate(_:completion:)` method:
 

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -98,54 +98,6 @@ class DatabaseMigratorTests : GRDBTestCase {
             .runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
     }
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    func testAsyncAwait_NonEmptyMigratorSync() async throws {
-        func test(writer: DatabaseWriter) async throws {
-            var migrator = DatabaseMigrator()
-            migrator.registerMigration("createPersons") { db in
-                try db.execute(sql: """
-                    CREATE TABLE persons (
-                        id INTEGER PRIMARY KEY,
-                        name TEXT)
-                    """)
-            }
-            migrator.registerMigration("createPets") { db in
-                try db.execute(sql: """
-                    CREATE TABLE pets (
-                        id INTEGER PRIMARY KEY,
-                        masterID INTEGER NOT NULL
-                                 REFERENCES persons(id)
-                                 ON DELETE CASCADE ON UPDATE CASCADE,
-                        name TEXT)
-                    """)
-            }
-            
-            var migrator2 = migrator
-            migrator2.registerMigration("destroyPersons") { db in
-                try db.execute(sql: "DROP TABLE pets")
-            }
-            
-            try await migrator.migrate(writer)
-            try await writer.read { db in
-                XCTAssertTrue(try db.tableExists("persons"))
-                XCTAssertTrue(try db.tableExists("pets"))
-            }
-            
-            try await migrator2.migrate(writer)
-            try await writer.read { db in
-                XCTAssertTrue(try db.tableExists("persons"))
-                XCTAssertFalse(try db.tableExists("pets"))
-            }
-        }
-        
-        try await AsyncTest(test)
-            .run { DatabaseQueue() }
-            .runAtTemporaryDatabasePath { try DatabaseQueue(path: $0) }
-            .runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
-    }
-#endif
-    
     func testNonEmptyMigratorAsync() throws {
         func test(writer: DatabaseWriter) throws {
             var migrator = DatabaseMigrator()
@@ -422,61 +374,6 @@ class DatabaseMigratorTests : GRDBTestCase {
             .runAtTemporaryDatabasePath { try DatabaseQueue(path: $0) }
             .runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
     }
-
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    func testAsyncAwait_MigrateUpTo() async throws {
-        func test(writer: DatabaseWriter) async throws {
-            var migrator = DatabaseMigrator()
-            migrator.registerMigration("a") { db in
-                try db.execute(sql: "CREATE TABLE a (id INTEGER PRIMARY KEY)")
-            }
-            migrator.registerMigration("b") { db in
-                try db.execute(sql: "CREATE TABLE b (id INTEGER PRIMARY KEY)")
-            }
-            migrator.registerMigration("c") { db in
-                try db.execute(sql: "CREATE TABLE c (id INTEGER PRIMARY KEY)")
-            }
-            
-            // one step
-            try await migrator.migrate(writer, upTo: "a")
-            try await writer.read { db in
-                XCTAssertTrue(try db.tableExists("a"))
-                XCTAssertFalse(try db.tableExists("b"))
-            }
-            
-            // zero step
-            try await migrator.migrate(writer, upTo: "a")
-            try await writer.read { db in
-                XCTAssertTrue(try db.tableExists("a"))
-                XCTAssertFalse(try db.tableExists("b"))
-            }
-            
-            // two steps
-            try await migrator.migrate(writer, upTo: "c")
-            try await writer.read { db in
-                XCTAssertTrue(try db.tableExists("a"))
-                XCTAssertTrue(try db.tableExists("b"))
-                XCTAssertTrue(try db.tableExists("c"))
-            }
-            
-            // zero step
-            try await migrator.migrate(writer, upTo: "c")
-            try await migrator.migrate(writer)
-            
-            // fatal error: undefined migration: "missing"
-            // try migrator.migrate(writer, upTo: "missing")
-            
-            // fatal error: database is already migrated beyond migration "b"
-            // try migrator.migrate(writer, upTo: "b")
-        }
-        
-        try await AsyncTest(test)
-            .run { DatabaseQueue() }
-            .runAtTemporaryDatabasePath { try DatabaseQueue(path: $0) }
-            .runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
-    }
-#endif
     
     func testMigrationFailureTriggersRollback() throws {
         var migrator = DatabaseMigrator()

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -258,3 +258,8 @@ public struct AnyValueReducer<Fetched, Value>: ValueReducer {
         __value(fetched)
     }
 }
+
+#if swift(>=5.5) && canImport(_Concurrency)
+// Assume this is correct :-/
+extension XCTestExpectation: @unchecked Sendable { }
+#endif

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -704,12 +704,11 @@ class ValueObservationTests: GRDBTestCase {
             try await writer.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
             
             let cancellationExpectation = expectation(description: "cancelled")
-            let observation = ValueObservation
-                .trackingConstantRegion(Table("t").fetchCount)
-                .handleEvents(didCancel: { cancellationExpectation.fulfill() })
-            
             let task = Task { () -> [Int] in
                 var counts: [Int] = []
+                let observation = ValueObservation
+                    .trackingConstantRegion(Table("t").fetchCount)
+                    .handleEvents(didCancel: { cancellationExpectation.fulfill() })
                 
                 for try await count in try observation.values(in: writer).prefix(while: { $0 < 3 }) {
                     counts.append(count)
@@ -740,12 +739,11 @@ class ValueObservationTests: GRDBTestCase {
             try await writer.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
             
             let cancellationExpectation = expectation(description: "cancelled")
-            let observation = ValueObservation
-                .trackingConstantRegion(Table("t").fetchCount)
-                .handleEvents(didCancel: { cancellationExpectation.fulfill() })
-            
             let task = Task { @MainActor () -> [Int] in
                 var counts: [Int] = []
+                let observation = ValueObservation
+                    .trackingConstantRegion(Table("t").fetchCount)
+                    .handleEvents(didCancel: { cancellationExpectation.fulfill() })
                 
                 for try await count in try observation.values(in: writer, scheduling: .immediate).prefix(while: { $0 < 3 }) {
                     counts.append(count)
@@ -776,12 +774,11 @@ class ValueObservationTests: GRDBTestCase {
             try await writer.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
             
             let cancellationExpectation = expectation(description: "cancelled")
-            let observation = ValueObservation
-                .trackingConstantRegion(Table("t").fetchCount)
-                .handleEvents(didCancel: { cancellationExpectation.fulfill() })
-            
             let task = Task { () -> [Int] in
                 var counts: [Int] = []
+                let observation = ValueObservation
+                    .trackingConstantRegion(Table("t").fetchCount)
+                    .handleEvents(didCancel: { cancellationExpectation.fulfill() })
                 
                 for try await count in observation.values(in: writer) {
                     counts.append(count)
@@ -816,12 +813,12 @@ class ValueObservationTests: GRDBTestCase {
             try await writer.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
             
             let cancellationExpectation = expectation(description: "cancelled")
-            let observation = ValueObservation
-                .trackingConstantRegion(Table("t").fetchCount)
-                .handleEvents(didCancel: { cancellationExpectation.fulfill() })
             
             let task = Task { @MainActor () -> [Int] in
                 var counts: [Int] = []
+                let observation = ValueObservation
+                    .trackingConstantRegion(Table("t").fetchCount)
+                    .handleEvents(didCancel: { cancellationExpectation.fulfill() })
                 
                 for try await count in observation.values(in: writer, scheduling: .immediate) {
                     counts.append(count)
@@ -851,22 +848,22 @@ class ValueObservationTests: GRDBTestCase {
             // We need something to change
             try await writer.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }
             
-            let observation = ValueObservation.trackingConstantRegion(Table("t").fetchCount)
-            
             let cancellationExpectation = expectation(description: "cancelled")
-            let cancelledObservation = observation.handleEvents(didCancel: {
-                cancellationExpectation.fulfill()
-            })
             
             // Launch a task that we'll cancel
             let cancelledTask = Task<String, Error> {
                 // Loops until cancelled
+                let observation = ValueObservation.trackingConstantRegion(Table("t").fetchCount)
+                let cancelledObservation = observation.handleEvents(didCancel: {
+                    cancellationExpectation.fulfill()
+                })
                 for try await _ in cancelledObservation.values(in: writer) { }
                 return "cancelled loop"
             }
             
             // Lanch the task that cancels
             Task {
+                let observation = ValueObservation.trackingConstantRegion(Table("t").fetchCount)
                 for try await count in observation.values(in: writer) {
                     if count == 3 {
                         cancelledTask.cancel()


### PR DESCRIPTION
The enhanced concurrency diagnostics brought by Swift 5.6 in Xcode 13.3 beta reveal that async DatabaseMigrator apis are not safely grounded.

Indeed, a DatabaseMigrator run regular closures, which are not [`@Sendable`](https://github.com/apple/swift-evolution/blob/main/proposals/0302-concurrent-value-and-concurrent-closures.md). This is why DatabaseMigrator can't be a good concurrency citizen:

```swift
var migrator = DatabaseMigrator()
migrator.registerMigration("version 1") { db in ... /* some unrestricted code */ }

// Unsafe
try await migrator.migrate(dbQueue)
```

Keeping the async apis would require migrations to run `@Sendable` closures, and this would be a breaking change.

This pull request thus _removes_ async apis from DatabaseMigrator.

```swift
// Back to the sync board:
try migrator.migrate(dbQueue)
```

---

Reminder: all async/await apis are currently [🔥 **EXPERIMENTAL**](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features), which means that breaking changes can be introduced in a minor release.