### PR TITLE
Record.find() convenience methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **New**: [#1299](https://github.com/groue/GRDB.swift/pull/1299) by [@groue](https://github.com/groue): Record.find() convenience methods
+
 ## 6.4.0
 
 Released November 28, 2022 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v6.3.1...v6.4.0)

--- a/GRDB/Documentation.docc/QueryInterface.md
+++ b/GRDB/Documentation.docc/QueryInterface.md
@@ -23,6 +23,11 @@ Record types and the query interface build SQL queries for you.
 - ``QueryInterfaceRequest``
 - ``Table``
 
+### Errors
+
+- ``RecordError``
+- ``PersistenceError``
+
 ### Supporting Types
 
 - ``DerivableRequest``

--- a/GRDB/Record/FetchableRecord+TableRecord.swift
+++ b/GRDB/Record/FetchableRecord+TableRecord.swift
@@ -189,6 +189,32 @@ extension FetchableRecord where Self: TableRecord {
         }
         return try filter(key: key).fetchOne(db)
     }
+    
+    /// Returns the record identified by a primary key, or throws an error if
+    /// the record does not exist.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let player = try Player.find(db, key: 123)
+    ///     let country = try Country.find(db, key: "FR")
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - key: A primary key value.
+    /// - returns: A record.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or a
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` if the record
+    ///   does not exist in the database.
+    public static func find(_ db: Database, key: some DatabaseValueConvertible) throws -> Self {
+        guard let record = try fetchOne(db, key: key) else {
+            try recordNotFound(db, key: key)
+        }
+        return record
+    }
 }
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *)
@@ -277,6 +303,29 @@ extension FetchableRecord where Self: TableRecord & Identifiable, ID: DatabaseVa
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
     public static func fetchOne(_ db: Database, id: ID) throws -> Self? {
         try filter(id: id).fetchOne(db)
+    }
+    
+    /// Returns the record identified by a primary key, or throws an error if
+    /// the record does not exist.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let player = try Player.find(db, id: 123)
+    ///     let country = try Country.find(db, id: "FR")
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - id: A primary key value.
+    /// - returns: A record.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or a
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` if the record
+    ///   does not exist in the database.
+    public static func find(_ db: Database, id: ID) throws -> Self {
+        try find(db, key: id)
     }
 }
 
@@ -430,6 +479,32 @@ extension FetchableRecord where Self: TableRecord {
             return nil
         }
         return try filter(key: key).fetchOne(db)
