### PR TITLE
DatabaseError provide error message as localizedFailureReason 

### DIFF
--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -506,5 +506,11 @@ extension DatabaseError {
     
     /// NSError bridging: the user-info dictionary.
     /// :nodoc:
-    public var errorUserInfo: [String: Any] { [NSLocalizedDescriptionKey: description] }
+    public var errorUserInfo: [String: Any] {
+        var userInfo = [NSLocalizedDescriptionKey: description]
+        if let message = message {
+            userInfo[NSLocalizedFailureReasonErrorKey] = message
+        }
+        return userInfo
+    }
 }

--- a/Tests/GRDBTests/DatabaseErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseErrorTests.swift
@@ -226,6 +226,7 @@ class DatabaseErrorTests: GRDBTestCase {
                 XCTAssertEqual(DatabaseError.errorDomain, "GRDB.DatabaseError")
                 XCTAssertEqual(error.domain, DatabaseError.errorDomain)
                 XCTAssertEqual(error.code, 787)
+                XCTAssertNotNil(error.localizedFailureReason)
             }
         }
     }


### PR DESCRIPTION
Where `DatabaseError` conforms to `CustomNSError` it provides an `errorUserInfo` dictionary with a localised description key. This item in the dictionary is a string with the error code, message and sql in a single paragraph.

I think it would be good to provide another entry in the `errorUserInfo` dictionary with just the error message. 

This would be helpful as error codes and often SQL are not meant to be presented to the user and it is currently not possible to access just the message in places where `DatabaseError` has been type-erased to the `Error` type.

The userInfo key `NSLocalizedFailureReasonErrorKey` looks like it would be a good fit for this. 

Note:
I have modified the `testNSErrorBridging()` test to check that `localizedFailureReason` is not nil. It *is* able to be nil, but not for the specific error in that test. I thought it best just to check that the dictionary was being filled with a value where one is available, rather than check for exact strings which might change.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [n/a] DOCUMENTATION: Inline documentation has been updated.
- [n/a] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
