### PR TITLE
fix: Remove inlining of functions that cause optimizer to crash

### DIFF
--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -58,8 +58,6 @@ public protocol StatementColumnConvertible {
 extension StatementColumnConvertible {
     // `Optional` overrides this default behavior.
     /// Default implementation fails on decoding NULL.
-    @inline(__always)
-    @inlinable
     public static func fromStatement(_ sqliteStatement: SQLiteStatement, atUncheckedIndex index: CInt) -> Self? {
         if sqlite3_column_type(sqliteStatement, index) == SQLITE_NULL {
             return nil

--- a/GRDB/Core/Support/StandardLibrary/Optional.swift
+++ b/GRDB/Core/Support/StandardLibrary/Optional.swift
@@ -73,8 +73,6 @@ extension Optional: DatabaseValueConvertible where Wrapped: DatabaseValueConvert
 }
 
 extension Optional: StatementColumnConvertible where Wrapped: StatementColumnConvertible {
-    @inline(__always)
-    @inlinable
     public static func fromStatement(_ sqliteStatement: SQLiteStatement, atUncheckedIndex index: CInt) -> Self? {
         if let value = Wrapped.fromStatement(sqliteStatement, atUncheckedIndex: index) {
             // Valid value

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -98,8 +98,6 @@ extension Int: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int(exactly: int64) else { return nil }
@@ -129,8 +127,6 @@ extension Int8: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int8(exactly: int64) else { return nil }
@@ -160,8 +156,6 @@ extension Int16: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int16(exactly: int64) else { return nil }
@@ -191,8 +185,6 @@ extension Int32: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = Int32(exactly: int64) else { return nil }
@@ -258,8 +250,6 @@ extension UInt: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt(exactly: int64) else { return nil }
@@ -289,8 +279,6 @@ extension UInt8: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt8(exactly: int64) else { return nil }
@@ -320,8 +308,6 @@ extension UInt16: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt16(exactly: int64) else { return nil }
@@ -351,8 +337,6 @@ extension UInt32: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt32(exactly: int64) else { return nil }
@@ -382,8 +366,6 @@ extension UInt64: DatabaseValueConvertible, StatementColumnConvertible {
     /// - parameters:
     ///     - sqliteStatement: A pointer to an SQLite statement.
     ///     - index: The column index.
-    @inline(__always)
-    @inlinable
     public init?(sqliteStatement: SQLiteStatement, index: CInt) {
         let int64 = sqlite3_column_int64(sqliteStatement, index)
         guard let v = UInt64(exactly: int64) else { return nil }


### PR DESCRIPTION
I also created a [bug against Swift](https://github.com/apple/swift/issues/61350) about this. This enables us to remove the optimizer hacks and also use WMO in the app.