+    }
+    
+    /// Returns the record identified by a unique key (the primary key or
+    /// any key with a unique index on it), or throws an error if the record
+    /// does not exist.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.read { db in
+    ///     let player = try Player.find(db, key: ["name": "Arthur"])
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - key: A key dictionary.
+    /// - returns: A record.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or a
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` if the record
+    ///   does not exist in the database.
+    public static func find(_ db: Database, key: [String: (any DatabaseValueConvertible)?]) throws -> Self {
+        guard let record = try filter(key: key).fetchOne(db) else {
+            try recordNotFound(key: key)
+        }
+        return record
     }
 }
 

--- a/GRDB/Record/FetchableRecord+TableRecord.swift
+++ b/GRDB/Record/FetchableRecord+TableRecord.swift
@@ -211,7 +211,7 @@ extension FetchableRecord where Self: TableRecord {
     ///   does not exist in the database.
     public static func find(_ db: Database, key: some DatabaseValueConvertible) throws -> Self {
         guard let record = try fetchOne(db, key: key) else {
-            try recordNotFound(db, key: key)
+            throw recordNotFound(db, key: key)
         }
         return record
     }
@@ -502,7 +502,7 @@ extension FetchableRecord where Self: TableRecord {
     ///   does not exist in the database.
     public static func find(_ db: Database, key: [String: (any DatabaseValueConvertible)?]) throws -> Self {
         guard let record = try filter(key: key).fetchOne(db) else {
-            try recordNotFound(key: key)
+            throw recordNotFound(key: key)
         }
         return record
     }

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -75,6 +75,9 @@ import Foundation
 /// - ``fetchAll(_:keys:)-4c8no``
 /// - ``fetchSet(_:keys:)-e6uy``
 /// - ``fetchOne(_:key:)-3f3hc``
+/// - ``find(_:id:)``
+/// - ``find(_:key:)-4kry5``
+/// - ``find(_:key:)-1dfbe``
 ///
 /// ### Fetching Record by Key
 ///

--- a/GRDB/Record/MutablePersistableRecord+DAO.swift
+++ b/GRDB/Record/MutablePersistableRecord+DAO.swift
@@ -226,12 +226,12 @@ final class DAO<Record: MutablePersistableRecord> {
         return statement
     }
     
-    /// Throws a PersistenceError.recordNotFound error
-    func makeRecordNotFoundError() -> Error {
+    /// Throws a RecordError.recordNotFound error
+    func recordNotFound() throws -> Never {
         let key = Dictionary(uniqueKeysWithValues: primaryKey.columns.map {
             ($0, persistenceContainer[caseInsensitive: $0]?.databaseValue ?? .null)
         })
-        return PersistenceError.recordNotFound(
+        throw RecordError.recordNotFound(
             databaseTableName: databaseTableName,
             key: key)
     }

--- a/GRDB/Record/MutablePersistableRecord+Save.swift
+++ b/GRDB/Record/MutablePersistableRecord+Save.swift
@@ -377,7 +377,7 @@ extension MutablePersistableRecord {
                     columns: columns,
                     selection: selection,
                     fetch: fetch)
-            } catch PersistenceError.recordNotFound(databaseTableName: type(of: self).databaseTableName, key: key) {
+            } catch RecordError.recordNotFound(databaseTableName: type(of: self).databaseTableName, key: key) {
                 // No row was updated: fallback on insert.
             }
         }

--- a/GRDB/Record/MutablePersistableRecord+Update.swift
+++ b/GRDB/Record/MutablePersistableRecord+Update.swift
@@ -39,7 +39,7 @@ extension MutablePersistableRecord {
     /// - parameter columns: The columns to update.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public func update<Columns>(
@@ -83,7 +83,7 @@ extension MutablePersistableRecord {
     /// - parameter columns: The columns to update.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public func update<Columns>(
@@ -115,7 +115,7 @@ extension MutablePersistableRecord {
     ///   is used.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public func update(
@@ -158,7 +158,7 @@ extension MutablePersistableRecord {
     /// - returns: Whether the record had changes.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - SeeAlso: updateChanges(_:with:)
     @discardableResult
@@ -202,7 +202,7 @@ extension MutablePersistableRecord {
     /// - returns: Whether the record had changes.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @discardableResult
     @inlinable // allow specialization so that empty callbacks are removed
@@ -233,7 +233,7 @@ extension MutablePersistableRecord {
     ///   conflict policy is `IGNORE`.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public func updateAndFetch(
@@ -257,7 +257,7 @@ extension MutablePersistableRecord {
     ///   the conflict policy is `IGNORE`.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public func updateAndFetch<T: FetchableRecord & TableRecord>(
@@ -285,7 +285,7 @@ extension MutablePersistableRecord {
     ///   in case of a failed update due to the `IGNORE` conflict policy.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public mutating func updateChangesAndFetch(
@@ -314,7 +314,7 @@ extension MutablePersistableRecord {
     ///   conflict policy.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     public mutating func updateChangesAndFetch<T: FetchableRecord & TableRecord>(
@@ -358,7 +358,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -419,7 +419,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -462,7 +462,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -497,7 +497,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -529,7 +529,7 @@ extension MutablePersistableRecord {
     ///   conflict policy is `IGNORE`.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) // SQLite 3.35.0+
@@ -554,7 +554,7 @@ extension MutablePersistableRecord {
     ///   the conflict policy is `IGNORE`.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) // SQLite 3.35.0+
@@ -583,7 +583,7 @@ extension MutablePersistableRecord {
     ///   in case of a failed update due to the `IGNORE` conflict policy.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) // SQLite 3.35.0+
@@ -613,7 +613,7 @@ extension MutablePersistableRecord {
     ///   conflict policy.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     @inlinable // allow specialization so that empty callbacks are removed
     @available(iOS 15.0, tvOS 15.0, watchOS 8.0, macOS 12.0, *) // SQLite 3.35.0+
@@ -658,7 +658,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -720,7 +720,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -764,7 +764,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -800,7 +800,7 @@ extension MutablePersistableRecord {
     /// - returns: The result of the `fetch` function.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
-    ///   or ``PersistenceError/recordNotFound(databaseTableName:key:)`` if the
+    ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
     ///   primary key does not match any row in the database.
     /// - precondition: `selection` is not empty.
     @inlinable // allow specialization so that empty callbacks are removed
@@ -942,12 +942,12 @@ extension MutablePersistableRecord {
             returning: selection)
         else {
             // Nil primary key
-            throw dao.makeRecordNotFoundError()
+            try dao.recordNotFound()
         }
         let returned = try fetch(statement)
         if db.changesCount == 0 {
             // No row was updated
-            throw dao.makeRecordNotFoundError()
+            try dao.recordNotFound()
         }
         let updated = PersistenceSuccess(persistenceContainer: dao.persistenceContainer)
         return (updated, returned)

--- a/GRDB/Record/MutablePersistableRecord.swift
+++ b/GRDB/Record/MutablePersistableRecord.swift
@@ -73,7 +73,6 @@
 /// - ``update(_:onConflict:columns:)-5hxyx``
 /// - ``updateChanges(_:onConflict:from:)``
 /// - ``updateChanges(_:onConflict:modify:)``
-/// - ``PersistenceError``
 ///
 /// ### Updating a Record and Fetching the Updated Row
 ///
@@ -340,28 +339,6 @@ extension MutablePersistableRecord {
             return false
         }
         return try Bool.fetchOne(statement)!
-    }
-}
-
-/// An error thrown by persistence methods of the
-/// ``MutablePersistableRecord`` protocol.
-public enum PersistenceError: Error {
-    /// Thrown by ``MutablePersistableRecord`` updating methods, when no
-    /// matching row could be found and updated.
-    ///
-    /// - parameters:
-    ///     - databaseTableName: The table of the unfound record.
-    ///     - key: The key of the unfound record (column and values).
-    case recordNotFound(databaseTableName: String, key: [String: DatabaseValue])
-}
-
-extension PersistenceError: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case let .recordNotFound(databaseTableName: databaseTableName, key: key):
-            let row = Row(key) // For nice output
-            return "Key not found in table \(databaseTableName): \(row.description)"
-        }
     }
 }
 

--- a/GRDB/Record/PersistableRecord+Save.swift
+++ b/GRDB/Record/PersistableRecord+Save.swift
@@ -260,7 +260,7 @@ extension PersistableRecord {
                     columns: columns,
                     selection: selection,
                     fetch: fetch)
-            } catch PersistenceError.recordNotFound(databaseTableName: type(of: self).databaseTableName, key: key) {
+            } catch RecordError.recordNotFound(databaseTableName: type(of: self).databaseTableName, key: key) {
                 // No row was updated: fallback on insert.
             }
         }

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -413,7 +413,7 @@ open class Record {
     /// - parameter db: A database connection.
     /// - returns: Whether the record had changes.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
-    ///   ``PersistenceError/recordNotFound(databaseTableName:key:)`` is thrown
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` is thrown
     ///   if the primary key does not match any row in the database and record
     ///   could not be updated.
     @discardableResult

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -651,6 +651,31 @@ extension TableRecord {
     }
 }
 
