### PR TITLE
Add @discardableResult to DatabaseWriter.write methods

### DIFF
--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -100,6 +100,7 @@ public protocol DatabaseWriter: DatabaseReader {
     /// - parameter updates: A closure which accesses the database.
     /// - throws: The error thrown by `updates`.
     @_disfavoredOverload // SR-15150 Async overloading in protocol implementation fails
+    @discardableResult
     func writeWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T
     
     /// Executes database operations, and returns their result after they have
@@ -140,6 +141,7 @@ public protocol DatabaseWriter: DatabaseReader {
     /// - parameter updates: A closure which accesses the database.
     /// - throws: The error thrown by `updates`.
     @_disfavoredOverload // SR-15150 Async overloading in protocol implementation fails
+    @discardableResult
     func barrierWriteWithoutTransaction<T>(_ updates: (Database) throws -> T) throws -> T
     
     /// Schedules database operations for execution, and returns immediately.
@@ -247,6 +249,7 @@ public protocol DatabaseWriter: DatabaseReader {
     ///
     /// - parameter updates: A closure which accesses the database.
     /// - throws: The error thrown by `updates`.
+    @discardableResult
     func unsafeReentrantWrite<T>(_ updates: (Database) throws -> T) rethrows -> T
     
     // MARK: - Reading from Database
@@ -375,6 +378,7 @@ extension DatabaseWriter {
     ///   would happen while establishing the database access or committing
     ///   the transaction.
     @_disfavoredOverload // SR-15150 Async overloading in protocol implementation fails
+    @discardableResult
     public func write<T>(_ updates: (Database) throws -> T) throws -> T {
         try writeWithoutTransaction { db in
             var result: T?
@@ -583,6 +587,7 @@ extension DatabaseWriter {
     ///   would happen while establishing the database access or committing
     ///   the transaction.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @discardableResult
     public func write<T>(_ updates: @Sendable @escaping (Database) throws -> T) async throws -> T {
         try await withUnsafeThrowingContinuation { continuation in
             asyncWrite(updates, completion: { _, result in
@@ -621,6 +626,7 @@ extension DatabaseWriter {
     /// - parameter updates: A closure which accesses the database.
     /// - throws: The error thrown by `updates`.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @discardableResult
     public func writeWithoutTransaction<T>(_ updates: @Sendable @escaping (Database) throws -> T) async throws -> T {
         try await withUnsafeThrowingContinuation { continuation in
             asyncWriteWithoutTransaction { db in
@@ -673,6 +679,7 @@ extension DatabaseWriter {
     /// - parameter updates: A closure which accesses the database.
     /// - throws: The error thrown by `updates`.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    @discardableResult
     public func barrierWriteWithoutTransaction<T>(
         _ updates: @Sendable @escaping (Database) throws -> T)
     async throws -> T
@@ -1006,11 +1013,13 @@ extension AnyDatabaseWriter: DatabaseReader {
 
 extension AnyDatabaseWriter: DatabaseWriter {
     @_disfavoredOverload // SR-15150 Async overloading in protocol implementation fails
+    @discardableResult
     public func writeWithoutTransaction<T>(_ updates: (Database) throws -> T) rethrows -> T {
         try base.writeWithoutTransaction(updates)
     }
     
     @_disfavoredOverload // SR-15150 Async overloading in protocol implementation fails
+    @discardableResult
     public func barrierWriteWithoutTransaction<T>(_ updates: (Database) throws -> T) throws -> T {
         try base.barrierWriteWithoutTransaction(updates)
     }
@@ -1022,7 +1031,7 @@ extension AnyDatabaseWriter: DatabaseWriter {
     public func asyncWriteWithoutTransaction(_ updates: @escaping (Database) -> Void) {
         base.asyncWriteWithoutTransaction(updates)
     }
-    
+    @discardableResult
     public func unsafeReentrantWrite<T>(_ updates: (Database) throws -> T) rethrows -> T {
         try base.unsafeReentrantWrite(updates)
     }


### PR DESCRIPTION
There are some use-cases where we only perform a single expression in the write and don't care about the result's value.

```swift
    func deleteAllPlayers() async throws {
        try await dbWriter.write { db in
            _ = try Player.deleteAll(db)
        }
    }
```
In this case we explicitly discard the result with `_ =` despite `deleteAll` having the `@discardableResult` annotation. Removing the explicit discard will result in a warning from Xcode as the `write` method now returns the result of `deleteAll`.

<img width="632" alt="Screenshot 2022-11-23 at 09 50 13" src="https://user-images.githubusercontent.com/1006684/203522264-3b6f052d-358f-47a4-b539-a6314a85c774.png">

This pull request extends the use of `@discardableResult` to the `write` methods to reduce the need to explicitly discard the result of writes with a single expression.

#### Questions
- Is there a preferred order for these annotations?
- Should we update existing samples as part of this?

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
