### PR TITLE
SQLite argument binding optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,9 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
+- **New**: [#1348](https://github.com/groue/GRDB.swift/pull/1348) by [@groue](https://github.com/groue): SQLite argument binding optimization
 - **New**: `FTS5.api(db)` returns a pointer to the `fts5_api` structure, useful for low-level [FTS5 customization](https://www.sqlite.org/fts5.html#extending_fts5).
-- **Documentation Updates**: Moved more README chapters into DocC, or enhanced DocC articles:
+- **Documentation Updates**: Moved more README chapters into DocC, enhanced and extended DocC articles:
     - [Database Connections](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/databaseconnections)
     - [Prepared Statements](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/statement)
     - [DatabaseValueConvertible](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/databasevalueconvertible)

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -156,7 +156,7 @@ public final class DatabaseValueCursor<Value: DatabaseValueConvertible>: Databas
         }
         
         // Assume cursor is created for immediate iteration: reset and set arguments
-        try statement.reset(withArguments: arguments)
+        try statement.prepareExecution(withArguments: arguments)
     }
     
     deinit {

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1366,7 +1366,7 @@ public final class RowCursor: DatabaseCursor {
         self._row = try Row(statement: statement).adapted(with: adapter, layout: statement)
         
         // Assume cursor is created for immediate iteration: reset and set arguments
-        try statement.reset(withArguments: arguments)
+        try statement.prepareExecution(withArguments: arguments)
     }
     
     deinit {

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -223,7 +223,7 @@ where Value: DatabaseValueConvertible & StatementColumnConvertible
         }
         
         // Assume cursor is created for immediate iteration: reset and set arguments
-        try statement.reset(withArguments: arguments)
+        try statement.prepareExecution(withArguments: arguments)
     }
     
     deinit {

--- a/GRDB/Core/Support/Foundation/Data.swift
+++ b/GRDB/Core/Support/Foundation/Data.swift
@@ -42,6 +42,23 @@ extension Data: DatabaseValueConvertible, StatementColumnConvertible {
             sqlite3_bind_blob(sqliteStatement, index, $0.baseAddress, CInt($0.count), SQLITE_TRANSIENT)
         }
     }
+    
+    /// Calls the given closure after binding a statement argument.
+    ///
+    /// The binding is valid only during the execution of this method.
+    ///
+    /// - parameter sqliteStatement: An SQLite statement.
+    /// - parameter index: 1-based index to statement arguments.
+    /// - parameter body: The closure to execute when argument is bound.
+    func withBinding<T>(to sqliteStatement: SQLiteStatement, at index: CInt, do body: () throws -> T) throws -> T {
+        try withUnsafeBytes {
+            let code = sqlite3_bind_blob(
+                sqliteStatement, index,
+                $0.baseAddress, CInt($0.count), nil /* SQLITE_STATIC */)
+            try checkBindingSuccess(code: code, sqliteStatement: sqliteStatement)
+            return try body()
+        }
+    }
 }
 
 // MARK: - Conversions

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -610,6 +610,21 @@ extension String: DatabaseValueConvertible, StatementColumnConvertible {
     public func bind(to sqliteStatement: SQLiteStatement, at index: CInt) -> CInt {
         sqlite3_bind_text(sqliteStatement, index, self, -1, SQLITE_TRANSIENT)
     }
+    
+    /// Calls the given closure after binding a statement argument.
+    ///
+    /// The binding is valid only during the execution of this method.
+    ///
+    /// - parameter sqliteStatement: An SQLite statement.
+    /// - parameter index: 1-based index to statement arguments.
+    /// - parameter body: The closure to execute when argument is bound.
+    func withBinding<T>(to sqliteStatement: SQLiteStatement, at index: CInt, do body: () throws -> T) throws -> T {
+        try withCString {
+            let code = sqlite3_bind_text(sqliteStatement, index, $0, -1, nil /* SQLITE_STATIC */)
+            try checkBindingSuccess(code: code, sqliteStatement: sqliteStatement)
+            return try body()
+        }
+    }
 }
 
 

--- a/GRDB/Documentation.docc/Extension/Statement.md
+++ b/GRDB/Documentation.docc/Extension/Statement.md
@@ -81,8 +81,8 @@ let player = try Player.fetchOne(selectStatement, arguments: ["Arthur"])
 >
 > Both perform exactly the same action, and most applications should not care about the difference. Yet:
 >
