### PR TITLE
Raise default Quality of Service to .userInitiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 - **New**: [#1226](https://github.com/groue/GRDB.swift/pull/1226) by [@naveensrinivasan](https://github.com/naveensrinivasan): Included githubactions in the dependabot config
 - **New**: [#1228](https://github.com/groue/GRDB.swift/pull/1228) by [@naveensrinivasan](https://github.com/naveensrinivasan): Set permissions for GitHub actions
+- **New**: [#1235](https://github.com/groue/GRDB.swift/pull/1235) by [@groue](https://github.com/groue): Raise default Quality of Service to `.userInitiated`.
 - **Fixed**: [#1233](https://github.com/groue/GRDB.swift/pull/1233) by [@GetToSet](https://github.com/GetToSet): Fix warnings of redundant conformance constraint on Xcode 14.
 
 ## 5.24.1

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -245,8 +245,8 @@ public struct Configuration {
     ///
     /// The quality of service is ignored if you supply a target queue.
     ///
-    /// Default: .default
-    public var qos: DispatchQoS = .default
+    /// Default: .userInitiated
+    public var qos: DispatchQoS = .userInitiated
     
     /// The quality of service of read accesses
     var readQoS: DispatchQoS {


### PR DESCRIPTION
The default quality of service of a database is now `.userInitiated`:

```swift
var configuration = Configuration()
configuration.qos = .userInitiated // the new default
let dbQueue = try DatabaseQueue(path: ..., configuration: configuration)
```

This change avoids priority inversion that could happen during synchronous database accesses from the main thread.

Starting from Xcode 14 beta, the Thread Performance Checker would emit runtime warnings without this change. This pull request fixes #1234.
