### PR TITLE
[GRDB6] Optional is a database value like others

### DIFF
--- a/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS.xcodeproj/xcshareddata/xcschemes/GRDBDemoWatchOS.xcscheme
+++ b/Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS.xcodeproj/xcshareddata/xcschemes/GRDBDemoWatchOS.xcscheme
@@ -78,8 +78,10 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/GRDBDemoiOS">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "568E5FBE1E926430002582E0"
@@ -87,7 +89,7 @@
             BlueprintName = "GRDBDemoWatchOS"
             ReferencedContainer = "container:GRDBDemoiOS.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -95,8 +97,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/GRDBDemoiOS">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "568E5FBE1E926430002582E0"
@@ -104,7 +108,16 @@
             BlueprintName = "GRDBDemoWatchOS"
             ReferencedContainer = "container:GRDBDemoiOS.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "568E5FBE1E926430002582E0"
+            BuildableName = "GRDBDemoWatchOS.app"
+            BlueprintName = "GRDBDemoWatchOS"
+            ReferencedContainer = "container:GRDBDemoiOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -564,6 +564,10 @@
 		56894FC82606589B00268F4D /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894F94260657D600268F4D /* Decimal.swift */; };
 		56894FD12606589C00268F4D /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894F94260657D600268F4D /* Decimal.swift */; };
 		56894FD22606589D00268F4D /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894F94260657D600268F4D /* Decimal.swift */; };
+		5689B90F27BBE08500697347 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5689B90E27BBE08500697347 /* Optional.swift */; };
+		5689B91027BBE08500697347 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5689B90E27BBE08500697347 /* Optional.swift */; };
+		5689B91127BBE08500697347 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5689B90E27BBE08500697347 /* Optional.swift */; };
+		5689B91227BBE08500697347 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5689B90E27BBE08500697347 /* Optional.swift */; };
 		568D131F2207213E00674B58 /* SQLQueryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568D13182207213E00674B58 /* SQLQueryGenerator.swift */; };
 		568D13202207213E00674B58 /* SQLQueryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568D13182207213E00674B58 /* SQLQueryGenerator.swift */; };
 		568D13212207213F00674B58 /* SQLQueryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568D13182207213E00674B58 /* SQLQueryGenerator.swift */; };
@@ -1488,6 +1492,7 @@
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		56894F742606576600268F4D /* FoundationDecimalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDecimalTests.swift; sourceTree = "<group>"; };
 		56894F94260657D600268F4D /* Decimal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decimal.swift; sourceTree = "<group>"; };
+		5689B90E27BBE08500697347 /* Optional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		568D13182207213E00674B58 /* SQLQueryGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLQueryGenerator.swift; sourceTree = "<group>"; };
 		568ECA8925D7013000B71526 /* SQLSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLSelection.swift; sourceTree = "<group>"; };
 		568ECA9E25D7E53E00B71526 /* SQLOrdering.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLOrdering.swift; sourceTree = "<group>"; };
@@ -1763,6 +1768,7 @@
 				5674A6E21F307F0E0095F066 /* DatabaseValueConvertible+Encodable.swift */,
 				5605F1571C672E4000235C62 /* DatabaseValueConvertible+RawRepresentable.swift */,
 				56713FDC2691F409006153C3 /* JSONRequiredEncoder.swift */,
+				5689B90E27BBE08500697347 /* Optional.swift */,
 				5605F1581C672E4000235C62 /* StandardLibrary.swift */,
 			);
 			path = StandardLibrary;
@@ -2921,6 +2927,7 @@
 				568ECB1A25D9161600B71526 /* SQLSubquery.swift in Sources */,
 				5613ED4621A95B2C00DC7A68 /* ValueReducer.swift in Sources */,
 				5698AD1C1DAAD17F0056AF8C /* FTS5Tokenizer.swift in Sources */,
+				5689B91127BBE08500697347 /* Optional.swift in Sources */,
 				56CEB5171EAA324B00BFAF62 /* FTS3+QueryInterface.swift in Sources */,
 				5656A8B22295BFD7001FF3FF /* TableRecord+QueryInterfaceRequest.swift in Sources */,
 				56B964B71DA51D010002DA19 /* FTS5TokenizerDescriptor.swift in Sources */,
@@ -3131,6 +3138,7 @@
 				56AE64132229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */,
 				56A2388C1B9C75030082EB20 /* Statement.swift in Sources */,
 				5659F4931EA8D964004A4992 /* ReadWriteBox.swift in Sources */,
+				5689B91027BBE08500697347 /* Optional.swift in Sources */,
 				56B7F43B1BEB42D500E39BBF /* Migration.swift in Sources */,
 				5690C3431D23E82A00E59934 /* Data.swift in Sources */,
 				5674A7001F307F600095F066 /* FetchableRecord+Decodable.swift in Sources */,
@@ -3734,6 +3742,7 @@
 				AAA4DCB4230F1E0600C74B15 /* HasOneThroughAssociation.swift in Sources */,
 				AAA4DCB5230F1E0600C74B15 /* Statement.swift in Sources */,
 				AAA4DCB6230F1E0600C74B15 /* ReadWriteBox.swift in Sources */,
+				5689B91227BBE08500697347 /* Optional.swift in Sources */,
 				AAA4DCB8230F1E0600C74B15 /* Migration.swift in Sources */,
 				AAA4DCB9230F1E0600C74B15 /* Data.swift in Sources */,
 				AAA4DCBA230F1E0600C74B15 /* FetchableRecord+Decodable.swift in Sources */,
@@ -4103,6 +4112,7 @@
 				5671FC201DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				56A238A41B9C753B0082EB20 /* Record.swift in Sources */,
 				56CEB5451EAA359A00BFAF62 /* Column.swift in Sources */,
+				5689B90F27BBE08500697347 /* Optional.swift in Sources */,
 				5657AB0F1D10899D006283EF /* URL.swift in Sources */,
 				560D924B1C672C4B00F4F92B /* TableRecord.swift in Sources */,
 				56DAA2DB1DE9C827006E10C8 /* Cursor.swift in Sources */,

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -721,6 +721,10 @@
 		56AACAA822ACED7100A40F2A /* Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AACAA722ACED7100A40F2A /* Fetch.swift */; };
 		56AACAA922ACED7100A40F2A /* Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AACAA722ACED7100A40F2A /* Fetch.swift */; };
 		56AACAAA22ACED7100A40F2A /* Fetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AACAA722ACED7100A40F2A /* Fetch.swift */; };
+		56AD72B027C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD72AF27C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */; };
+		56AD72B127C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD72AF27C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */; };
+		56AD72B227C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD72AF27C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */; };
+		56AD72B327C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD72AF27C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */; };
 		56AE64122229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE64112229A53700AD1B0B /* HasOneThroughAssociation.swift */; };
 		56AE64132229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE64112229A53700AD1B0B /* HasOneThroughAssociation.swift */; };
 		56AE64142229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE64112229A53700AD1B0B /* HasOneThroughAssociation.swift */; };
@@ -1582,6 +1586,7 @@
 		56A8C22F1D1914540096E9D4 /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
 		56A8C2361D1914790096E9D4 /* FoundationNSUUIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationNSUUIDTests.swift; sourceTree = "<group>"; };
 		56AACAA722ACED7100A40F2A /* Fetch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fetch.swift; sourceTree = "<group>"; };
+		56AD72AF27C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatementColumnConvertible+RawRepresentable.swift"; sourceTree = "<group>"; };
 		56AE64112229A53700AD1B0B /* HasOneThroughAssociation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HasOneThroughAssociation.swift; sourceTree = "<group>"; };
 		56AE6423222AAC9500AD1B0B /* AssociationHasOneThroughSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasOneThroughSQLTests.swift; sourceTree = "<group>"; };
 		56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEscapingTests.swift; sourceTree = "<group>"; };
@@ -1770,6 +1775,7 @@
 				56713FDC2691F409006153C3 /* JSONRequiredEncoder.swift */,
 				5689B90E27BBE08500697347 /* Optional.swift */,
 				5605F1581C672E4000235C62 /* StandardLibrary.swift */,
+				56AD72AF27C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */,
 			);
 			path = StandardLibrary;
 			sourceTree = "<group>";
@@ -2965,6 +2971,7 @@
 				569D6DE0220EF9E100A058A9 /* SQLInterpolation.swift in Sources */,
 				5611620A25757583007AAF99 /* JoinAssociation.swift in Sources */,
 				567ECE512222E431009245CA /* Fixits.swift in Sources */,
+				56AD72B227C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */,
 				565490BF1D5AE236005622CB /* DatabaseValueConvertible.swift in Sources */,
 				566B91191FA4C3F50012D5B0 /* DatabaseCollation.swift in Sources */,
 				560233C62724234F00529DF3 /* SharedValueObservation.swift in Sources */,
@@ -3156,6 +3163,7 @@
 				5656A8AE2295BFD7001FF3FF /* TableRecord+Association.swift in Sources */,
 				569EF0E3200D2D8400A9FA45 /* DatabaseRegion.swift in Sources */,
 				56A238841B9C75030082EB20 /* DatabaseQueue.swift in Sources */,
+				56AD72B127C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */,
 				563B06AC217EF0CC00B38F35 /* ValueObservation.swift in Sources */,
 				560233C52724234F00529DF3 /* SharedValueObservation.swift in Sources */,
 				5611620925757583007AAF99 /* JoinAssociation.swift in Sources */,
@@ -3760,6 +3768,7 @@
 				AAA4DCCA230F1E0600C74B15 /* TableRecord+Association.swift in Sources */,
 				AAA4DCCB230F1E0600C74B15 /* DatabaseRegion.swift in Sources */,
 				AAA4DCCC230F1E0600C74B15 /* DatabaseQueue.swift in Sources */,
+				56AD72B327C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */,
 				AAA4DCCD230F1E0600C74B15 /* ValueObservation.swift in Sources */,
 				560233C72724234F00529DF3 /* SharedValueObservation.swift in Sources */,
 				5611620B25757583007AAF99 /* JoinAssociation.swift in Sources */,
@@ -4130,6 +4139,7 @@
 				566BE71E2342542F00A8254B /* LockedBox.swift in Sources */,
 				56A238931B9C750B0082EB20 /* DatabaseMigrator.swift in Sources */,
 				5611620825757583007AAF99 /* JoinAssociation.swift in Sources */,
+				56AD72B027C10B8A00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */,
 				5695311F1C907A8C00CF1A2B /* DatabaseSchemaCache.swift in Sources */,
 				560233C42724234F00529DF3 /* SharedValueObservation.swift in Sources */,
 				569D6DDE220EF9E100A058A9 /* SQLInterpolation.swift in Sources */,

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -18,10 +18,12 @@ public protocol DatabaseValueConvertible: SQLExpressible, StatementBinding {
     /// Returns a value that can be stored in the database.
     var databaseValue: DatabaseValue { get }
     
-    /// Creates a value from a missing column, if possible.
+    /// Creates a value from a missing column, if possible. This method makes
+    /// it possible to decode missing columns as nil optionals.
     ///
     /// - returns: A decoded value, or, if decoding is impossible, nil.
-    static func fromMissingColumn() -> Self?
+    /// :nodoc:
+    static func _fromMissingColumn() -> Self?
     
     /// Creates a value from `dbValue`, if possible.
     ///
@@ -39,8 +41,11 @@ extension DatabaseValueConvertible {
         databaseValue.bind(to: sqliteStatement, at: index)
     }
     
-    public static func fromMissingColumn() -> Self? {
-        nil // failure
+    /// Default implementation fails to decode a value from a missing column.
+    /// `Optional` overrides this default behavior.
+    /// :nodoc:
+    public static func _fromMissingColumn() -> Self? {
+        nil // failure.
     }
 }
 

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -259,7 +259,7 @@ extension DatabaseValueConvertible {
         adapter: RowAdapter? = nil)
     throws -> Self?
     {
-        // fetchOne returns nil if there is no row, or if there is a row with a null value
+        // fetchOne handles both a missing row, and one row with a NULL value.
         let cursor = try DatabaseValueCursor<Self?>(
             statement: statement,
             arguments: arguments,

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -18,7 +18,15 @@ public protocol DatabaseValueConvertible: SQLExpressible, StatementBinding {
     /// Returns a value that can be stored in the database.
     var databaseValue: DatabaseValue { get }
     
-    /// Returns a value initialized from `dbValue`, if possible.
+    /// Creates a value from a missing column, if possible.
+    ///
+    /// - returns: A decoded value, or, if decoding is impossible, nil.
+    static func fromMissingColumn() -> Self?
+    
+    /// Creates a value from `dbValue`, if possible.
+    ///
+    /// - parameter dbValue: A DatabaseValue.
+    /// - returns: A decoded value, or, if decoding is impossible, nil.
     static func fromDatabaseValue(_ dbValue: DatabaseValue) -> Self?
 }
 
@@ -29,6 +37,10 @@ extension DatabaseValueConvertible {
     
     public func bind(to sqliteStatement: SQLiteStatement, at index: CInt) -> CInt {
         databaseValue.bind(to: sqliteStatement, at: index)
+    }
+    
+    public static func fromMissingColumn() -> Self? {
+        nil // failure
     }
 }
 
@@ -162,51 +174,6 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Databas
     }
 }
 
-/// A cursor of optional database values extracted from a single column.
-/// For example:
-///
-///     try dbQueue.read { db in
-///         let urls: NullableDatabaseValueCursor<URL> = try Optional<URL>.fetchCursor(db, sql: "SELECT url FROM link")
-///         while let url = urls.next() { // URL?
-///             print(url)
-///         }
-///     }
-public final class NullableDatabaseValueCursor<Value: DatabaseValueConvertible>: DatabaseCursor {
-    public typealias Element = Value?
-    public let statement: Statement
-    /// :nodoc:
-    public var _isDone = false
-    private let columnIndex: Int32
-    
-    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
-        self.statement = statement
-        if let adapter = adapter {
-            // adapter may redefine the index of the leftmost column
-            columnIndex = try Int32(adapter.baseColumnIndex(atIndex: 0, layout: statement))
-        } else {
-            columnIndex = 0
-        }
-        
-        // Assume cursor is created for immediate iteration: reset and set arguments
-        try statement.reset(withArguments: arguments)
-    }
-    
-    deinit {
-        // Statement reset fails when sqlite3_step has previously failed.
-        // Just ignore reset error.
-        try? statement.reset()
-    }
-    
-    /// :nodoc:
-    public func _element(sqliteStatement: SQLiteStatement) -> Value? {
-        // TODO GRDB6: don't crash on decoding errors
-        try! Value.decodeIfPresent(
-            fromStatement: sqliteStatement,
-            atUncheckedIndex: columnIndex,
-            context: RowDecodingContext(statement: statement, index: Int(columnIndex)))
-    }
-}
-
 /// DatabaseValueConvertible comes with built-in methods that allow to fetch
 /// cursors, arrays, or single values:
 ///