-> - `setArguments(_:)` performs a copy of string and blob arguments. It uses the low-level [`SQLITE_TRANSIENT`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with the same arguments.
-> - `execute(arguments:)` avoids a temporary allocation for string and blob arguments. It uses the low-level [`SQLITE_STATIC`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with various arguments.
+> - ``setArguments(_:)`` performs a copy of string and blob arguments. It uses the low-level [`SQLITE_TRANSIENT`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with the same arguments.
+> - ``execute(arguments:)`` avoids a temporary allocation for string and blob arguments. It uses the low-level [`SQLITE_STATIC`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with various arguments.
 >
 > Don't make a blind choice, and monitor your app performance if it really matters!
 

--- a/GRDB/Documentation.docc/Extension/Statement.md
+++ b/GRDB/Documentation.docc/Extension/Statement.md
@@ -68,6 +68,24 @@ let player = try Player.fetchOne(selectStatement, arguments: ["Arthur"])
 
 > Note: A prepared statement that has failed with an error can not be recovered. Create a new instance, or use a cached statement as described below.
 
+> Tip: When you look after the best performance, take care about a difference between setting the arguments before execution, and setting the arguments at the moment of execution:
+>
+> ```swift
+> // First option
+> try statement.setArguments(...)
+> try statement.execute()
+>
+> // Second option
+> try statement.execute(arguments: ...)
+> ```
+>
+> Both perform exactly the same action, and most applications should not care about the difference. Yet:
+>
+> - `setArguments(_:)` performs a copy of string and blob arguments. It uses the low-level [`SQLITE_TRANSIENT`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with the same arguments.
+> - `execute(arguments:)` avoids a temporary allocation for string and blob arguments. It uses the low-level [`SQLITE_STATIC`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with various arguments.
+>
+> Don't make a blind choice, and monitor your app performance if it really matters!
+
 ## Caching Prepared Statements
 
 When the same query will be used several times in the lifetime of an application, one may feel a natural desire to cache prepared statements.

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -807,7 +807,7 @@ public final class RecordCursor<Record: FetchableRecord>: DatabaseCursor {
         _row = try Row(statement: statement).adapted(with: adapter, layout: statement)
         
         // Assume cursor is created for immediate iteration: reset and set arguments
-        try statement.reset(withArguments: arguments)
+        try statement.prepareExecution(withArguments: arguments)
     }
     
     deinit {

--- a/GRDB/Utils/LockedBox.swift
+++ b/GRDB/Utils/LockedBox.swift
@@ -26,6 +26,8 @@ final class LockedBox<T> {
     ///     $count.read { print($0) }
     ///
     /// - parameter block: A closure that accepts the value.
+    @inline(__always)
+    @usableFromInline
     func read<U>(_ block: (T) throws -> U) rethrows -> U {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/Performance/GRDBPerformance/ArgumentsTests.swift
+++ b/Tests/Performance/GRDBPerformance/ArgumentsTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import GRDB
+
+class ArgumentsTests: XCTestCase {
+    static let shortString = "foo"
+    static let longString = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus consectetur felis eget nibh aliquet ullamcorper. Nam sodales, tellus a cursus tincidunt, arcu purus suscipit elit, nec congue erat ipsum a purus."
+    
+    var dbDirectoryPath: String!
+    var dbQueue: DatabaseQueue!
+    
+    override func setUpWithError() throws {
+        let dbDirectoryName = "ArgumentsTests-\(ProcessInfo.processInfo.globallyUniqueString)"
+        dbDirectoryPath = (NSTemporaryDirectory() as NSString).appendingPathComponent(dbDirectoryName)
+        try FileManager.default.createDirectory(atPath: dbDirectoryPath, withIntermediateDirectories: true)
+        let dbPath = (dbDirectoryPath as NSString).appendingPathComponent("db.sqlite")
+        dbQueue = try DatabaseQueue(path: dbPath)
+    }
+    
+    override func tearDownWithError() throws {
+        dbQueue = nil
+        try FileManager.default.removeItem(atPath: dbDirectoryPath)
+    }
+    
+    func test_shortString_legacy_performance_() throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "CREATE TABLE t(a)")
+            
+            let statement = try db.makeStatement(sql: "INSERT INTO t(a) VALUES (?)")
+            let arguments: StatementArguments = [Self.shortString]
+            measure {
+                for _ in 0..<1_000_000 {
+                    // Simulate old implementation of statement.execute(arguments: arguments)
+                    try! statement.setArguments(arguments)
+                    try! statement.execute()
+                }
+            }
+        }
+    }
+    
+    func test_shortString_SQLITE_STATIC_performance() throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "CREATE TABLE t(a)")
+            
+            let statement = try db.makeStatement(sql: "INSERT INTO t(a) VALUES (?)")
+            let arguments: StatementArguments = [Self.shortString]
+            measure {
+                for _ in 0..<1_000_000 {
+                    try! statement.execute(arguments: arguments)
+                }
+            }
+        }
+    }
+    
+    func test_shortString_SQLITE_TRANSIENT_performance() throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "CREATE TABLE t(a)")
+            
+            let statement = try db.makeStatement(sql: "INSERT INTO t(a) VALUES (?)")
+            let arguments: StatementArguments = [Self.shortString]
+            try statement.setArguments(arguments)
+            measure {
+                for _ in 0..<1_000_000 {
+                    try! statement.execute()
+                }
+            }
+        }
+    }
+    
+    func test_longString_legacy_performance_() throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "CREATE TABLE t(a)")
+            
+            let statement = try db.makeStatement(sql: "INSERT INTO t(a) VALUES (?)")
+            let arguments: StatementArguments = [Self.longString]
+            measure {
+                for _ in 0..<1_000_000 {
+                    // Simulate old implementation of statement.execute(arguments: arguments)
+                    try! statement.setArguments(arguments)
+                    try! statement.execute()
+                }
+            }
+        }
+    }
+    
+    func test_longString_SQLITE_STATIC_performance() throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "CREATE TABLE t(a)")
+            
+            let statement = try db.makeStatement(sql: "INSERT INTO t(a) VALUES (?)")
+            let arguments: StatementArguments = [Self.longString]
+            measure {
+                for _ in 0..<1_000_000 {
+                    try! statement.execute(arguments: arguments)
+                }
+            }
+        }
+    }
+    
+    func test_longString_SQLITE_TRANSIENT_performance() throws {
+        try dbQueue.write { db in
+            try db.execute(sql: "CREATE TABLE t(a)")
+            
+            let statement = try db.makeStatement(sql: "INSERT INTO t(a) VALUES (?)")
+            let arguments: StatementArguments = [Self.longString]
+            try! statement.setArguments(arguments)
+            measure {
+                for _ in 0..<1_000_000 {
+                    try! statement.execute()
+                }
+            }
+        }
+    }
+}

