### PR TITLE
Immediate (synchronous) read & write Combine publishers

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		567F45A81F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		568068311EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
 		5682D721239582AA004B58C4 /* DatabaseSuspensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5682D71A239582AA004B58C4 /* DatabaseSuspensionTests.swift */; };
+		56832C8F28D0571800E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56832C8E28D0571800E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift */; };
 		56848973242DE36F002F9702 /* ValueObservationScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56848972242DE36F002F9702 /* ValueObservationScheduler.swift */; };
 		56894F752606576600268F4D /* FoundationDecimalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894F742606576600268F4D /* FoundationDecimalTests.swift */; };
 		56894FB72606589700268F4D /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894F94260657D600268F4D /* Decimal.swift */; };
@@ -249,6 +250,7 @@
 		56AE64122229A53700AD1B0B /* HasOneThroughAssociation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE64112229A53700AD1B0B /* HasOneThroughAssociation.swift */; };
 		56AE6424222AAC9500AD1B0B /* AssociationHasOneThroughSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE6423222AAC9500AD1B0B /* AssociationHasOneThroughSQLTests.swift */; };
 		56B021C91D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B021C81D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift */; };
+		56B05DDD28D0541E00E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B05DDC28D0541E00E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift */; };
 		56B6EF56208CB4E3002F0ACB /* ColumnExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6EF55208CB4E3002F0ACB /* ColumnExpressionTests.swift */; };
 		56B7EE832863781300C0525F /* WALSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7EE822863781300C0525F /* WALSnapshot.swift */; };
 		56B7F43A1BEB42D500E39BBF /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B7F4391BEB42D500E39BBF /* Migration.swift */; };
@@ -611,6 +613,7 @@
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
 		5682D71A239582AA004B58C4 /* DatabaseSuspensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseSuspensionTests.swift; sourceTree = "<group>"; };
+		56832C8E28D0571800E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseWriterImmediateWritePublisherTests.swift; sourceTree = "<group>"; };
 		56848972242DE36F002F9702 /* ValueObservationScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueObservationScheduler.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		56894F742606576600268F4D /* FoundationDecimalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationDecimalTests.swift; sourceTree = "<group>"; };
@@ -708,6 +711,7 @@
 		56AE6423222AAC9500AD1B0B /* AssociationHasOneThroughSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasOneThroughSQLTests.swift; sourceTree = "<group>"; };
 		56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEscapingTests.swift; sourceTree = "<group>"; };
 		56B021C81D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordPersistenceConflictPolicyTests.swift; sourceTree = "<group>"; };
+		56B05DDC28D0541E00E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseReaderImmediateReadPublisherTests.swift; sourceTree = "<group>"; };
 		56B14E7E1D4DAE54000BF4A3 /* RowFromDictionaryLiteralTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowFromDictionaryLiteralTests.swift; sourceTree = "<group>"; };
 		56B6EF55208CB4E3002F0ACB /* ColumnExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnExpressionTests.swift; sourceTree = "<group>"; };
 		56B7EE822863781300C0525F /* WALSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WALSnapshot.swift; sourceTree = "<group>"; };
@@ -1095,10 +1099,12 @@
 		56419A6924A51601004967E1 /* GRDBCombineTests */ = {
 			isa = PBXGroup;
 			children = (
-				56419A6A24A51601004967E1 /* DatabaseWriterWritePublisherTests.swift */,
+				56B05DDC28D0541E00E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift */,
 				56419A6B24A51601004967E1 /* DatabaseReaderReadPublisherTests.swift */,
-				56419A6C24A51601004967E1 /* Support.swift */,
 				56419A6D24A51601004967E1 /* DatabaseRegionObservationPublisherTests.swift */,
+				56832C8E28D0571800E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift */,
+				56419A6A24A51601004967E1 /* DatabaseWriterWritePublisherTests.swift */,
+				56419A6C24A51601004967E1 /* Support.swift */,
 				56419A6E24A51601004967E1 /* ValueObservationPublisherTests.swift */,
 			);
 			path = GRDBCombineTests;
@@ -1811,6 +1817,7 @@
 				56D4967C1D8130DB008276D7 /* CGFloatTests.swift in Sources */,
 				56D496631D81304E008276D7 /* FoundationURLTests.swift in Sources */,
 				563C67B324628BEA00E94EDC /* DatabasePoolTests.swift in Sources */,
+				56B05DDD28D0541E00E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift in Sources */,
 				56D496B71D81344B008276D7 /* RecordUniqueIndexTests.swift in Sources */,
 				5653EAE220944B4F00F46237 /* AssociationHasOneSQLTests.swift in Sources */,
 				56D496671D813086008276D7 /* Record+QueryInterfaceRequestTests.swift in Sources */,
@@ -1827,6 +1834,7 @@
 				56012B552573EED000B4925B /* CommonTableExpressionTests.swift in Sources */,
 				56D496BA1D813482008276D7 /* DatabaseQueueSchemaCacheTests.swift in Sources */,
 				56D496781D81309E008276D7 /* RecordSubClassTests.swift in Sources */,
+				56832C8F28D0571800E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift in Sources */,
 				5656A7FF22946B34001FF3FF /* ValueObservationQueryInterfaceRequestTests.swift in Sources */,
 				5615B262222AE1B400061C1C /* AssociationHasOneThroughSQLDerivationTests.swift in Sources */,
 				56D4965F1D81304E008276D7 /* FoundationNSURLTests.swift in Sources */,

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		567E420A242AB3CB00CAAD2C /* FailureTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567E4207242AB3CB00CAAD2C /* FailureTestCase.swift */; };
 		567F45AB1F888B2600030B59 /* TruncateOptimizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */; };
 		568068341EBBA26100EFB8AA /* SQLRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568068301EBBA26100EFB8AA /* SQLRequestTests.swift */; };