+// MARK: - RecordError
+
+/// A record error.
+public enum RecordError: Error {
+    /// A record does not exist in the database.
+    ///
+    /// - parameters:
+    ///     - databaseTableName: The table of the missing record.
+    ///     - key: The key of the missing record (column and values).
+    case recordNotFound(databaseTableName: String, key: [String: DatabaseValue])
+}
+
+extension RecordError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .recordNotFound(databaseTableName: databaseTableName, key: key):
+            let row = Row(key) // For nice output
+            return "Key not found in table \(databaseTableName): \(row.description)"
+        }
+    }
+}
+
+@available(*, deprecated, renamed: "RecordError")
+public typealias PersistenceError = RecordError
+
 /// Calculating `defaultDatabaseTableName` is somewhat expensive due to the regular expression evaluation
 ///
 /// This cache mitigates the cost of the calculation by storing the name for later retrieval

--- a/README.md
+++ b/README.md
@@ -2946,7 +2946,7 @@ For more information about batch updates, see [Update Requests](#update-requests
 
 - All persistence methods can throw a [DatabaseError](#error-handling).
 
-- `update` and `updateChanges` throw [PersistenceError](#persistenceerror) if the database does not contain any row for the primary key of the record.
+- `update` and `updateChanges` throw [RecordError] if the database does not contain any row for the primary key of the record.
 
 - `save` makes sure your values are stored in the database. It performs an UPDATE if the record has a non-null primary key, and then, if no row was modified, an INSERT. It directly performs an INSERT if the record has no primary key, or a null primary key.
 
@@ -6308,12 +6308,12 @@ try dbQueue.write { db in
 
 ## Error Handling
 
-GRDB can throw [DatabaseError](#databaseerror), [PersistenceError](#persistenceerror), or crash your program with a [fatal error](#fatal-errors).
+GRDB can throw [DatabaseError](#databaseerror), [RecordError], or crash your program with a [fatal error](#fatal-errors).
 
 Considering that a local database is not some JSON loaded from a remote server, GRDB focuses on **trusted databases**. Dealing with [untrusted databases](#how-to-deal-with-untrusted-inputs) requires extra care.
 
 - [DatabaseError](#databaseerror)
-- [PersistenceError](#persistenceerror)
+- [RecordError]
 - [Fatal Errors](#fatal-errors)
 - [How to Deal with Untrusted Inputs](#how-to-deal-with-untrusted-inputs)
 - [Error Log](#error-log)
@@ -6391,14 +6391,14 @@ Each DatabaseError has two codes: an `extendedResultCode` (see [extended result 
 > **Warning**: SQLite has progressively introduced extended result codes across its versions. The [SQLite release notes](http://www.sqlite.org/changes.html) are unfortunately not quite clear about that: write your handling of extended result codes with care.
 
 
-### PersistenceError
+### RecordError
 
-**PersistenceError** is thrown by the [PersistableRecord] protocol, in a single case: when the `update` method could not find any row to update:
+**RecordError** is thrown by the [PersistableRecord] protocol, in a single case: when the `update` method could not find any row to update:
 
 ```swift
 do {
     try player.update(db)
-} catch let PersistenceError.recordNotFound(databaseTableName: table, key: key) {
+} catch let RecordError.recordNotFound(databaseTableName: table, key: key) {
     print("Key \(key) was not found in table \(table).")
 }
 ```
@@ -7410,3 +7410,4 @@ This chapter has been superseded by [ValueObservation] and [DatabaseRegionObserv
 [Database Configuration]: #database-configuration
 [Persistence Methods]: #persistence-methods
 [persistence methods]: #persistence-methods
+[RecordError]: #recorderror

--- a/README.md
+++ b/README.md
@@ -7338,6 +7338,10 @@ This chapter has [moved](#nsnumber-nsdecimalnumber-and-decimal)
 
 This protocol has been renamed [PersistableRecord] in GRDB 3.0.
 
+#### PersistenceError
+
+This error was renamed to [RecordError].
+
 #### RowConvertible Protocol
 
 This protocol has been renamed [FetchableRecord] in GRDB 3.0.

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -387,8 +387,8 @@ class MutablePersistableRecordTests: GRDBTestCase {
             try record.insert(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError")
-            } catch is PersistenceError { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound { }
         }
     }
     
@@ -860,7 +860,7 @@ class MutablePersistableRecordTests: GRDBTestCase {
         }
     }
     
-    func testPersistenceErrorMutablePersistableRecordCustomizedCountry() throws {
+    func testRecordErrorMutablePersistableRecordCustomizedCountry() throws {
         let country = MutablePersistableRecordCustomizedCountry(
             rowID: nil,
             isoCode: "FR",
@@ -871,8 +871,8 @@ class MutablePersistableRecordTests: GRDBTestCase {
             try dbQueue.inDatabase { db in
                 try country.update(db)
             }
-            XCTFail("Expected PersistenceError")
-        } catch PersistenceError.recordNotFound(databaseTableName: "countries", key: ["isoCode": "FR".databaseValue]) { }
+            XCTFail("Expected RecordError")
+        } catch RecordError.recordNotFound(databaseTableName: "countries", key: ["isoCode": "FR".databaseValue]) { }
         
         XCTAssertEqual(country.callbacks.willInsertCount, 0)
         XCTAssertEqual(country.callbacks.aroundInsertEnterCount, 0)
@@ -1173,9 +1173,9 @@ class MutablePersistableRecordTests: GRDBTestCase {
         }
     }
     
-    func testPersistenceErrorRecordNotFoundDescription() {
+    func testRecordErrorRecordNotFoundDescription() {
         do {
-            let error = PersistenceError.recordNotFound(
+            let error = RecordError.recordNotFound(
                 databaseTableName: "place",
                 key: ["id": .null])
             XCTAssertEqual(
@@ -1183,7 +1183,7 @@ class MutablePersistableRecordTests: GRDBTestCase {
                 "Key not found in table place: [id:NULL]")
         }
         do {
-            let error = PersistenceError.recordNotFound(
+            let error = RecordError.recordNotFound(
                 databaseTableName: "user",
                 key: ["uuid": "E621E1F8-C36C-495A-93FC-0C247A3E6E5F".databaseValue])
             XCTAssertEqual(
@@ -1702,8 +1702,8 @@ extension MutablePersistableRecordTests {
             var player = FullPlayer(id: 1, name: "Arthur", score: 1000)
             do {
                 _ = try player.updateAndFetch(db)
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             player.name = "Barbara"
@@ -1753,8 +1753,8 @@ extension MutablePersistableRecordTests {
             var player = FullPlayer(id: 1, name: "Arthur", score: 1000)
             do {
                 _ = try player.updateAndFetch(db, as: PartialPlayer.self)
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             player.name = "Barbara"
@@ -1805,8 +1805,8 @@ extension MutablePersistableRecordTests {
                 _ = try player.updateAndFetch(db, selection: [AllColumns()]) { statement in
                     try Row.fetchOne(statement)
                 }
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             player.name = "Barbara"
@@ -1859,8 +1859,8 @@ extension MutablePersistableRecordTests {
                 _ = try player.updateAndFetch(db, columns: [Column("score")], selection: [AllColumns()]) { statement in
                     try Row.fetchOne(statement)
                 }
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             player.name = "Barbara"
@@ -1913,8 +1913,8 @@ extension MutablePersistableRecordTests {
                 _ = try player.updateChangesAndFetch(db) {
                     $0.name = "Barbara"
                 }
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             
@@ -1974,8 +1974,8 @@ extension MutablePersistableRecordTests {
                 _ = try player.updateChangesAndFetch(db, as: PartialPlayer.self) {
                     $0.name = "Barbara"
                 }
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             
@@ -2035,8 +2035,8 @@ extension MutablePersistableRecordTests {
                     db, selection: [AllColumns()],
                     fetch: { statement in try Row.fetchOne(statement) },
                     modify: { $0.name = "Barbara" })
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "player", key: ["id": 1.databaseValue]) { }
             
             try player.insert(db)
             

--- a/Tests/GRDBTests/PersistableRecordTests.swift
+++ b/Tests/GRDBTests/PersistableRecordTests.swift
@@ -745,7 +745,7 @@ class PersistableRecordTests: GRDBTestCase {
         }
     }
     
-    func testPersistenceErrorPersistableRecordCustomizedCountry() throws {
+    func testRecordErrorPersistableRecordCustomizedCountry() throws {
         let country = PersistableRecordCustomizedCountry(
             isoCode: "FR",
             name: "France")
@@ -755,8 +755,8 @@ class PersistableRecordTests: GRDBTestCase {
             try dbQueue.inDatabase { db in
                 try country.update(db)
             }
-            XCTFail("Expected PersistenceError")
-        } catch PersistenceError.recordNotFound(databaseTableName: "countries", key: ["isoCode": "FR".databaseValue]) { }
+            XCTFail("Expected RecordError")
+        } catch RecordError.recordNotFound(databaseTableName: "countries", key: ["isoCode": "FR".databaseValue]) { }
         
         XCTAssertEqual(country.callbacks.willInsertCount, 0)
         XCTAssertEqual(country.callbacks.aroundInsertEnterCount, 0)

--- a/Tests/GRDBTests/RecordEditedTests.swift
+++ b/Tests/GRDBTests/RecordEditedTests.swift
@@ -675,8 +675,8 @@ class RecordEditedTests: GRDBTestCase {
             do {
                 XCTAssertTrue(person.hasDatabaseChanges)
                 try person.updateChanges(db)
-                XCTFail("Expected PersistenceError")
-            } catch PersistenceError.recordNotFound(databaseTableName: "persons", key: ["id": .null]) { }
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "persons", key: ["id": .null]) { }
             
             try person.insert(db)
 

--- a/Tests/GRDBTests/RecordMinimalNonOptionalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalNonOptionalPrimaryKeySingleTests.swift
@@ -314,6 +314,18 @@ class RecordMinimalNonOptionalPrimaryKeySingleTests: GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalNonOptionalPrimaryKeySingle(id: "theUUID")
+            try record.insert(db)
+            
+            let fetchedRecord = try MinimalNonOptionalPrimaryKeySingle.find(db, key: ["id": record.id])
+            XCTAssertTrue(fetchedRecord.id == record.id)
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"id\" = '\(record.id)'")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     
@@ -570,7 +582,40 @@ class RecordMinimalNonOptionalPrimaryKeySingleTests: GRDBTestCase {
         }
     }
     
+    func testFindWithPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalNonOptionalPrimaryKeySingle(id: "theUUID")
+            try record.insert(db)
+            
+            do {
+                let id: String? = nil
+                _ = try MinimalNonOptionalPrimaryKeySingle.find(db, key: id)
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "minimalSingles", key: ["id": .null]) { }
+            
+            do {
+                let fetchedRecord = try MinimalNonOptionalPrimaryKeySingle.find(db, key: record.id)
+                XCTAssertTrue(fetchedRecord.id == record.id)
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"id\" = '\(record.id)'")
+            }
+            
+            if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *) {
+                do {
+                    _ = try MinimalNonOptionalPrimaryKeySingle.find(db, key: "missing")
+                    XCTFail("Expected RecordError")
+                } catch RecordError.recordNotFound(databaseTableName: "minimalSingles", key: ["id": "missing".databaseValue]) { }
+                
+                do {
+                    let fetchedRecord = try MinimalNonOptionalPrimaryKeySingle.find(db, id: record.id)
+                    XCTAssertTrue(fetchedRecord.id == record.id)
+                    XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"id\" = '\(record.id)'")
+                }
+            }
+        }
+    }
     
+
     // MARK: - Fetch With Primary Key Request
     
     func testFetchCursorWithPrimaryKeysRequest() throws {

--- a/Tests/GRDBTests/RecordMinimalNonOptionalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalNonOptionalPrimaryKeySingleTests.swift
@@ -102,9 +102,9 @@ class RecordMinimalNonOptionalPrimaryKeySingleTests: GRDBTestCase {
             let record = MinimalNonOptionalPrimaryKeySingle(id: "theUUID")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "minimalSingles")
                 XCTAssertEqual(key, ["id": "theUUID".databaseValue])
             }
@@ -131,9 +131,9 @@ class RecordMinimalNonOptionalPrimaryKeySingleTests: GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "minimalSingles")
                 XCTAssertEqual(key, ["id": "theUUID".databaseValue])
             }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -121,9 +121,9 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             record.id = 123456
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "minimalRowIDs")
                 XCTAssertEqual(key, ["id": record.id!.databaseValue])
             }
@@ -150,9 +150,9 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "minimalRowIDs")
                 XCTAssertEqual(key, ["id": record.id!.databaseValue])
             }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -348,6 +348,18 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalRowID()
+            try record.insert(db)
+            
+            let fetchedRecord = try MinimalRowID.find(db, key: ["id": record.id])
+            XCTAssertTrue(fetchedRecord.id == record.id)
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     
@@ -607,6 +619,42 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
         }
     }
     
+    func testFindWithPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalRowID()
+            try record.insert(db)
+            
+            do {
+                let id: Int64? = nil
+                _ = try MinimalRowID.find(db, key: id)
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "minimalRowIDs", key: ["id": .null]) { }
+
+            do {
+                let fetchedRecord = try MinimalRowID.find(db, key: record.id)
+                XCTAssertTrue(fetchedRecord.id == record.id)
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
+            }
+            
+            if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *) {
+                do {
+                    _ = try MinimalRowID.find(db, id: -1)
+                    XCTFail("Expected RecordError")
+                } catch RecordError.recordNotFound(databaseTableName: "minimalRowIDs", key: ["id": (-1).databaseValue]) { }
+                
+                do {
+                    let fetchedRecord = try MinimalRowID.find(db, id: record.id!)
+                    XCTAssertTrue(fetchedRecord.id == record.id)
+                    XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalRowIDs\" WHERE \"id\" = \(record.id!)")
+                }
+                do {
+                    try XCTAssertNil(MinimalRowID.fetchOne(db, id: nil))
+                }
+            }
+        }
+    }
+
     
     // MARK: - Fetch With Primary Key Request
     

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
@@ -121,9 +121,9 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             record.UUID = "theUUID"
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "minimalSingles")
                 XCTAssertEqual(key, ["UUID": "theUUID".databaseValue])
             }
@@ -152,9 +152,9 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "minimalSingles")
                 XCTAssertEqual(key, ["UUID": "theUUID".databaseValue])
             }

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -434,6 +434,21 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Person(name: "Arthur")
+            try record.insert(db)
+            
+            let fetchedRecord = try Person.find(db, key: ["rowid": record.id])
+            XCTAssertTrue(fetchedRecord.id == record.id)
+            XCTAssertTrue(fetchedRecord.name == record.name)
+            XCTAssertTrue(fetchedRecord.age == record.age)
+            XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
+            XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     
@@ -702,6 +717,48 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
         }
     }
     
+    func testFindWithPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Person(name: "Arthur")
+            try record.insert(db)
+            
+            do {
+                let id: Int64? = nil
+                _ = try Person.find(db, key: id)
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "persons", key: ["rowid": .null]) { }
+
+            do {
+                let fetchedRecord = try Person.find(db, key: record.id)
+                XCTAssertTrue(fetchedRecord.id == record.id)
+                XCTAssertTrue(fetchedRecord.name == record.name)
+                XCTAssertTrue(fetchedRecord.age == record.age)
+                XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
+                XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
+            }
+            
+            if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6, *) {
+                do {
+                    _ = try Person.find(db, id: -1)
+                    XCTFail("Expected RecordError")
+                } catch RecordError.recordNotFound(databaseTableName: "persons", key: ["rowid": (-1).databaseValue]) { }
+                
+                do {
+                    let fetchedRecord = try Person.find(db, id: record.id!)
+                    XCTAssertTrue(fetchedRecord.id == record.id)
+                    XCTAssertTrue(fetchedRecord.name == record.name)
+                    XCTAssertTrue(fetchedRecord.age == record.age)
+                    XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
+                    XCTAssertEqual(lastSQLQuery, "SELECT *, \"rowid\" FROM \"persons\" WHERE \"rowid\" = \(record.id!)")
+                }
+                do {
+                    try XCTAssertNil(Person.fetchOne(db, id: nil))
+                }
+            }
+        }
+    }
+
     
     // MARK: - Fetch With Primary Key Request
     
@@ -915,6 +972,8 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             XCTAssertTrue(try Person.fetchOne(db)!.id != nil)
             XCTAssertTrue(try Person.fetchOne(db, key: 1)!.id != nil)
             XCTAssertTrue(try Person.fetchOne(db, key: ["rowid": 1])!.id != nil)
+            XCTAssertTrue(try Person.find(db, key: 1).id != nil)
+            XCTAssertTrue(try Person.find(db, key: ["rowid": 1]).id != nil)
             XCTAssertTrue(try Person.fetchAll(db).first!.id != nil)
             XCTAssertTrue(try Person.fetchAll(db, keys: [1]).first!.id != nil)
             XCTAssertTrue(try Person.fetchAll(db, keys: [["rowid": 1]]).first!.id != nil)

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -178,9 +178,9 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             let record = Person(id: nil, name: "Arthur")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "persons")
                 XCTAssertEqual(key, ["rowid": .null])
             }
@@ -193,9 +193,9 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             let record = Person(id: 123456, name: "Arthur")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "persons")
                 XCTAssertEqual(key, ["rowid": record.id!.databaseValue])
             }
