### PR TITLE
Update doc issue on TableRequest.filter(keys:).

### DIFF
--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -325,7 +325,7 @@ extension TableRequest where Self: FilteredRequest, Self: TypedRequest {
     
     /// Creates a request filtered by unique key.
     ///
-    ///     // SELECT * FROM player WHERE ... email = 'arthur@example.com' OR ...
+    ///     // SELECT * FROM player WHERE ... email = 'arthur@example.com' AND ...
     ///     let request = try Player...filter(keys: [["email": "arthur@example.com"], ...])
     ///
     /// When executed, this request raises a fatal error if there is no unique


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I'm working with GRDB.swift on my own app and after hitting the `fatalError` on `TableRequest.filter(keys:)`, I found a minor issue on its documentation.

* Should be `AND` on the SQL statement.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
