### PR TITLE
Fix ValueObservation deadlock

### DIFF
--- a/GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift
+++ b/GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift
@@ -365,9 +365,6 @@ extension ValueConcurrentObserver {
                             }
                         }
                         
-                        // FIXME: this sleep is for demonstration of Issue 1362 only.
-                        Thread.sleep(forTimeInterval: 0.01)
-                        
                         // Start observation
                         self.asyncStartObservation(
                             from: databaseAccess,

--- a/GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift
+++ b/GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift
@@ -365,6 +365,9 @@ extension ValueConcurrentObserver {
                             }
                         }
                         
+                        // FIXME: this sleep is for demonstration of Issue 1362 only.
+                        Thread.sleep(forTimeInterval: 0.01)
+                        
                         // Start observation
                         self.asyncStartObservation(
                             from: databaseAccess,

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,17 @@ MAX_IOS_DESTINATION := $(shell xcrun simctl list -j devices available | Scripts/
 MIN_TVOS_DESTINATION := $(shell xcrun simctl list -j devices available | Scripts/destination.rb | grep tvOS | sort -n | head -1 | cut -wf 3 | sed 's/\(.*\)/"platform=tvOS Simulator,id=\1"/')
 MAX_TVOS_DESTINATION := $(shell xcrun simctl list -j devices available | Scripts/destination.rb | grep tvOS | sort -rn | head -1 | cut -wf 3 | sed 's/\(.*\)/"platform=tvOS Simulator,id=\1"/')
 
-# If xcbeautify or xcpretty is available, use it for xcodebuild output
-XCPRETTY = 
-XCBEAUTIFY_PATH := $(shell command -v xcbeautify 2> /dev/null)
-XCPRETTY_PATH := $(shell command -v xcpretty 2> /dev/null)
-ifdef XCBEAUTIFY_PATH
-  XCPRETTY = | xcbeautify
-else ifdef XCPRETTY_PATH
-  XCPRETTY = | xcpretty -c
+  # If xcbeautify or xcpretty is available, use it for xcodebuild output, except in CI.
+XCPRETTY =
+ifeq ($(CI),true)
+else
+  XCBEAUTIFY_PATH := $(shell command -v xcbeautify 2> /dev/null)
+  XCPRETTY_PATH := $(shell command -v xcpretty 2> /dev/null)
+  ifdef XCBEAUTIFY_PATH
+    XCPRETTY = | xcbeautify
+  else ifdef XCPRETTY_PATH
+    XCPRETTY = | xcpretty -c
+  endif
 endif
 
 # =====

--- a/Tests/GRDBTests/ValueObservationRecorderTests.swift
+++ b/Tests/GRDBTests/ValueObservationRecorderTests.swift
@@ -679,112 +679,105 @@ class ValueObservationRecorderTests: FailureTestCase {
     func testAssertValueObservationRecordingMatch() {
         do {
             let expected = [3]
-            assertValueObservationRecordingMatch(recorded: [3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [3, 3], expected: expected)
-            assertFailure("failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [2]", "failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [2], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [2]") {
-                assertValueObservationRecordingMatch(recorded: [2, 3], expected: expected)
-            }
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 3], expected: expected))
+            
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2, 3], expected: expected))
         }
         do {
             let expected = [2, 3]
-            assertValueObservationRecordingMatch(recorded: [3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [3, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [3, 3, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [2, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [2, 2, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [2, 2, 3, 3], expected: expected)
-            assertFailure("failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [], expected: expected)
-            }
-            assertFailure("failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [2], expected: expected)
-            }
-            assertFailure("failed - missing expected value 3", "failed - unexpected recorded prefix [3]") {
-                assertValueObservationRecordingMatch(recorded: [3, 2], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [1]") {
-                assertValueObservationRecordingMatch(recorded: [1, 3], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [1]") {
-                assertValueObservationRecordingMatch(recorded: [1, 2, 3], expected: expected)
-            }
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 3, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 2, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 2, 3, 3], expected: expected))
+            
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [3, 2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [1, 3], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [1, 2, 3], expected: expected))
         }
         do {
             let expected = [3, 3]
-            assertValueObservationRecordingMatch(recorded: [3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [3, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [3, 3, 3], expected: expected)
-            assertFailure("failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [], expected: expected)
-            }
-            assertFailure("failed - missing expected value 3", "failed - unexpected recorded prefix [2]") {
-                assertValueObservationRecordingMatch(recorded: [2], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [2]") {
-                assertValueObservationRecordingMatch(recorded: [2, 3], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [2, 2]") {
-                assertValueObservationRecordingMatch(recorded: [2, 2, 3], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [1, 2]") {
-                assertValueObservationRecordingMatch(recorded: [1, 2, 3], expected: expected)
-            }
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 3, 3], expected: expected))
+            
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2, 3], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2, 2, 3], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [1, 2, 3], expected: expected))
         }
         do {
             let expected = [1, 2, 2, 3]
-            assertValueObservationRecordingMatch(recorded: [3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [3, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 3, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 1, 3, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 2, 2, 3], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 2, 3], expected: expected)
-            assertFailure("failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [], expected: expected)
-            }
-            assertFailure("failed - missing expected value 3") {
-                assertValueObservationRecordingMatch(recorded: [2], expected: expected)
-            }
-            assertFailure("failed - missing expected value 3", "failed - unexpected recorded prefix [3]") {
-                assertValueObservationRecordingMatch(recorded: [3, 2], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [2]") {
-                assertValueObservationRecordingMatch(recorded: [2, 1, 3], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [0]") {
-                assertValueObservationRecordingMatch(recorded: [0, 3], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [0]") {
-                assertValueObservationRecordingMatch(recorded: [0, 1, 2, 3], expected: expected)
-            }
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 3, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 1, 3, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 2, 3], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 3], expected: expected))
+            
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [3, 2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2, 1, 3], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [0, 3], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [0, 1, 2, 3], expected: expected))
         }
         do {
             let expected = [1, 2, 1]
-            assertValueObservationRecordingMatch(recorded: [1], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 1], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [2, 1], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 2, 1], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 1, 2, 1], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 2, 1, 1], expected: expected)
-            assertValueObservationRecordingMatch(recorded: [1, 2, 2, 1], expected: expected)
-            assertFailure("failed - missing expected value 1") {
-                assertValueObservationRecordingMatch(recorded: [], expected: expected)
-            }
-            assertFailure("failed - missing expected value 1") {
-                assertValueObservationRecordingMatch(recorded: [2], expected: expected)
-            }
-            assertFailure("failed - missing expected value 1") {
-                assertValueObservationRecordingMatch(recorded: [1, 2], expected: expected)
-            }
-            assertFailure("failed - unexpected recorded prefix [0]") {
-                assertValueObservationRecordingMatch(recorded: [0, 1], expected: expected)
-            }
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 1, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 1, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 2, 1], expected: expected))
+            
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [1, 2], expected: expected))
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [0, 1], expected: expected))
+        }
+        do {
+            let expected = [1, 2, 3, 2, 1]
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 3, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 3, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 3, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 3, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 1], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 3, 1], expected: expected))
+            
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [3, 1, 2, 1], expected: expected))
+        }
+        do {
+            let expected = [1, 2, 1, 3, 1, 4]
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 3, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 3, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 2, 1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 1, 1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [1, 3, 1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [3, 1, 1, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 1, 3, 4], expected: expected))
+            XCTAssertTrue(valueObservationRecordingMatch(recorded: [2, 3, 1, 4], expected: expected))
+
+            XCTAssertFalse(valueObservationRecordingMatch(recorded: [3, 2, 4], expected: expected))
         }
     }
 }

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -769,7 +769,7 @@ class ValueObservationTests: GRDBTestCase {
                     .trackingConstantRegion(Table("t").fetchCount)
                     .handleEvents(didCancel: { cancellationExpectation.fulfill() })
                 
-                for try await count in try observation.values(in: writer).prefix(while: { $0 < 3 }) {
+                for try await count in try observation.values(in: writer).prefix(while: { $0 <= 3 }) {
                     counts.append(count)
                     try await writer.write { try $0.execute(sql: "INSERT INTO t DEFAULT VALUES") }
                 }
@@ -777,9 +777,9 @@ class ValueObservationTests: GRDBTestCase {
             }
             
             let counts = try await task.value
-            
-            // All values were published
-            assertValueObservationRecordingMatch(recorded: counts, expected: [0, 1, 2])
+            XCTAssertTrue(counts.contains(0))
+            XCTAssertTrue(counts.contains(where: { $0 >= 2 }))
+            XCTAssertEqual(counts.sorted(), counts)
             
             // Observation was ended
 #if compiler(>=5.8)
@@ -807,7 +807,7 @@ class ValueObservationTests: GRDBTestCase {
                     .trackingConstantRegion(Table("t").fetchCount)
                     .handleEvents(didCancel: { cancellationExpectation.fulfill() })
                 
-                for try await count in try observation.values(in: writer, scheduling: .immediate).prefix(while: { $0 < 3 }) {
+                for try await count in try observation.values(in: writer, scheduling: .immediate).prefix(while: { $0 <= 3 }) {
                     counts.append(count)
                     try await writer.write { try $0.execute(sql: "INSERT INTO t DEFAULT VALUES") }
                 }
@@ -815,9 +815,9 @@ class ValueObservationTests: GRDBTestCase {
             }
             
             let counts = try await task.value
-            
-            // All values were published
-            assertValueObservationRecordingMatch(recorded: counts, expected: [0, 1, 2])
+            XCTAssertTrue(counts.contains(0))
+            XCTAssertTrue(counts.contains(where: { $0 >= 2 }))
+            XCTAssertEqual(counts.sorted(), counts)
             
             // Observation was ended
 #if compiler(>=5.8)
@@ -847,7 +847,7 @@ class ValueObservationTests: GRDBTestCase {
                 
                 for try await count in observation.values(in: writer) {
                     counts.append(count)
-                    if count == 2 {
+                    if count > 3 {
                         break
                     } else {
                         try await writer.write { try $0.execute(sql: "INSERT INTO t DEFAULT VALUES") }
@@ -857,9 +857,9 @@ class ValueObservationTests: GRDBTestCase {
             }
             
             let counts = try await task.value
-            
-            // All values were published
-            assertValueObservationRecordingMatch(recorded: counts, expected: [0, 1, 2])
+            XCTAssertTrue(counts.contains(0))
+            XCTAssertTrue(counts.contains(where: { $0 >= 2 }))
+            XCTAssertEqual(counts.sorted(), counts)
             
             // Observation was ended
 #if compiler(>=5.8)

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -1105,7 +1105,7 @@ class ValueObservationTests: GRDBTestCase {
                 let observation = ValueObservation.trackingConstantRegion(Table("s").fetchCount)
                 let cancellable = observation.start(
                     in: writer,
-                    scheduling: .async(onQueue: DispatchQueue(label: "", qos: .utility)),
+                    scheduling: .async(onQueue: DispatchQueue(label: "")),
                     onError: { error in XCTFail("Unexpected error: \(error)") },
                     onChange: { value in
                         receiveExpectation.fulfill()
@@ -1135,10 +1135,6 @@ class ValueObservationTests: GRDBTestCase {
 #endif
             withExtendedLifetime(cancellables) {}
         }
-        try await AsyncTest(test).runAtTemporaryDatabasePath {
-            var configuration = Configuration()
-            configuration.qos = .userInitiated
-            return try DatabasePool(path: $0, configuration: configuration)
-        }
+        try await AsyncTest(test).runAtTemporaryDatabasePath { try DatabasePool(path: $0) }
     }
 }


### PR DESCRIPTION
This test demonstrates the possible deadlock between observers and writers as reported in issue #1362 . The observers all hold the `Pool.itemSemaphore` and the writer holds the `SerializedDatabase.queue` and neither can proceed since each is waiting for the other's resource.

To get this test reliable, I needed to insert a `Thread.sleep` inside the `ValueConcurrentObserver`. Obviously, this PR is not for merging. However, this `Thread.sleep` does not change the overall logic and exists primarily to simulate the system being under load.

The `observerCount` of 10 is not arbitrary. If you reduce the `observerCount` by 1, then the code doesn't deadlock so you can confirm that the test is otherwise logically sound.