@@ -223,9 +223,9 @@ class RecordPrimaryKeyHiddenRowIDTests : GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "persons")
                 XCTAssertEqual(key, ["rowid": record.id!.databaseValue])
             }

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
@@ -129,9 +129,9 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             let record = Citizenship(personName: nil, countryName: nil, native: true)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "citizenships")
                 XCTAssertEqual(key, ["countryName": .null, "personName": .null])
             }
@@ -144,9 +144,9 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             let record = Citizenship(personName: "Arthur", countryName: "France", native: true)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "citizenships")
                 XCTAssertEqual(key, ["countryName": "France".databaseValue, "personName": "Arthur".databaseValue])
             }
@@ -174,9 +174,9 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "citizenships")
                 XCTAssertEqual(key, ["countryName": "France".databaseValue, "personName": "Arthur".databaseValue])
             }

--- a/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyMultipleTests.swift
@@ -384,6 +384,20 @@ class RecordPrimaryKeyMultipleTests: GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Citizenship(personName: "Arthur", countryName: "France", native: true)
+            try record.insert(db)
+            
+            let fetchedRecord = try Citizenship.find(db, key: ["personName": record.personName, "countryName": record.countryName])
+            XCTAssertTrue(fetchedRecord.personName == record.personName)
+            XCTAssertTrue(fetchedRecord.countryName == record.countryName)
+            XCTAssertTrue(fetchedRecord.native == record.native)
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"citizenships\" WHERE (\"personName\" = '\(record.personName!)') AND (\"countryName\" = '\(record.countryName!)')")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     