@@ -293,7 +260,10 @@ extension DatabaseValueConvertible {
     throws -> Self?
     {
         // fetchOne returns nil if there is no row, or if there is a row with a null value
-        let cursor = try NullableDatabaseValueCursor<Self>(statement: statement, arguments: arguments, adapter: adapter)
+        let cursor = try DatabaseValueCursor<Self?>(
+            statement: statement,
+            arguments: arguments,
+            adapter: adapter)
         return try cursor.next() ?? nil
     }
 }
@@ -563,297 +533,5 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & Hashable {
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public func fetchSet(_ db: Database) throws -> Set<RowDecoder> {
         try RowDecoder.fetchSet(db, self)
-    }
-}
-
-/// Swift's Optional comes with built-in methods that allow to fetch cursors
-/// and arrays of optional DatabaseValueConvertible:
-///
-///     try Optional<String>.fetchCursor(db, sql: "SELECT name FROM ...", arguments:...) // Cursor of String?
-///     try Optional<String>.fetchAll(db, sql: "SELECT name FROM ...", arguments:...)    // [String?]
-///
-///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-///     try Optional<String>.fetchCursor(statement, arguments:...) // Cursor of String?
-///     try Optional<String>.fetchAll(statement, arguments:...)    // [String?]
-///
-/// DatabaseValueConvertible is adopted by Bool, Int, String, etc.
-extension Optional where Wrapped: DatabaseValueConvertible {
-    
-    // MARK: Fetching From Prepared Statement
-    
-    /// Returns a cursor over optional values fetched from a prepared statement.
-    ///
-    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-    ///     let names = try Optional<String>.fetchCursor(statement) // Cursor of String?
-    ///     while let name = try names.next() { // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A cursor over fetched optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor(
-        _ statement: Statement,
-        arguments: StatementArguments? = nil,
-        adapter: RowAdapter? = nil)
-    throws -> NullableDatabaseValueCursor<Wrapped>
-    {
-        try NullableDatabaseValueCursor(statement: statement, arguments: arguments, adapter: adapter)
-    }
-    
-    /// Returns an array of optional values fetched from a prepared statement.
-    ///
-    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-    ///     let names = try Optional<String>.fetchAll(statement)  // [String?]
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: An array of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll(
-        _ statement: Statement,
-        arguments: StatementArguments? = nil,
-        adapter: RowAdapter? = nil)
-    throws -> [Wrapped?]
-    {
-        try Array(fetchCursor(statement, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & Hashable {
-    /// Returns a set of optional values fetched from a prepared statement.
-    ///
-    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-    ///     let names = try Optional<String>.fetchSet(statement)  // Set<String?>
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A set of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet(
-        _ statement: Statement,
-        arguments: StatementArguments? = nil,
-        adapter: RowAdapter? = nil)
-    throws -> Set<Wrapped?>
-    {
-        try Set(fetchCursor(statement, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible {
-    
-    // MARK: Fetching From SQL
-    
-    /// Returns a cursor over optional values fetched from an SQL query.
-    ///
-    ///     let names = try Optional<String>.fetchCursor(db, sql: "SELECT name FROM ...") // Cursor of String?
-    ///     while let name = try names.next() { // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A cursor over fetched optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor(
-        _ db: Database,
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-    throws -> NullableDatabaseValueCursor<Wrapped>
-    {
-        try fetchCursor(db, SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
-    }
-    
-    /// Returns an array of optional values fetched from an SQL query.
-    ///
-    ///     let names = try String.fetchAll(db, sql: "SELECT name FROM ...") // [String?]
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: An array of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll(
-        _ db: Database,
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-    throws -> [Wrapped?]
-    {
-        try fetchAll(db, SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & Hashable {
-    /// Returns a set of optional values fetched from an SQL query.
-    ///
-    ///     let names = try String.fetchSet(db, sql: "SELECT name FROM ...") // Set<String?>
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A set of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet(
-        _ db: Database,
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-    throws -> Set<Wrapped?>
-    {
-        try fetchSet(db, SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible {
-    
-    // MARK: Fetching From FetchRequest
-    
-    /// Returns a cursor over optional values fetched from a fetch request.
-    ///
-    ///     let request = Player.select(Column("name"))
-    ///     let names = try Optional<String>.fetchCursor(db, request) // Cursor of String?
-    ///     while let name = try names.next() { // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: A cursor over fetched optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor<R: FetchRequest>(_ db: Database, _ request: R)
-    throws -> NullableDatabaseValueCursor<Wrapped>
-    {
-        let request = try request.makePreparedRequest(db, forSingleResult: false)
-        return try fetchCursor(request.statement, adapter: request.adapter)
-    }
-    
-    /// Returns an array of optional values fetched from a fetch request.
-    ///
-    ///     let request = Player.select(Column("name"))
-    ///     let names = try Optional<String>.fetchAll(db, request) // [String?]
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: An array of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll<R: FetchRequest>(_ db: Database, _ request: R) throws -> [Wrapped?] {
-        let request = try request.makePreparedRequest(db, forSingleResult: false)
-        return try fetchAll(request.statement, adapter: request.adapter)
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & Hashable {
-    /// Returns a set of optional values fetched from a fetch request.
-    ///
-    ///     let request = Player.select(Column("name"))
-    ///     let names = try Optional<String>.fetchSet(db, request) // Set<String?>
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: A set of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet<R: FetchRequest>(_ db: Database, _ request: R) throws -> Set<Wrapped?> {
-        let request = try request.makePreparedRequest(db, forSingleResult: false)
-        return try fetchSet(request.statement, adapter: request.adapter)
-    }
-}
-
-extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: DatabaseValueConvertible {
-    
-    // MARK: Fetching Optional values
-    
-    /// A cursor over fetched optional values.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches Optional<String>
-    ///     let strings = try request.fetchCursor(db) // Cursor of String?
-    ///     while let string = try strings.next() {   // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: A cursor over fetched values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchCursor(_ db: Database) throws -> NullableDatabaseValueCursor<RowDecoder.Wrapped> {
-        try Optional<RowDecoder.Wrapped>.fetchCursor(db, self)
-    }
-    
-    /// An array of fetched optional values.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches Optional<String>
-    ///     let strings = try request.fetchAll(db) // [String?]
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: An array of values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchAll(_ db: Database) throws -> [RowDecoder.Wrapped?] {
-        try Optional<RowDecoder.Wrapped>.fetchAll(db, self)
-    }
-    
-    /// The first fetched value.
-    ///
-    /// The result is nil if the request returns no row, or if no value can be
-    /// extracted from the first row.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches String?
-    ///     let string = try request.fetchOne(db) // String?
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: An optional value.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchOne(_ db: Database) throws -> RowDecoder.Wrapped? {
-        try RowDecoder.Wrapped.fetchOne(db, self)
-    }
-}
-
-extension FetchRequest where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: DatabaseValueConvertible & Hashable {
-    /// A set of fetched optional values.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches Optional<String>
-    ///     let strings = try request.fetchSet(db) // Set<String?>
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: A set of values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchSet(_ db: Database) throws -> Set<RowDecoder.Wrapped?> {
-        try Optional<RowDecoder.Wrapped>.fetchSet(db, self)
     }
 }

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -82,48 +82,10 @@ extension DatabaseValueConvertible {
             context: RowDecodingContext(row: row, key: .columnIndex(index)))
     }
     
-    static func decodeIfPresent(
-        fromDatabaseValue dbValue: DatabaseValue,
-        context: @autoclosure () -> RowDecodingContext)
-    throws -> Self?
-    {
-        // Use fromDatabaseValue before checking for null: this allows DatabaseValue to convert NULL to .null.
-        if let value = fromDatabaseValue(dbValue) {
-            return value
-        } else if dbValue.isNull {
-            return nil
-        } else {
-            throw RowDecodingError.valueMismatch(Self.self, context: context(), databaseValue: dbValue)
-        }
-    }
-    
-    static func decodeIfPresent(
-        fromStatement sqliteStatement: SQLiteStatement,
-        atUncheckedIndex index: Int32,
-        context: @autoclosure () -> RowDecodingContext)
-    throws -> Self?
-    {
-        let dbValue = DatabaseValue(sqliteStatement: sqliteStatement, index: index)
-        if let value = fromDatabaseValue(dbValue) {
-            return value
-        } else if dbValue.isNull {
-            return nil
-        } else {
-            throw RowDecodingError.valueMismatch(Self.self, context: context(), databaseValue: dbValue)
-        }
-    }
-    
+    // Support for Decodable
     @usableFromInline
     static func decodeIfPresent(fromRow row: Row, atUncheckedIndex index: Int) throws -> Self? {
-        if let sqliteStatement = row.sqliteStatement {
-            return try decodeIfPresent(
-                fromStatement: sqliteStatement,
-                atUncheckedIndex: Int32(index),
-                context: RowDecodingContext(row: row, key: .columnIndex(index)))
-        }
-        return try decodeIfPresent(
-            fromDatabaseValue: row.impl.databaseValue(atUncheckedIndex: index),
-            context: RowDecodingContext(row: row, key: .columnIndex(index)))
+        try Optional<Self>.decode(fromRow: row, atUncheckedIndex: index)
     }
 }
 

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -223,10 +223,21 @@ extension Row {
     /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
     /// righmost column.
     ///
-    /// This method crashes if the fetched SQLite value is NULL, or if the
-    /// SQLite value can not be converted to `Value`.
+    /// For example:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 42")!
+    ///     let score: Int = row[0] // 42
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 'Alice'")!
+    ///     let name: String = row[0] // "Alice"
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT NULL")!
+    ///     let name: String? = row[0] // nil
     @inlinable
     public subscript<Value: DatabaseValueConvertible>(_ index: Int) -> Value {
+        // TODO GRDB6: don't crash on decoding errors
         try! decode(Value.self, atIndex: index)
     }
     
@@ -235,15 +246,26 @@ extension Row {
     /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
     /// righmost column.
     ///
-    /// This method crashes if the fetched SQLite value is NULL, or if the
-    /// SQLite value can not be converted to `Value`.
-    ///
     /// This method exists as an optimization opportunity for types that adopt
-    /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
+    /// `StatementColumnConvertible`. It can trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    ///
+    /// For example:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 42")!
+    ///     let score: Int = row[0] // 42
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 'Alice'")!
+    ///     let name: String = row[0] // "Alice"
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT NULL")!
+    ///     let name: String? = row[0] // nil
     @inline(__always)
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ index: Int) -> Value {
+        // TODO GRDB6: don't crash on decoding errors
         try! decode(Value.self, atIndex: index)
     }
     
@@ -273,10 +295,23 @@ extension Row {
     /// Column name lookup is case-insensitive, and when several columns have
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, a fatal error is raised.
+    /// For example:
     ///
-    /// This method crashes if the fetched SQLite value is NULL, or if the
-    /// SQLite value can not be converted to `Value`.
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    ///     let score: Int = row["score"] // 42
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    ///     let name: String = row["name"] // "Alice"
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    ///     let name: String? = row["name"] // nil
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT ...")!
+    ///     let name: String? = row["missing"] // nil
     @inlinable
     public subscript<Value: DatabaseValueConvertible>(_ columnName: String) -> Value {
         try! decode(Value.self, forKey: columnName)
@@ -287,20 +322,33 @@ extension Row {
     /// Column name lookup is case-insensitive, and when several columns have
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, a fatal error is raised.
-    ///
-    /// This method crashes if the fetched SQLite value is NULL, or if the
-    /// SQLite value can not be converted to `Value`.
-    ///
     /// This method exists as an optimization opportunity for types that adopt
-    /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
+    /// `StatementColumnConvertible`. It can trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    ///
+    /// For example:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    ///     let score: Int = row["score"] // 42
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    ///     let name: String = row["name"] // "Alice"
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    ///     let name: String? = row["name"] // nil
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT ...")!
+    ///     let name: String? = row["missing"] // nil
     @inlinable
     public subscript<Value: DatabaseValueConvertible & StatementColumnConvertible>(_ columnName: String) -> Value {
         try! decode(Value.self, forKey: columnName)
     }
     
-    /// Returns Int64, Double, String, NSData or nil, depending on the value
+    /// Returns Int64, Double, String, Data or nil, depending on the value
     /// stored at the given column.
     ///
     /// Column name lookup is case-insensitive, and when several columns have
@@ -316,10 +364,23 @@ extension Row {
     /// Column name lookup is case-insensitive, and when several columns have
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, a fatal error is raised.
+    /// For example:
     ///
-    /// This method crashes if the fetched SQLite value is NULL, or if the
-    /// SQLite value can not be converted to `Value`.
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    ///     let score: Int = row[Column("score")] // 42
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    ///     let name: String = row[Column("name")] // "Alice"
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    ///     let name: String? = row[Column("name")] // nil
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT ...")!
+    ///     let name: String? = row[Column("missing")] // nil
     @inlinable
     public subscript<Value: DatabaseValueConvertible, Column: ColumnExpression>(_ column: Column) -> Value {
         try! decode(Value.self, forKey: column.name)
@@ -330,14 +391,27 @@ extension Row {
     /// Column name lookup is case-insensitive, and when several columns have
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, a fatal error is raised.
-    ///
-    /// This method crashes if the fetched SQLite value is NULL, or if the
-    /// SQLite value can not be converted to `Value`.
-    ///
     /// This method exists as an optimization opportunity for types that adopt
-    /// StatementColumnConvertible. It *may* trigger SQLite built-in conversions
+    /// `StatementColumnConvertible`. It can trigger SQLite built-in conversions
     /// (see <https://www.sqlite.org/datatype3.html>).
+    ///
+    /// For example:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    ///     let score: Int = row[Column("score")] // 42
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    ///     let name: String = row[Column("name")] // "Alice"
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    ///     let name: String? = row[Column("name")] // nil
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    ///     let row = try Row.fetchOne(db, sql: "SELECT ...")!
+    ///     let name: String? = row[Column("missing")] // nil
     @inlinable
     public subscript<Value, Column>(_ column: Column)
     -> Value
@@ -362,7 +436,7 @@ extension Row {
         try! decodeDataNoCopyIfPresent(atIndex: index)
     }
     
-    /// Returns the optional Data at given column.
+    /// Returns the optional `Data` at given column.
     ///
     /// Column name lookup is case-insensitive, and when several columns have
     /// the same name, the leftmost column is considered.
@@ -377,13 +451,13 @@ extension Row {
         try! decodeDataNoCopyIfPresent(forKey: columnName)
     }
     
-    /// Returns the optional `NSData` at given column.
+    /// Returns the optional `Data` at given column.
     ///
     /// Column name lookup is case-insensitive, and when several columns have
     /// the same name, the leftmost column is considered.
     ///
     /// If the column is missing or if the SQLite value is NULL, the result is
-    /// nil. If the SQLite value can not be converted to NSData, a fatal error
+    /// nil. If the SQLite value can not be converted to Data, a fatal error
     /// is raised.
     ///
     /// The returned data does not owns its bytes: it must not be used longer

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -611,24 +611,6 @@ extension Row {
     /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
     /// righmost column.
     ///
-    /// If the SQLite value is NULL, the result is nil. Otherwise the SQLite
-    /// value is converted to the requested type `Value`. If the conversion
-    /// fail, a `RowDecodingError` is thrown.
-    @inlinable
-    func decodeIfPresent<Value: DatabaseValueConvertible>(
-        _ type: Value.Type = Value.self,
-        atIndex index: Int)
-    throws -> Value?
-    {
-        _checkIndex(index)
-        return try Value.decodeIfPresent(fromRow: self, atUncheckedIndex: index)
-    }
-    
-    /// Returns the value at given index, converted to the requested type.
-    ///
-    /// Indexes span from 0 for the leftmost column to (row.count - 1) for the
-    /// righmost column.
-    ///
     /// If the SQLite value is NULL, or if the conversion fails, a
     /// `RowDecodingError` is thrown.
     @inlinable
@@ -639,26 +621,6 @@ extension Row {
     {
         _checkIndex(index)
         return try Value.decode(fromRow: self, atUncheckedIndex: index)
-    }
-    
-    /// Returns the value at given column, converted to the requested type.
-    ///
-    /// Column name lookup is case-insensitive, and when several columns have
-    /// the same name, the leftmost column is considered.
-    ///
-    /// If the column is missing or if the SQLite value is NULL, the result is
-    /// nil. Otherwise the SQLite value is converted to the requested type
-    /// `Value`. If the conversion fails, a `RowDecodingError` is thrown.
-    @inlinable
-    func decodeIfPresent<Value: DatabaseValueConvertible>(
-        _ type: Value.Type = Value.self,
-        forKey columnName: String)
-    throws -> Value?
-    {
-        guard let index = index(forColumn: columnName) else {
-            return nil
-        }
-        return try Value.decodeIfPresent(fromRow: self, atUncheckedIndex: index)
     }
     
     /// Returns the value at given column, converted to the requested type.
@@ -1981,7 +1943,7 @@ extension RowImpl {
     
     func fastDecodeDataNoCopyIfPresent(atUncheckedIndex index: Int) throws -> Data? {
         // unless customized, copy data (see StatementRowImpl and AdaptedRowImpl for customization)
-        return try Data.decodeIfPresent(
+        return try Optional<Data>.decode(
             fromDatabaseValue: databaseValue(atUncheckedIndex: index),
             context: RowDecodingContext(row: Row(impl: self), key: .columnIndex(index)))
     }

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -712,7 +712,7 @@ extension Row {
     throws -> Value
     {
         guard let index = index(forColumn: columnName) else {
-            if let value = Value.fromMissingColumn() {
+            if let value = Value._fromMissingColumn() {
                 return value
             } else {
                 throw RowDecodingError.columnNotFound(columnName, context: RowDecodingContext(row: self))
@@ -766,7 +766,7 @@ extension Row {
     throws -> Value
     {
         guard let index = index(forColumn: columnName) else {
-            if let value = Value.fromMissingColumn() {
+            if let value = Value._fromMissingColumn() {
                 return value
             } else {
                 throw RowDecodingError.columnNotFound(columnName, context: RowDecodingContext(row: self))

--- a/GRDB/Core/RowAdapter.swift
+++ b/GRDB/Core/RowAdapter.swift
@@ -501,15 +501,6 @@ struct AdaptedRowImpl: RowImpl {
         return try Value.fastDecode(fromRow: base, atUncheckedIndex: mappedIndex)
     }
     
-    func fastDecodeIfPresent<Value: DatabaseValueConvertible & StatementColumnConvertible>(
-        _ type: Value.Type,
-        atUncheckedIndex index: Int)
-    throws -> Value?
-    {
-        let mappedIndex = mapping.baseColumnIndex(atMappingIndex: index)
-        return try Value.fastDecodeIfPresent(fromRow: base, atUncheckedIndex: mappedIndex)
-    }
-    
     func fastDecodeDataNoCopy(atUncheckedIndex index: Int) throws -> Data {
         let mappedIndex = mapping.baseColumnIndex(atMappingIndex: index)
         return try base.impl.fastDecodeDataNoCopy(atUncheckedIndex: mappedIndex)

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -273,7 +273,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         adapter: RowAdapter? = nil)
     throws -> Self?
     {
-        // fetchOne returns nil if there is no row, or if there is a row with a null value
+        // fetchOne handles both a missing row, and one row with a NULL value.
         let cursor = try FastDatabaseValueCursor<Self?>(
             statement: statement,
             arguments: arguments,

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -120,23 +120,6 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         }
     }
 
-//    @inline(__always)
-//    @inlinable
-//    static func fastDecodeIfPresent(
-//        fromStatement sqliteStatement: SQLiteStatement,
-//        atUncheckedIndex index: Int32,
-//        context: @autoclosure () -> RowDecodingContext)
-//    throws -> Self?
-//    {
-//        if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
-//            return nil
-//        }
-//        guard let value = fromSQLiteStatement(sqliteStatement, at: index) else {
-//            try _valueMismatch(fromStatement: sqliteStatement, atUncheckedIndex: index, context: context())
-//        }
-//        return value
-//    }
-    
     // Support for Decodable
     @inline(__always)
     @inlinable

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -1,3 +1,21 @@
+/// Implementation details of `StatementColumnConvertible`.
+///
+/// :nodoc:
+public protocol _StatementColumnConvertible {
+    /// Creates a value from a raw SQLite statement pointer, if possible.
+    ///
+    /// This method can be called with a NULL database value.
+    ///
+    /// - parameters:
+    ///     - sqliteStatement: A pointer to an SQLite statement.
+    ///     - index: The column index.
+    /// - returns: A decoded value, or, if decoding is impossible, nil.
+    static func _fromStatement(
+        _ sqliteStatement: SQLiteStatement,
+        atUncheckedIndex index: Int32)
+    -> Self?
+}
+
 /// The `StatementColumnConvertible` protocol grants access to the low-level C
 /// interface that extracts values from query results:
 /// <https://www.sqlite.org/c3ref/column_blob.html>. It can bring performance
@@ -18,28 +36,39 @@
 ///             score = row["score"]              // there
 ///         }
 ///     }
-public protocol StatementColumnConvertible {
-    
-    /// Initializes a value from a raw SQLite statement pointer, if possible.
+public protocol StatementColumnConvertible: _StatementColumnConvertible {
+    /// Creates a value from a raw SQLite statement pointer, if possible.
     ///
     /// For example, here is the how Int64 adopts StatementColumnConvertible:
     ///
     ///     extension Int64: StatementColumnConvertible {
-    ///         init?(sqliteStatement: SQLiteStatement, index: Int32) {
+    ///         init(sqliteStatement: SQLiteStatement, index: Int32) {
     ///             self = sqlite3_column_int64(sqliteStatement, index)
     ///         }
     ///     }
     ///
-    /// This initializer is never called for NULL database values. Just return
-    /// `nil` for failed conversions: GRDB will interpret a nil result as a
-    /// decoding failure.
-    ///
     /// See <https://www.sqlite.org/c3ref/column_blob.html> for more information.
     ///
+    /// - precondition: This initializer must not be called with NULL database
+    ///   values.
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
+    /// - returns: A decoded value, or, if decoding is impossible, nil.
     init?(sqliteStatement: SQLiteStatement, index: Int32)
+}
+
+extension _StatementColumnConvertible where Self: StatementColumnConvertible {
+    // Default implementation fails on decoding NULL.
+    /// :nodoc:
+    @inline(__always)
+    @inlinable
+    public static func _fromStatement(_ sqliteStatement: SQLiteStatement, atUncheckedIndex index: Int32) -> Self? {
+        if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
+            return nil
+        }
+        return self.init(sqliteStatement: sqliteStatement, index: index)
+    }
 }
 
 // MARK: - Conversions
@@ -62,22 +91,6 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     @inline(__always)
     @inlinable
     static func fastDecode(
-        fromStatement sqliteStatement: SQLiteStatement,
-        atUncheckedIndex index: Int32,
-        context: @autoclosure () -> RowDecodingContext)
-    throws -> Self
-    {
-        guard sqlite3_column_type(sqliteStatement, index) != SQLITE_NULL,
-              let value = self.init(sqliteStatement: sqliteStatement, index: index)
-        else {
-            try _valueMismatch(fromStatement: sqliteStatement, atUncheckedIndex: index, context: context())
-        }
-        return value
-    }
-    
-    @inline(__always)
-    @inlinable
-    static func fastDecode(
         fromRow row: Row,
         atUncheckedIndex index: Int)
     throws -> Self
@@ -94,21 +107,37 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     
     @inline(__always)
     @inlinable
-    static func fastDecodeIfPresent(
+    static func fastDecode(
         fromStatement sqliteStatement: SQLiteStatement,
         atUncheckedIndex index: Int32,
         context: @autoclosure () -> RowDecodingContext)
-    throws -> Self?
+    throws -> Self
     {
-        if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
-            return nil
-        }
-        guard let value = self.init(sqliteStatement: sqliteStatement, index: index) else {
+        if let value = _fromStatement(sqliteStatement, atUncheckedIndex: index) {
+            return value
+        } else {
             try _valueMismatch(fromStatement: sqliteStatement, atUncheckedIndex: index, context: context())
         }
-        return value
     }
+
+//    @inline(__always)
+//    @inlinable
+//    static func fastDecodeIfPresent(
+//        fromStatement sqliteStatement: SQLiteStatement,
+//        atUncheckedIndex index: Int32,
+//        context: @autoclosure () -> RowDecodingContext)
+//    throws -> Self?
+//    {
+//        if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
+//            return nil
+//        }
+//        guard let value = fromSQLiteStatement(sqliteStatement, at: index) else {
+//            try _valueMismatch(fromStatement: sqliteStatement, atUncheckedIndex: index, context: context())
+//        }
+//        return value
+//    }
     
+    // Support for Decodable
     @inline(__always)
     @inlinable
     static func fastDecodeIfPresent(
@@ -116,14 +145,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
         atUncheckedIndex index: Int)
     throws -> Self?
     {
-        if let sqliteStatement = row.sqliteStatement {
-            return try fastDecodeIfPresent(
-                fromStatement: sqliteStatement,
-                atUncheckedIndex: Int32(index),
-                context: RowDecodingContext(row: row, key: .columnIndex(index)))
-        }
-        // Support for fast decoding from adapted rows
-        return try row.fastDecodeIfPresent(Self.self, atUncheckedIndex: index)
+        try Optional<Self>.fastDecode(fromRow: row, atUncheckedIndex: index)
     }
 }
 
@@ -171,55 +193,6 @@ where Value: DatabaseValueConvertible & StatementColumnConvertible
     public func _element(sqliteStatement: SQLiteStatement) -> Value {
         // TODO GRDB6: don't crash on decoding errors
         try! Value.fastDecode(
-            fromStatement: sqliteStatement,
-            atUncheckedIndex: columnIndex,
-            context: RowDecodingContext(statement: statement, index: Int(columnIndex)))
-    }
-}
-
-/// A cursor of optional database values extracted from a single column.
-/// For example:
-///
-///     try dbQueue.read { db in
-///         let emails: FastNullableDatabaseValueCursor<String> =
-///             try Optional<String>.fetchCursor(db, sql: "SELECT email FROM player")
-///         while let email = emails.next() { // String?
-///             print(email ?? "<NULL>")
-///         }
-///     }
-public final class FastNullableDatabaseValueCursor<Value>: DatabaseCursor
-where Value: DatabaseValueConvertible & StatementColumnConvertible
-{
-    public typealias Element = Value?
-    public let statement: Statement
-    /// :nodoc:
-    public var _isDone = false
-    @usableFromInline let columnIndex: Int32
-    
-    init(statement: Statement, arguments: StatementArguments? = nil, adapter: RowAdapter? = nil) throws {
-        self.statement = statement
-        if let adapter = adapter {
-            // adapter may redefine the index of the leftmost column
-            columnIndex = try Int32(adapter.baseColumnIndex(atIndex: 0, layout: statement))
-        } else {
-            columnIndex = 0
-        }
-        
-        // Assume cursor is created for immediate iteration: reset and set arguments
-        try statement.reset(withArguments: arguments)
-    }
-    
-    deinit {
-        // Statement reset fails when sqlite3_step has previously failed.
-        // Just ignore reset error.
-        try? statement.reset()
-    }
-    
-    /// :nodoc:
-    @inlinable
-    public func _element(sqliteStatement: SQLiteStatement) -> Value? {
-        // TODO GRDB6: don't crash on decoding errors
-        try! Value.fastDecodeIfPresent(
             fromStatement: sqliteStatement,
             atUncheckedIndex: columnIndex,
             context: RowDecodingContext(statement: statement, index: Int(columnIndex)))
@@ -301,7 +274,7 @@ extension DatabaseValueConvertible where Self: StatementColumnConvertible {
     throws -> Self?
     {
         // fetchOne returns nil if there is no row, or if there is a row with a null value
-        let cursor = try FastNullableDatabaseValueCursor<Self>(
+        let cursor = try FastDatabaseValueCursor<Self?>(
             statement: statement,
             arguments: arguments,
             adapter: adapter)
@@ -570,305 +543,5 @@ extension FetchRequest where RowDecoder: DatabaseValueConvertible & StatementCol
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public func fetchSet(_ db: Database) throws -> Set<RowDecoder> {
         try RowDecoder.fetchSet(db, self)
-    }
-}
-
-/// Swift's Optional comes with built-in methods that allow to fetch cursors
-/// and arrays of optional DatabaseValueConvertible:
-///
-///     try Optional<String>.fetchCursor(db, sql: "SELECT name FROM ...", arguments:...) // Cursor of String?
-///     try Optional<String>.fetchAll(db, sql: "SELECT name FROM ...", arguments:...)    // [String?]
-///
-///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-///     try Optional<String>.fetchCursor(statement, arguments:...) // Cursor of String?
-///     try Optional<String>.fetchAll(statement, arguments:...)    // [String?]
-///
-/// DatabaseValueConvertible is adopted by Bool, Int, String, etc.
-extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible {
-    
-    // MARK: Fetching From Prepared Statement
-    
-    /// Returns a cursor over optional values fetched from a prepared statement.
-    ///
-    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-    ///     let names = try Optional<String>.fetchCursor(statement) // Cursor of String?
-    ///     while let name = try names.next() { // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A cursor over fetched optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor(
-        _ statement: Statement,
-        arguments: StatementArguments? = nil,
-        adapter: RowAdapter? = nil)
-    throws -> FastNullableDatabaseValueCursor<Wrapped>
-    {
-        try FastNullableDatabaseValueCursor(statement: statement, arguments: arguments, adapter: adapter)
-    }
-    
-    /// Returns an array of optional values fetched from a prepared statement.
-    ///
-    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-    ///     let names = try Optional<String>.fetchAll(statement)  // [String?]
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: An array of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll(
-        _ statement: Statement,
-        arguments: StatementArguments? = nil,
-        adapter: RowAdapter? = nil)
-    throws -> [Wrapped?]
-    {
-        try Array(fetchCursor(statement, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible & Hashable {
-    /// Returns a set of optional values fetched from a prepared statement.
-    ///
-    ///     let statement = try db.makeStatement(sql: "SELECT name FROM ...")
-    ///     let names = try Optional<String>.fetchSet(statement)  // Set<String?>
-    ///
-    /// - parameters:
-    ///     - statement: The statement to run.
-    ///     - arguments: Optional statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A set of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet(
-        _ statement: Statement,
-        arguments: StatementArguments? = nil,
-        adapter: RowAdapter? = nil)
-    throws -> Set<Wrapped?>
-    {
-        try Set(fetchCursor(statement, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible {
-    
-    // MARK: Fetching From SQL
-    
-    /// Returns a cursor over optional values fetched from an SQL query.
-    ///
-    ///     let names = try Optional<String>.fetchCursor(db, sql: "SELECT name FROM ...") // Cursor of String?
-    ///     while let name = try names.next() { // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A cursor over fetched optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor(
-        _ db: Database,
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-    throws -> FastNullableDatabaseValueCursor<Wrapped>
-    {
-        try fetchCursor(db, SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
-    }
-    
-    /// Returns an array of optional values fetched from an SQL query.
-    ///
-    ///     let names = try Optional<String>.fetchAll(db, sql: "SELECT name FROM ...") // [String?]
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: An array of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll(
-        _ db: Database,
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-    throws -> [Wrapped?]
-    {
-        try fetchAll(db, SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible & Hashable {
-    /// Returns a set of optional values fetched from an SQL query.
-    ///
-    ///     let names = try Optional<String>.fetchSet(db, sql: "SELECT name FROM ...") // Set<String?>
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - sql: An SQL query.
-    ///     - arguments: Statement arguments.
-    ///     - adapter: Optional RowAdapter
-    /// - returns: A set of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet(
-        _ db: Database,
-        sql: String,
-        arguments: StatementArguments = StatementArguments(),
-        adapter: RowAdapter? = nil)
-    throws -> Set<Wrapped?>
-    {
-        try fetchSet(db, SQLRequest(sql: sql, arguments: arguments, adapter: adapter))
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible {
-    
-    // MARK: Fetching From FetchRequest
-    
-    /// Returns a cursor over optional values fetched from a fetch request.
-    ///
-    ///     let request = Player.select(Column("name"))
-    ///     let names = try Optional<String>.fetchCursor(db, request) // Cursor of String?
-    ///     while let name = try names.next() { // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: A cursor over fetched optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor<R: FetchRequest>(_ db: Database, _ request: R)
-    throws -> FastNullableDatabaseValueCursor<Wrapped>
-    {
-        let request = try request.makePreparedRequest(db, forSingleResult: false)
-        return try fetchCursor(request.statement, adapter: request.adapter)
-    }
-    
-    /// Returns an array of optional values fetched from a fetch request.
-    ///
-    ///     let request = Player.select(Column("name"))
-    ///     let names = try Optional<String>.fetchAll(db, request) // [String?]
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: An array of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll<R: FetchRequest>(_ db: Database, _ request: R) throws -> [Wrapped?] {
-        let request = try request.makePreparedRequest(db, forSingleResult: false)
-        return try fetchAll(request.statement, adapter: request.adapter)
-    }
-}
-
-extension Optional where Wrapped: DatabaseValueConvertible & StatementColumnConvertible & Hashable {
-    /// Returns a set of optional values fetched from a fetch request.
-    ///
-    ///     let request = Player.select(Column("name"))
-    ///     let names = try Optional<String>.fetchSet(db, request) // Set<String?>
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - request: A FetchRequest.
-    /// - returns: A set of optional values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet<R: FetchRequest>(_ db: Database, _ request: R) throws -> Set<Wrapped?> {
-        let request = try request.makePreparedRequest(db, forSingleResult: false)
-        return try fetchSet(request.statement, adapter: request.adapter)
-    }
-}
-
-extension FetchRequest
-where
-    RowDecoder: _OptionalProtocol,
-    RowDecoder.Wrapped: DatabaseValueConvertible & StatementColumnConvertible
-{
-    
-    // MARK: Fetching Optional values
-    
-    /// A cursor over fetched optional values.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches Optional<String>
-    ///     let strings = try request.fetchCursor(db) // Cursor of String?
-    ///     while let string = try strings.next() {   // String?
-    ///         ...
-    ///     }
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: A cursor over fetched values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchCursor(_ db: Database) throws -> FastNullableDatabaseValueCursor<RowDecoder.Wrapped> {
-        try Optional<RowDecoder.Wrapped>.fetchCursor(db, self)
-    }
-    
-    /// An array of fetched optional values.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches Optional<String>
-    ///     let strings = try request.fetchAll(db) // [String?]
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: An array of values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchAll(_ db: Database) throws -> [RowDecoder.Wrapped?] {
-        try Optional<RowDecoder.Wrapped>.fetchAll(db, self)
-    }
-    
-    /// The first fetched value.
-    ///
-    /// The result is nil if the request returns no row, or if no value can be
-    /// extracted from the first row.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches String?
-    ///     let string = try request.fetchOne(db) // String?
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: An optional value.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchOne(_ db: Database) throws -> RowDecoder.Wrapped? {
-        try RowDecoder.Wrapped.fetchOne(db, self)
-    }
-}
-
-extension FetchRequest
-where
-    RowDecoder: _OptionalProtocol,
-    RowDecoder.Wrapped: DatabaseValueConvertible & StatementColumnConvertible & Hashable
-{
-    /// A set of fetched optional values.
-    ///
-    ///     let request: ... // Some FetchRequest that fetches Optional<String>
-    ///     let strings = try request.fetchSet(db) // Set<String?>
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: A set of values.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchSet(_ db: Database) throws -> Set<RowDecoder.Wrapped?> {
-        try Optional<RowDecoder.Wrapped>.fetchSet(db, self)
     }
 }

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -1,21 +1,3 @@
-/// Implementation details of `StatementColumnConvertible`.
-///
-/// :nodoc:
-public protocol _StatementColumnConvertible {
-    /// Creates a value from a raw SQLite statement pointer, if possible.
-    ///
-    /// This method can be called with a NULL database value.
-    ///
-    /// - parameters:
-    ///     - sqliteStatement: A pointer to an SQLite statement.
-    ///     - index: The column index.
-    /// - returns: A decoded value, or, if decoding is impossible, nil.
-    static func _fromStatement(
-        _ sqliteStatement: SQLiteStatement,
-        atUncheckedIndex index: Int32)
-    -> Self?
-}
-
 /// The `StatementColumnConvertible` protocol grants access to the low-level C
 /// interface that extracts values from query results:
 /// <https://www.sqlite.org/c3ref/column_blob.html>. It can bring performance
@@ -36,7 +18,21 @@ public protocol _StatementColumnConvertible {
 ///             score = row["score"]              // there
 ///         }
 ///     }
-public protocol StatementColumnConvertible: _StatementColumnConvertible {
+public protocol StatementColumnConvertible {
+    /// Creates a value from a raw SQLite statement pointer, if possible.
+    ///
+    /// This method can be called with a NULL database value.
+    ///
+    /// - parameters:
+    ///     - sqliteStatement: A pointer to an SQLite statement.
+    ///     - index: The column index.
+    /// - returns: A decoded value, or, if decoding is impossible, nil.
+    /// :nodoc:
+    static func _fromStatement(
+        _ sqliteStatement: SQLiteStatement,
+        atUncheckedIndex index: Int32)
+    -> Self?
+    
     /// Creates a value from a raw SQLite statement pointer, if possible.
     ///
     /// For example, here is the how Int64 adopts StatementColumnConvertible:
@@ -58,8 +54,9 @@ public protocol StatementColumnConvertible: _StatementColumnConvertible {
     init?(sqliteStatement: SQLiteStatement, index: Int32)
 }
 
-extension _StatementColumnConvertible where Self: StatementColumnConvertible {
-    // Default implementation fails on decoding NULL.
+extension StatementColumnConvertible {
+    /// Default implementation fails on decoding NULL.
+    /// `Optional` overrides this default behavior.
     /// :nodoc:
     @inline(__always)
     @inlinable

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -72,9 +72,6 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
     @inline(__always)
     @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
-        if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
-            return nil
-        }
         guard let cString = sqlite3_column_text(sqliteStatement, index) else {
             return nil
         }

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -72,6 +72,9 @@ public struct DatabaseDateComponents: DatabaseValueConvertible, StatementColumnC
     @inline(__always)
     @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
+        if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
+            return nil
+        }
         guard let cString = sqlite3_column_text(sqliteStatement, index) else {
             return nil
         }

--- a/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+RawRepresentable.swift
+++ b/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+RawRepresentable.swift
@@ -10,6 +10,8 @@ extension SQLOrderingTerm where Self: RawRepresentable, Self.RawValue: SQLOrderi
     }
 }
 
+extension SQLSpecificExpressible where Self: RawRepresentable, Self.RawValue: SQLSpecificExpressible { }
+
 extension SQLExpressible where Self: RawRepresentable, Self.RawValue: SQLExpressible {
     /// Returns the raw value as an SQL expression.
     public var sqlExpression: SQLExpression {

--- a/GRDB/Core/Support/StandardLibrary/Optional.swift
+++ b/GRDB/Core/Support/StandardLibrary/Optional.swift
@@ -1,0 +1,97 @@
+extension Optional: StatementBinding where Wrapped: StatementBinding {
+    public func bind(to sqliteStatement: SQLiteStatement, at index: CInt) -> CInt {
+        switch self {
+        case .none:
+            return sqlite3_bind_null(sqliteStatement, index)
+        case let .some(value):
+            return value.bind(to: sqliteStatement, at: index)
+        }
+    }
+}
+
+extension Optional: SQLExpressible where Wrapped: SQLExpressible {
+    public var sqlExpression: SQLExpression {
+        switch self {
+        case .none:
+            return .null
+        case let .some(value):
+            return value.sqlExpression
+        }
+    }
+}
+
+extension Optional: SQLOrderingTerm where Wrapped: SQLOrderingTerm {
+    public var sqlOrdering: SQLOrdering {
+        switch self {
+        case .none:
+            return .expression(.null)
+        case let .some(value):
+            return value.sqlOrdering
+        }
+    }
+}
+
+extension Optional: SQLSelectable where Wrapped: SQLSelectable {
+    public var sqlSelection: SQLSelection {
+        switch self {
+        case .none:
+            return .expression(.null)
+        case let .some(value):
+            return value.sqlSelection
+        }
+    }
+}
+
+extension Optional: SQLSpecificExpressible where Wrapped: SQLSpecificExpressible { }
+
+extension Optional: DatabaseValueConvertible where Wrapped: DatabaseValueConvertible {
+    public var databaseValue: DatabaseValue {
+        switch self {
+        case .none:
+            return .null
+        case let .some(value):
+            return value.databaseValue
+        }
+    }
+    
+    public static func fromMissingColumn() -> Self? {
+        .some(.none) // success
+    }
+    
+    public static func fromDatabaseValue(_ dbValue: DatabaseValue) -> Self? {
+        if let value = Wrapped.fromDatabaseValue(dbValue) {
+            // Valid value
+            return value
+        } else if dbValue.isNull {
+            // NULL
+            return .some(.none)
+        } else {
+            // Invalid value
+            return .none
+        }
+    }
+}
+
+extension Optional: _StatementColumnConvertible where Wrapped: StatementColumnConvertible {
+    /// :nodoc:
+    @inline(__always)
+    @inlinable
+    public static func _fromStatement(_ sqliteStatement: SQLiteStatement, atUncheckedIndex index: Int32) -> Self? {
+        if let value = Wrapped._fromStatement(sqliteStatement, atUncheckedIndex: index) {
+            // Valid value
+            return value
+        } else if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
+            // NULL
+            return .some(.none)
+        } else {
+            // Invalid value
+            return .none
+        }
+    }
+}
+
+extension Optional: StatementColumnConvertible where Wrapped: StatementColumnConvertible {
+    public init?(sqliteStatement: SQLiteStatement, index: Int32) {
+        self = Wrapped(sqliteStatement: sqliteStatement, index: index)
+    }
+}

--- a/GRDB/Core/Support/StandardLibrary/Optional.swift
+++ b/GRDB/Core/Support/StandardLibrary/Optional.swift
@@ -54,7 +54,8 @@ extension Optional: DatabaseValueConvertible where Wrapped: DatabaseValueConvert
         }
     }
     
-    public static func fromMissingColumn() -> Self? {
+    /// :nodoc:
+    public static func _fromMissingColumn() -> Self? {
         .some(.none) // success
     }
     

--- a/GRDB/Core/Support/StandardLibrary/Optional.swift
+++ b/GRDB/Core/Support/StandardLibrary/Optional.swift
@@ -73,7 +73,7 @@ extension Optional: DatabaseValueConvertible where Wrapped: DatabaseValueConvert
     }
 }
 
-extension Optional: _StatementColumnConvertible where Wrapped: StatementColumnConvertible {
+extension Optional: StatementColumnConvertible where Wrapped: StatementColumnConvertible {
     /// :nodoc:
     @inline(__always)
     @inlinable
@@ -89,9 +89,7 @@ extension Optional: _StatementColumnConvertible where Wrapped: StatementColumnCo
             return .none
         }
     }
-}
-
-extension Optional: StatementColumnConvertible where Wrapped: StatementColumnConvertible {
+    
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
         guard let value = Wrapped(sqliteStatement: sqliteStatement, index: index) else {
             return nil

--- a/GRDB/Core/Support/StandardLibrary/Optional.swift
+++ b/GRDB/Core/Support/StandardLibrary/Optional.swift
@@ -92,6 +92,9 @@ extension Optional: _StatementColumnConvertible where Wrapped: StatementColumnCo
 
 extension Optional: StatementColumnConvertible where Wrapped: StatementColumnConvertible {
     public init?(sqliteStatement: SQLiteStatement, index: Int32) {
-        self = Wrapped(sqliteStatement: sqliteStatement, index: index)
+        guard let value = Wrapped(sqliteStatement: sqliteStatement, index: index) else {
+            return nil
+        }
+        self = .some(value)
     }
 }

--- a/GRDB/Core/Support/StandardLibrary/StatementColumnConvertible+RawRepresentable.swift
+++ b/GRDB/Core/Support/StandardLibrary/StatementColumnConvertible+RawRepresentable.swift
@@ -1,0 +1,23 @@
+/// `StatementColumnConvertible` is free for `RawRepresentable` types whose raw
+/// value is itself `StatementColumnConvertible`.
+///
+///     // If the RawValue adopts StatementColumnConvertible...
+///     enum Color : Int {
+///         case red
+///         case white
+///         case rose
+///     }
+///
+///     // ... then the RawRepresentable type can freely
+///     // adopt StatementColumnConvertible:
+///     extension Color: StatementColumnConvertible { }
+extension StatementColumnConvertible where Self: RawRepresentable, Self.RawValue: StatementColumnConvertible {
+    @inline(__always)
+    @inlinable
+    public init?(sqliteStatement: SQLiteStatement, index: Int32) {
+        guard let rawValue = RawValue(sqliteStatement: sqliteStatement, index: index) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+}

--- a/GRDB/Fixits.swift
+++ b/GRDB/Fixits.swift
@@ -63,10 +63,16 @@ extension DatabaseUUIDEncodingStrategy {
     public static var string: Self { preconditionFailure() }
 }
 
+@available(*, unavailable, message: "FastNullableDatabaseValueCursor<T> has been replaced with FastDatabaseValueCursor<T?>")
+typealias FastNullableDatabaseValueCursor<T: DatabaseValueConvertible & StatementColumnConvertible> = FastDatabaseValueCursor<T?>
+
 extension FilteredRequest {
     @available(*, unavailable, message: "Did you mean filter(id:) or filter(key:)? If not, prefer filter(value.databaseValue) instead. See also none().")
     public func filter(_ predicate: SQLExpressible) -> Self { preconditionFailure() }
 }
+
+@available(*, unavailable, message: "NullableDatabaseValueCursor<T> has been replaced with DatabaseValueCursor<T?>")
+typealias NullableDatabaseValueCursor<T: DatabaseValueConvertible> = DatabaseValueCursor<T?>
 
 @available(*, unavailable, renamed: "Statement")
 public typealias SelectStatement = Statement

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -185,27 +185,6 @@ where RowDecoder: Identifiable,
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension QueryInterfaceRequest
-where RowDecoder: Identifiable,
-      RowDecoder.ID: _OptionalProtocol,
-      RowDecoder.ID.Wrapped: DatabaseValueConvertible
-{
-    /// Creates a request which selects the primary key.
-    ///
-    ///     // SELECT id FROM player WHERE ...
-    ///     let request = try Player.filter(...).selectID()
-    public func selectID() -> QueryInterfaceRequest<RowDecoder.ID.Wrapped> {
-        select { db in
-            let primaryKey = try db.primaryKey(self.databaseTableName)
-            GRDBPrecondition(
-                primaryKey.columns.count == 1,
-                "selectID requires a single-column primary key in the table \(self.databaseTableName)")
-            return [Column(primaryKey.columns[0])]
-        }.asRequest(of: RowDecoder.ID.Wrapped.self)
-    }
-}
-
 extension QueryInterfaceRequest: FilteredRequest {
     /// Creates a request with the provided *predicate promise* added to the
     /// eventual set of already applied predicates.

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -395,38 +395,6 @@ where Self: FilteredRequest,
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension TableRequest
-where Self: FilteredRequest,
-      Self: TypedRequest,
-      RowDecoder: Identifiable,
-      RowDecoder.ID: _OptionalProtocol,
-      RowDecoder.ID.Wrapped: DatabaseValueConvertible
-{
-    /// Creates a request filtered by primary key.
-    ///
-    ///     // SELECT * FROM player WHERE ... id = 1
-    ///     let request = try Player...filter(id: 1)
-    ///
-    /// - parameter id: A primary key
-    public func filter(id: RowDecoder.ID.Wrapped) -> Self {
-        filter(key: id)
-    }
-    
-    /// Creates a request filtered by primary key.
-    ///
-    ///     // SELECT * FROM player WHERE ... id IN (1, 2, 3)
-    ///     let request = try Player...filter(ids: [1, 2, 3])
-    ///
-    /// - parameter ids: A collection of primary keys
-    public func filter<Collection: Swift.Collection>(ids: Collection)
-    -> Self
-    where Collection.Element == RowDecoder.ID.Wrapped
-    {
-        filter(keys: ids)
-    }
-}
-
 extension TableRequest where Self: OrderedRequest {
     /// Creates a request ordered by primary key.
     public func orderByPrimaryKey() -> Self {

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -411,47 +411,6 @@ extension Table where RowDecoder: Identifiable, RowDecoder.ID: DatabaseValueConv
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension Table
-where RowDecoder: Identifiable,
-      RowDecoder.ID: _OptionalProtocol,
-      RowDecoder.ID.Wrapped: DatabaseValueConvertible
-{
-    /// Creates a request filtered by primary key.
-    ///
-    ///     // SELECT * FROM player WHERE id = 1
-    ///     let table = Table<Player>("player")
-    ///     let request = table.filter(id: 1)
-    ///
-    /// - parameter id: A primary key
-    public func filter(id: RowDecoder.ID.Wrapped) -> QueryInterfaceRequest<RowDecoder> {
-        all().filter(id: id)
-    }
-    
-    /// Creates a request filtered by primary key.
-    ///
-    ///     // SELECT * FROM player WHERE id IN (1, 2, 3)
-    ///     let table = Table<Player>("player")
-    ///     let request = table.filter(ids: [1, 2, 3])
-    ///
-    /// - parameter ids: A collection of primary keys
-    public func filter<Collection>(ids: Collection)
-    -> QueryInterfaceRequest<RowDecoder>
-    where Collection: Swift.Collection, Collection.Element == RowDecoder.ID.Wrapped
-    {
-        all().filter(ids: ids)
-    }
-    
-    /// Creates a request which selects the primary key.
-    ///
-    ///     // SELECT id FROM player
-    ///     let table = Table("player")
-    ///     let request = try table.selectID()
-    public func selectID() -> QueryInterfaceRequest<RowDecoder.ID.Wrapped> {
-        all().selectID()
-    }
-}
-
 extension Table {
     
     // MARK: - Counting All
@@ -657,72 +616,6 @@ extension Table where RowDecoder: DatabaseValueConvertible & Hashable {
     }
 }
 
-extension Table where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: DatabaseValueConvertible {
-    /// A cursor over all values fetched from the leftmost column.
-    ///
-    ///     // SELECT * FROM name
-    ///     let table = Table<String?>("name")
-    ///     let names = try table.fetchCursor(db) // Cursor of String?
-    ///     while let name = try names.next() {   // String?
-    ///         ...
-    ///     }
-    ///
-    /// Values are iterated in the natural ordering of the table.
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: A cursor over fetched records.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchCursor(_ db: Database) throws -> NullableDatabaseValueCursor<RowDecoder.Wrapped> {
-        try all().fetchCursor(db)
-    }
-    
-    /// An array of all values fetched from the leftmost column.
-    ///
-    ///     // SELECT * FROM name
-    ///     let table = Table<String?>("name")
-    ///     let names = try table.fetchAll(db) // [String?]
-    ///
-    /// - parameter db: A database connection.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchAll(_ db: Database) throws -> [RowDecoder.Wrapped?] {
-        try all().fetchAll(db)
-    }
-    
-    /// The value from the leftmost column of the first row.
-    ///
-    ///     // SELECT * FROM name LIMIT 1
-    ///     let table = Table<String?>("name")
-    ///     let name = try table.fetchOne(db) // String?
-    ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
-    ///
-    /// - parameter db: A database connection.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchOne(_ db: Database) throws -> RowDecoder.Wrapped? {
-        try all().fetchOne(db)
-    }
-}
-
-extension Table where RowDecoder: _OptionalProtocol, RowDecoder.Wrapped: DatabaseValueConvertible & Hashable {
-    /// A set of all values fetched from the leftmost column.
-    ///
-    ///     // SELECT * FROM name
-    ///     let table = Table<String?>("name")
-    ///     let names = try table.fetchSet(db) // Set<String?>
-    ///
-    /// - parameter db: A database connection.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchSet(_ db: Database) throws -> Set<RowDecoder.Wrapped?> {
-        try all().fetchSet(db)
-    }
-}
-
 // MARK: - Fetching Fast Values from Table
 
 extension Table where RowDecoder: DatabaseValueConvertible & StatementColumnConvertible {
@@ -784,78 +677,6 @@ extension Table where RowDecoder: DatabaseValueConvertible & StatementColumnConv
     /// - parameter db: A database connection.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
     public func fetchSet(_ db: Database) throws -> Set<RowDecoder> {
-        try all().fetchSet(db)
-    }
-}
-
-extension Table
-where RowDecoder: _OptionalProtocol,
-      RowDecoder.Wrapped: DatabaseValueConvertible & StatementColumnConvertible
-{
-    /// A cursor over all values fetched from the leftmost column.
-    ///
-    ///     // SELECT * FROM name
-    ///     let table = Table<String?>("name")
-    ///     let names = try table.fetchCursor(db) // Cursor of String?
-    ///     while let name = try names.next() {   // String?
-    ///         ...
-    ///     }
-    ///
-    /// Values are iterated in the natural ordering of the table.
-    ///
-    /// If the database is modified during the cursor iteration, the remaining
-    /// elements are undefined.
-    ///
-    /// The cursor must be iterated in a protected dispatch queue.
-    ///
-    /// - parameter db: A database connection.
-    /// - returns: A cursor over fetched records.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchCursor(_ db: Database) throws -> FastNullableDatabaseValueCursor<RowDecoder.Wrapped> {
-        try all().fetchCursor(db)
-    }
-    
-    /// An array of all values fetched from the leftmost column.
-    ///
-    ///     // SELECT * FROM name
-    ///     let table = Table<String?>("name")
-    ///     let names = try table.fetchAll(db) // [String?]
-    ///
-    /// - parameter db: A database connection.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchAll(_ db: Database) throws -> [RowDecoder.Wrapped?] {
-        try all().fetchAll(db)
-    }
-    
-    /// The value from the leftmost column of the first row.
-    ///
-    ///     // SELECT * FROM name LIMIT 1
-    ///     let table = Table<String?>("name")
-    ///     let name = try table.fetchOne(db) // String?
-    ///
-    /// The result is nil if the query returns no row, or if no value can be
-    /// extracted from the first row.
-    ///
-    /// - parameter db: A database connection.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchOne(_ db: Database) throws -> RowDecoder.Wrapped? {
-        try all().fetchOne(db)
-    }
-}
-
-extension Table
-where RowDecoder: _OptionalProtocol,
-      RowDecoder.Wrapped: DatabaseValueConvertible & StatementColumnConvertible & Hashable
-{
-    /// A set of all values fetched from the leftmost column.
-    ///
-    ///     // SELECT * FROM name
-    ///     let table = Table<String?>("name")
-    ///     let names = try table.fetchSet(db) // Set<String?>
-    ///
-    /// - parameter db: A database connection.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public func fetchSet(_ db: Database) throws -> Set<RowDecoder.Wrapped?> {
         try all().fetchSet(db)
     }
 }
@@ -1373,31 +1194,6 @@ where RowDecoder: Identifiable,
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension Table
-where RowDecoder: Identifiable,
-      RowDecoder.ID: _OptionalProtocol,
-      RowDecoder.ID.Wrapped: DatabaseValueConvertible
-{
-    /// Returns whether a row exists for this primary key.
-    ///
-    ///     try Table<Player>("player").exists(db, id: 123)
-    ///     try Table<Country>("country").exists(db, id: "FR")
-    ///
-    /// When the table has no explicit primary key, GRDB uses the hidden
-    /// "rowid" column:
-    ///
-    ///     try Table<Document>("document").exists(db, id: 1)
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - id: A primary key value.
-    /// - returns: Whether a row exists for this primary key.
-    public func exists(_ db: Database, id: RowDecoder.ID.Wrapped) throws -> Bool {
-        try !filter(id: id).isEmpty(db)
-    }
-}
-
 // MARK: - Check Existence by Key
 
 extension Table {
@@ -1539,68 +1335,6 @@ where RowDecoder: Identifiable,
     /// - returns: Whether a database row was deleted.
     @discardableResult
     public func deleteOne(_ db: Database, id: RowDecoder.ID) throws -> Bool {
-        try deleteAll(db, ids: [id]) > 0
-    }
-}
-
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension Table
-where RowDecoder: Identifiable,
-      RowDecoder.ID: _OptionalProtocol,
-      RowDecoder.ID.Wrapped: DatabaseValueConvertible
-{
-    /// Delete rows identified by their primary keys; returns the number of
-    /// deleted rows.
-    ///
-    ///     // DELETE FROM player WHERE id IN (1, 2, 3)
-    ///     try Table<Player>("player").deleteAll(db, ids: [1, 2, 3])
-    ///
-    ///     // DELETE FROM country WHERE code IN ('FR', 'US', 'DE')
-    ///     try Table<Country>("country").deleteAll(db, ids: ["FR", "US", "DE"])
-    ///
-    /// When the table has no explicit primary key, GRDB uses the hidden
-    /// "rowid" column:
-    ///
-    ///     // DELETE FROM document WHERE rowid IN (1, 2, 3)
-    ///     try Table<Document>("document").deleteAll(db, ids: [1, 2, 3])
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - ids: A collection of primary keys.
-    /// - returns: The number of deleted rows
-    @discardableResult
-    public func deleteAll<Collection>(_ db: Database, ids: Collection)
-    throws -> Int
-    where Collection: Swift.Collection, Collection.Element == RowDecoder.ID.Wrapped
-    {
-        if ids.isEmpty {
-            // Avoid hitting the database
-            return 0
-        }
-        return try filter(ids: ids).deleteAll(db)
-    }
-    
-    /// Delete a row, identified by its primary key; returns whether a
-    /// database row was deleted.
-    ///
-    ///     // DELETE FROM player WHERE id = 123
-    ///     try Table<Player>("player").deleteOne(db, id: 123)
-    ///
-    ///     // DELETE FROM country WHERE code = 'FR'
-    ///     try Table<Country>("country").deleteOne(db, id: "FR")
-    ///
-    /// When the table has no explicit primary key, GRDB uses the hidden
-    /// "rowid" column:
-    ///
-    ///     // DELETE FROM document WHERE rowid = 1
-    ///     try Table<Document>("document").deleteOne(db, id: 1)
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - id: A primary key value.
-    /// - returns: Whether a database row was deleted.
-    @discardableResult
-    public func deleteOne(_ db: Database, id: RowDecoder.ID.Wrapped) throws -> Bool {
         try deleteAll(db, ids: [id]) > 0
     }
 }

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -221,7 +221,7 @@ extension Table {
     ///     // SELECT * FROM player WHERE id = 1
     ///     let table = Table<Player>("player")
     ///     let request = table.filter(key: 1)
-    public func filter<PrimaryKeyType>(key: PrimaryKeyType?)
+    public func filter<PrimaryKeyType>(key: PrimaryKeyType)
     -> QueryInterfaceRequest<RowDecoder>
     where PrimaryKeyType: DatabaseValueConvertible
     {

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -1190,7 +1190,11 @@ where RowDecoder: Identifiable,
     ///     - id: A primary key value.
     /// - returns: Whether a row exists for this primary key.
     public func exists(_ db: Database, id: RowDecoder.ID) throws -> Bool {
-        try !filter(id: id).isEmpty(db)
+        if id.databaseValue.isNull {
+            // Don't hit the database
+            return false
+        }
+        return try !filter(id: id).isEmpty(db)
     }
 }
 
@@ -1266,12 +1270,12 @@ extension Table {
     ///     - key: A primary key value.
     /// - returns: Whether a database row was deleted.
     @discardableResult
-    public func deleteOne<PrimaryKeyType>(_ db: Database, key: PrimaryKeyType?)
+    public func deleteOne<PrimaryKeyType>(_ db: Database, key: PrimaryKeyType)
     throws -> Bool
     where PrimaryKeyType: DatabaseValueConvertible
     {
-        guard let key = key else {
-            // Avoid hitting the database
+        if key.databaseValue.isNull {
+            // Don't hit the database
             return false
         }
         return try deleteAll(db, keys: [key]) > 0
@@ -1335,7 +1339,11 @@ where RowDecoder: Identifiable,
     /// - returns: Whether a database row was deleted.
     @discardableResult
     public func deleteOne(_ db: Database, id: RowDecoder.ID) throws -> Bool {
-        try deleteAll(db, ids: [id]) > 0
+        if id.databaseValue.isNull {
+            // Don't hit the database
+            return false
+        }
+        return try deleteAll(db, ids: [id]) > 0
     }
 }
 

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -165,7 +165,7 @@ extension TableRecord {
     ///
     ///     // SELECT * FROM player WHERE id = 1
     ///     let request = Player.filter(key: 1)
-    public static func filter<PrimaryKeyType>(key: PrimaryKeyType?)
+    public static func filter<PrimaryKeyType>(key: PrimaryKeyType)
     -> QueryInterfaceRequest<Self>
     where PrimaryKeyType: DatabaseValueConvertible
     {

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -380,37 +380,3 @@ extension TableRecord where Self: Identifiable, ID: DatabaseValueConvertible {
         all().selectID()
     }
 }
-
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension TableRecord where Self: Identifiable, ID: _OptionalProtocol, ID.Wrapped: DatabaseValueConvertible {
-    /// Creates a request filtered by primary key.
-    ///
-    ///     // SELECT * FROM player WHERE id = 1
-    ///     let request = Player.filter(id: 1)
-    ///
-    /// - parameter id: A primary key
-    public static func filter(id: ID.Wrapped) -> QueryInterfaceRequest<Self> {
-        all().filter(id: id)
-    }
-    
-    /// Creates a request filtered by primary key.
-    ///
-    ///     // SELECT * FROM player WHERE id IN (1, 2, 3)
-    ///     let request = Player.filter(ids: [1, 2, 3])
-    ///
-    /// - parameter ids: A collection of primary keys
-    public static func filter<Collection>(ids: Collection)
-    -> QueryInterfaceRequest<Self>
-    where Collection: Swift.Collection, Collection.Element == ID.Wrapped
-    {
-        all().filter(ids: ids)
-    }
-    
-    /// Creates a request which selects the primary key.
-    ///
-    ///     // SELECT id FROM player
-    ///     let request = try Player.selectID()
-    public static func selectID() -> QueryInterfaceRequest<ID.Wrapped> {
-        all().selectID()
-    }
-}

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -526,12 +526,15 @@ extension DatabaseDateDecodingStrategy {
         }
     }
     
+    /// - precondition: value is not NULL
     fileprivate func decode(
         fromStatement sqliteStatement: SQLiteStatement,
         atUncheckedIndex index: Int32,
         context: @autoclosure () -> RowDecodingContext)
     throws -> Date
     {
+        assert(sqlite3_column_type(sqliteStatement, index) != SQLITE_NULL, "unexpected NULL value")
+        
         switch self {
         case .deferredToDate:
             guard let date = Date(sqliteStatement: sqliteStatement, index: index) else {

--- a/GRDB/Record/FetchableRecord+TableRecord.swift
+++ b/GRDB/Record/FetchableRecord+TableRecord.swift
@@ -133,12 +133,12 @@ extension FetchableRecord where Self: TableRecord {
     ///     - key: A primary key value.
     /// - returns: An optional record.
     /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchOne<PrimaryKeyType>(_ db: Database, key: PrimaryKeyType?)
+    public static func fetchOne<PrimaryKeyType>(_ db: Database, key: PrimaryKeyType)
     throws -> Self?
     where PrimaryKeyType: DatabaseValueConvertible
     {
-        guard let key = key else {
-            // Avoid hitting the database
+        if key.databaseValue.isNull {
+            // Don't hit the database
             return nil
         }
         return try filter(key: key).fetchOne(db)

--- a/GRDB/Record/FetchableRecord+TableRecord.swift
+++ b/GRDB/Record/FetchableRecord+TableRecord.swift
@@ -207,72 +207,6 @@ extension FetchableRecord where Self: TableRecord & Identifiable, ID: DatabaseVa
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension FetchableRecord
-where Self: TableRecord & Identifiable,
-      ID: _OptionalProtocol,
-      ID.Wrapped: DatabaseValueConvertible
-{
-    
-    // MARK: Fetching by Single-Column Primary Key
-    
-    /// Returns a cursor over records, given their primary keys.
-    ///
-    ///     let players = try Player.fetchCursor(db, ids: [1, 2, 3]) // Cursor of Player
-    ///     while let player = try players.next() { // Player
-    ///         ...
-    ///     }
-    ///
-    /// Records are iterated in unspecified order.
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - ids: A collection of primary keys.
-    /// - returns: A cursor over fetched records.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchCursor<Collection>(_ db: Database, ids: Collection)
-    throws -> RecordCursor<Self>
-    where Collection: Swift.Collection, Collection.Element == ID.Wrapped
-    {
-        try filter(ids: ids).fetchCursor(db)
-    }
-    
-    /// Returns an array of records, given their primary keys.
-    ///
-    ///     let players = try Player.fetchAll(db, ids: [1, 2, 3]) // [Player]
-    ///
-    /// The order of records in the returned array is undefined.
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - ids: A collection of primary keys.
-    /// - returns: An array of records.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchAll<Collection>(_ db: Database, ids: Collection)
-    throws -> [Self]
-    where Collection: Swift.Collection, Collection.Element == ID.Wrapped
-    {
-        if ids.isEmpty {
-            // Avoid hitting the database
-            return []
-        }
-        return try filter(ids: ids).fetchAll(db)
-    }
-    
-    /// Returns a single record given its primary key.
-    ///
-    ///     let player = try Player.fetchOne(db, id: 123) // Player?
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - id: A primary key value.
-    /// - returns: An optional record.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchOne(_ db: Database, id: ID.Wrapped) throws -> Self? {
-        try filter(id: id).fetchOne(db)
-    }
-}
-
 extension FetchableRecord where Self: TableRecord & Hashable {
     /// Returns a set of records, given their primary keys.
     ///
@@ -310,33 +244,6 @@ extension FetchableRecord where Self: TableRecord & Hashable & Identifiable, ID:
     public static func fetchSet<Collection>(_ db: Database, ids: Collection)
     throws -> Set<Self>
     where Collection: Swift.Collection, Collection.Element == ID
-    {
-        if ids.isEmpty {
-            // Avoid hitting the database
-            return []
-        }
-        return try filter(ids: ids).fetchSet(db)
-    }
-}
-
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension FetchableRecord
-where Self: TableRecord & Hashable & Identifiable,
-      ID: _OptionalProtocol,
-      ID.Wrapped: DatabaseValueConvertible
-{
-    /// Returns a set of records, given their primary keys.
-    ///
-    ///     let players = try Player.fetchSet(db, ids: [1, 2, 3]) // Set<Player>
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - ids: A collection of primary keys.
-    /// - returns: A set of records.
-    /// - throws: A DatabaseError is thrown whenever an SQLite error occurs.
-    public static func fetchSet<Collection>(_ db: Database, ids: Collection)
-    throws -> Set<Self>
-    where Collection: Swift.Collection, Collection.Element == ID.Wrapped
     {
         if ids.isEmpty {
             // Avoid hitting the database

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -197,7 +197,11 @@ extension TableRecord where Self: Identifiable, ID: DatabaseValueConvertible {
     ///     - id: A primary key value.
     /// - returns: Whether a row exists for this primary key.
     public static func exists(_ db: Database, id: ID) throws -> Bool {
-        try !filter(id: id).isEmpty(db)
+        if id.databaseValue.isNull {
+            // Don't hit the database
+            return false
+        }
+        return try !filter(id: id).isEmpty(db)
     }
 }
 
@@ -274,12 +278,12 @@ extension TableRecord {
     ///     - key: A primary key value.
     /// - returns: Whether a database row was deleted.
     @discardableResult
-    public static func deleteOne<PrimaryKeyType>(_ db: Database, key: PrimaryKeyType?)
+    public static func deleteOne<PrimaryKeyType>(_ db: Database, key: PrimaryKeyType)
     throws -> Bool
     where PrimaryKeyType: DatabaseValueConvertible
     {
-        guard let key = key else {
-            // Avoid hitting the database
+        if key.databaseValue.isNull {
+            // Don't hit the database
             return false
         }
         return try deleteAll(db, keys: [key]) > 0

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -201,31 +201,6 @@ extension TableRecord where Self: Identifiable, ID: DatabaseValueConvertible {
     }
 }
 
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension TableRecord
-where Self: Identifiable,
-      ID: _OptionalProtocol,
-      ID.Wrapped: DatabaseValueConvertible
-{
-    /// Returns whether a row exists for this primary key.
-    ///
-    ///     try Player.deleteOne(db, id: 123)
-    ///     try Country.deleteOne(db, id: "FR")
-    ///
-    /// When the table has no explicit primary key, GRDB uses the hidden
-    /// "rowid" column:
-    ///
-    ///     try Document.deleteOne(db, id: 1)
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - id: A primary key value.
-    /// - returns: Whether a row exists for this primary key.
-    public static func exists(_ db: Database, id: ID.Wrapped) throws -> Bool {
-        try !filter(id: id).isEmpty(db)
-    }
-}
-
 // MARK: - Check Existence by Key
 
 extension TableRecord {
@@ -365,68 +340,6 @@ extension TableRecord where Self: Identifiable, ID: DatabaseValueConvertible {
     /// - returns: Whether a database row was deleted.
     @discardableResult
     public static func deleteOne(_ db: Database, id: ID) throws -> Bool {
-        try deleteAll(db, ids: [id]) > 0
-    }
-}
-
-@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension TableRecord
-where Self: Identifiable,
-      ID: _OptionalProtocol,
-      ID.Wrapped: DatabaseValueConvertible
-{
-    /// Delete records identified by their primary keys; returns the number of
-    /// deleted rows.
-    ///
-    ///     // DELETE FROM player WHERE id IN (1, 2, 3)
-    ///     try Player.deleteAll(db, ids: [1, 2, 3])
-    ///
-    ///     // DELETE FROM country WHERE code IN ('FR', 'US', 'DE')
-    ///     try Country.deleteAll(db, ids: ["FR", "US", "DE"])
-    ///
-    /// When the table has no explicit primary key, GRDB uses the hidden
-    /// "rowid" column:
-    ///
-    ///     // DELETE FROM document WHERE rowid IN (1, 2, 3)
-    ///     try Document.deleteAll(db, ids: [1, 2, 3])
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - ids: A collection of primary keys.
-    /// - returns: The number of deleted rows
-    @discardableResult
-    public static func deleteAll<Collection>(_ db: Database, ids: Collection)
-    throws -> Int
-    where Collection: Swift.Collection, Collection.Element == ID.Wrapped
-    {
-        if ids.isEmpty {
-            // Avoid hitting the database
-            return 0
-        }
-        return try filter(ids: ids).deleteAll(db)
-    }
-    
-    /// Delete a record, identified by its primary key; returns whether a
-    /// database row was deleted.
-    ///
-    ///     // DELETE FROM player WHERE id = 123
-    ///     try Player.deleteOne(db, id: 123)
-    ///
-    ///     // DELETE FROM country WHERE code = 'FR'
-    ///     try Country.deleteOne(db, id: "FR")
-    ///
-    /// When the table has no explicit primary key, GRDB uses the hidden
-    /// "rowid" column:
-    ///
-    ///     // DELETE FROM document WHERE rowid = 1
-    ///     try Document.deleteOne(db, id: 1)
-    ///
-    /// - parameters:
-    ///     - db: A database connection.
-    ///     - id: A primary key value.
-    /// - returns: Whether a database row was deleted.
-    @discardableResult
-    public static func deleteOne(_ db: Database, id: ID.Wrapped) throws -> Bool {
         try deleteAll(db, ids: [id]) > 0
     }
 }

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -20,18 +20,6 @@ public func databaseQuestionMarks(count: Int) -> String {
     repeatElement("?", count: count).joined(separator: ",")
 }
 
-/// This protocol is an implementation detail of GRDB. Don't use it.
-///
-/// :nodoc:
-public protocol _OptionalProtocol {
-    associatedtype Wrapped
-}
-
-/// This conformance is an implementation detail of GRDB. Don't rely on it.
-///
-/// :nodoc:
-extension Optional: _OptionalProtocol { }
-
 // MARK: - Internal
 
 /// Reserved for GRDB: do not use.

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -452,6 +452,8 @@
 		56A8C2461D1918EF0096E9D4 /* FoundationUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A8C21E1D1914110096E9D4 /* FoundationUUIDTests.swift */; };
 		56A8C24D1D1918F30096E9D4 /* FoundationNSUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A8C2361D1914790096E9D4 /* FoundationNSUUIDTests.swift */; };
 		56A8C24E1D1918F30096E9D4 /* FoundationUUIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A8C21E1D1914110096E9D4 /* FoundationUUIDTests.swift */; };
+		56AD72B627C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD72B427C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */; };
+		56AD72B727C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AD72B427C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */; };
 		56AE6427222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE6426222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift */; };
 		56AE6428222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE6426222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift */; };
 		56AF746E1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */; };
@@ -1078,6 +1080,7 @@
 		56A8C21E1D1914110096E9D4 /* FoundationUUIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationUUIDTests.swift; sourceTree = "<group>"; };
 		56A8C22F1D1914540096E9D4 /* UUID.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UUID.swift; sourceTree = "<group>"; };
 		56A8C2361D1914790096E9D4 /* FoundationNSUUIDTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationNSUUIDTests.swift; sourceTree = "<group>"; };
+		56AD72B427C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatementColumnConvertible+RawRepresentable.swift"; sourceTree = "<group>"; };
 		56AE6426222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasOneThroughSQLTests.swift; sourceTree = "<group>"; };
 		56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEscapingTests.swift; sourceTree = "<group>"; };
 		56B021C81D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordPersistenceConflictPolicyTests.swift; sourceTree = "<group>"; };
@@ -1237,6 +1240,7 @@
 				56713FE12691F487006153C3 /* JSONRequiredEncoder.swift */,
 				5689B91327BBE22900697347 /* Optional.swift */,
 				5605F1581C672E4000235C62 /* StandardLibrary.swift */,
+				56AD72B427C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift */,
 			);
 			path = StandardLibrary;
 			sourceTree = "<group>";
@@ -2377,6 +2381,7 @@
 				5656A8582295BD56001FF3FF /* SQLQueryGenerator.swift in Sources */,
 				5656A8842295BD56001FF3FF /* SQLExpression.swift in Sources */,
 				5659F48D1EA8D94E004A4992 /* Utils.swift in Sources */,
+				56AD72B727C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */,
 				F3BA80231CFB288C003DC1BA /* NSString.swift in Sources */,
 				560233D227243A9200529DF3 /* SharedValueObservation.swift in Sources */,
 				5656A85A2295BD56001FF3FF /* SQLGenerationContext.swift in Sources */,
@@ -2746,6 +2751,7 @@
 				5656A8572295BD56001FF3FF /* SQLQueryGenerator.swift in Sources */,
 				5656A8832295BD56001FF3FF /* SQLExpression.swift in Sources */,
 				5659F48A1EA8D94E004A4992 /* Utils.swift in Sources */,
+				56AD72B627C10B9F00DCB2DF /* StatementColumnConvertible+RawRepresentable.swift in Sources */,
 				F3BA807F1CFB2E61003DC1BA /* NSString.swift in Sources */,
 				560233D127243A9200529DF3 /* SharedValueObservation.swift in Sources */,
 				5656A8592295BD56001FF3FF /* SQLGenerationContext.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -376,6 +376,8 @@
 		56894FE8260658A500268F4D /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894FA0260657F600268F4D /* Decimal.swift */; };
 		56894FF2260658E600268F4D /* FoundationDecimalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894FF1260658E600268F4D /* FoundationDecimalTests.swift */; };
 		56894FF3260658E600268F4D /* FoundationDecimalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894FF1260658E600268F4D /* FoundationDecimalTests.swift */; };
+		5689B91527BBE22900697347 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5689B91327BBE22900697347 /* Optional.swift */; };
+		5689B91627BBE22900697347 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5689B91327BBE22900697347 /* Optional.swift */; };
 		568ECB0D25D904CA00B71526 /* SQLSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568ECB0C25D904CA00B71526 /* SQLSelection.swift */; };
 		568ECB0E25D904CA00B71526 /* SQLSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568ECB0C25D904CA00B71526 /* SQLSelection.swift */; };
 		568ECB3525D91CEF00B71526 /* SQLSubquery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568ECB3425D91CEE00B71526 /* SQLSubquery.swift */; };
@@ -998,6 +1000,7 @@
 		56894F322604FC1E00268F4D /* Table.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Table.swift; sourceTree = "<group>"; };
 		56894FA0260657F600268F4D /* Decimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Decimal.swift; sourceTree = "<group>"; };
 		56894FF1260658E600268F4D /* FoundationDecimalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDecimalTests.swift; sourceTree = "<group>"; };
+		5689B91327BBE22900697347 /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		568ECB0C25D904CA00B71526 /* SQLSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLSelection.swift; sourceTree = "<group>"; };
 		568ECB3425D91CEE00B71526 /* SQLSubquery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLSubquery.swift; sourceTree = "<group>"; };
 		5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDateComponentsTests.swift; sourceTree = "<group>"; };
@@ -1232,6 +1235,7 @@
 				5674A6E21F307F0E0095F066 /* DatabaseValueConvertible+Encodable.swift */,
 				5605F1571C672E4000235C62 /* DatabaseValueConvertible+RawRepresentable.swift */,
 				56713FE12691F487006153C3 /* JSONRequiredEncoder.swift */,
+				5689B91327BBE22900697347 /* Optional.swift */,
 				5605F1581C672E4000235C62 /* StandardLibrary.swift */,
 			);
 			path = StandardLibrary;
@@ -2355,6 +2359,7 @@
 				56256EDF25D1BC07008C2BDD /* ForeignKey.swift in Sources */,
 				F3BA800A1CFB286A003DC1BA /* Configuration.swift in Sources */,
 				5656A86C2295BD56001FF3FF /* HasManyAssociation.swift in Sources */,
+				5689B91627BBE22900697347 /* Optional.swift in Sources */,
 				5671FC251DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				5656A8862295BD56001FF3FF /* SQLOrdering.swift in Sources */,
 				F3BA80311CFB289F003DC1BA /* Migration.swift in Sources */,
@@ -2723,6 +2728,7 @@
 				56256EDE25D1BC07008C2BDD /* ForeignKey.swift in Sources */,
 				F3BA80661CFB2E55003DC1BA /* Configuration.swift in Sources */,
 				5656A86B2295BD56001FF3FF /* HasManyAssociation.swift in Sources */,
+				5689B91527BBE22900697347 /* Optional.swift in Sources */,
 				5671FC221DA3CAC9003BF4FF /* FTS3TokenizerDescriptor.swift in Sources */,
 				5656A8852295BD56001FF3FF /* SQLOrdering.swift in Sources */,
 				F3BA808D1CFB2E75003DC1BA /* Migration.swift in Sources */,

--- a/Tests/GRDBTests/DatabaseCursorTests.swift
+++ b/Tests/GRDBTests/DatabaseCursorTests.swift
@@ -260,7 +260,7 @@ class DatabaseCursorTests: GRDBTestCase {
     func testNullableDatabaseValueCursorStep() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let cursor: NullableDatabaseValueCursor<Int> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
+            let cursor: DatabaseValueCursor<Int?> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
             while let _ = try cursor.next() { }
         }
     }
@@ -269,7 +269,7 @@ class DatabaseCursorTests: GRDBTestCase {
     func testNullableDatabaseValueCursorForEach() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let cursor: NullableDatabaseValueCursor<Int> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
+            let cursor: DatabaseValueCursor<Int?> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
             try cursor.forEach { _ in }
         }
     }
@@ -296,7 +296,7 @@ class DatabaseCursorTests: GRDBTestCase {
     func testFastNullableDatabaseValueCursorStep() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let cursor: FastNullableDatabaseValueCursor<Int> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
+            let cursor: FastDatabaseValueCursor<Int?> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
             while let _ = try cursor.next() { }
         }
     }
@@ -305,7 +305,7 @@ class DatabaseCursorTests: GRDBTestCase {
     func testFastNullableDatabaseValueCursorForEach() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.read { db in
-            let cursor: FastNullableDatabaseValueCursor<Int> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
+            let cursor: FastDatabaseValueCursor<Int?> = try Optional<Int>.fetchCursor(db, sql: profilingSQL)
             try cursor.forEach { _ in }
         }
     }

--- a/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
@@ -51,14 +51,19 @@ private struct RecordWithDate<Strategy: StrategyProvider>: EncodableRecord, Enco
     var date: Date
 }
 
+@available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
+extension RecordWithDate: Identifiable {
+    var id: Date { date }
+}
+
 private struct RecordWithOptionalDate<Strategy: StrategyProvider>: EncodableRecord, Encodable {
     static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy { Strategy.strategy }
     var date: Date?
 }
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
-extension RecordWithDate: Identifiable {
-    var id: Date { date }
+extension RecordWithOptionalDate: Identifiable {
+    var id: Date? { date }
 }
 
 class DatabaseDateEncodingStrategyTests: GRDBTestCase {
@@ -288,6 +293,48 @@ extension DatabaseDateEncodingStrategyTests {
                     SELECT * FROM "t" WHERE "id" IN (-979294854.321, -978183743.211, 0.0, 123456.789)
                     """)
             }
+            
+            do {
+                let request = Table<RecordWithOptionalDate<StrategyDeferredToDate>>("t").filter(id: nil)
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "t" WHERE 0
+                    """)
+            }
+            
+            do {
+                let request = Table<RecordWithOptionalDate<StrategyDeferredToDate>>("t").filter(id: testedDates[0])
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "t" WHERE "id" = '1969-12-20 13:39:05.679'
+                    """)
+            }
+            
+            do {
+                let request = Table<RecordWithOptionalDate<StrategyDeferredToDate>>("t").filter(ids: testedDates)
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "t" WHERE "id" IN ('1969-12-20 13:39:05.679', '1970-01-02 10:17:36.789', '2001-01-01 00:00:00.000', '2001-01-02 10:17:36.789')
+                    """)
+            }
+            
+            do {
+                let request = Table<RecordWithOptionalDate<StrategyTimeIntervalSinceReferenceDate>>("t").filter(id: nil)
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "t" WHERE 0
+                    """)
+            }
+            
+            do {
+                let request = Table<RecordWithOptionalDate<StrategyTimeIntervalSinceReferenceDate>>("t").filter(id: testedDates[0])
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "t" WHERE "id" = -979294854.321
+                    """)
+            }
+            
+            do {
+                let request = Table<RecordWithOptionalDate<StrategyTimeIntervalSinceReferenceDate>>("t").filter(ids: testedDates)
+                try assertEqualSQL(db, request, """
+                    SELECT * FROM "t" WHERE "id" IN (-979294854.321, -978183743.211, 0.0, 123456.789)
+                    """)
+            }
         }
     }
     
@@ -322,6 +369,46 @@ extension DatabaseDateEncodingStrategyTests {
             
             do {
                 try Table<RecordWithDate<StrategyTimeIntervalSinceReferenceDate>>("t").deleteAll(db, ids: testedDates)
+                XCTAssertEqual(lastSQLQuery, """
+                    DELETE FROM "t" WHERE "id" IN (-979294854.321, -978183743.211, 0.0, 123456.789)
+                    """)
+            }
+            
+            do {
+                sqlQueries.removeAll()
+                try Table<RecordWithOptionalDate<StrategyDeferredToDate>>("t").deleteOne(db, id: nil)
+                XCTAssertNil(lastSQLQuery) // Database not hit
+            }
+            
+            do {
+                try Table<RecordWithOptionalDate<StrategyDeferredToDate>>("t").deleteOne(db, id: testedDates[0])
+                XCTAssertEqual(lastSQLQuery, """
+                    DELETE FROM "t" WHERE "id" = '1969-12-20 13:39:05.679'
+                    """)
+            }
+            
+            do {
+                try Table<RecordWithOptionalDate<StrategyDeferredToDate>>("t").deleteAll(db, ids: testedDates)
+                XCTAssertEqual(lastSQLQuery, """
+                    DELETE FROM "t" WHERE "id" IN ('1969-12-20 13:39:05.679', '1970-01-02 10:17:36.789', '2001-01-01 00:00:00.000', '2001-01-02 10:17:36.789')
+                    """)
+            }
+            
+            do {
+                sqlQueries.removeAll()
+                try Table<RecordWithOptionalDate<StrategyTimeIntervalSinceReferenceDate>>("t").deleteOne(db, id: nil)
+                XCTAssertNil(lastSQLQuery) // Database not hit
+            }
+            
+            do {
+                try Table<RecordWithOptionalDate<StrategyTimeIntervalSinceReferenceDate>>("t").deleteOne(db, id: testedDates[0])
+                XCTAssertEqual(lastSQLQuery, """
+                    DELETE FROM "t" WHERE "id" = -979294854.321
+                    """)
+            }
+            
+            do {
+                try Table<RecordWithOptionalDate<StrategyTimeIntervalSinceReferenceDate>>("t").deleteAll(db, ids: testedDates)
                 XCTAssertEqual(lastSQLQuery, """
                     DELETE FROM "t" WHERE "id" IN (-979294854.321, -978183743.211, 0.0, 123456.789)
                     """)

--- a/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConvertibleFetchTests.swift
@@ -486,7 +486,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     func testOptionalFetchCursor() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            func test(_ cursor: NullableDatabaseValueCursor<Fetched>) throws {
+            func test(_ cursor: DatabaseValueCursor<Fetched?>) throws {
                 XCTAssertEqual(try cursor.next()!!.int, 1)
                 XCTAssertTrue(try cursor.next()! == nil)
                 XCTAssertTrue(try cursor.next() == nil) // end
@@ -527,7 +527,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
         try dbQueue.inDatabase { db in
             let customError = NSError(domain: "Custom", code: 0xDEAD)
             db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
-            func test(_ cursor: NullableDatabaseValueCursor<Fetched>, sql: String) throws {
+            func test(_ cursor: DatabaseValueCursor<Fetched?>, sql: String) throws {
                 do {
                     _ = try cursor.next()
                     XCTFail()
@@ -566,7 +566,7 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
     func testOptionalFetchCursorCompilationFailure() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            func test(_ cursor: @autoclosure () throws -> NullableDatabaseValueCursor<Fetched>, sql: String) throws {
+            func test(_ cursor: @autoclosure () throws -> DatabaseValueCursor<Fetched?>, sql: String) throws {
                 do {
                     _ = try cursor()
                     XCTFail()
@@ -795,6 +795,159 @@ class DatabaseValueConvertibleFetchTests: GRDBTestCase {
                 try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
+            }
+        }
+    }
+
+    func testOptionalFetchOne() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                func test(_ nilBecauseMissingRow: Fetched??) {
+                    switch nilBecauseMissingRow {
+                    case .none: break
+                    default: XCTFail("Expected nil because missing row")
+                    }
+                }
+                do {
+                    let sql = "SELECT 1 WHERE 0"
+                    let statement = try db.makeStatement(sql: sql)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
+                    try test(Optional<Fetched>.fetchOne(statement))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql)))
+                    try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
+                }
+                do {
+                    let sql = "SELECT 0, 1 WHERE 0"
+                    let statement = try db.makeStatement(sql: sql)
+                    let adapter = SuffixRowAdapter(fromIndex: 1)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql, adapter: adapter)))
+                    try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
+                }
+            }
+            do {
+                func test(_ nilBecauseNull: Fetched??) {
+                    switch nilBecauseNull {
+                    case .some(.none): break
+                    default: XCTFail("Expected .some(nil) because NULL")
+                    }
+                }
+                do {
+                    let sql = "SELECT NULL"
+                    let statement = try db.makeStatement(sql: sql)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
+                    try test(Optional<Fetched>.fetchOne(statement))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql)))
+                    try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
+                }
+                do {
+                    let sql = "SELECT 0, NULL"
+                    let statement = try db.makeStatement(sql: sql)
+                    let adapter = SuffixRowAdapter(fromIndex: 1)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql, adapter: adapter)))
+                    try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
+                }
+            }
+            do {
+                func test(_ value: Fetched??) {
+                    XCTAssertEqual(value!!.int, 1)
+                }
+                do {
+                    let sql = "SELECT 1"
+                    let statement = try db.makeStatement(sql: sql)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
+                    try test(Optional<Fetched>.fetchOne(statement))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql)))
+                    try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
+                }
+                do {
+                    let sql = "SELECT 0, 1"
+                    let statement = try db.makeStatement(sql: sql)
+                    let adapter = SuffixRowAdapter(fromIndex: 1)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql, adapter: adapter)))
+                    try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
+                }
+            }
+        }
+    }
+    
+    func testOptionalFetchOneWithInterpolation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request: SQLRequest<Fetched?> = "SELECT \(42)"
+            let fetched = try request.fetchOne(db)
+            XCTAssertEqual(fetched!!.int, 42)
+        }
+    }
+    
+    func testOptionalFetchOneStepFailure() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let customError = NSError(domain: "Custom", code: 0xDEAD)
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+            func test(_ value: @autoclosure () throws -> Fetched??, sql: String) throws {
+                do {
+                    _ = try value()
+                    XCTFail()
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                    XCTAssertEqual(error.message, "\(customError)")
+                    XCTAssertEqual(error.sql!, sql)
+                    XCTAssertEqual(error.description, "SQLite error 1: \(customError) - while executing `\(sql)`")
+                }
+            }
+            do {
+                let sql = "SELECT throw()"
+                try test(Optional<Fetched>.fetchOne(db, sql: sql), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db), sql: sql)
+            }
+            do {
+                let sql = "SELECT 0, throw()"
+                let adapter = SuffixRowAdapter(fromIndex: 1)
+                try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql, adapter: adapter)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
+            }
+        }
+    }
+
+    func testOptionalFetchOneCompilationFailure() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            func test(_ value: @autoclosure () throws -> Fetched??, sql: String) throws {
+                do {
+                    _ = try value()
+                    XCTFail()
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                    XCTAssertEqual(error.message, "no such table: nonExistingTable")
+                    XCTAssertEqual(error.sql!, sql)
+                    XCTAssertEqual(error.description, "SQLite error 1: no such table: nonExistingTable - while executing `\(sql)`")
+                }
+            }
+            do {
+                let sql = "SELECT * FROM nonExistingTable"
+                try test(Optional<Fetched>.fetchOne(db, sql: sql), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db), sql: sql)
+            }
+            do {
+                let sql = "SELECT * FROM nonExistingTable"
+                let adapter = SuffixRowAdapter(fromIndex: 1)
+                try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest(sql: sql, adapter: adapter)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
         }
     }

--- a/Tests/GRDBTests/RawRepresentable+DatabaseValueConvertibleTests.swift
+++ b/Tests/GRDBTests/RawRepresentable+DatabaseValueConvertibleTests.swift
@@ -49,6 +49,9 @@ extension Wrapper: SQLExpressible where RawValue: SQLExpressible { }
 extension Wrapper: StatementBinding where RawValue: StatementBinding { }
 extension Wrapper: DatabaseValueConvertible where RawValue: DatabaseValueConvertible { }
 
+extension FastWrapper: SQLSelectable where RawValue: SQLSelectable { }
+extension FastWrapper: SQLOrderingTerm where RawValue: SQLOrderingTerm { }
+extension FastWrapper: SQLSpecificExpressible where RawValue: SQLSpecificExpressible { }
 extension FastWrapper: SQLExpressible where RawValue: SQLExpressible { }
 extension FastWrapper: StatementBinding where RawValue: StatementBinding { }
 extension FastWrapper: DatabaseValueConvertible where RawValue: DatabaseValueConvertible { }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -599,6 +599,9 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
                     XCTAssertTrue(fetchedRecord.id == record.id)
                     XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
                 }
+                do {
+                    try XCTAssertNil(MinimalRowID.fetchOne(db, id: nil))
+                }
             }
         }
     }
@@ -745,6 +748,9 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
                     let fetchedRecord = try MinimalRowID.filter(id: record.id!).fetchOne(db)!
                     XCTAssertTrue(fetchedRecord.id == record.id)
                     XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
+                }
+                do {
+                    try XCTAssertNil(MinimalRowID.filter(id: nil).fetchOne(db))
                 }
             }
         }

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -700,6 +700,9 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
                     XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
                     XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
                 }
+                do {
+                    try XCTAssertNil(Person.fetchOne(db, id: nil))
+                }
             }
         }
     }
@@ -852,6 +855,9 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
                     XCTAssertTrue(fetchedRecord.age == record.age)
                     XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
                     XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
+                }
+                do {
+                    try XCTAssertNil(Person.filter(id: nil).fetchOne(db))
                 }
             }
         }

--- a/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
@@ -479,6 +479,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
             do {
                 func test(_ value: Fetched?) {
                     XCTAssertEqual(value!.int, 1)
+                    XCTAssertTrue(value!.fast)
                 }
                 do {
                     let sql = "SELECT 1"
@@ -582,7 +583,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
     func testOptionalFetchCursor() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            func test(_ cursor: FastNullableDatabaseValueCursor<Fetched>) throws {
+            func test(_ cursor: FastDatabaseValueCursor<Fetched?>) throws {
                 let i = try cursor.next()!
                 XCTAssertEqual(i!.int, 1)
                 XCTAssertTrue(i!.fast)
@@ -624,7 +625,7 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
     func testOptionalFetchCursorCompilationFailure() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            func test(_ cursor: @autoclosure () throws -> FastNullableDatabaseValueCursor<Fetched>, sql: String) throws {
+            func test(_ cursor: @autoclosure () throws -> FastDatabaseValueCursor<Fetched?>, sql: String) throws {
                 do {
                     _ = try cursor()
                     XCTFail()
@@ -857,6 +858,161 @@ class StatementColumnConvertibleFetchTests: GRDBTestCase {
                 try test(Optional<Fetched>.fetchSet(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
                 try test(Optional<Fetched>.fetchSet(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
                 try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchSet(db), sql: sql)
+            }
+        }
+    }
+
+    func testOptionalFetchOne() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                func test(_ nilBecauseMissingRow: Fetched??) {
+                    switch nilBecauseMissingRow {
+                    case .none: break
+                    default: XCTFail("Expected nil because missing row")
+                    }
+                }
+                do {
+                    let sql = "SELECT 1 WHERE 0"
+                    let statement = try db.makeStatement(sql: sql)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
+                    try test(Optional<Fetched>.fetchOne(statement))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)))
+                    try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
+                }
+                do {
+                    let sql = "SELECT 0, 1 WHERE 0"
+                    let statement = try db.makeStatement(sql: sql)
+                    let adapter = SuffixRowAdapter(fromIndex: 1)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)))
+                    try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
+                }
+            }
+            do {
+                func test(_ nilBecauseNull: Fetched??) {
+                    switch nilBecauseNull {
+                    case .some(.none): break
+                    default: XCTFail("Expected .some(nil) because NULL")
+                    }
+                }
+                do {
+                    let sql = "SELECT NULL"
+                    let statement = try db.makeStatement(sql: sql)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
+                    try test(Optional<Fetched>.fetchOne(statement))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)))
+                    try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
+                }
+                do {
+                    let sql = "SELECT 0, NULL"
+                    let statement = try db.makeStatement(sql: sql)
+                    let adapter = SuffixRowAdapter(fromIndex: 1)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)))
+                    try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
+                }
+            }
+            do {
+                func test(_ value: Fetched??) {
+                    XCTAssertEqual(value!!.int, 1)
+                    XCTAssertTrue(value!!.fast)
+                }
+                do {
+                    let sql = "SELECT 1"
+                    let statement = try db.makeStatement(sql: sql)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql))
+                    try test(Optional<Fetched>.fetchOne(statement))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)))
+                    try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db))
+                }
+                do {
+                    let sql = "SELECT 0, 1"
+                    let statement = try db.makeStatement(sql: sql)
+                    let adapter = SuffixRowAdapter(fromIndex: 1)
+                    try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(statement, adapter: adapter))
+                    try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)))
+                    try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db))
+                }
+            }
+        }
+    }
+    
+    func testOptionalFetchOneWithInterpolation() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let request: SQLRequest<Fetched?> = "SELECT \(42)"
+            let fetched = try request.fetchOne(db)
+            XCTAssertEqual(fetched!!.int, 42)
+            XCTAssertTrue(fetched!!.fast)
+        }
+    }
+    
+    func testOptionalFetchOneStepFailure() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let customError = NSError(domain: "Custom", code: 0xDEAD)
+            db.add(function: DatabaseFunction("throw", argumentCount: 0, pure: true) { _ in throw customError })
+            func test(_ value: @autoclosure () throws -> Fetched??, sql: String) throws {
+                do {
+                    _ = try value()
+                    XCTFail()
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                    XCTAssertEqual(error.message, "\(customError)")
+                    XCTAssertEqual(error.sql!, sql)
+                    XCTAssertEqual(error.description, "SQLite error 1: \(customError) - while executing `\(sql)`")
+                }
+            }
+            do {
+                let sql = "SELECT throw()"
+                try test(Optional<Fetched>.fetchOne(db, sql: sql), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db), sql: sql)
+            }
+            do {
+                let sql = "SELECT 0, throw()"
+                let adapter = SuffixRowAdapter(fromIndex: 1)
+                try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
+            }
+        }
+    }
+
+    func testOptionalFetchOneCompilationFailure() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            func test(_ value: @autoclosure () throws -> Fetched??, sql: String) throws {
+                do {
+                    _ = try value()
+                    XCTFail()
+                } catch let error as DatabaseError {
+                    XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                    XCTAssertEqual(error.message, "no such table: nonExistingTable")
+                    XCTAssertEqual(error.sql!, sql)
+                    XCTAssertEqual(error.description, "SQLite error 1: no such table: nonExistingTable - while executing `\(sql)`")
+                }
+            }
+            do {
+                let sql = "SELECT * FROM nonExistingTable"
+                try test(Optional<Fetched>.fetchOne(db, sql: sql), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql)), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql).fetchOne(db), sql: sql)
+            }
+            do {
+                let sql = "SELECT * FROM nonExistingTable"
+                let adapter = SuffixRowAdapter(fromIndex: 1)
+                try test(Optional<Fetched>.fetchOne(db, sql: sql, adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db.makeStatement(sql: sql), adapter: adapter), sql: sql)
+                try test(Optional<Fetched>.fetchOne(db, SQLRequest<Void>(sql: sql, adapter: adapter)), sql: sql)
+                try test(SQLRequest<Fetched?>(sql: sql, adapter: adapter).fetchOne(db), sql: sql)
             }
         }
     }

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -386,6 +386,10 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             try XCTAssertFalse(Player.exists(db, id: 1))
             XCTAssertEqual(lastSQLQuery, "SELECT EXISTS (SELECT * FROM \"player\" WHERE \"id\" = 1)")
             
