### PR TITLE
TimestampedRecord sample code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,12 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **New**: [#1338](https://github.com/groue/GRDB.swift/pull/1338) by [@groue](https://github.com/groue): TimestampedRecord sample code
+- **New**: `EncodableRecord.databaseChanges(modify:)` modifies a record and returns a dictionary of changes.
+- **Documentation Update**: The [Record Timestamps and Transaction Date](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/recordtimestamps) article provides a sample `TimestampedRecord` protocol that application may adapt for their own use.
+
 ## 6.7.0
 
 Released February 19, 2023 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v6.6.1...v6.7.0)

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -174,7 +174,7 @@ public struct Configuration {
     /// - note: [**🔥 EXPERIMENTAL**](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features)
     ///
     /// The default clock is ``DefaultTransactionClock`` (which returns the
-    /// current date with `Date()`).
+    /// start date of the current transaction).
     ///
     /// For example:
     ///

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -312,8 +312,8 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     ///
     /// See <doc:RecordTimestamps> for an example of usage.
     ///
-    /// Transaction dates, by default, are built from a new `Date()` instance.
-    /// You can override this default behavior by configuring
+    /// The transaction date, by default, is the start date of the current
+    /// transaction. You can override this default behavior by configuring
     /// ``Configuration/transactionClock``.
     public var transactionDate: Date {
         get throws {

--- a/GRDB/Core/TransactionClock.swift
+++ b/GRDB/Core/TransactionClock.swift
@@ -41,8 +41,9 @@ extension TransactionClock where Self == CustomTransactionClock {
     }
 }
 
-/// The default clock.
+/// The default transaction clock.
 public struct DefaultTransactionClock: TransactionClock {
+    /// Returns the start date of the current transaction.
     public func now(_ db: Database) throws -> Date {
         // An opportunity to fetch transaction time from the database when
         // SQLite supports the feature.

--- a/GRDB/Documentation.docc/RecordTimestamps.md
+++ b/GRDB/Documentation.docc/RecordTimestamps.md
@@ -62,8 +62,8 @@ On insertion, the record should get fresh `creationDate` and `modificationDate`.
 
 ```swift
 extension Player: Encodable, MutablePersistableRecord {
-    /// Sets both `creationDate` and `modificationDate` to the transaction date,
-    /// if they are not set yet.
+    /// Sets both `creationDate` and `modificationDate` to the
+    /// transaction date, if they are not set yet.
     mutating func willInsert(_ db: Database) throws {
         if creationDate == nil {
             creationDate = try db.transactionDate
@@ -316,8 +316,8 @@ extension Player: Encodable, MutablePersistableRecord {
         id = inserted.rowID
     }
     
-    /// Sets both `creationDate` and `modificationDate` to the transaction date,
-    /// if they are not set yet.
+    /// Sets both `creationDate` and `modificationDate` to the
+    /// transaction date, if they are not set yet.
     mutating func willInsert(_ db: Database) throws {
         if creationDate == nil {
             creationDate = try db.transactionDate

--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -35,6 +35,7 @@ import Foundation // For JSONEncoder
 /// ### Comparing Records
 ///
 /// - ``databaseChanges(from:)``
+/// - ``databaseChanges(modify:)``
 /// - ``databaseEquals(_:)``
 public protocol EncodableRecord {
     /// Encodes the record into the provided persistence container.
@@ -262,6 +263,37 @@ extension EncodableRecord {
     throws -> [String: DatabaseValue]
     {
         let changes = try PersistenceContainer(self).changesIterator(from: PersistenceContainer(record))
+        return Dictionary(uniqueKeysWithValues: changes)
+    }
+    
+    /// Modifies the record according to the provided `modify` closure, and
+    /// returns a dictionary of changed values.
+    ///
+    /// The keys of the dictionary are the changed column names. Values are
+    /// the database values from the initial version record.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// var player = Player(id: 1, score: 1000, hasAward: false)
+    /// let changes = player.databaseChanges {
+    ///     $0.score = 1000
+    ///     $0.hasAward = true
+    /// }
+    ///
+    /// player.hasAward     // true (changed)
+    ///
+    /// changes["score"]    // nil (not changed)
+    /// changes["hasAward"] // false (old value)
+    /// ```
+    ///
+    /// - parameter modify: A closure that modifies the record.
+    public mutating func databaseChanges(modify: (inout Self) throws -> Void)
+    throws -> [String: DatabaseValue]
+    {
+        let container = try PersistenceContainer(self)
+        try modify(&self)
+        let changes = try PersistenceContainer(self).changesIterator(from: container)
         return Dictionary(uniqueKeysWithValues: changes)
     }
 }

--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -276,7 +276,7 @@ extension EncodableRecord {
     ///
     /// ```swift
     /// var player = Player(id: 1, score: 1000, hasAward: false)
-    /// let changes = player.databaseChanges {
+    /// let changes = try player.databaseChanges {
     ///     $0.score = 1000
     ///     $0.hasAward = true
     /// }

--- a/GRDB/Record/MutablePersistableRecord+Save.swift
+++ b/GRDB/Record/MutablePersistableRecord+Save.swift
@@ -369,15 +369,15 @@ extension MutablePersistableRecord {
     {
         // Attempt at updating if the record has a primary key
         if let key = try primaryKey(db) {
+            let databaseTableName = type(of: self).databaseTableName
             do {
-                let databaseTableName = type(of: self).databaseTableName
                 let columns = try Set(db.columns(in: databaseTableName).map(\.name))
                 return try updateAndFetchWithCallbacks(
                     db, onConflict: conflictResolution,
                     columns: columns,
                     selection: selection,
                     fetch: fetch)
-            } catch RecordError.recordNotFound(databaseTableName: type(of: self).databaseTableName, key: key) {
+            } catch RecordError.recordNotFound(databaseTableName: databaseTableName, key: key) {
                 // No row was updated: fallback on insert.
             }
         }

--- a/GRDB/Record/MutablePersistableRecord+Update.swift
+++ b/GRDB/Record/MutablePersistableRecord+Update.swift
@@ -25,10 +25,9 @@ extension MutablePersistableRecord {
     ///
     /// ```swift
     /// try dbQueue.write { db in
-    ///     if var player = Player.fetchOne(db, id: 1) {
-    ///         player.score += 10
-    ///         try player.update(db, columns: ["score"])
-    ///     }
+    ///     var player = Player.find(db, id: 1)
+    ///     player.score += 10
+    ///     try player.update(db, columns: ["score"])
     /// }
     /// ```
     ///
@@ -69,10 +68,9 @@ extension MutablePersistableRecord {
     ///
     /// ```swift
     /// try dbQueue.write { db in
-    ///     if var player = Player.fetchOne(db, id: 1) {
-    ///         player.score += 10
-    ///         try player.update(db, columns: [Column("score")])
-    ///     }
+    ///     var player = Player.find(db, id: 1)
+    ///     player.score += 10
+    ///     try player.update(db, columns: [Column("score")])
     /// }
     /// ```
     ///
@@ -102,10 +100,9 @@ extension MutablePersistableRecord {
     ///
     /// ```swift
     /// try dbQueue.write { db in
-    ///     if var player = Player.fetchOne(db, id: 1) {
-    ///         player.score += 10
-    ///         try player.update(db)
-    ///     }
+    ///     var player = Player.find(db, id: 1)
+    ///     player.score += 10
+    ///     try player.update(db)
     /// }
     /// ```
     ///
@@ -180,16 +177,15 @@ extension MutablePersistableRecord {
     ///
     /// ```swift
     /// try dbQueue.write { db in
-    ///     if var player = Player.fetchOne(db, id: 1) {
-    ///         let modified = try player.updateChanges(db) {
-    ///             $0.score = 1000
-    ///             $0.hasAward = true
-    ///         }
-    ///         if modified {
-    ///             print("player was modified")
-    ///         } else {
-    ///             print("player was not modified")
-    ///         }
+    ///     var player = Player.find(db, id: 1)
+    ///     let modified = try player.updateChanges(db) {
+    ///         $0.score = 1000
+    ///         $0.hasAward = true
+    ///     }
+    ///     if modified {
+    ///         print("player was modified")
+    ///     } else {
+    ///         print("player was not modified")
     ///     }
     /// }
     /// ```

--- a/GRDB/Record/MutablePersistableRecord+Update.swift
+++ b/GRDB/Record/MutablePersistableRecord+Update.swift
@@ -152,7 +152,7 @@ extension MutablePersistableRecord {
     ///   nil, <doc:/MutablePersistableRecord/persistenceConflictPolicy-1isyv>
     ///   is used.
     /// - parameter record: The comparison record.
-    /// - returns: Whether the record had changes.
+    /// - returns: Whether the record had changes and was updated.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
     ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the
@@ -195,7 +195,7 @@ extension MutablePersistableRecord {
     ///   nil, <doc:/MutablePersistableRecord/persistenceConflictPolicy-1isyv>
     ///   is used.
     /// - parameter modify: A closure that modifies the record.
-    /// - returns: Whether the record had changes.
+    /// - returns: Whether the record was changed and updated.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type,
     ///   or ``RecordError/recordNotFound(databaseTableName:key:)`` if the

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -411,7 +411,7 @@ open class Record {
     /// On success, this method sets the `hasDatabaseChanges` flag to false.
     ///
     /// - parameter db: A database connection.
-    /// - returns: Whether the record had changes.
+    /// - returns: Whether the record had changes and was updated.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
     ///   ``RecordError/recordNotFound(databaseTableName:key:)`` is thrown
     ///   if the primary key does not match any row in the database and record

--- a/Tests/GRDBTests/MutablePersistableRecordChangesTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordChangesTests.swift
@@ -561,4 +561,64 @@ class MutablePersistableRecordChangesTests: GRDBTestCase {
             }
         }
     }
+    
+    func testDatabaseChangesWithClass() throws {
+        class Player: Encodable, EncodableRecord {
+            var id: Int64
+            var name: String
+            var score: Int
+            
+            init(id: Int64, name: String, score: Int) {
+                self.id = id
+                self.name = name
+                self.score = score
+            }
+        }
+        
+        var player = Player(id: 1, name: "Arthur", score: 1000)
+        do {
+            let changes = try player.databaseChanges { _ in }
+            XCTAssert(changes.isEmpty)
+        }
+        do {
+            let changes = try player.databaseChanges {
+                $0.name = "Barbara"
+            }
+            XCTAssertEqual(changes, ["name": "Arthur".databaseValue])
+        }
+        do {
+            let changes = try player.databaseChanges {
+                $0.name = "Craig"
+                $0.score = 200
+            }
+            XCTAssertEqual(changes, ["name": "Barbara".databaseValue, "score": 1000.databaseValue])
+        }
+    }
+    
+    func testDatabaseChangesWithStruct() throws {
+        struct Player: Encodable, EncodableRecord {
+            var id: Int64
+            var name: String
+            var score: Int
+        }
+        
+        var player = Player(id: 1, name: "Arthur", score: 1000)
+        do {
+            let changes = try player.databaseChanges { _ in }
+            XCTAssert(changes.isEmpty)
+        }
+        do {
+            let changes = try player.databaseChanges {
+                $0.name = "Barbara"
+            }
+            XCTAssertEqual(changes, ["name": "Arthur".databaseValue])
+        }
+        do {
+            let changes = try player.databaseChanges {
+                $0.name = "Craig"
+                $0.score = 200
+            }
+            XCTAssertEqual(changes, ["name": "Barbara".databaseValue, "score": 1000.databaseValue])
+        }
+    }
 }

--- a/Tests/GRDBTests/TransactionDateTests.swift
+++ b/Tests/GRDBTests/TransactionDateTests.swift
@@ -173,7 +173,7 @@ class TransactionDateTests: GRDBTestCase {
         let newTransactionDate = Date()
         currentDate = newTransactionDate
         try dbQueue.write { db in
-            var player = try Player.fetchOne(db, key: 1)!
+            var player = try Player.find(db, key: 1)
             
             player.name = "Barbara"
             try player.updateWithTimestamp(db)
@@ -219,7 +219,7 @@ class TransactionDateTests: GRDBTestCase {
         let newTransactionDate = Date()
         currentDate = newTransactionDate
         try dbQueue.write { db in
-            var player = try Player.fetchOne(db, key: 1)!
+            var player = try Player.find(db, key: 1)
             
             let changed = try player.updateChangesWithTimestamp(db) {
                 $0.name = "Barbara"
@@ -230,7 +230,7 @@ class TransactionDateTests: GRDBTestCase {
         }
         
         try dbQueue.write { db in
-            var player = try Player.fetchOne(db, key: 1)!
+            var player = try Player.find(db, key: 1)
             
             let changed = try player.updateChangesWithTimestamp(db) {
                 $0.name = "Barbara"
@@ -269,7 +269,7 @@ class TransactionDateTests: GRDBTestCase {
         let newTransactionDate = Date()
         currentDate = newTransactionDate
         try dbQueue.write { db in
-            var player = try Player.fetchOne(db, key: 1)!
+            var player = try Player.find(db, key: 1)
             try player.touch(db)
             XCTAssertEqual(player.modificationDate, newTransactionDate)
 

--- a/Tests/GRDBTests/TransactionDateTests.swift
+++ b/Tests/GRDBTests/TransactionDateTests.swift
@@ -399,6 +399,10 @@ extension TimestampedRecord {
     
     /// Sets `creationDate` and `modificationDate` to the transaction date,
     /// if they are nil.
+    ///
+    /// It is called automatically before insertion, if your type does not
+    /// customize the `willInsert` persistence callback. If you customize
+    /// this callback, call `initializeTimestamps` from your implementation.
     mutating func initializeTimestamps(_ db: Database) throws {
         if creationDate == nil {
             creationDate = try db.transactionDate
@@ -443,7 +447,7 @@ extension TimestampedRecord {
     ///     - modificationDate: The modification date. If nil, the
     ///       transaction date is used.
     ///     - modify: A closure that modifies the record.
-    /// - returns: Whether the record had changes.
+    /// - returns: Whether the record was changed and updated.
     @discardableResult
     mutating func updateChangesWithTimestamp(
         _ db: Database,

--- a/Tests/GRDBTests/TransactionDateTests.swift
+++ b/Tests/GRDBTests/TransactionDateTests.swift
@@ -95,7 +95,7 @@ class TransactionDateTests: GRDBTestCase {
         XCTAssertEqual(collectedDates, [dates[0], dates[1], dates[1], dates[2]])
     }
     
-    func test_TimestampedRecord_default() throws {
+    func test_TimestampedRecord_default_willInsert() throws {
         struct Player: Codable, MutablePersistableRecord, FetchableRecord, TimestampedRecord {
             var id: Int64?
             var creationDate: Date?
@@ -138,6 +138,37 @@ class TransactionDateTests: GRDBTestCase {
                 XCTAssertEqual(player.modificationDate, customDate)
             }
         }
+    }
+    
+    func test_TimestampedRecord_updateWithTimestamp() throws {
+        struct Player: Codable, MutablePersistableRecord, FetchableRecord, TimestampedRecord {
+            var id: Int64?
+            var creationDate: Date?
+            var modificationDate: Date?
+            var name: String
+            
+            mutating func didInsert(_ inserted: InsertionSuccess) {
+                id = inserted.rowID
+            }
+        }
+        
+        var currentDate = Date.distantPast
+        dbConfiguration.transactionClock = .custom { _ in currentDate }
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("creationDate", .datetime).notNull()
+                t.column("modificationDate", .datetime).notNull()
+                t.column("name", .text).notNull()
+            }
+        }
+        
+        currentDate = Date.distantPast
+        try dbQueue.write { db in
+            var player = Player(name: "Arthur")
+            try player.insert(db)
+        }
         
         let newTransactionDate = Date()
         currentDate = newTransactionDate
@@ -152,6 +183,59 @@ class TransactionDateTests: GRDBTestCase {
             try player.updateWithTimestamp(db, modificationDate: .distantFuture)
             XCTAssertEqual(player.creationDate, .distantPast)
             XCTAssertEqual(player.modificationDate, .distantFuture)
+        }
+    }
+    
+    func test_TimestampedRecord_updateChangesWithTimestamp() throws {
+        struct Player: Codable, MutablePersistableRecord, FetchableRecord, TimestampedRecord {
+            var id: Int64?
+            var creationDate: Date?
+            var modificationDate: Date?
+            var name: String
+            
+            mutating func didInsert(_ inserted: InsertionSuccess) {
+                id = inserted.rowID
+            }
+        }
+        
+        var currentDate = Date.distantPast
+        dbConfiguration.transactionClock = .custom { _ in currentDate }
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("creationDate", .datetime).notNull()
+                t.column("modificationDate", .datetime).notNull()
+                t.column("name", .text).notNull()
+            }
+        }
+        
+        currentDate = Date.distantPast
+        try dbQueue.write { db in
+            var player = Player(name: "Arthur")
+            try player.insert(db)
+        }
+        
+        let newTransactionDate = Date()
+        currentDate = newTransactionDate
+        try dbQueue.write { db in
+            var player = try Player.fetchOne(db, key: 1)!
+            
+            let changed = try player.updateChangesWithTimestamp(db) {
+                $0.name = "Barbara"
+            }
+            XCTAssertTrue(changed)
+            XCTAssertEqual(player.creationDate, .distantPast)
+            XCTAssertEqual(player.modificationDate, newTransactionDate)
+        }
+        
+        try dbQueue.write { db in
+            var player = try Player.fetchOne(db, key: 1)!
+            
+            let changed = try player.updateChangesWithTimestamp(db) {
+                $0.name = "Barbara"
+            }
+            XCTAssertFalse(changed)
         }
     }
     
@@ -277,18 +361,64 @@ extension TimestampedRecord where Self: MutablePersistableRecord {
     /// Sets `modificationDate`, and executes an `UPDATE` statement
     /// on all columns.
     ///
-    /// - parameter date: The modification date. If nil, the
+    /// - parameter modificationDate: The modification date. If nil, the
     ///   transaction date is used.
     mutating func updateWithTimestamp(_ db: Database, modificationDate: Date? = nil) throws {
         self.modificationDate = try modificationDate ?? db.transactionDate
         try update(db)
     }
     
+    /// Modifies the record according to the provided `modify` closure, and,
+    /// if and only if the record was modified, sets `modificationDate` and
+    /// executes an `UPDATE` statement that updates the modified columns.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.write { db in
+    ///     var player = Player.find(db, id: 1)
+    ///     let modified = try player.updateChangesWithTimestamp(db) {
+    ///         $0.score = 1000
+    ///     }
+    ///     if modified {
+    ///         print("player was modified")
+    ///     } else {
+    ///         print("player was not modified")
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - parameters:
+    ///     - db: A database connection.
+    ///     - modificationDate: The modification date. If nil, the
+    ///       transaction date is used.
+    ///     - modify: A closure that modifies the record.
+    /// - returns: Whether the record had changes.
+    @discardableResult
+    mutating func updateChangesWithTimestamp(
+        _ db: Database,
+        modificationDate: Date? = nil,
+        modify: (inout Self) -> Void)
+    throws -> Bool
+    {
+        let initialChanges = try databaseChanges(modify: modify)
+        if initialChanges.isEmpty {
+            return false
+        }
+        
+        let dateChanges = try databaseChanges(modify: {
+            $0.modificationDate = try modificationDate ?? db.transactionDate
+        })
+        let changedColumns = Set(initialChanges.keys).union(dateChanges.keys)
+        try update(db, columns: changedColumns)
+        return true
+    }
+    
     /// Sets `modificationDate`, and executes an `UPDATE` statement that
     /// updates the `modificationDate` column, if and only if the record
     /// was modified.
     ///
-    /// - parameter date: The modification date. If nil, the
+    /// - parameter modificationDate: The modification date. If nil, the
     ///   transaction date is used.
     mutating func touch(_ db: Database, modificationDate: Date? = nil) throws {
         try updateChanges(db) {

--- a/Tests/GRDBTests/TransactionDateTests.swift
+++ b/Tests/GRDBTests/TransactionDateTests.swift
@@ -451,16 +451,20 @@ extension TimestampedRecord {
         modify: (inout Self) -> Void)
     throws -> Bool
     {
+        // Grab the changes performed by `modify`
         let initialChanges = try databaseChanges(modify: modify)
         if initialChanges.isEmpty {
             return false
         }
         
+        // Update modification date and grab its column name
         let dateChanges = try databaseChanges(modify: {
             $0.modificationDate = try modificationDate ?? db.transactionDate
         })
-        let changedColumns = Set(initialChanges.keys).union(dateChanges.keys)
-        try update(db, columns: changedColumns)
+        
+        // Update the modified columns
+        let modifiedColumns = Set(initialChanges.keys).union(dateChanges.keys)
+        try update(db, columns: modifiedColumns)
         return true
     }
     


### PR DESCRIPTION
This pull request enhances the [Record Timestamps and Transaction Date](https://swiftpackageindex.com/groue/grdb.swift/v6.7.0/documentation/grdb/recordtimestamps) documentation article with a sample `TimestampedRecord` protocol that applications may adapt for their own use.

`TimestampedRecord` needed a new library feature: the `EncodableRecord.databaseChanges(modify:)` method. It modifies the record according to the provided closure, and returns a dictionary of changed columns and values. Database is not involved:

```swift
var player = Player(id: 1, score: 1000, hasAward: false)
let changes = try player.databaseChanges {
    $0.score = 1000
    $0.hasAward = true
}
player.hasAward     // true (changed)
changes["score"]    // nil (not changed)
changes["hasAward"] // false (old value)
```