--- a/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
@@ -172,9 +172,9 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             let record = Person(id: nil, name: "Arthur")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "persons")
                 XCTAssertEqual(key, ["id": .null])
             }
@@ -187,9 +187,9 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             let record = Person(id: 123456, name: "Arthur")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "persons")
                 XCTAssertEqual(key, ["id": record.id.databaseValue])
             }
@@ -217,9 +217,9 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "persons")
                 XCTAssertEqual(key, ["id": record.id.databaseValue])
             }

--- a/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyRowIDTests.swift
@@ -427,6 +427,21 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Person(name: "Arthur")
+            try record.insert(db)
+            
+            let fetchedRecord = try Person.find(db, key: ["id": record.id])
+            XCTAssertTrue(fetchedRecord.id == record.id)
+            XCTAssertTrue(fetchedRecord.name == record.name)
+            XCTAssertTrue(fetchedRecord.age == record.age)
+            XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE \"id\" = \(record.id!)")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     
@@ -635,6 +650,29 @@ class RecordPrimaryKeyRowIDTests: GRDBTestCase {
         }
     }
     
+    func testFindWithPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Person(name: "Arthur")
+            try record.insert(db)
+            
+            do {
+                let id: Int64? = nil
+                _ = try Person.find(db, key: id)
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "persons", key: ["id": .null]) { }
+
+            do {
+                let fetchedRecord = try Person.find(db, key: record.id)
+                XCTAssertTrue(fetchedRecord.id == record.id)
+                XCTAssertTrue(fetchedRecord.name == record.name)
+                XCTAssertTrue(fetchedRecord.age == record.age)
+                XCTAssertTrue(abs(fetchedRecord.creationDate.timeIntervalSince(record.creationDate)) < 1e-3)    // ISO-8601 is precise to the millisecond.
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"persons\" WHERE \"id\" = \(record.id!)")
+            }
+        }
+    }
+
     
     // MARK: - Fetch With Primary Key Request
     