+		56832C9428D0574400E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56832C9328D0574400E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift */; };
 		56894F332604FC1E00268F4D /* Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894F322604FC1E00268F4D /* Table.swift */; };
 		56894FE3260658A400268F4D /* Decimal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894FA0260657F600268F4D /* Decimal.swift */; };
 		56894FF2260658E600268F4D /* FoundationDecimalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56894FF1260658E600268F4D /* FoundationDecimalTests.swift */; };
@@ -239,6 +240,7 @@
 		56AE6428222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AE6426222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift */; };
 		56AF746E1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */; };
 		56B021CC1D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B021C81D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift */; };
+		56B05DE028D0543700E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B05DDE28D0543700E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift */; };
 		56B14E821D4DAE54000BF4A3 /* RowFromDictionaryLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B14E7E1D4DAE54000BF4A3 /* RowFromDictionaryLiteralTests.swift */; };
 		56B6EF60208CB746002F0ACB /* ColumnExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6EF5E208CB746002F0ACB /* ColumnExpressionTests.swift */; };
 		56B86E70220FF4C900524C16 /* SQLLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B86E6E220FF4C800524C16 /* SQLLiteralTests.swift */; };
@@ -635,6 +637,7 @@
 		567E4207242AB3CB00CAAD2C /* FailureTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FailureTestCase.swift; sourceTree = "<group>"; };
 		567F45A71F888B2600030B59 /* TruncateOptimizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TruncateOptimizationTests.swift; sourceTree = "<group>"; };
 		568068301EBBA26100EFB8AA /* SQLRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRequestTests.swift; sourceTree = "<group>"; };
+		56832C9328D0574400E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseWriterImmediateWritePublisherTests.swift; sourceTree = "<group>"; };
 		5687359E1CEDE16C009B9116 /* Betty.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Betty.jpeg; sourceTree = "<group>"; };
 		56894F322604FC1E00268F4D /* Table.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Table.swift; sourceTree = "<group>"; };
 		56894FA0260657F600268F4D /* Decimal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Decimal.swift; sourceTree = "<group>"; };
@@ -719,6 +722,7 @@
 		56AE6426222AACE300AD1B0B /* AssociationHasOneThroughSQLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssociationHasOneThroughSQLTests.swift; sourceTree = "<group>"; };
 		56AF746A1D41FB9C005E9FF3 /* DatabaseValueConvertibleEscapingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseValueConvertibleEscapingTests.swift; sourceTree = "<group>"; };
 		56B021C81D8C0D3900B239BB /* MutablePersistableRecordPersistenceConflictPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutablePersistableRecordPersistenceConflictPolicyTests.swift; sourceTree = "<group>"; };
+		56B05DDE28D0543700E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseReaderImmediateReadPublisherTests.swift; sourceTree = "<group>"; };
 		56B14E7E1D4DAE54000BF4A3 /* RowFromDictionaryLiteralTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RowFromDictionaryLiteralTests.swift; sourceTree = "<group>"; };
 		56B6EF5E208CB746002F0ACB /* ColumnExpressionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColumnExpressionTests.swift; sourceTree = "<group>"; };
 		56B7F4291BE14A1900E39BBF /* CGFloatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGFloatTests.swift; sourceTree = "<group>"; };
@@ -1070,10 +1074,12 @@
 		56419A6F24A51613004967E1 /* GRDBCombineTests */ = {
 			isa = PBXGroup;
 			children = (
-				56419A7024A51613004967E1 /* DatabaseWriterWritePublisherTests.swift */,
+				56B05DDE28D0543700E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift */,
 				56419A7124A51613004967E1 /* DatabaseReaderReadPublisherTests.swift */,
-				56419A7224A51613004967E1 /* Support.swift */,
 				56419A7324A51613004967E1 /* DatabaseRegionObservationPublisherTests.swift */,
+				56832C9328D0574400E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift */,
+				56419A7024A51613004967E1 /* DatabaseWriterWritePublisherTests.swift */,
+				56419A7224A51613004967E1 /* Support.swift */,
 				56419A7424A51613004967E1 /* ValueObservationPublisherTests.swift */,
 			);
 			path = GRDBCombineTests;
@@ -2160,6 +2166,7 @@
 				F3BA812E1CFB3064003DC1BA /* RecordPrimaryKeyMultipleTests.swift in Sources */,
 				F3BA81021CFB3032003DC1BA /* CGFloatTests.swift in Sources */,
 				5676FBAA22F5CEB9004717D9 /* ValueObservationRegionRecordingTests.swift in Sources */,
+				56B05DE028D0543700E7D039 /* DatabaseReaderImmediateReadPublisherTests.swift in Sources */,
 				566A84432041AB2D00E50BFD /* MutablePersistableRecordChangesTests.swift in Sources */,
 				567DAF381EAB789800FC0928 /* DatabaseLogErrorTests.swift in Sources */,
 				569BBA2B228DE53200478429 /* AssociationPrefetchingFetchableRecordTests.swift in Sources */,
@@ -2198,6 +2205,7 @@
 				F3BA80B51CFB2FCA003DC1BA /* DatabaseQueueInMemoryTests.swift in Sources */,
 				56A4CDB31D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift in Sources */,
 				566A843520413DE400E50BFD /* DatabaseSnapshotTests.swift in Sources */,
+				56832C9428D0574400E43AFA /* DatabaseWriterImmediateWritePublisherTests.swift in Sources */,
 				F3BA80DF1CFB300F003DC1BA /* RawRepresentable+DatabaseValueConvertibleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/GRDBCombineTests/DatabaseReaderImmediateReadPublisherTests.swift
+++ b/Tests/GRDBCombineTests/DatabaseReaderImmediateReadPublisherTests.swift
@@ -1,0 +1,100 @@
+#if canImport(Combine)
+import Combine
+import GRDB
+import XCTest
+
+private struct Player: Codable, FetchableRecord, PersistableRecord {
+    var id: Int64
+    var name: String
+    var score: Int?
+    
+    static func createTable(_ db: Database) throws {
+        try db.create(table: "player") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("name", .text).notNull()
+            t.column("score", .integer)
+        }
+    }
+}
+
+class DatabaseReaderImmediateReadPublisherTests : XCTestCase {
+    
+    // MARK: -
+    
+    func testImmediateReadPublisher() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func setUp<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(reader: some DatabaseReader) throws {
+            let publisher = reader.immediateReadPublisher(value: { db in
+                try Player.fetchCount(db)
+            })
+            let recorder = publisher.record()
+            let value = try recorder.single.get()
+            XCTAssertEqual(value, 0)
+        }
+        
+        try Test(test).run { try setUp(DatabaseQueue()) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabaseQueue(path: $0)) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabasePool(path: $0)) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabasePool(path: $0)).makeSnapshot() }
+    }
+    
+    // MARK: -
+    
+    func testImmediateReadPublisherError() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func test(reader: some DatabaseReader) throws {
+            let publisher = reader.immediateReadPublisher(value: { db in
+                try Row.fetchAll(db, sql: "THIS IS NOT SQL")
+            })
+            let recorder = publisher.record()
+            let recording = try recorder.recording.get()
+            XCTAssertTrue(recording.output.isEmpty)
+            assertFailure(recording.completion) { (error: DatabaseError) in
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.sql, "THIS IS NOT SQL")
+            }
+        }
+        
+        try Test(test).run { try DatabaseQueue() }
+        try Test(test).runAtTemporaryDatabasePath { try DatabaseQueue(path: $0) }
+        try Test(test).runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
+        try Test(test).runAtTemporaryDatabasePath { try DatabasePool(path: $0).makeSnapshot() }
+    }
+    
+    // MARK: -
+    
+    func testImmediateReadPublisherIsReadonly() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func test(reader: some DatabaseReader) throws {
+            let publisher = reader.immediateReadPublisher(value: { db in
+                try Player.createTable(db)
+            })
+            let recorder = publisher.record()
+            let recording = try recorder.recording.get()
+            XCTAssertTrue(recording.output.isEmpty)
+            assertFailure(recording.completion) { (error: DatabaseError) in
+                XCTAssertEqual(error.resultCode, .SQLITE_READONLY)
+            }
+        }
+        
+        try Test(test).run { try DatabaseQueue() }
+        try Test(test).runAtTemporaryDatabasePath { try DatabaseQueue(path: $0) }
+        try Test(test).runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
+        try Test(test).runAtTemporaryDatabasePath { try DatabasePool(path: $0).makeSnapshot() }
+    }
+}
+#endif

--- a/Tests/GRDBCombineTests/DatabaseWriterImmediateWritePublisherTests.swift
+++ b/Tests/GRDBCombineTests/DatabaseWriterImmediateWritePublisherTests.swift
@@ -1,0 +1,168 @@
+#if canImport(Combine)
+import Combine
+import GRDB
+import XCTest
+
+private struct Player: Codable, FetchableRecord, PersistableRecord {
+    var id: Int64
+    var name: String
+    var score: Int?
+    
+    static func createTable(_ db: Database) throws {
+        try db.create(table: "player") { t in
+            t.autoIncrementedPrimaryKey("id")
+            t.column("name", .text).notNull()
+            t.column("score", .integer)
+        }
+    }
+}
+
+class DatabaseWriterImmediateWritePublisherTests : XCTestCase {
+    
+    // MARK: -
+    
+    func testImmediateWritePublisher() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func setUp<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(writer: some DatabaseWriter) throws {
+            try XCTAssertEqual(writer.read(Player.fetchCount), 0)
+            let publisher = writer.immediateWritePublisher(updates: { db in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+            })
+            let recorder = publisher.record()
+            try recorder.single.get()
+            try XCTAssertEqual(writer.read(Player.fetchCount), 1)
+        }
+        
+        try Test(test).run { try setUp(DatabaseQueue()) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabaseQueue(path: $0)) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabasePool(path: $0)) }
+    }
+    
+    // MARK: -
+    
+    func testImmediateWritePublisherValue() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func setUp<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(writer: some DatabaseWriter) throws {
+            let publisher = writer.immediateWritePublisher(updates: { db -> Int in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                return try Player.fetchCount(db)
+            })
+            let recorder = publisher.record()
+            let count = try recorder.single.get()
+            XCTAssertEqual(count, 1)
+        }
+        
+        try Test(test).run { try setUp(DatabaseQueue()) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabaseQueue(path: $0)) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabasePool(path: $0)) }
+    }
+    
+    // MARK: -
+    
+    func testImmediateWritePublisherError() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func test(writer: some DatabaseWriter) throws {
+            let publisher = writer.immediateWritePublisher(updates: { db in
+                try db.execute(sql: "THIS IS NOT SQL")
+            })
+            let recorder = publisher.record()
+            let recording = try recorder.recording.get()
+            XCTAssertTrue(recording.output.isEmpty)
+            assertFailure(recording.completion) { (error: DatabaseError) in
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.sql, "THIS IS NOT SQL")
+            }
+        }
+        
+        try Test(test).run { try DatabaseQueue() }
+        try Test(test).runAtTemporaryDatabasePath { try DatabaseQueue(path: $0) }
+        try Test(test).runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
+    }
+    
+    func testImmediateWritePublisherErrorRollbacksTransaction() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func setUp<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(writer: some DatabaseWriter) throws {
+            let publisher = writer.immediateWritePublisher(updates: { db in
+                try Player(id: 1, name: "Arthur", score: 1000).insert(db)
+                try db.execute(sql: "THIS IS NOT SQL")
+            })
+            let recorder = publisher.record()
+            let recording = try recorder.recording.get()
+            XCTAssertTrue(recording.output.isEmpty)
+            assertFailure(recording.completion) { (error: DatabaseError) in
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.sql, "THIS IS NOT SQL")
+            }
+            let count = try writer.read(Player.fetchCount)
+            XCTAssertEqual(count, 0)
+        }
+        
+        try Test(test).run { try setUp(DatabaseQueue()) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabaseQueue(path: $0)) }
+        try Test(test).runAtTemporaryDatabasePath { try setUp(DatabasePool(path: $0)) }
+    }
+    
+    // MARK: - Regression tests
+    
+    func testDeadlockPrevention() throws {
+        guard #available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *) else {
+            throw XCTSkip("Combine is not available")
+        }
+        
+        func setUp<Writer: DatabaseWriter>(_ writer: Writer) throws -> Writer {
+            try writer.write(Player.createTable)
+            return writer
+        }
+        
+        func test(writer: DatabaseWriter, iteration: Int) throws {
+            // print(iteration)
+            let scoreSubject = PassthroughSubject<Int, Error>()
+            let publisher = scoreSubject
+                .map { score in
+                    writer.immediateWritePublisher { db -> Int in
+                        try Player(id: 1, name: "Arthur", score: score).insert(db)
+                        return try Player.fetchCount(db)
+                    }
+                }
+                .switchToLatest()
+                .prefix(1)
+            let recorder = publisher.record()
+            scoreSubject.send(0)
+            let count = try recorder.single.get()
+            XCTAssertEqual(count, 1)
+        }
+        
+        try Test(repeatCount: 100, test).run { try setUp(DatabaseQueue()) }
+        try Test(repeatCount: 100, test).runAtTemporaryDatabasePath { try setUp(DatabaseQueue(path: $0)) }
+        try Test(repeatCount: 100, test).runAtTemporaryDatabasePath { try setUp(DatabasePool(path: $0)) }
+    }
+}
+#endif
+


### PR DESCRIPTION
While using with [GRDBQuery](https://github.com/groue/GRDBQuery), it happens that some SwiftUI views don't want to stay in sync with the database content (thanks to database observation), but rather only fetch a unique database value that is not automatically updated. This is useful when building forms, for example: you feed the form with one state of the database, and then let the user deal with it.

Fetching a single database value with a Combine publisher is already possible with the `readPublisher` method. However, this publisher is asynchronous, meaning that any SwiftUI view that uses it has to deal with an absence of value, until it has been fetched. The Optional type is a good candidate for representing such situation: a nil value means that the fetch has not yet completed:

```swift
struct PlayerCountRequest: Queryable {
    static let defaultValue: Int? = nil

    func publisher(in dbQueue: DatabaseQueue) -> AnyPublisher<Int?, Error> {
        dbQueue
            .readPublisher { try Player.fetchCount($0) }
            .eraseToAnyPublisher()
    }
}

struct PlayerCountView: View {
    @Query(PlayerCountRequest()) var playerCount: Int?

    var body: some View {
        if let playerCount {
            Text("\(playerCount) players")
        } else {
            ProgressView()
        }
    }
}
```

This technique suffers from two problems:

- Some apps do not want the view to have a loading state. They want to opt in for synchronous, aka "immediate", database fetches - even if the database is accessed from the main thread. SQLite is very fast: this is not an unreasonable decision.
- Optional can't distinguish between 1. value was not fetched yet, 2. fetch was performed and value is missing, 3. value was fetched.

Consider:

```swift
struct PlayerRequest: Queryable {
    static let defaultValue: Player? = nil

    var playerId: Player.ID

    func publisher(in dbQueue: DatabaseQueue) -> AnyPublisher<Player?, Error> {
        dbQueue
            .readPublisher { try Player.fetchOne($0, id: playerId) }
            .eraseToAnyPublisher()
    }
}

struct PlayerView: View {
    @Query<PlayerRequest> var player: Player?

    init(playerId: Player.ID) {
        _player = Query(PlayerRequest(playerId: playerId))
    }

    var body: some View {
        if let player = player {
            Text(player.name)
        } else {
            // Player is not loaded yet, or missing 🤔
        }
    }
}
```

A workaround for the two problems is to build a synchronous publisher by hand:

```swift
struct PlayerRequest: Queryable {
    static let defaultValue: Player? = nil

    var playerId: Player.ID

    func publisher(in dbQueue: DatabaseQueue) -> AnyPublisher<Player?, Error> {
        Deferred {
            Result {
                try dbQueue.read { try Player.fetchOne($0, id: playerId) }
            }.publisher
        }.eraseToAnyPublisher()
    }
}

struct PlayerView: View {
    @Query<PlayerRequest> var player: Player?

    init(playerId: Player.ID) {
        _player = Query(PlayerRequest(playerId: playerId))
    }

    var body: some View {
        if let player = player {
            Text(player.name)
        } else {
            Text("Player does not exist") // 🙂
        }
    }
}
```

The `Deferred { Result { try ... }.publisher }` construct is totally OK, but requires a lot of Combine skills to come up with.

That's why this PR introduces the `immediateReadPublisher`, which is equivalent:

```swift
struct PlayerRequest: Queryable {
    static let defaultValue: Player? = nil

    var playerId: Player.ID

    func publisher(in dbQueue: DatabaseQueue) -> AnyPublisher<Player?, Error> {
        dbQueue
            .immediateReadPublisher { try Player.fetchOne($0, id: playerId) }
            .eraseToAnyPublisher()
    }
}
```

The goal of `immediateReadPublisher` is to streamline some documentations, as well as reuse the "immediate" word that has ValueObservation publishers perform an initial synchronous fetch as well:

```swift
ValueObservation
    .tracking { try Player.fetchOne($0, id: playerId) }
    .publisher(in: dbQueue, scheduling: .immediate)
    //                                  ~~~~~~~~~~
```

By symmetry with `immediateReadPublisher`, this PR defines `immediateWritePublisher` as well.