### PR TITLE
Require Swift 5.6 Compiler for Concurrency Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Version
+
+- **Breaking Change**: [#1200](https://github.com/groue/GRDB.swift/pull/1200) by [@groue](https://github.com/groue): Require Swift 5.6 Compiler for Concurrency Support
+
 ## 5.22.2
 
 Released April 2, 2022 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v5.22.1...v5.22.2)

--- a/Documentation/Concurrency.md
+++ b/Documentation/Concurrency.md
@@ -137,7 +137,7 @@ try dbQueue.write { db in
 <details>
     <summary><b>Swift concurrency</b> (async/await)</summary>
 
-[**:fire: EXPERIMENTAL**](../README.md#what-are-experimental-features) GRDB support for Swift concurrency requires Xcode 13.2+.
+[**:fire: EXPERIMENTAL**](../README.md#what-are-experimental-features) GRDB support for Swift concurrency requires Xcode 13.3.1+.
 
 ```swift
 let playerCount = try await dbQueue.read { db in

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -160,7 +160,7 @@ public final class DatabasePool: DatabaseWriter {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 // @unchecked because of databaseSnapshotCount and readerPool
 extension DatabasePool: @unchecked Sendable { }
 #endif

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -371,7 +371,7 @@ extension DatabaseReader {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
 extension DatabaseReader {
     // MARK: - Asynchronous Database Access
     

--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -159,7 +159,7 @@ extension DatabaseValue: StatementBinding {
 
 extension DatabaseValue: GRDBSendable { }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 // @unchecked due to Foundation.Data not conforming to Sendable
 // TODO: Remove @unchecked when Foundation has been upgraded
 extension DatabaseValue.Storage: @unchecked Sendable { }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -380,7 +380,7 @@ extension DatabaseWriter {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
 extension DatabaseWriter {
     // MARK: - Asynchronous Database Access
     

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -2182,7 +2182,7 @@ struct ArrayRowImpl: RowImpl {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 // @unchecked because columns property is not inferred as Sendable
 // TODO: remove this @unchecked when compiler can handle tuples.
 extension ArrayRowImpl: @unchecked Sendable { }

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -249,7 +249,7 @@ final class SerializedDatabase {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 // @unchecked because the wrapped `Database` itself is not Sendable.
 // It happens the job of SerializedDatabase is precisely to provide thread-safe
 // access to `Database`.

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -32,7 +32,7 @@ public protocol _OptionalProtocol {
 /// :nodoc:
 extension Optional: _OptionalProtocol { }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 public typealias GRDBSendable = Swift.Sendable
 #else
 public typealias GRDBSendable = Any

--- a/GRDB/ValueObservation/SharedValueObservation.swift
+++ b/GRDB/ValueObservation/SharedValueObservation.swift
@@ -299,7 +299,7 @@ public final class SharedValueObservation<Element> {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
 extension SharedValueObservation {
     // MARK: - Asynchronous Observation
     /// The database observation, as an asynchronous sequence of

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -252,7 +252,7 @@ extension ValueObservation: Refinable {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
 extension ValueObservation {
     // MARK: - Asynchronous Observation
     /// The database observation, as an asynchronous sequence of

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ GRDB ships with:
 - [WAL Mode Support](#database-pools): Extra performance for multi-threaded applications.
 - [Migrations]: Transform your database as your application evolves.
 - [Database Observation]: Observe database changes and transactions.
-- [Swift Concurrency]: `try await` your database (Xcode 13.2+).
+- [Swift Concurrency]: `try await` your database (Xcode 13.3.1+).
 - [Combine Support]: Access and observe the database with Combine publishers.
 - [RxSwift Support](http://github.com/RxSwiftCommunity/RxGRDB): Access and observe the database with RxSwift observables.
 - [Full-Text Search]

--- a/Tests/GRDBCombineTests/Support.swift
+++ b/Tests/GRDBCombineTests/Support.swift
@@ -51,7 +51,7 @@ final class Test<Context> {
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncTest<Context> {
     // Raise the repeatCount in order to help spotting flaky tests.

--- a/Tests/GRDBTests/DatabaseReaderTests.swift
+++ b/Tests/GRDBTests/DatabaseReaderTests.swift
@@ -30,7 +30,7 @@ class DatabaseReaderTests : GRDBTestCase {
         try test(setup(makeDatabasePool()).makeSnapshot())
     }
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_ReadCanRead() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {
@@ -68,7 +68,7 @@ class DatabaseReaderTests : GRDBTestCase {
         try test(makeDatabasePool().makeSnapshot())
     }
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_ReadPreventsDatabaseModification() async throws {
         func test(_ dbReader: DatabaseReader) async throws {
@@ -107,7 +107,7 @@ class DatabaseReaderTests : GRDBTestCase {
         try test(setup(makeDatabasePool()).makeSnapshot())
     }
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_UnsafeReadCanRead() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -266,7 +266,7 @@ class DatabaseWriterTests : GRDBTestCase {
         try DatabaseQueue().backup(to: dbQueue)
     }
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_write() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {
@@ -288,7 +288,7 @@ class DatabaseWriterTests : GRDBTestCase {
     }
 #endif
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_writeWithoutTransaction() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {
@@ -313,7 +313,7 @@ class DatabaseWriterTests : GRDBTestCase {
     }
 #endif
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_barrierWriteWithoutTransaction() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {
@@ -338,7 +338,7 @@ class DatabaseWriterTests : GRDBTestCase {
     }
 #endif
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_erase() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {
@@ -358,7 +358,7 @@ class DatabaseWriterTests : GRDBTestCase {
     }
 #endif
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait_vacuum() async throws {
         func setup<T: DatabaseWriter>(_ dbWriter: T) throws -> T {
@@ -376,7 +376,7 @@ class DatabaseWriterTests : GRDBTestCase {
     }
 #endif
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.16, iOS 14, tvOS 14, watchOS 7, *) // async + vacuum into
     func testAsyncAwait_vacuumInto() async throws {
         // Prevent SQLCipher failures

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -259,7 +259,7 @@ public struct AnyValueReducer<Fetched, Value>: ValueReducer {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
+#if swift(>=5.6) && canImport(_Concurrency)
 // Assume this is correct :-/
 extension XCTestExpectation: @unchecked Sendable { }
 #endif

--- a/Tests/GRDBTests/SharedValueObservationTests.swift
+++ b/Tests/GRDBTests/SharedValueObservationTests.swift
@@ -621,7 +621,7 @@ class SharedValueObservationTests: GRDBTestCase {
     }
 #endif
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func testAsyncAwait() async throws {
         let dbQueue = try makeDatabaseQueue()

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -694,7 +694,7 @@ class ValueObservationTests: GRDBTestCase {
         try test(makeDatabasePool())
     }
     
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+#if compiler(>=5.6) && canImport(_Concurrency)
     // MARK: - Async Await
     
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
This pull request addresses #1185 and #1198 by bumping the Swift compiler version required to build the Swift Concurrency features to 5.6. The required Xcode version is 13.3.1.

Thanks to @jshier for sweating the details, and making the first move in https://github.com/Alamofire/Alamofire/pull/3590 👏 