### PR TITLE
Fix SQL generation of CHECK constraints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **Fix**: [#1268](https://github.com/groue/GRDB.swift/pull/1268) by [@groue](https://github.com/groue): Fix SQL generation of CHECK constraints
+- **Breaking**: The `Column` type is no longer `Equatable`
+
 ## 6.0.0-beta.2
 
 Released August 23, 2022 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v6.0.0-beta...v6.0.0-beta.2)

--- a/GRDB/QueryInterface/SQL/Column.swift
+++ b/GRDB/QueryInterface/SQL/Column.swift
@@ -63,7 +63,7 @@ extension ColumnExpression where Self == Column {
 /// Instead, adopt the ColumnExpression protocol.
 ///
 /// See <https://github.com/groue/GRDB.swift#the-query-interface>
-public struct Column: ColumnExpression, Equatable {
+public struct Column: ColumnExpression {
     /// The hidden rowID column
     public static let rowID = Column("rowid")
     
@@ -78,12 +78,6 @@ public struct Column: ColumnExpression, Equatable {
     /// Creates a column given a CodingKey.
     public init(_ codingKey: some CodingKey) {
         self.name = codingKey.stringValue
-    }
-    
-    // Avoid a wrong resolution when BUILD_LIBRARY_FOR_DISTRIBUTION is set
-    @_disfavoredOverload
-    public static func == (lhs: Column, rhs: Column) -> Bool {
-        lhs.name == rhs.name
     }
 }
 

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -241,12 +241,14 @@ class TableDefinitionTests: GRDBTestCase {
                 t.column("a", .integer).check { $0 > 0 }
                 t.column("b", .integer).check(sql: "b <> 2")
                 t.column("c", .integer).check { $0 > 0 }.check { $0 < 10 }
+                t.column("d", .integer).check { $0 != Column("c") }
             }
             assertEqualSQL(lastSQLQuery!, """
                 CREATE TABLE "test" (\
                 "a" INTEGER CHECK ("a" > 0), \
                 "b" INTEGER CHECK (b <> 2), \
-                "c" INTEGER CHECK ("c" > 0) CHECK ("c" < 10)\
+                "c" INTEGER CHECK ("c" > 0) CHECK ("c" < 10), \
+                "d" INTEGER CHECK ("d" <> "c")\
                 )
                 """)
 


### PR DESCRIPTION
This PR fixes the GRDB6 regression described in #1267.

See 58f970701f47283478e95161df49bfd7f6d9d8f9 for details.