### PR TITLE
Add `DerivableRequest.all()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,8 +114,10 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
+- **New**: [#1382](https://github.com/groue/GRDB.swift/pull/1382) Add `DerivableRequest.all()`
 - **New**: [#1384](https://github.com/groue/GRDB.swift/pull/1384) Allow ValueObservation to start from a truncated wal file
 - **Documentation Update**: The [ValueObservation Performance](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/valueobservation#ValueObservation-Performance)) documentation chapter explains how truncating WAL checkpoints impact `ValueObservation`.
+
 
 ## 6.14.0
 

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -214,6 +214,7 @@ extension SelectionRequest {
 ///
 /// ### The WHERE and JOIN ON Clauses
 ///
+/// - ``all()``
 /// - ``filter(_:)``
 /// - ``filter(literal:)``
 /// - ``filter(sql:arguments:)``
@@ -291,6 +292,13 @@ extension FilteredRequest {
     public func none() -> Self {
         filterWhenConnected { _ in false }
     }
+  
+  /// Returns `self`: a request that fetches all rows from this request.
+  ///
+  /// This method, which does nothing, exists in order to match ``none()``.
+  public func all() -> Self {
+      self
+  }
 }
 
 // MARK: - TableRequest
@@ -1328,6 +1336,7 @@ extension JoinableRequest where Self: SelectionRequest {
 ///
 /// ### The WHERE Clause
 ///
+/// - ``FilteredRequest/all()``
 /// - ``FilteredRequest/filter(_:)``
 /// - ``TableRequest/filter(id:)``
 /// - ``TableRequest/filter(ids:)``

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -124,6 +124,30 @@ extension DerivableRequest<Book> {
 }
 
 class DerivableRequestTests: GRDBTestCase {
+    func testAll() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try libraryMigrator.migrate(dbQueue)
+        try dbQueue.inDatabase { db in
+            let baseRequest = Author.all().filter(country: "FR")
+            let request = baseRequest.all()
+            let (sql, arguments) = try request.build(db)
+            XCTAssertEqual(sql, #"SELECT * FROM "author" WHERE "country" = ?"#)
+            XCTAssertEqual(arguments, ["FR"])
+        }
+    }
+    
+    func testNone() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try libraryMigrator.migrate(dbQueue)
+        try dbQueue.inDatabase { db in
+            let baseRequest = Author.all().filter(country: "FR")
+            let request = baseRequest.none()
+            let (sql, arguments) = try request.build(db)
+            XCTAssertEqual(sql, #"SELECT * FROM "author" WHERE ("country" = ?) AND ?"#)
+            XCTAssertEqual(arguments, ["FR", false])
+        }
+    }
+    
     func testFilteredRequest() throws {
         let dbQueue = try makeDatabaseQueue()
         try libraryMigrator.migrate(dbQueue)


### PR DESCRIPTION
The new `DerivableRequest.all()` method does nothing (it returns `self`), but it pairs nicely with `none()`, and fills an api hole.

```swift
extension DerivableRequest<Book> {
    func matching(searchString: String) -> Self {
        if searchString.isEmpty {
            return all() // equivalent to `return self`
        } else {
            return filter(...)
        }
    }
}
```

cc @pierlo 