### PR TITLE
Added an external documentation link for the Swift Package Index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,3 @@
 version: 1
 external_links:
-  documentation: "https://github.com/groue/GRDB.swift#documentation"
+  documentation: "https://github.com/groue/GRDB.swift/blob/master/README.md"

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,3 @@
+version: 1
+external_links:
+  documentation: "https://github.com/groue/GRDB.swift#documentation"


### PR DESCRIPTION
Hi @groue! You expressed interest in having the Swift Package Index point back to your own hosted documentation. I just finished implementing the feature and thought you might be up for being our first adopter of it!

Adding this file will add a "Documentation" link to the [GRDB page on SPI](https://swiftpackageindex.com/groue/GRDB.swift) that links people to https://github.com/groue/GRDB.swift#documentation, which seems to be your preferred documentation URL. Of course, if you would prefer a different URL, please let me know.

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [ ] TESTS: Changes are tested.
- [ ] TESTS: The `make smokeTest` terminal command runs without failure.