--- a/Tests/Performance/GRDBPerformance/GRDBPerformance.xcodeproj/project.pbxproj
+++ b/Tests/Performance/GRDBPerformance/GRDBPerformance.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		5690AFDC212058CB001530EA /* FetchRecordDecodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690AFDA212058CB001530EA /* FetchRecordDecodableTests.swift */; };
 		56A3FEA827A85F4800B0292E /* Realm in Frameworks */ = {isa = PBXBuildFile; productRef = 56A3FEA727A85F4800B0292E /* Realm */; };
 		56A3FEAA27A85F4800B0292E /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 56A3FEA927A85F4800B0292E /* RealmSwift */; };
+		56A6F4AC29BBC8E200E22662 /* ArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A6F4AB29BBC8E200E22662 /* ArgumentsTests.swift */; };
 		56B6D0E52618BF78003CC455 /* FetchRecordOptimizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6D0E42618BF78003CC455 /* FetchRecordOptimizedTests.swift */; };
 		56B6D0E62618BF78003CC455 /* FetchRecordOptimizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6D0E42618BF78003CC455 /* FetchRecordOptimizedTests.swift */; };
 		56B6D0EA2618C00C003CC455 /* InsertRecordOptimizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B6D0E92618C00C003CC455 /* InsertRecordOptimizedTests.swift */; };
