### PR TITLE
Fix a crash when an observation is quickly cancelled

### DIFF
--- a/GRDB/ValueObservation/ValueConcurrentObserver.swift
+++ b/GRDB/ValueObservation/ValueConcurrentObserver.swift
@@ -192,7 +192,8 @@ extension ValueConcurrentObserver {
             (self.notificationCallbacks, self.databaseAccess)
         }
         guard let notificationCallbacks = notificationCallbacksOpt, let databaseAccess = databaseAccessOpt else {
-            // Likely a GRDB bug
+            // Likely a GRDB bug: during a synchronous start, user is not
+            // able to cancel observation.
             fatalError("can't start a cancelled or failed observation")
         }
         


### PR DESCRIPTION
This should fix #1195.

In `ValueWriteOnlyObserver.fetchAndStartObservation()`, it is possible to have `eventsOpt` be `nil` if the observation is cancelled right after the `isNotifying` check in `ValueWriteOnlyObserver.asyncStart()` as the lock is released in-between.

I'm making `ValueWriteOnlyObserver.fetchAndStartObservation()` return `nil` in case the observation was cancelled before it even got started (maybe a dedicated `Error` would be better?), and `ValueWriteOnlyObserver.asyncStart()` simply bails out in that case.
On the other hand, having `ValueWriteOnlyObserver.fetchAndStartObservation()` return `nil` in `ValueWriteOnlyObserver.syncStart()` is unexpected, so add a `fatalError` there.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [X] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [X] BRANCH: This pull request is submitted against the `development` branch.
- [X] DOCUMENTATION: Inline documentation has been updated.
- [X] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [X] TESTS: Changes are tested.
- [X] TESTS: The `make smokeTest` terminal command runs without failure.