--- a/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
@@ -119,9 +119,9 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             let record = Pet(UUID: nil, name: "Bobby")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "pets")
                 XCTAssertEqual(key, ["UUID": .null])
             }
@@ -134,9 +134,9 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             let record = Pet(UUID: "BobbyUUID", name: "Bobby")
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "pets")
                 XCTAssertEqual(key, ["UUID": "BobbyUUID".databaseValue])
             }
@@ -164,9 +164,9 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "pets")
                 XCTAssertEqual(key, ["UUID": "BobbyUUID".databaseValue])
             }

--- a/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleTests.swift
@@ -373,6 +373,19 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Pet(UUID: "BobbyUUID", name: "Bobby")
+            try record.insert(db)
+            
+            let fetchedRecord = try Pet.find(db, key: ["UUID": record.UUID])
+            XCTAssertTrue(fetchedRecord.UUID == record.UUID)
+            XCTAssertTrue(fetchedRecord.name == record.name)
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE \"UUID\" = '\(record.UUID!)'")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     
@@ -577,6 +590,27 @@ class RecordPrimaryKeySingleTests: GRDBTestCase {
         }
     }
     
+    func testFindWithPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Pet(UUID: "BobbyUUID", name: "Bobby")
+            try record.insert(db)
+            
+            do {
+                let id: String? = nil
+                _ = try Pet.find(db, key: id)
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "pets", key: ["UUID": .null]) { }
+
+            do {
+                let fetchedRecord = try Pet.find(db, key: record.UUID)
+                XCTAssertTrue(fetchedRecord.UUID == record.UUID)
+                XCTAssertTrue(fetchedRecord.name == record.name)
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"pets\" WHERE \"UUID\" = '\(record.UUID!)'")
+            }
+        }
+    }
+
     
     // MARK: - Fetch With Primary Key Request
     

