### PR TITLE
DatabasePool won't close read-only connections if requested, and ValueObservation no longer opens a new database connection when it starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
-- **New**: [#1350](https://github.com/groue/GRDB.swift/pull/1350) by [@groue](https://github.com/groue): ValueObservation on DatabasePool no longer opens a new database connection when it starts
+- **New**: [#1350](https://github.com/groue/GRDB.swift/pull/1350) by [@groue](https://github.com/groue): DatabasePool won't close read-only connections if requested, and ValueObservation no longer opens a new database connection when it starts.
 
 ## 6.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **New**: [#1350](https://github.com/groue/GRDB.swift/pull/1350) by [@groue](https://github.com/groue): ValueObservation on DatabasePool no longer opens a new database connection when it starts
+
 ## 6.9.2
 
 Released March 14, 2023 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v6.9.1...v6.9.2)

--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		56D110D828AFC84000E64463 /* PersistableRecord+Insert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D110D728AFC84000E64463 /* PersistableRecord+Insert.swift */; };
 		56D110DD28AFC8B400E64463 /* PersistableRecord+Save.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D110DC28AFC8B400E64463 /* PersistableRecord+Save.swift */; };
 		56D110FA28AFC97E00E64463 /* MutablePersistableRecord+DAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D110F928AFC97E00E64463 /* MutablePersistableRecord+DAO.swift */; };
+		56D3332029C38D6700430680 /* WALSnapshotTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D3331F29C38D6700430680 /* WALSnapshotTransaction.swift */; };
 		56D496541D812F5B008276D7 /* SQLExpressionLiteralTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56A4CDAF1D4234B200B1A9B9 /* SQLExpressionLiteralTests.swift */; };
 		56D496551D812F83008276D7 /* FoundationDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5657AB2F1D108BA9006283EF /* FoundationDataTests.swift */; };
 		56D496571D81303E008276D7 /* FoundationDateComponentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5690C3251D23E6D800E59934 /* FoundationDateComponentsTests.swift */; };
@@ -753,6 +754,7 @@
 		56D110D728AFC84000E64463 /* PersistableRecord+Insert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PersistableRecord+Insert.swift"; sourceTree = "<group>"; };
 		56D110DC28AFC8B400E64463 /* PersistableRecord+Save.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PersistableRecord+Save.swift"; sourceTree = "<group>"; };
 		56D110F928AFC97E00E64463 /* MutablePersistableRecord+DAO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MutablePersistableRecord+DAO.swift"; sourceTree = "<group>"; };
+		56D3331F29C38D6700430680 /* WALSnapshotTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WALSnapshotTransaction.swift; sourceTree = "<group>"; };
 		56D5075D1F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryKeyInfoTests.swift; sourceTree = "<group>"; };
 		56D51CFF1EA789FA0074638A /* FetchableRecord+TableRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FetchableRecord+TableRecord.swift"; sourceTree = "<group>"; };
 		56D91AA12205E03700770D8D /* SQLRelation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLRelation.swift; sourceTree = "<group>"; };
@@ -1466,6 +1468,7 @@
 				566B9C1F25C6CC24004542CF /* RowDecodingError.swift */,
 				56BB6EA81D3009B100A1CA52 /* SchedulingWatchdog.swift */,
 				560A37A61C8FF6E500949E71 /* SerializedDatabase.swift */,
+				56D3331F29C38D6700430680 /* WALSnapshotTransaction.swift */,
 				56E9FAD7221053DC00C703A8 /* SQL.swift */,
 				569D6DDD220EF9E100A058A9 /* SQLInterpolation.swift */,
 				56FBFED82210731A00945324 /* SQLRequest.swift */,
@@ -2157,6 +2160,7 @@
 				5653EC122098738B00F46237 /* SQLGenerationContext.swift in Sources */,
 				560D92471C672C4B00F4F92B /* MutablePersistableRecord.swift in Sources */,
 				5674A6E41F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
