### PR TITLE
DatabaseMigrator.eraseDatabaseOnSchemaChange ignores internal schema objects

### DIFF
--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -457,7 +457,13 @@ public struct DatabaseMigrator {
                         }
                     }()
                     
-                    if try db.schema(.main) != tmpSchema {
+                    // Only compare user objects
+                    func isUserObject(_ object: SchemaObject) -> Bool {
+                        !Database.isSQLiteInternalTable(object.name) && !Database.isGRDBInternalTable(object.name)
+                    }
+                    let tmpUserSchema = tmpSchema.filter(isUserObject)
+                    let userSchema = try db.schema(.main).filter(isUserObject)
+                    if userSchema != tmpUserSchema {
                         needsErase = true
                         return .commit
                     }


### PR DESCRIPTION
`DatabaseMigrator.eraseDatabaseOnSchemaChange` ignores internal schema objects when it detects schema changes.

This pull request addresses #1360.