+            sqlQueries.removeAll()
+            try XCTAssertFalse(Player.exists(db, id: nil))
+            XCTAssertNil(lastSQLQuery) // Database not hit
+
             return .rollback
         }
         try dbQueue.inTransaction { db in

--- a/Tests/GRDBTests/TableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/TableRecordDeleteTests.swift
@@ -46,6 +46,7 @@ class TableRecordDeleteTests: GRDBTestCase {
             
             if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *) {
                 try db.execute(sql: "INSERT INTO hackers (rowid, name) VALUES (?, ?)", arguments: [1, "Arthur"])
+                try XCTAssertFalse(Hacker.deleteOne(db, id: nil))
                 deleted = try Hacker.deleteOne(db, id: 1)
                 XCTAssertTrue(deleted)
                 XCTAssertEqual(try Hacker.fetchCount(db), 0)

--- a/Tests/GRDBTests/TableTests.swift
+++ b/Tests/GRDBTests/TableTests.swift
@@ -134,6 +134,9 @@ class TableTests: GRDBTestCase {
                 try assertEqualSQL(db, t.filter(id: 1), """
                     SELECT * FROM "player" WHERE "id" = 1
                     """)
+                try assertEqualSQL(db, t.filter(id: nil), """
+                    SELECT * FROM "player" WHERE 0
+                    """)
                 try assertEqualSQL(db, t.filter(ids: [1, 2, 3]), """
                     SELECT * FROM "player" WHERE "id" IN (1, 2, 3)
                     """)
@@ -319,7 +322,7 @@ class TableTests: GRDBTestCase {
             do {
                 try db.execute(sql: "DELETE FROM player")
                 try db.execute(sql: "INSERT INTO player VALUES (NULL)")
-                try XCTAssertEqual(t.fetchOne(db), nil)
+                try XCTAssertEqual(t.fetchOne(db), .some(.none))
             }
         }
     }
@@ -822,6 +825,10 @@ class TableTests: GRDBTestCase {
                     DELETE FROM "country" WHERE "code" = 'FR'
                     """)
                 
+                sqlQueries.removeAll()
+                try Table<Country>("country").deleteOne(db, id: nil)
+                XCTAssertNil(lastSQLQuery) // Database not hit
+                
                 try Table<Country>("country").deleteAll(db, ids: ["FR", "DE"])
                 XCTAssertEqual(lastSQLQuery, """
                     DELETE FROM "country" WHERE "code" IN ('FR', 'DE')
@@ -926,6 +933,10 @@ class TableTests: GRDBTestCase {
                 XCTAssertEqual(lastSQLQuery, """
                     SELECT EXISTS (SELECT * FROM "country" WHERE "code" = 'FR')
                     """)
+                
+                sqlQueries.removeAll()
+                try XCTAssertFalse(Table<Country>("country").exists(db, id: nil))
+                XCTAssertNil(lastSQLQuery) // Database not hit
             }
         }
     }

--- a/Tests/GRDBTests/TableTests.swift
+++ b/Tests/GRDBTests/TableTests.swift
@@ -249,7 +249,7 @@ class TableTests: GRDBTestCase {
             
             do {
                 try db.execute(sql: "DELETE FROM player")
-                try XCTAssertEqual(t.fetchOne(db), nil)
+                try XCTAssertEqual(t.fetchOne(db), .none) // no row
             }
             
             do {
@@ -261,7 +261,7 @@ class TableTests: GRDBTestCase {
             do {
                 try db.execute(sql: "DELETE FROM player")
                 try db.execute(sql: "INSERT INTO player VALUES (NULL)")
-                try XCTAssertEqual(t.fetchOne(db), nil)
+                try XCTAssertEqual(t.fetchOne(db), .some(nil)) // one row with NULL value
             }
         }
     }

--- a/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
+++ b/Tests/GRDBTests/ValueObservationDatabaseValueConvertibleTests.swift
@@ -188,15 +188,16 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
         try assertValueObservation(
             ValueObservation.trackingConstantRegion(request.fetchOne),
             records: [
-                nil,
+                .none,
                 Name(rawValue: "foo"),
                 Name(rawValue: "foo"),
                 Name(rawValue: "bar"),
-                nil,
+                .none,
                 Name(rawValue: "baz"),
+                .some(nil),
                 nil,
-                nil,
-                nil,
+                .some(nil),
+                .some(nil),
                 Name(rawValue: "qux")],
             setup: { db in
                 try db.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
@@ -215,18 +216,21 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
                 try db.execute(sql: "UPDATE t SET name = NULL")
                 try db.execute(sql: "DELETE FROM t")
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, NULL)")
+                try db.execute(sql: "UPDATE t SET name = NULL")
                 try db.execute(sql: "UPDATE t SET name = 'qux'")
         })
         
         try assertValueObservation(
             ValueObservation.trackingConstantRegion(request.fetchOne).removeDuplicates(),
             records: [
-                nil,
+                .none,
                 Name(rawValue: "foo"),
                 Name(rawValue: "bar"),
-                nil,
+                .none,
                 Name(rawValue: "baz"),
+                .some(nil),
                 nil,
+                .some(nil),
                 Name(rawValue: "qux")],
             setup: { db in
                 try db.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
@@ -245,6 +249,7 @@ class ValueObservationDatabaseValueConvertibleTests: GRDBTestCase {
                 try db.execute(sql: "UPDATE t SET name = NULL")
                 try db.execute(sql: "DELETE FROM t")
                 try db.execute(sql: "INSERT INTO t (id, name) VALUES (1, NULL)")
+                try db.execute(sql: "UPDATE t SET name = NULL")
                 try db.execute(sql: "UPDATE t SET name = 'qux'")
         })
     }


### PR DESCRIPTION
This pull request simplifies GRDB implementation by allowing `Optional` to participate in database requests as soon as it wrapped type does. Until this PR, Optional was always handled as a special case.

A few method signatures have changed, and this is the reason why this is a breaking change. It should have no effect on regular user code, though.