### PR TITLE
Fix crash when the number of active ValueObservations is high

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **Fixed**: [#1213](https://github.com/groue/GRDB.swift/pull/1213) by [@groue](https://github.com/groue): Fix crash when the number of active ValueObservations is high
+- **Breaking Change**: Transactions performed during a read-only database access are no longer notified to transaction observers. This is, strictly speaking, a breaking change. However it should have no impact since read-only transactions have very little interest.
+
 ## 5.23.0
 
 Released April 16, 2022 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v5.22.2...v5.23.0)

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -233,7 +233,9 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         setupDefaultFunctions()
         setupDefaultCollations()
         setupAuthorizer()
-        observationBroker.installCommitAndRollbackHooks()
+        if !configuration.readonly {
+            observationBroker.installCommitAndRollbackHooks()
+        }
         try activateExtendedCodes()
         
         #if SQLITE_HAS_CODEC

--- a/README.md
+++ b/README.md
@@ -6683,6 +6683,8 @@ By default, database holds weak references to its transaction observers: they ar
 **A transaction observer is notified of all database changes**: inserts, updates and deletes. This includes indirect changes triggered by ON DELETE and ON UPDATE actions associated to [foreign keys](https://www.sqlite.org/foreignkeys.html#fk_actions), and [SQL triggers](https://www.sqlite.org/lang_createtrigger.html).
 
 > :point_up: **Note**: Some changes are not notified: changes to internal system tables (such as `sqlite_master`), changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables, and the deletion of duplicate rows triggered by [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) clauses (this last exception might change in a future release of SQLite).
+>
+> :point_up:  **Note**: Transactions performed during read-only database accesses are not notified.
 
 Notified changes are not actually written to disk until the [transaction](#transactions-and-savepoints) commits, and the `databaseDidCommit` callback is called. On the other side, `databaseDidRollback` confirms their invalidation:
 
@@ -6794,7 +6796,7 @@ class PlayerScoreObserver: TransactionObserver {
 }
 ```
 
-When the `observes(eventsOfKind:)` method returns false for all event kinds, the observer is still notified of commits and rollbacks:
+When the `observes(eventsOfKind:)` method returns false for all event kinds, the observer is still notified of commits and rollbacks (except during read-only database accesses):
 
 ```swift
 class PureTransactionObserver: TransactionObserver {

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -649,7 +649,7 @@ class ValueObservationTests: GRDBTestCase {
         try test(makeDatabasePool())
     }
     
-    func tesCancellableInvalidation2() throws {
+    func testCancellableInvalidation2() throws {
         // Test that observation stops when cancellable is deallocated
         func test(_ dbWriter: DatabaseWriter) throws {
             try dbWriter.write { try $0.execute(sql: "CREATE TABLE t(id INTEGER PRIMARY KEY AUTOINCREMENT)") }


### PR DESCRIPTION
This pull request fixes #1209.

---

The root of the issue was a `ValueObservation` reentrancy problem:

When a database transaction would commit changes on disk, active observations would fetch fresh values. Those fresh values are fetched in a transaction (since [v5.15.0](https://github.com/groue/GRDB.swift/blob/master/CHANGELOG.md#5150)), so that we can guarantee [snapshot isolation](https://www.sqlite.org/isolation.html), a fundamental concurrency safeguard. Those transactions would... trigger observations again, in a nasty quadratic behavior. 📈 

When only a few observations are active, they just ignore the transactions performed by their peers, because no changes are committed. The quadratic loop eventually ends. That's how this behavior went unnoticed. 🙈 

But when many observations are active, the quadratic loop eventually triggers a crash, reported in #1209. 💥 

---

The fix was to stop notifying transaction observers of transactions performed during read-only database accesses. This removes the quadratic behavior. And fixes the crash.

This is also a breaking change, but I do not expect any transaction observer to be interested in read-only transactions.

---

Thank you @xmanu for the initial report!