+				56D3332029C38D6700430680 /* WALSnapshotTransaction.swift in Sources */,
 				5653EB0C20944C7C00F46237 /* HasManyAssociation.swift in Sources */,
 				5657AAB91D107001006283EF /* NSData.swift in Sources */,
 				560D92421C672C3E00F4F92B /* StatementColumnConvertible.swift in Sources */,

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -374,25 +374,19 @@ public struct Configuration {
 #endif
     
     /// A boolean value indicating whether read-only connections should be
-    /// kept open as long as they remain in a valid state.
+    /// kept open.
     ///
-    /// This configuration applies to ``DatabasePool`` only. The default value
-    /// is false.
+    /// This configuration flag applies to ``DatabasePool`` only. The
+    /// default value is false.
     ///
-    /// A `DatabasePool` automatically closes read-only connections on
-    /// various occasions, in order to spare memory
-    /// (see ``DatabasePool/releaseMemory()``), or when connections enter an
-    /// invalid state.
+    /// When the flag is false, a `DatabasePool` closes read-only
+    /// connections when requested to dispose non-essential memory with
+    /// ``DatabasePool/releaseMemory()``. When true, those connections are
+    /// kept open.
     ///
-    /// When this flag is true, only invalid connections are automatically
-    /// closed. Valid connections, once opened, are kept alive until the
-    /// `DatabasePool` is deinitialized, or one of those methods is called:
-    /// ``DatabaseReader/close()``,
-    /// ``DatabasePool/invalidateReadOnlyConnections()``.
-    ///
-    /// Consider using this flag when profiling your application reveals
-    /// that a lot of time is spent opening new SQLite connections.
-    public var persistentReaderConnections = false
+    /// Consider setting this flag to true when profiling your application
+    /// reveals that a lot of time is spent opening new SQLite connections.
+    public var persistentReadOnlyConnections = false
     
     // MARK: - Factory Configuration
     

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -301,7 +301,7 @@ public struct Configuration {
     /// If nil, GRDB picks a default one.
     var readonlyBusyMode: Database.BusyMode? = nil
     
-    /// The maximum number of concurrent readers.
+    /// The maximum number of concurrent read-only connections.
     ///
     /// This configuration applies to ``DatabasePool`` only. The default value
     /// is 5.
@@ -372,7 +372,28 @@ public struct Configuration {
     /// The default is true.
     public var automaticMemoryManagement = true
 #endif
-
+    
+    /// A boolean value indicating whether read-only connections should be
+    /// kept open as long as they remain in a valid state.
+    ///
+    /// This configuration applies to ``DatabasePool`` only. The default value
+    /// is false.
+    ///
+    /// A `DatabasePool` automatically closes read-only connections on
+    /// various occasions, in order to spare memory
+    /// (see ``DatabasePool/releaseMemory()``), or when connections enter an
+    /// invalid state.
+    ///
+    /// When this flag is true, only invalid connections are automatically
+    /// closed. Valid connections, once opened, are kept alive until the
+    /// `DatabasePool` is deinitialized, or one of those methods is called:
+    /// ``DatabaseReader/close()``,
+    /// ``DatabasePool/invalidateReadOnlyConnections()``.
+    ///
+    /// Consider using this flag when profiling your application reveals
+    /// that a lot of time is spent opening new SQLite connections.
+    public var persistentReaderConnections = false
+    
     // MARK: - Factory Configuration
     
     /// Creates a factory configuration.

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -301,13 +301,15 @@ public struct Configuration {
     /// If nil, GRDB picks a default one.
     var readonlyBusyMode: Database.BusyMode? = nil
     
-    /// The maximum number of concurrent read-only connections.
+    /// The maximum number of concurrent reader connections.
     ///
-    /// This configuration applies to ``DatabasePool`` only. The default value
-    /// is 5.
+    /// This configuration has effect on ``DatabasePool`` and
+    /// ``DatabaseSnapshotPool`` only. The default value is 5.
     ///
     /// You can query this value at runtime in order to get the actual capacity
-    /// for concurrent reads of any ``DatabaseReader``. For example:
+    /// for concurrent reads of any ``DatabaseReader``. In this context,
+    /// ``DatabaseQueue`` and ``DatabaseSnapshot`` have a capacity of 1,
+    /// because they can't perform two concurrent reads. For example:
     ///
     /// ```swift
     /// var config = Configuration()
@@ -321,6 +323,7 @@ public struct Configuration {
     /// print(dbQueue.configuration.maximumReaderCount)    // 1
     /// print(dbPool.configuration.maximumReaderCount)     // 5
     /// print(dbSnapshot.configuration.maximumReaderCount) // 1
+    /// ```
     public var maximumReaderCount: Int = 5
     
     /// The quality of service of database accesses.

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -168,11 +168,14 @@ extension DatabasePool {
     
     // MARK: - Memory management
     
-    /// Frees as much memory as possible, by disposing non-essential memory from
-    /// the writer connection, and closing all reader connections.
+    /// Frees as much memory as possible, by disposing non-essential memory.
     ///
     /// This method is synchronous, and blocks the current thread until all
     /// database accesses are completed.
+    ///
+    /// This method closes all reader connections, unless the
+    /// ``Configuration/persistentReaderConnections`` configuration flag
+    /// is set.
     ///
     /// - warning: This method can prevent concurrent reads from executing,
     ///   until it returns. Prefer ``releaseMemoryEventually()`` if you intend
@@ -181,34 +184,50 @@ extension DatabasePool {
         // Release writer memory
         writer.sync { $0.releaseMemory() }
         
-        // Release readers memory by closing all connections.
-        //
-        // We must use a barrier in order to guarantee that memory has been
-        // freed (reader connections closed) when the method exits, as
-        // documented.
-        //
-        // Without the barrier, connections would only close _eventually_ (after
-        // their eventual concurrent jobs have completed).
-        readerPool?.barrier {
-            readerPool?.removeAll()
+        if configuration.persistentReaderConnections {
+            // Keep existing readers
+            readerPool?.forEach { reader in
+                reader.sync { $0.releaseMemory() }
+            }
+        } else {
+            // Release readers memory by closing all connections.
+            //
+            // We must use a barrier in order to guarantee that memory has been
+            // freed (reader connections closed) when the method exits, as
+            // documented.
+            //
+            // Without the barrier, connections would only close _eventually_ (after
+            // their eventual concurrent jobs have completed).
+            readerPool?.barrier {
+                readerPool?.removeAll()
+            }
         }
     }
     
-    /// Eventually frees as much memory as possible, by disposing non-essential
-    /// memory from the writer connection, and closing all reader connections.
+    /// Eventually frees as much memory as possible, by disposing
+    /// non-essential memory.
+    ///
+    /// This method eventually closes all reader connections, unless the
+    /// ``Configuration/persistentReaderConnections`` configuration flag
+    /// is set.
     ///
     /// Unlike ``releaseMemory()``, this method does not prevent concurrent
     /// database accesses when it is executing. But it does not notify when
     /// non-essential memory has been freed.
     public func releaseMemoryEventually() {
-        // Release readers memory by eventually closing all reader connections
-        // (they will close after their current jobs have completed).
-        readerPool?.removeAll()
+        if configuration.persistentReaderConnections {
+            // Keep existing readers
+            readerPool?.forEach { reader in
+                reader.async { $0.releaseMemory() }
+            }
+        } else {
+            // Release readers memory by eventually closing all reader connections
+            // (they will close after their current jobs have completed).
+            readerPool?.removeAll()
+        }
         
         // Release writer memory eventually.
-        writer.async { db in
-            db.releaseMemory()
-        }
+        writer.async { $0.releaseMemory() }
     }
     
     #if os(iOS)
@@ -610,6 +629,10 @@ extension DatabasePool: DatabaseReader {
     ///
     /// Eventual concurrent read-only accesses are not invalidated: they will
     /// proceed until completion.
+    ///
+    /// - This method closes all read-only connections, even if the
+    /// ``Configuration/persistentReaderConnections`` configuration flag
+    /// is set.
     public func invalidateReadOnlyConnections() {
         readerPool?.removeAll()
     }

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -173,8 +173,8 @@ extension DatabasePool {
     /// This method is synchronous, and blocks the current thread until all
     /// database accesses are completed.
     ///
-    /// This method closes all reader connections, unless the
-    /// ``Configuration/persistentReaderConnections`` configuration flag
+    /// This method closes all read-only connections, unless the
+    /// ``Configuration/persistentReadOnlyConnections`` configuration flag
     /// is set.
     ///
     /// - warning: This method can prevent concurrent reads from executing,
@@ -184,7 +184,7 @@ extension DatabasePool {
         // Release writer memory
         writer.sync { $0.releaseMemory() }
         
-        if configuration.persistentReaderConnections {
+        if configuration.persistentReadOnlyConnections {
             // Keep existing readers
             readerPool?.forEach { reader in
                 reader.sync { $0.releaseMemory() }
@@ -207,15 +207,15 @@ extension DatabasePool {
     /// Eventually frees as much memory as possible, by disposing
     /// non-essential memory.
     ///
-    /// This method eventually closes all reader connections, unless the
-    /// ``Configuration/persistentReaderConnections`` configuration flag
+    /// This method eventually closes all read-only connections, unless the
+    /// ``Configuration/persistentReadOnlyConnections`` configuration flag
     /// is set.
     ///
     /// Unlike ``releaseMemory()``, this method does not prevent concurrent
     /// database accesses when it is executing. But it does not notify when
     /// non-essential memory has been freed.
     public func releaseMemoryEventually() {
-        if configuration.persistentReaderConnections {
+        if configuration.persistentReadOnlyConnections {
             // Keep existing readers
             readerPool?.forEach { reader in
                 reader.async { $0.releaseMemory() }
@@ -627,11 +627,11 @@ extension DatabasePool: DatabaseReader {
     /// After this method is called, read-only database access methods will use
     /// new SQLite connections.
     ///
-    /// Eventual concurrent read-only accesses are not invalidated: they will
+    /// Eventual concurrent read-only accesses are not interrupted, and
     /// proceed until completion.
     ///
     /// - This method closes all read-only connections, even if the
-    /// ``Configuration/persistentReaderConnections`` configuration flag
+    /// ``Configuration/persistentReadOnlyConnections`` configuration flag
     /// is set.
     public func invalidateReadOnlyConnections() {
         readerPool?.removeAll()

--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -683,6 +683,9 @@ extension DatabasePool: DatabaseReader {
     }
     
     /// Returns a long-lived WAL snapshot transaction on a reader connection.
+    ///
+    /// - important: The `completion` argument is executed in a serial
+    ///   dispatch queue, so make sure you use the transaction asynchronously.
     func asyncWALSnapshotTransaction(_ completion: @escaping (Result<WALSnapshotTransaction, Error>) -> Void) {
         guard let readerPool else {
             completion(.failure(DatabaseError.connectionIsClosed()))

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -222,7 +222,7 @@ final class SerializedDatabase {
         }
     }
     
-    // Schedules database operations for execution, and returns immediately.
+    /// Schedules database operations for execution, and returns immediately.
     func async(_ block: @escaping (Database) -> Void) {
         queue.async {
             block(self.db)

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -9,6 +9,8 @@ final class SerializedDatabase {
     var configuration: Configuration { db.configuration }
     
     /// If true, overrides `configuration.allowsUnsafeTransactions`.
+    ///
+    /// See `WALSnapshotTransaction`.
     var allowsUnsafeTransactions = false
     
     /// The path to the database file

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -140,6 +140,21 @@ final class SerializedDatabase {
         }
     }
     
+    /// Executes database operations, returns their result after they have
+    /// finished executing, and allows or forbids long-lived transactions.
+    ///
+    /// This method is not reentrant.
+    ///
+    /// - parameter allowingLongLivedTransaction: When true, the
+    ///   ``Configuration/allowsUnsafeTransactions`` configuration flag is
+    ///   ignored until this method is called again with false.
+    func reentrantSync<T>(allowingLongLivedTransaction: Bool, _ body: (Database) throws -> T) rethrows -> T {
+        try reentrantSync { db in
+            self.allowsUnsafeTransactions = allowingLongLivedTransaction
+            return try body(db)
+        }
+    }
+    
     /// Executes database operations, and returns their result after they
     /// have finished executing.
     ///

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -8,16 +8,14 @@ final class SerializedDatabase {
     /// The database configuration
     var configuration: Configuration { db.configuration }
     
-    /// If true, overrides `configuration.allowsUnsafeTransactions`.
-    ///
-    /// See `WALSnapshotTransaction`.
-    var allowsUnsafeTransactions = false
-    
     /// The path to the database file
     let path: String
     
     /// The dispatch queue
     private let queue: DispatchQueue
+    
+    /// If true, overrides `configuration.allowsUnsafeTransactions`.
+    private var allowsUnsafeTransactions = false
     
     init(
         path: String,
@@ -81,10 +79,25 @@ final class SerializedDatabase {
         }
     }
     
-    /// Synchronously executes a block the serialized dispatch queue, and
-    /// returns its result.
+    /// Executes database operations, returns their result after they have
+    /// finished executing, and allows or forbids long-lived transactions.
     ///
-    /// This method is *not* reentrant.
+    /// This method is not reentrant.
+    ///
+    /// - parameter allowingLongLivedTransaction: When true, the
+    ///   ``Configuration/allowsUnsafeTransactions`` configuration flag is
+    ///   ignored until this method is called again with false.
+    func sync<T>(allowingLongLivedTransaction: Bool, _ body: (Database) throws -> T) rethrows -> T {
+        try sync { db in
+            self.allowsUnsafeTransactions = allowingLongLivedTransaction
+            return try body(db)
+        }
+    }
+    
+    /// Executes database operations, and returns their result after they
+    /// have finished executing.
+    ///
+    /// This method is not reentrant.
     func sync<T>(_ block: (Database) throws -> T) rethrows -> T {
         // Three different cases:
         //
@@ -127,8 +140,8 @@ final class SerializedDatabase {
         }
     }
     
-    /// Synchronously executes a block the serialized dispatch queue, and
-    /// returns its result.
+    /// Executes database operations, and returns their result after they
+    /// have finished executing.
     ///
     /// This method is reentrant.
     func reentrantSync<T>(_ block: (Database) throws -> T) rethrows -> T {
@@ -194,7 +207,7 @@ final class SerializedDatabase {
         }
     }
     
-    /// Asynchronously executes a block in the serialized dispatch queue.
+    // Schedules database operations for execution, and returns immediately.
     func async(_ block: @escaping (Database) -> Void) {
         queue.async {
             block(self.db)

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -143,7 +143,7 @@ final class SerializedDatabase {
     /// Executes database operations, returns their result after they have
     /// finished executing, and allows or forbids long-lived transactions.
     ///
-    /// This method is not reentrant.
+    /// This method is reentrant.
     ///
     /// - parameter allowingLongLivedTransaction: When true, the
     ///   ``Configuration/allowsUnsafeTransactions`` configuration flag is

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -8,6 +8,9 @@ final class SerializedDatabase {
     /// The database configuration
     var configuration: Configuration { db.configuration }
     
+    /// If true, overrides `configuration.allowsUnsafeTransactions`.
+    var allowsUnsafeTransactions = false
+    
     /// The path to the database file
     let path: String
     
@@ -242,7 +245,7 @@ final class SerializedDatabase {
         line: UInt = #line)
     {
         GRDBPrecondition(
-            configuration.allowsUnsafeTransactions || !db.isInsideTransaction,
+            allowsUnsafeTransactions || configuration.allowsUnsafeTransactions || !db.isInsideTransaction,
             message(),
             file: file,
             line: line)

--- a/GRDB/Core/WALSnapshotTransaction.swift
+++ b/GRDB/Core/WALSnapshotTransaction.swift
@@ -1,0 +1,74 @@
+// swiftlint:disable:next line_length
+#if SQLITE_ENABLE_SNAPSHOT || (!GRDBCUSTOMSQLITE && !GRDBCIPHER && (compiler(>=5.7.1) || !(os(macOS) || targetEnvironment(macCatalyst))))
+/// A long-live read-only WAL transaction.
+///
+/// `WALSnapshotTransaction` **takes ownership** of its reader
+/// `SerializedDatabase` (TODO: make it a move-only type eventually).
+class WALSnapshotTransaction {
+    private let reader: SerializedDatabase
+    private let transactionDidComplete: (Bool) -> Void
+    
+    /// The state of the database at the beginning of the transaction.
+    let walSnapshot: WALSnapshot
+    
+    /// Creates a long-live WAL transaction on a read-only connection.
+    ///
+    /// The `transactionDidComplete` closure is called when the
+    /// `WALSnapshotTransaction` is deallocated, or if the
+    /// initializer throws. Its argument tells if the long-lived
+    /// transaction could be properly terminated.
+    ///
+    /// - parameter reader: A read-only database connection.
+    /// - parameter transactionDidComplete: A closure to call when the
+    ///   snapshot transaction ends.
+    init(
+        reader: SerializedDatabase,
+        transactionDidComplete: @escaping (Bool) -> Void)
+    throws
+    {
+        assert(reader.configuration.readonly)
+        
+        // Open a transaction and enter snapshot isolation
+        reader.allowsUnsafeTransactions = true
+        do {
+            try reader.sync { db in
+                try db.beginTransaction(.deferred)
+                try db.execute(sql: "SELECT rootpage FROM sqlite_master LIMIT 1")
+            }
+        } catch {
+            // self is not initialized, so deinit will not run.
+            Self.commitAndRelease(reader: reader, transactionDidComplete: transactionDidComplete)
+            throw error
+        }
+        
+        self.reader = reader
+        self.transactionDidComplete = transactionDidComplete
+        self.walSnapshot = try reader.sync { db in
+            return try WALSnapshot(db)
+        }
+    }
+    
+    deinit {
+        Self.commitAndRelease(reader: reader, transactionDidComplete: transactionDidComplete)
+    }
+    
+    /// Executes database operations in the snapshot transaction, and
+    /// returns their result after they have finished executing.
+    func read<T>(_ value: (Database) throws -> T) rethrows -> T {
+        // TODO: we should check the validity of the snapshot, as DatabaseSnapshotPool does.
+        try reader.sync(value)
+    }
+    
+    private static func commitAndRelease(
+        reader: SerializedDatabase,
+        transactionDidComplete: (Bool) -> Void)
+    {
+        reader.allowsUnsafeTransactions = false
+        let success = reader.sync { db in
+            try? db.commit()
+            return db.isInsideTransaction
+        }
+        transactionDidComplete(success)
+    }
+}
+#endif

--- a/GRDB/Documentation.docc/Extension/Configuration.md
+++ b/GRDB/Documentation.docc/Extension/Configuration.md
@@ -92,6 +92,7 @@ do {
 - ``label``
 - ``maximumReaderCount``
 - ``observesSuspensionNotifications``
+- ``persistentReaderConnections``
 - ``prepareDatabase(_:)``
 - ``publicStatementArguments``
 - ``transactionClock``

--- a/GRDB/Documentation.docc/Extension/Configuration.md
+++ b/GRDB/Documentation.docc/Extension/Configuration.md
@@ -92,7 +92,7 @@ do {
 - ``label``
 - ``maximumReaderCount``
 - ``observesSuspensionNotifications``
-- ``persistentReaderConnections``
+- ``persistentReadOnlyConnections``
 - ``prepareDatabase(_:)``
 - ``publicStatementArguments``
 - ``transactionClock``

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		56D110F528AFC90800E64463 /* MutablePersistableRecord+Save.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D110E728AFC90800E64463 /* MutablePersistableRecord+Save.swift */; };
 		56D110F728AFC90800E64463 /* MutablePersistableRecord+Update.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D110E828AFC90800E64463 /* MutablePersistableRecord+Update.swift */; };
 		56D110FF28AFC9C600E64463 /* MutablePersistableRecord+DAO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D110FE28AFC9C600E64463 /* MutablePersistableRecord+DAO.swift */; };
+		56D3332329C38D7B00430680 /* WALSnapshotTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D3332129C38D7A00430680 /* WALSnapshotTransaction.swift */; };
 		56D507611F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D5075D1F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift */; };
 		56D51D021EA789FA0074638A /* FetchableRecord+TableRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56D51CFF1EA789FA0074638A /* FetchableRecord+TableRecord.swift */; };
 		56DA7D03260FAA1B00A8D97B /* RecordMinimalNonOptionalPrimaryKeySingleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56DA7D02260FAA1A00A8D97B /* RecordMinimalNonOptionalPrimaryKeySingleTests.swift */; };
@@ -763,6 +764,7 @@
 		56D110E728AFC90800E64463 /* MutablePersistableRecord+Save.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MutablePersistableRecord+Save.swift"; sourceTree = "<group>"; };
 		56D110E828AFC90800E64463 /* MutablePersistableRecord+Update.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MutablePersistableRecord+Update.swift"; sourceTree = "<group>"; };
 		56D110FE28AFC9C600E64463 /* MutablePersistableRecord+DAO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MutablePersistableRecord+DAO.swift"; sourceTree = "<group>"; };
+		56D3332129C38D7A00430680 /* WALSnapshotTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WALSnapshotTransaction.swift; sourceTree = "<group>"; };
 		56D5075D1F6BAE8600AE1C5B /* PrimaryKeyInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryKeyInfoTests.swift; sourceTree = "<group>"; };
 		56D51CFF1EA789FA0074638A /* FetchableRecord+TableRecord.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FetchableRecord+TableRecord.swift"; sourceTree = "<group>"; };
 		56DA7D02260FAA1A00A8D97B /* RecordMinimalNonOptionalPrimaryKeySingleTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecordMinimalNonOptionalPrimaryKeySingleTests.swift; sourceTree = "<group>"; };
@@ -1462,6 +1464,7 @@
 				56231E6025CEBF06001DFD2F /* RowDecodingError.swift */,
 				56BB6EA81D3009B100A1CA52 /* SchedulingWatchdog.swift */,
 				560A37A61C8FF6E500949E71 /* SerializedDatabase.swift */,
+				56D3332129C38D7A00430680 /* WALSnapshotTransaction.swift */,
 				56A6EB2226076F6A00C27594 /* SQL.swift */,
 				56E9FAC32210468500C703A8 /* SQLInterpolation.swift */,
 				56FBFED52210731000945324 /* SQLRequest.swift */,
@@ -1981,6 +1984,7 @@
 				56D110F328AFC90800E64463 /* MutablePersistableRecord.swift in Sources */,
 				F3BA80831CFB2E67003DC1BA /* DatabaseValueConvertible+RawRepresentable.swift in Sources */,
 				5657AABB1D107001006283EF /* NSData.swift in Sources */,
+				56D3332329C38D7B00430680 /* WALSnapshotTransaction.swift in Sources */,
 				5674A6E51F307F0E0095F066 /* DatabaseValueConvertible+Decodable.swift in Sources */,
 				5656A8652295BD56001FF3FF /* BelongsToAssociation.swift in Sources */,
 				F3BA806A1CFB2E55003DC1BA /* DatabaseQueue.swift in Sources */,

--- a/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
@@ -198,7 +198,7 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         XCTAssertEqual(openConnectionCount, 1)
     }
     
-    func test_DatabasePool_releaseMemory_closes_reader_connections_when_persistentReaderConnections_is_false() throws {
+    func test_DatabasePool_releaseMemory_closes_reader_connections_when_persistentReadOnlyConnections_is_false() throws {
         var persistentConnectionCount = 0
         
         dbConfiguration.SQLiteConnectionDidOpen = {
@@ -209,7 +209,7 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
             persistentConnectionCount -= 1
         }
         
-        dbConfiguration.persistentReaderConnections = false
+        dbConfiguration.persistentReadOnlyConnections = false
         
         let dbPool = try makeDatabasePool()
         XCTAssertEqual(persistentConnectionCount, 1) // writer
@@ -221,7 +221,7 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
         XCTAssertEqual(persistentConnectionCount, 1) // writer
     }
     
-    func test_DatabasePool_releaseMemory_does_not_close_reader_connections_when_persistentReaderConnections_is_true() throws {
+    func test_DatabasePool_releaseMemory_does_not_close_reader_connections_when_persistentReadOnlyConnections_is_true() throws {
         var persistentConnectionCount = 0
         
         dbConfiguration.SQLiteConnectionDidOpen = {
@@ -232,7 +232,7 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
             persistentConnectionCount -= 1
         }
         
-        dbConfiguration.persistentReaderConnections = true
+        dbConfiguration.persistentReadOnlyConnections = true
         
         let dbPool = try makeDatabasePool()
         XCTAssertEqual(persistentConnectionCount, 1) // writer

--- a/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
@@ -120,83 +120,129 @@ class DatabasePoolReleaseMemoryTests: GRDBTestCase {
 
 #endif
 
-    // TODO: fix flaky test
-//    func testDatabasePoolReleaseMemoryClosesReaderConnections() throws {
-//        let countQueue = DispatchQueue(label: "GRDB")
-//        var openConnectionCount = 0
-//        var totalOpenConnectionCount = 0
-//        
-//        dbConfiguration.SQLiteConnectionDidOpen = {
-//            countQueue.sync {
-//                totalOpenConnectionCount += 1
-//                openConnectionCount += 1
-//            }
-//        }
-//        
-//        dbConfiguration.SQLiteConnectionDidClose = {
-//            countQueue.sync {
-//                openConnectionCount -= 1
-//            }
-//        }
-//        
-//        let dbPool = try makeDatabasePool()
-//        try dbPool.write { db in
-//            try db.execute(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
-//            for _ in 0..<2 {
-//                try db.execute(sql: "INSERT INTO items (id) VALUES (NULL)")
-//            }
-//        }
-//        
-//        // Block 1                  Block 2                 Block3
-//        // SELECT * FROM items
-//        // step
-//        // >
-//        let s1 = DispatchSemaphore(value: 0)
-//        //                          SELECT * FROM items
-//        //                          step
-//        //                          >
-//        let s2 = DispatchSemaphore(value: 0)
-//        // step                     step
-//        // >
-//        let s3 = DispatchSemaphore(value: 0)
-//        // end                      end                     releaseMemory
-//        
-//        let block1 = { () in
-//            try! dbPool.read { db in
-//                let cursor = try Row.fetchCursor(db, sql: "SELECT * FROM items")
-//                XCTAssertTrue(try cursor.next() != nil)
-//                s1.signal()
-//                _ = s2.wait(timeout: .distantFuture)
-//                XCTAssertTrue(try cursor.next() != nil)
-//                s3.signal()
-//                XCTAssertTrue(try cursor.next() == nil)
-//            }
-//        }
-//        let block2 = { () in
-//            _ = s1.wait(timeout: .distantFuture)
-//            try! dbPool.read { db in
-//                let cursor = try Row.fetchCursor(db, sql: "SELECT * FROM items")
-//                XCTAssertTrue(try cursor.next() != nil)
-//                s2.signal()
-//                XCTAssertTrue(try cursor.next() != nil)
-//                XCTAssertTrue(try cursor.next() == nil)
-//            }
-//        }
-//        let block3 = { () in
-//            _ = s3.wait(timeout: .distantFuture)
-//            dbPool.releaseMemory()
-//        }
-//        let blocks = [block1, block2, block3]
-//        DispatchQueue.concurrentPerform(iterations: blocks.count) { index in // FIXME: this crashes sometimes
-//            blocks[index]()
-//        }
-//        
-//        // Two readers, one writer
-//        XCTAssertEqual(totalOpenConnectionCount, 3)
-//        
-//        // Writer is still open
-//        XCTAssertEqual(openConnectionCount, 1)
-//    }
+    func test_DatabasePool_releaseMemory_closes_reader_connections() throws {
+        // A complicated test setup that opens multiple reader connections.
+        let countQueue = DispatchQueue(label: "GRDB")
+        var openConnectionCount = 0
+        var totalOpenConnectionCount = 0
+        
+        dbConfiguration.SQLiteConnectionDidOpen = {
+            countQueue.sync {
+                totalOpenConnectionCount += 1
+                openConnectionCount += 1
+            }
+        }
+        
+        dbConfiguration.SQLiteConnectionDidClose = {
+            countQueue.sync {
+                openConnectionCount -= 1
+            }
+        }
+        
+        let dbPool = try makeDatabasePool()
+        try dbPool.write { db in
+            try db.execute(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
+            for _ in 0..<2 {
+                try db.execute(sql: "INSERT INTO items (id) VALUES (NULL)")
+            }
+        }
+        
+        // Block 1                  Block 2                 Block3
+        // SELECT * FROM items
+        // step
+        // >
+        let s1 = DispatchSemaphore(value: 0)
+        //                          SELECT * FROM items
+        //                          step
+        //                          >
+        let s2 = DispatchSemaphore(value: 0)
+        // step                     step
+        // >
+        let s3 = DispatchSemaphore(value: 0)
+        // end                      end                     releaseMemory
+        
+        let block1 = { () in
+            try! dbPool.read { db in
+                let cursor = try Row.fetchCursor(db, sql: "SELECT * FROM items")
+                XCTAssertTrue(try cursor.next() != nil)
+                s1.signal()
+                _ = s2.wait(timeout: .distantFuture)
+                XCTAssertTrue(try cursor.next() != nil)
+                s3.signal()
+                XCTAssertTrue(try cursor.next() == nil)
+            }
+        }
+        let block2 = { () in
+            _ = s1.wait(timeout: .distantFuture)
+            try! dbPool.read { db in
+                let cursor = try Row.fetchCursor(db, sql: "SELECT * FROM items")
+                XCTAssertTrue(try cursor.next() != nil)
+                s2.signal()
+                XCTAssertTrue(try cursor.next() != nil)
+                XCTAssertTrue(try cursor.next() == nil)
+            }
+        }
+        let block3 = { () in
+            _ = s3.wait(timeout: .distantFuture)
+            dbPool.releaseMemory()
+        }
+        let blocks = [block1, block2, block3]
+        DispatchQueue.concurrentPerform(iterations: blocks.count) { index in // FIXME: this crashes sometimes
+            blocks[index]()
+        }
+        
+        // Two readers, one writer
+        XCTAssertEqual(totalOpenConnectionCount, 3)
+        
+        // Writer is still open
+        XCTAssertEqual(openConnectionCount, 1)
+    }
+    
+    func test_DatabasePool_releaseMemory_closes_reader_connections_when_persistentReaderConnections_is_false() throws {
+        var persistentConnectionCount = 0
+        
+        dbConfiguration.SQLiteConnectionDidOpen = {
+            persistentConnectionCount += 1
+        }
+        
+        dbConfiguration.SQLiteConnectionDidClose = {
+            persistentConnectionCount -= 1
+        }
+        
+        dbConfiguration.persistentReaderConnections = false
+        
+        let dbPool = try makeDatabasePool()
+        XCTAssertEqual(persistentConnectionCount, 1) // writer
+        
+        try dbPool.read { _ in }
+        XCTAssertEqual(persistentConnectionCount, 2) // writer + reader
+        
+        dbPool.releaseMemory()
+        XCTAssertEqual(persistentConnectionCount, 1) // writer
+    }
+    
+    func test_DatabasePool_releaseMemory_does_not_close_reader_connections_when_persistentReaderConnections_is_true() throws {
+        var persistentConnectionCount = 0
+        
+        dbConfiguration.SQLiteConnectionDidOpen = {
+            persistentConnectionCount += 1
+        }
+        
+        dbConfiguration.SQLiteConnectionDidClose = {
+            persistentConnectionCount -= 1
+        }
+        
+        dbConfiguration.persistentReaderConnections = true
+        
+        let dbPool = try makeDatabasePool()
+        XCTAssertEqual(persistentConnectionCount, 1) // writer
+        
+        try dbPool.read { _ in }
+        XCTAssertEqual(persistentConnectionCount, 2) // writer + reader
+        
+        dbPool.releaseMemory()
+        XCTAssertEqual(persistentConnectionCount, 2) // writer + reader
+    }
 
     func testBlocksRetainConnection() throws {
         let countQueue = DispatchQueue(label: "GRDB")

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -412,8 +412,8 @@ class ValueObservationTests: GRDBTestCase {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                     try! dbPool.write { db in
                         try db.execute(sql: """
-                        INSERT INTO t DEFAULT VALUES;
-                        """)
+                            INSERT INTO t DEFAULT VALUES;
+                            """)
                     }
                 }
             }


### PR DESCRIPTION
This PR completes #1248, and aims at solving #1256:

- Enhances performances of `ValueObservation` on `DatabasePool`, because it no longer opens a new database connection when it starts.
- Allows applications to keep read-only connections open.

    `Configuration` has gained a `persistentReadOnlyConnections` property. The default is false: `DatabasePool` manages read-only connections in order to spare memory. When true, `DatabasePool` keeps read-only connections open.
    
    ```swift
    // Keep read-only connections open
    var config = Configuration()
    config.persistentReadOnlyConnections = true
    let dbPool = try DatabasePool(path: "...", configuration: config)
    ```
    
    When profiling your application reveals that a lot of time is spent opening a new SQLite connection at the wrong place:
    
    - Set `persistentReadOnlyConnections` to true.
    - Make sure the needed read-only connection was opened beforehand. A plain `try dbPool.read { _ in }`, for example, creates a read-only connection if no one is available yet. There's no built-in api for creating multiple read-only connections (open a feature request if you need this).
    - Check your eventual use of `invalidateReadOnlyConnections()`, because this method closes read-only connections regardless of the `persistentReadOnlyConnections` configuration.

---

Since #1248, ValueObservation on DatabasePool creates a new database connection when it starts, on the thread that starts the observation. #1256 has revealed that opening a connection can take a long time, with unfortunate consequences for the main thread :-/

In this PR, ValueObservation on DatabasePool just uses one of the available read-only connections:

- Starting a synchronous `.immediate` observation still blocks the main thread until the initial value is fetched, but no time is spent opening a new connection if there is an available read-only connection. If there is no available read-only connection, the main thread is blocked until one is opened, or becomes available. That's where `persistentReadOnlyConnections` is useful: it helps finding an available read-only connection, as long as the app has already performed reads before the observation starts.
- Starting an asynchronous observation schedules the fetch of the initial value and returns immediately. Again, `persistentReadOnlyConnections` is useful, because starting an observation asynchronously also needs an available read-only connection.

When WAL snapshots are available, a long-running transaction is kept opened on the read-only connection, until we can acquire a write access, compare database versions, perform a fetch+notification if and only if the database was modified, and start observing the write transactions.

When WAL snapshots are not available (Xcode 14.0 and macOS, and some SQLCipher/SQLite builds), a double notification of the initial value is always performed, because we can't prove that the database was not changed between the initial fetch and the write access (we need WAL snapshots for that).