@@ -97,6 +98,7 @@
 		567986AD23A378CD0076902D /* GRDB.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GRDB.xcodeproj; path = ../../../GRDB.xcodeproj; sourceTree = "<group>"; };
 		5690AFD72120589A001530EA /* InsertRecordEncodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsertRecordEncodableTests.swift; sourceTree = "<group>"; };
 		5690AFDA212058CB001530EA /* FetchRecordDecodableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRecordDecodableTests.swift; sourceTree = "<group>"; };
+		56A6F4AB29BBC8E200E22662 /* ArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentsTests.swift; sourceTree = "<group>"; };
 		56B6D0E42618BF78003CC455 /* FetchRecordOptimizedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRecordOptimizedTests.swift; sourceTree = "<group>"; };
 		56B6D0E92618C00C003CC455 /* InsertRecordOptimizedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsertRecordOptimizedTests.swift; sourceTree = "<group>"; };
 		56BB86121BA9886D001F9168 /* InsertRecordClassTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InsertRecordClassTests.swift; sourceTree = "<group>"; };
@@ -143,7 +145,7 @@
 			isa = PBXGroup;
 			children = (
 				567986B923A378CD0076902D /* GRDB.framework */,
-				567986BB23A378CD0076902D /* GRDBOSXTests.xctest */,
+				567986BB23A378CD0076902D /* GRDBTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -160,6 +162,7 @@
 			children = (
 				56BB862D1BA98933001F9168 /* GRDBPerformanceComparisonTests-Bridging.h */,
 				56DE7B2D1C42B23B00861EB8 /* PerformanceModel.xcdatamodeld */,
+				56A6F4AB29BBC8E200E22662 /* ArgumentsTests.swift */,
 				567071FA208A509C006AD95A /* DateParsingTests.swift */,
 				56DE7B271C41302500861EB8 /* FetchNamedValuesTests.swift */,
 				56DE7B291C4130AF00861EB8 /* FetchPositionalValuesTests.swift */,