--- a/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
@@ -364,6 +364,19 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
         }
     }
     
+    func testFindWithKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Email()
+            record.email = "me@domain.com"
+            try record.insert(db)
+            
+            let fetchedRecord = try Email.find(db, key: ["email": record.email])
+            XCTAssertTrue(fetchedRecord.email == record.email)
+            XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE \"email\" = '\(record.email!)'")
+        }
+    }
+
     
     // MARK: - Fetch With Key Request
     
@@ -580,6 +593,27 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
         }
     }
     
+    func testFindWithPrimaryKey() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = Email()
+            record.email = "me@domain.com"
+            try record.insert(db)
+            
+            do {
+                let id: String? = nil
+                _ = try Email.find(db, key: id)
+                XCTFail("Expected RecordError")
+            } catch RecordError.recordNotFound(databaseTableName: "emails", key: ["email": .null]) { }
+
+            do {
+                let fetchedRecord = try Email.find(db, key: record.email)
+                XCTAssertTrue(fetchedRecord.email == record.email)
+                XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"emails\" WHERE \"email\" = '\(record.email!)'")
+            }
+        }
+    }
+
     
     // MARK: - Fetch With Primary Key Request
     

--- a/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift
@@ -123,9 +123,9 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             record.email = "me@domain.com"
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "emails")
                 XCTAssertEqual(key, ["email": record.email.databaseValue])
             }
