### PR TITLE
Fix inline documentation typo in Row

### DIFF
--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -287,7 +287,7 @@ extension Row {
     /// The result is nil if the row does not contain the column.
     public subscript(_ columnName: String) -> DatabaseValueConvertible? {
         // IMPLEMENTATION NOTE
-        // This method has a single know use case: checking if the value is nil,
+        // This method has a single known use case: checking if the value is nil,
         // as in:
         //
         //     if row["foo"] != nil { ... }


### PR DESCRIPTION
This PR fixes a small type inline documentation in `Row`.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [ ] TESTS: Changes are tested.
- [ ] TESTS: The `make smokeTest` terminal command runs without failure.
