### PR TITLE
Make memory management optional.

### DIFF
--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -276,15 +276,11 @@ public struct Configuration {
     /// Default: nil
     public var writeTargetQueue: DispatchQueue? = nil
 
+#if os(iOS)
     /// Sets whether GRDB will release memory when entering the background or
     /// upon receiving a memory warning in iOS.
     ///
-    /// Enabling this setting may help keep iOS from terminating your app when
-    /// memory pressure becomes high. However, it can also cause database
-    /// readers to block longer than they normally would.
-    ///
     /// Default: true
-#if os(iOS)
     public var automaticMemoryManagement = true
 #endif
 

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -275,7 +275,19 @@ public struct Configuration {
     ///
     /// Default: nil
     public var writeTargetQueue: DispatchQueue? = nil
-    
+
+    /// Sets whether GRDB will release memory when entering the background or
+    /// upon receiving a memory warning in iOS.
+    ///
+    /// Enabling this setting may help keep iOS from terminating your app when
+    /// memory pressure becomes high. However, it can also cause database
+    /// readers to block longer than they normally would.
+    ///
+    /// Default: true
+#if os(iOS)
+    public var automaticMemoryManagement = true
+#endif
+
     // MARK: - Factory Configuration
     
     /// Creates a factory configuration

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1184,7 +1184,8 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     // MARK: - Memory Management
     
-    func releaseMemory() {
+    public func releaseMemory() {
+        SchedulingWatchdog.preconditionValidQueue(self)
         sqlite3_db_release_memory(sqliteConnection)
         schemaCache.clear()
         internalStatementCache.clear()

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -103,7 +103,9 @@ public final class DatabasePool: DatabaseWriter {
         // Be a nice iOS citizen, and don't consume too much memory
         // See https://github.com/groue/GRDB.swift/#memory-management
         #if os(iOS)
-        setupMemoryManagement()
+        if configuration.automaticMemoryManagement {
+            setupMemoryManagement()
+        }
         #endif
     }
     
@@ -160,6 +162,17 @@ public final class DatabasePool: DatabaseWriter {
     fileprivate func forEachConnection(_ body: (Database) -> Void) {
         writer.sync(body)
         readerPool?.forEach { $0.sync(body) }
+    }
+
+    var numberOfReaders: Int {
+        guard let readerPool = readerPool else {
+            return 0
+        }
+        var count = 0
+        readerPool.forEach { _ in
+            count += 1
+        }
+        return count
     }
 }
 

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -156,24 +156,6 @@ public final class DatabasePool: DatabaseWriter {
         
         return configuration
     }
-    
-    /// Blocks the current thread until all database connections have
-    /// executed the *body* block.
-    fileprivate func forEachConnection(_ body: (Database) -> Void) {
-        writer.sync(body)
-        readerPool?.forEach { $0.sync(body) }
-    }
-
-    var numberOfReaders: Int {
-        guard let readerPool = readerPool else {
-            return 0
-        }
-        var count = 0
-        readerPool.forEach { _ in
-            count += 1
-        }
-        return count
-    }
 }
 
 #if swift(>=5.6) && canImport(_Concurrency)

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -180,7 +180,14 @@ extension DatabasePool {
         // Release writer memory
         writer.sync { $0.releaseMemory() }
         
-        // Release readers memory by closing all connections
+        // Release readers memory by closing all connections.
+        //
+        // We must use a barrier in order to guarantee that memory has been
+        // freed (reader connections closed) when the method exits, as
+        // documented.
+        //
+        // Without the barrier, connections would only close _eventually_ (after
+        // their eventual concurrent jobs have completed).
         readerPool?.barrier {
             readerPool?.removeAll()
         }

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -43,7 +43,9 @@ public final class DatabaseQueue: DatabaseWriter {
         // Be a nice iOS citizen, and don't consume too much memory
         // See https://github.com/groue/GRDB.swift/#memory-management
         #if os(iOS)
-        setupMemoryManagement()
+        if configuration.automaticMemoryManagement {
+            setupMemoryManagement()
+        }
         #endif
     }
     

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -119,12 +119,12 @@ extension DatabaseQueue {
         
         let task: UIBackgroundTaskIdentifier = application.beginBackgroundTask(expirationHandler: nil)
         if task == .invalid {
-            // Perform releaseMemory() synchronously.
+            // Release memory synchronously
             releaseMemory()
         } else {
-            // Perform releaseMemory() asynchronously.
-            DispatchQueue.global().async {
-                self.releaseMemory()
+            // Release memory asynchronously
+            writer.async { db in
+                db.releaseMemory()
                 application.endBackgroundTask(task)
             }
         }
@@ -132,8 +132,8 @@ extension DatabaseQueue {
     
     @objc
     private func applicationDidReceiveMemoryWarning(_ notification: NSNotification) {
-        DispatchQueue.global().async {
-            self.releaseMemory()
+        writer.async { db in
+            db.releaseMemory()
         }
     }
     #endif

--- a/README.md
+++ b/README.md
@@ -7718,12 +7718,36 @@ dbPool.releaseMemory()
 
 This method blocks the current thread until all current database accesses are completed, and the memory collected.
 
+> :warning: **Warning**: If `DatabasePool.releaseMemory()` is called while a long read is performed concurrently, then no other read access will be possible until this long read has completed, and the memory has been released. If this does not suit your application needs, look for the asynchronous options below:
+
+You can release memory in an asynchronous way as well:
+
+```swift
+// On a DatabaseQueue
+dbQueue.asyncWriteWithoutTransaction { db in
+    db.releaseMemory()
+}
+
+// On a DatabasePool
+dbPool.releaseMemoryEventually()
+```
+
+`DatabasePool.releaseMemoryEventually()` does not block the current thread, and does not prevent concurrent database accesses. In exchange for this convenience, you don't know when memory has been freed.
+
 
 ### Memory Management on iOS
 
 **The iOS operating system likes applications that do not consume much memory.**
 
-[Database queues](#database-queues) and [pools](#database-pools) automatically call the `releaseMemory` method when the application receives a memory warning, and when the application enters background.
+[Database queues](#database-queues) and [pools](#database-pools) automatically free non-essential memory when the application receives a memory warning, and when the application enters background.
+
+You can opt out of this automatic memory management:
+
+```swift
+var config = Configuration()
+config.automaticMemoryManagement = false
+let dbQueue = try DatabaseQueue(path: dbPath, configuration: config) // or DatabasePool
+```
 
 
 ## Data Protection

--- a/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
@@ -58,7 +58,9 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         try dbPool.read { _ in }
         
         // Simulate memory warning.
-        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        NotificationCenter.default.post(
+            name: NSNotification.Name(rawValue: "UIApplicationDidReceiveMemoryWarningNotification"),
+            object: nil)
         
         // Postcondition: reader connection was closed
         withExtendedLifetime(dbPool) { _ in
@@ -84,7 +86,9 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         try dbPool.read { _ in }
         
         // Simulate memory warning.
-        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        NotificationCenter.default.post(
+            name: NSNotification.Name(rawValue: "UIApplicationDidReceiveMemoryWarningNotification"),
+            object: nil)
         
         // Postcondition: no reader connection was closed
         withExtendedLifetime(dbPool) { _ in
@@ -103,7 +107,9 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         }
         
         // Simulate memory warning.
-        NotificationCenter.default.post(name: UIApplication.didReceiveMemoryWarningNotification, object: nil)
+        NotificationCenter.default.post(
+            name: NSNotification.Name(rawValue: "UIApplicationDidReceiveMemoryWarningNotification"),
+            object: nil)
         
         // Make sure we can read
         try dbPool.read { _ in }


### PR DESCRIPTION
Memory management may not be desirable for all
users of GRDB. `DatabasePool.releaseMemory`
creates a barrier which may cause normally fast
readers to block for a long time. If this is not a
desirable tradeoff, the new
`automaticMemoryManagement` flag in
`Configuration` allows you to disable this feature
of GRDB.

- [✓ ] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [ ✓] BRANCH: This pull request is submitted against the `development` branch.
- [ ✓] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [ ✓] TESTS: Changes are tested.
- [ ✓] TESTS: The `make smokeTest` terminal command runs without failure.
