### PR TITLE
REFACTOR :: deprecated API Migration

### DIFF
--- a/Tests/GRDBTests/DataMemoryTests.swift
+++ b/Tests/GRDBTests/DataMemoryTests.swift
@@ -37,10 +37,11 @@ class DataMemoryTests: GRDBTestCase {
                     
                     do {
                         // This data should not be copied
-                        let nonCopiedData = row.dataNoCopy(atIndex: 0)!
-                        XCTAssertEqual(nonCopiedData, data)
-                        nonCopiedData.withUnsafeBytes {
-                            XCTAssertEqual($0.baseAddress, blobPointer)
+                        try row.withUnsafeData(atIndex: 0) { nonCopiedData in
+                            XCTAssertEqual(nonCopiedData, data)
+                            nonCopiedData!.withUnsafeBytes {
+                                XCTAssertEqual($0.baseAddress, blobPointer)
+                            }
                         }
                     }
                 }
@@ -74,10 +75,11 @@ class DataMemoryTests: GRDBTestCase {
 
                     do {
                         // This data should not be copied
-                        let nonCopiedData = nestedRow.dataNoCopy(atIndex: 0)!
-                        XCTAssertEqual(nonCopiedData, data)
-                        nonCopiedData.withUnsafeBytes {
-                            XCTAssertEqual($0.baseAddress, blobPointer)
+                        try nestedRow.withUnsafeData(atIndex: 0) { nonCopiedData in
+                            XCTAssertEqual(nonCopiedData, data)
+                            nonCopiedData!.withUnsafeBytes {
+                                XCTAssertEqual($0.baseAddress, blobPointer)
+                            }
                         }
                     }
                 }
@@ -109,10 +111,11 @@ class DataMemoryTests: GRDBTestCase {
                         }
                         do {
                             // This data should not be copied:
-                            let nonCopiedData = row.dataNoCopy(atIndex: 0)!
-                            XCTAssertEqual(nonCopiedData, data)
-                            nonCopiedData.withUnsafeBytes { nonCopiedBuffer in
-                                XCTAssertEqual(nonCopiedBuffer.baseAddress, buffer.baseAddress)
+                            try row.withUnsafeData(atIndex: 0) { nonCopiedData in
+                                XCTAssertEqual(nonCopiedData, data)
+                                nonCopiedData!.withUnsafeBytes { nonCopiedBuffer in
+                                    XCTAssertEqual(nonCopiedBuffer.baseAddress, buffer.baseAddress)
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
```swift
do {
    // This data should not be copied:
    let nonCopiedData = row.dataNoCopy(atIndex: 0)!
    XCTAssertEqual(nonCopiedData, data)
    nonCopiedData.withUnsafeBytes { nonCopiedBuffer in
        XCTAssertEqual(nonCopiedBuffer.baseAddress, buffer.baseAddress)
    }
}
```

This code causes error `'dataNoCopy(atIndex:)' is deprecated: Use withUnsafeData(atIndex:_:) instead.`.
So I changed this 'dataNoCopy(atIndex:)' to use 'withUnsafeData(atIndex:_:)'

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
