### PR TITLE
Bitwise operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ---
 
+## Next Release
+
+- **New**: [#1376](https://github.com/groue/GRDB.swift/pull/1376) Bitwise operations
+
+
 ## 6.13.0
 
 Released May 15, 2023 &bull; [diff](https://github.com/groue/GRDB.swift/compare/v6.12.0...v6.13.0)

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -1279,6 +1279,90 @@ extension ColumnExpression {
     public static func /= (column: Self, value: some SQLExpressible) -> ColumnAssignment {
         column.set(to: column / value)
     }
+    
+    /// Creates an assignment that applies a bitwise and.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// Column("mask") &= 2
+    /// Column("mask") &= Column("other")
+    /// ```
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// try dbQueue.write { db in
+    ///     // UPDATE player SET score = score & 2
+    ///     try Player.updateAll(db, Column("mask") &= 2)
+    /// }
+    /// ```
+    public static func &= (column: Self, value: some SQLExpressible) -> ColumnAssignment {
+        column.set(to: column & value)
+    }
+    
+    /// Creates an assignment that applies a bitwise or.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// Column("mask") |= 2
+    /// Column("mask") |= Column("other")
+    /// ```
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// try dbQueue.write { db in
+    ///     // UPDATE player SET score = score | 2
+    ///     try Player.updateAll(db, Column("mask") |= 2)
+    /// }
+    /// ```
+    public static func |= (column: Self, value: some SQLExpressible) -> ColumnAssignment {
+        column.set(to: column | value)
+    }
+    
+    /// Creates an assignment that applies a bitwise left shift.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// Column("mask") <<= 2
+    /// Column("mask") <<= Column("other")
+    /// ```
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// try dbQueue.write { db in
+    ///     // UPDATE player SET score = score << 2
+    ///     try Player.updateAll(db, Column("mask") <<= 2)
+    /// }
+    /// ```
+    public static func <<= (column: Self, value: some SQLExpressible) -> ColumnAssignment {
+        column.set(to: column << value)
+    }
+    
+    /// Creates an assignment that applies a bitwise right shift.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// Column("mask") >>= 2
+    /// Column("mask") >>= Column("other")
+    /// ```
+    ///
+    /// Usage:
+    ///
+    /// ```swift
+    /// try dbQueue.write { db in
+    ///     // UPDATE player SET score = score >> 2
+    ///     try Player.updateAll(db, Column("mask") >>= 2)
+    /// }
+    /// ```
+    public static func >>= (column: Self, value: some SQLExpressible) -> ColumnAssignment {
+        column.set(to: column >> value)
+    }
 }
 
 // MARK: - Eager loading of hasMany associations

--- a/GRDB/QueryInterface/SQL/SQLOperators.swift
+++ b/GRDB/QueryInterface/SQL/SQLOperators.swift
@@ -436,6 +436,75 @@ extension SQLSpecificExpressible {
     }
 }
 
+// MARK: - Bitwise Operators (&, |, ~, <<, >>)
+
+extension SQLSpecificExpressible {
+    /// The `&` SQL operator.
+    public static func & (lhs: Self, rhs: some SQLExpressible) -> SQLExpression {
+        .associativeBinary(.bitwiseAnd, [lhs.sqlExpression, rhs.sqlExpression])
+    }
+    
+    /// The `&` SQL operator.
+    public static func & (lhs: some SQLExpressible, rhs: Self) -> SQLExpression {
+        .associativeBinary(.bitwiseAnd, [lhs.sqlExpression, rhs.sqlExpression])
+    }
+    
+    /// The `&` SQL operator.
+    public static func & (lhs: Self, rhs: some SQLSpecificExpressible) -> SQLExpression {
+        .associativeBinary(.bitwiseAnd, [lhs.sqlExpression, rhs.sqlExpression])
+    }
+    
+    /// The `|` SQL operator.
+    public static func | (lhs: Self, rhs: some SQLExpressible) -> SQLExpression {
+        .associativeBinary(.bitwiseOr, [lhs.sqlExpression, rhs.sqlExpression])
+    }
+    
+    /// The `|` SQL operator.
+    public static func | (lhs: some SQLExpressible, rhs: Self) -> SQLExpression {
+        .associativeBinary(.bitwiseOr, [lhs.sqlExpression, rhs.sqlExpression])
+    }
+    
+    /// The `|` SQL operator.
+    public static func | (lhs: Self, rhs: some SQLSpecificExpressible) -> SQLExpression {
+        .associativeBinary(.bitwiseOr, [lhs.sqlExpression, rhs.sqlExpression])
+    }
+    
+    /// The `<<` SQL operator.
+    public static func << (lhs: Self, rhs: some SQLExpressible) -> SQLExpression {
+        .binary(.leftShift, lhs.sqlExpression, rhs.sqlExpression)
+    }
+    
+    /// The `<<` SQL operator.
+    public static func << (lhs: some SQLExpressible, rhs: Self) -> SQLExpression {
+        .binary(.leftShift, lhs.sqlExpression, rhs.sqlExpression)
+    }
+    
+    /// The `<<` SQL operator.
+    public static func << (lhs: Self, rhs: some SQLSpecificExpressible) -> SQLExpression {
+        .binary(.leftShift, lhs.sqlExpression, rhs.sqlExpression)
+    }
+    
+    /// The `>>` SQL operator.
+    public static func >> (lhs: Self, rhs: some SQLExpressible) -> SQLExpression {
+        .binary(.rightShift, lhs.sqlExpression, rhs.sqlExpression)
+    }
+    
+    /// The `>>` SQL operator.
+    public static func >> (lhs: some SQLExpressible, rhs: Self) -> SQLExpression {
+        .binary(.rightShift, lhs.sqlExpression, rhs.sqlExpression)
+    }
+    
+    /// The `>>` SQL operator.
+    public static func >> (lhs: Self, rhs: some SQLSpecificExpressible) -> SQLExpression {
+        .binary(.rightShift, lhs.sqlExpression, rhs.sqlExpression)
+    }
+    
+    /// The `~` SQL operator.
+    public static prefix func ~ (value: Self) -> SQLExpression {
+        .unary(.bitwiseNot, value.sqlExpression)
+    }
+}
+
 // MARK: - Like Operator
 
 extension SQLSpecificExpressible {

--- a/README.md
+++ b/README.md
@@ -4033,6 +4033,15 @@ GRDB comes with a Swift version of many SQLite [built-in operators](https://sqli
     
     When the sequence is empty, `joined(operator: .add)` returns 0, and `joined(operator: .multiply)` returns 1.
 
+- `&`, `|`, `~`, `<<`, `>>`
+    
+    Bitwise operations (bitwise and, or, not, left shift, right shift) are derived from their Swift equivalent:
+    
+    ```swift
+    // SELECT mask & 2 AS isRocky FROM planet
+    Planet.select((Column("mask") & 2).forKey("isRocky"))
+    ```
+
 - `||`
     
     Concatenate several strings:

--- a/Tests/GRDBTests/TableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/TableRecordUpdateTests.swift
@@ -347,6 +347,110 @@ class TableRecordUpdateTests: GRDBTestCase {
         }
     }
     
+    func testAssignmentBitwiseAndAssign() throws {
+        try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
+            try Player.updateAll(db, Columns.score &= 1)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" & 1
+                """)
+            
+            try Player.updateAll(db, Columns.score &= Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" & "bonus"
+                """)
+            
+            try Player.updateAll(db, Columns.score &= -Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" & (-"bonus")
+                """)
+            
+            try Player.updateAll(db, Columns.score &= Columns.bonus * 2)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" & ("bonus" * 2)
+                """)
+        }
+    }
+    
+    func testAssignmentBitwiseOrAssign() throws {
+        try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
+            try Player.updateAll(db, Columns.score |= 1)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" | 1
+                """)
+            
+            try Player.updateAll(db, Columns.score |= Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" | "bonus"
+                """)
+            
+            try Player.updateAll(db, Columns.score |= -Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" | (-"bonus")
+                """)
+            
+            try Player.updateAll(db, Columns.score |= Columns.bonus * 2)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" | ("bonus" * 2)
+                """)
+        }
+    }
+    
+    func testAssignmentLeftShiftAssign() throws {
+        try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
+            try Player.updateAll(db, Columns.score <<= 1)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" << 1
+                """)
+            
+            try Player.updateAll(db, Columns.score <<= Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" << "bonus"
+                """)
+            
+            try Player.updateAll(db, Columns.score <<= -Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" << (-"bonus")
+                """)
+            
+            try Player.updateAll(db, Columns.score <<= Columns.bonus * 2)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" << ("bonus" * 2)
+                """)
+        }
+    }
+    
+    func testAssignmentRightShiftAssign() throws {
+        try makeDatabaseQueue().write { db in
+            try Player.createTable(db)
+            
+            try Player.updateAll(db, Columns.score >>= 1)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" >> 1
+                """)
+            
+            try Player.updateAll(db, Columns.score >>= Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" >> "bonus"
+                """)
+            
+            try Player.updateAll(db, Columns.score >>= -Columns.bonus)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" >> (-"bonus")
+                """)
+            
+            try Player.updateAll(db, Columns.score >>= Columns.bonus * 2)
+            XCTAssertEqual(self.lastSQLQuery, """
+                UPDATE "player" SET "score" = "score" >> ("bonus" * 2)
+                """)
+        }
+    }
+    
     func testMultipleAssignments() throws {
         try makeDatabaseQueue().write { db in
             try Player.createTable(db)


### PR DESCRIPTION
This pull request adds support for the bitwise operations `&`, `|`, `~`, `<<`, `>>` (and, or, not, left shift, right shift).

Note that SQLite has no built-in support for bitwise xor (`^`), and this operation is not included in the pull request.

Fixes #1374.