@@ -307,7 +310,7 @@
 			remoteRef = 567986B823A378CD0076902D /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		567986BB23A378CD0076902D /* GRDBOSXTests.xctest */ = {
+		567986BB23A378CD0076902D /* GRDBTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = GRDBTests.xctest;
@@ -346,6 +349,7 @@
 				56DE7B281C41302500861EB8 /* FetchNamedValuesTests.swift in Sources */,
 				5690AFD82120589A001530EA /* InsertRecordEncodableTests.swift in Sources */,
 				56B6D0EA2618C00C003CC455 /* InsertRecordOptimizedTests.swift in Sources */,
+				56A6F4AC29BBC8E200E22662 /* ArgumentsTests.swift in Sources */,
 				5690AFDB212058CB001530EA /* FetchRecordDecodableTests.swift in Sources */,
 				56D507831F6D7B2E00AE1C5B /* InsertRecordStructTests.swift in Sources */,
 				56DE7B241C412F7E00861EB8 /* InsertPositionalValuesTests.swift in Sources */,

--- a/Tests/Performance/GRDBPerformance/GRDBPerformance.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/Performance/GRDBPerformance/GRDBPerformance.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "realm-core",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/realm/realm-core",
+      "location" : "https://github.com/realm/realm-core.git",
       "state" : {
-        "revision" : "3c4b86da569368c4ee5ccca2a112d511cc6fa936",
-        "version" : "12.11.0"
+        "revision" : "dd91f5f967c4ae89c37e24ab2a0315c31106648f",
+        "version" : "13.6.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/realm/realm-swift.git",
       "state" : {
-        "revision" : "dc1672b3011eb992ce95db4feec83cd897626a16",
-        "version" : "10.32.1"
+        "revision" : "8ac6fe1aa5d0fb0100062d80863416a4d70de8ca",
+        "version" : "10.37.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephencelis/SQLite.swift.git",
       "state" : {
-        "revision" : "4d543d811ee644fa4cc4bfa0be996b4dd6ba0f54",
-        "version" : "0.13.3"
+        "revision" : "7a2e3cd27de56f6d396e84f63beefd0267b55ccb",
+        "version" : "0.14.1"
       }
     }
   ],

--- a/Tests/generatePerformanceReport.rb
+++ b/Tests/generatePerformanceReport.rb
@@ -40,7 +40,7 @@ BUILD_ROOT = $1
 
 # DERIVED_DATA
 tmp = BUILD_ROOT
-while !File.exists?(File.join(tmp, 'SourcePackages'))
+while !File.exist?(File.join(tmp, 'SourcePackages'))
   parent = File.dirname(tmp)
   exit 1 if tmp == parent
   tmp = parent


### PR DESCRIPTION
This draft pull request improves the performance of `Statement.execute(arguments:)` by avoiding a temporary memory allocation for strings and blobs arguments. It uses `SQLITE_STATIC` instead of `SQLITE_TRANSIENT`.

This change was inspired by https://hachyderm.io/@helge@mastodon.social/109978514220902036.

Quoting the updated `Statement` documentation:

> Tip: When you look after the best performance, take care about a difference between setting the arguments before execution, and setting the arguments at the moment of execution:
>
> ```swift
> // First option
> try statement.setArguments(...)
> try statement.execute()
>
> // Second option
> try statement.execute(arguments: ...)
> ```
>
> Both perform exactly the same action, and most applications should not care about the difference. Yet:
>
> - ``setArguments(_:)`` performs a copy of string and blob arguments. It uses the low-level [`SQLITE_TRANSIENT`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with the same arguments.
> - ``execute(arguments:)`` avoids a temporary allocation for string and blob arguments. It uses the low-level [`SQLITE_STATIC`](https://www.sqlite.org/c3ref/c_static.html) option, and fits well the reuse of a given statement with various arguments.
>
> Don't make a blind choice, and monitor your app performance if it really matters!

This pull request only applies to explicit calls to `execute(arguments:)`. The library allows other uses of prepared statements, and those still use `SQLITE_TRANSIENT`:

<details>
<summary>Click for details</summary>

The insert/upsert/update/delete methods of record types are not impacted by this optimization: string and blob arguments still need a temporary `SQLITE_TRANSIENT` memory allocation.

The difficulty here is the fact that GRDB does not distinguish *unchecked* from *unbound* arguments. Arguments checking is a safety GRDB feature that let developers know when they do not provide all arguments expected by a statement. Checking is the default behavior, but it is also possible to provide "unchecked" arguments, when the program is sure it provides correct arguments, and is willing to trade safety for performance. But unchecked arguments are currently bound and copied with `SQLITE_TRANSIENT`, preventing the `SQLITE_STATIC` optimization. In other words, one optimization defeats the other one.

---

Fetch requests are not impacted by this optimization: their string and blob arguments still need a temporary `SQLITE_TRANSIENT` memory allocation. A lot of refactoring would be needed, because all fetch requests are currently based on [cursors](https://swiftpackageindex.com/groue/grdb.swift/v6.8.0/documentation/grdb/databasecursor).

Cursors can be iterated step after step, and in this case we must not use the  `SQLITE_STATIC` storage of string and blobs arguments:

```swift
let players = try Player.fetchCursor(db, sql: """
    SELECT * FROM player WHERE name = ?
    """, arguments: ["Arthur"])
while let player = try players.next() {
    // use player
}
// <- Now we can finalize the SQLite statement
```

Related [SQLite Documentation](https://www.sqlite.org/c3ref/bind_blob.html):

> The special constant, [SQLITE_STATIC](https://www.sqlite.org/c3ref/c_static.html), may be passed to indicate that the application remains responsible for disposing of the object. In this case, the object and the provided pointer to it must remain valid until either the prepared statement is finalized or the same SQL parameter is bound to something else, whichever occurs sooner.

There are opportunities for optimization, though: all fetching methods that wrap iteration and return single values, arrays, or sets:

```swift
let player  = try Player.fetchOne(db, sql: "...", arguments: ...)
let players = try Player.fetchAll(db, sql: "...", arguments: ...)
let players = try Player.fetchSet(db, sql: "...", arguments: ...)
let player  = try Player.find(db, id: ...)
let players = try Player.filter(Column("name") == "Arthur").fetchAll(db)
// etc
```

Since they wrap statement iteration, they can guarantee the validity on temporary bindings and use the `SQLITE_STATIC` storage. But we'd have to stop using cursors - that's the heavy refactoring.

</details>