@@ -154,9 +154,9 @@ class RecordPrimaryKeySingleWithReplaceConflictResolutionTests: GRDBTestCase {
             try record.delete(db)
             do {
                 try record.update(db)
-                XCTFail("Expected PersistenceError.recordNotFound")
-            } catch let PersistenceError.recordNotFound(databaseTableName: databaseTableName, key: key) {
-                // Expected PersistenceError.recordNotFound
+                XCTFail("Expected RecordError.recordNotFound")
+            } catch let RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
+                // Expected RecordError.recordNotFound
                 XCTAssertEqual(databaseTableName, "emails")
                 XCTAssertEqual(key, ["email": record.email.databaseValue])
             }


### PR DESCRIPTION
This pull request introduces two sets of convenience methods: `find` and `recordNotFound`, that are useful when some primary or unique key is expected to be found in the database.

Unlike `fetchOne`, the `find` methods throw a `RecordError.errorNotFound` instead of returning nil:

```swift
let player = try Player.find(db, id: 42)
let country = try Country.find(db, key: "FR")
let passport = try Passport.find(db, key: ["citizenId": 12, "countryId": "DE"])
```

When the absence of a key is detected in an indirect way, you can directly throw `RecordError.errorNotFound`:

```swift
throw Player.recordNotFound(db, id: 42)
throw Country.recordNotFound(db, key: "FR")
throw Passport.recordNotFound(key: ["citizenId": 12, "countryId": "DE"])
```

The pull request also renames `PersistenceError` to `RecordError`. As before, the `update` methods throws `RecordError.errorNotFound` when there is no row to update:

```swift
// May throw RecordError.errorNotFound
try player.update(db)
```