### PR TITLE
Add support for passing in categories to the unicode61 tokenizer

### DIFF
--- a/Tests/GRDBTests/FTS5TokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5TokenizerTests.swift
@@ -197,6 +197,20 @@ class FTS5TokenizerTests: GRDBTestCase {
     }
     #endif
 
+    func testUnicode61TokenizerCategories() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .unicode61(categories: "L* N* S*")
+                t.column("content")
+            }
+            
+            XCTAssertTrue(match(db, "👍", "👍"))
+            XCTAssertTrue(match(db, "👁‍🗨", "🗨"))
+            XCTAssertFalse(match(db, "🔎🐠", "🐠"))
+        }
+    }
+
     func testUnicode61TokenizerSeparators() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in


### PR DESCRIPTION
Extends the existing tokenizer to allow specifying categories. Feel free to close out if intentionally left out as a configuration option.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [X] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [X] BRANCH: This pull request is submitted against the `development` branch.
- [X] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.

`tokenCharacters` didn't seem to be mentioned in the dedicated guide, so followed that example.

- [X] TESTS: Changes are tested.
- [X] TESTS: The `make smokeTest` terminal command runs without failure.
