### PR TITLE
Swift API for creating database views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,11 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
+- **New**: [#1397](https://github.com/groue/GRDB.swift/pull/1397) by [@groue](https://github.com/groue): Swift API for creating database views
 - **New**: [#1401](https://github.com/groue/GRDB.swift/pull/1401) by [@kustra](https://github.com/kustra): Linux compilation fixes
 - **New**: [#1402](https://github.com/groue/GRDB.swift/pull/1402) by [@groue](https://github.com/groue): Upgrade custom SQLite builds to 3.42.0
 - **New**: [#1403](https://github.com/groue/GRDB.swift/pull/1403) by [@groue](https://github.com/groue): GitHub CI: test Xcode 14.3.1, macOS 13
+
 
 ## 6.15.1
 

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -16,7 +16,7 @@ try db.create(table: "player") { t in
 
 When you plan to evolve the schema as new versions of your application ship, wrap all schema changes in <doc:Migrations>.
 
-Prefer Swift methods over raw SQL queries. They allow the compiler to check if a schema change is available on the target operating system. Only use a raw SQL query when no Swift method exist (when creating views or triggers, for example).
+Prefer Swift methods over raw SQL queries. They allow the compiler to check if a schema change is available on the target operating system. Only use a raw SQL query when no Swift method exist (when creating triggers, for example).
 
 When a schema change is not directly supported by SQLite, or not available on the target operating system, database tables have to be recreated. See <doc:Migrations> for the detailed procedure.
 

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -372,6 +372,13 @@ extension Team: TableRecord {
 - ``TableOptions``
 - ``VirtualTableModule``
 
+### Database Views
+
+- ``Database/create(view:options:columns:as:)``
+- ``Database/create(view:options:columns:asLiteral:)``
+- ``Database/drop(view:)``
+- ``ViewOptions``
+
 ### Database Indexes
 
 - ``Database/create(indexOn:columns:options:condition:)``

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -848,7 +848,7 @@ extension SQLExpression {
     ///
     ///     try "foo'bar".databaseValue.quotedSQL(db) // "'foo''bar'""
     func quotedSQL(_ db: Database) throws -> String {
-        let context = SQLGenerationContext(db, argumentsSink: .forRawSQL)
+        let context = SQLGenerationContext(db, argumentsSink: .literalValues)
         return try sql(context)
     }
     

--- a/GRDB/QueryInterface/SQLGeneration/SQLGenerationContext.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLGenerationContext.swift
@@ -172,15 +172,21 @@ class StatementArgumentsSink {
     private(set) var arguments: StatementArguments
     private let rawSQL: Bool
     
-    /// A sink which does not accept any arguments.
-    static let forRawSQL = StatementArgumentsSink(rawSQL: true)
+    /// A sink which turns all argument values into SQL literals.
+    ///
+    /// The `"WHERE name = \("O'Brien")"` SQL literal is turned into the
+    /// `WHERE name = 'O''Brien'` SQL.
+    static let literalValues = StatementArgumentsSink(rawSQL: true)
     
     private init(rawSQL: Bool) {
         self.arguments = []
         self.rawSQL = rawSQL
     }
     
-    /// A sink which accepts arguments
+    /// A sink which turns all argument values into `?` SQL parameters.
+    ///
+    /// The `"WHERE name = \("O'Brien")"` SQL literal is turned into the
+    /// `WHERE name = ?` SQL.
     convenience init() {
         self.init(rawSQL: false)
     }

--- a/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
+++ b/GRDB/QueryInterface/SQLInterpolation+QueryInterface.swift
@@ -38,6 +38,15 @@ extension SQLInterpolation {
         appendInterpolation(type(of: record))
     }
     
+    /// Appends a quoted identifier.
+    ///
+    ///     // INSERT INTO "group" ...
+    ///     let tableName = "group"
+    ///     let request: SQLRequest<Player> = "INSERT INTO \(identifier: tableName) ..."
+    public mutating func appendInterpolation(identifier: String) {
+        appendLiteral(identifier.quotedDatabaseIdentifier)
+    }
+    
     /// Appends the table name of the record.
     ///
     ///     // INSERT INTO player ...

--- a/Tests/GRDBTests/SQLExpressionLiteralTests.swift
+++ b/Tests/GRDBTests/SQLExpressionLiteralTests.swift
@@ -20,7 +20,7 @@ class SQLExpressionLiteralTests: GRDBTestCase {
     func testWithoutArguments() throws {
         try DatabaseQueue().inDatabase { db in
             let expression = Column("foo").collating(.nocase) == "'fooéı👨👨🏿🇫🇷🇨🇮'" && Column("baz") >= 1
-            let context = SQLGenerationContext(db, argumentsSink: .forRawSQL)
+            let context = SQLGenerationContext(db, argumentsSink: .literalValues)
             let sql = try expression.sql(context, wrappedInParenthesis: true)
             XCTAssert(context.arguments.isEmpty)
             XCTAssertEqual(sql, "((\"foo\" = '''fooéı👨👨🏿🇫🇷🇨🇮''' COLLATE NOCASE) AND (\"baz\" >= 1))")


### PR DESCRIPTION
This pull request addresses https://github.com/groue/GRDB.swift/discussions/1394 and introduces the `create(view:options:columns:as:)` and `drop(view:)` methods.

You can create a view with an [`SQL`](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/sql) literal:

```swift
// CREATE VIEW hero AS SELECT * FROM player WHERE isHero == 1
let sql: SQL = """
    SELECT * FROM player WHERE isHero == 1
    """
try db.create(view: "hero", asLiteral: sql)
```

You can create a view with an [`SQLRequest`](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/sqlrequest):

```swift
// CREATE VIEW hero AS SELECT * FROM player WHERE isHero == 1
let request = SQLRequest(literal: """
    SELECT * FROM player WHERE isHero == 1
    """)
try db.create(view: "hero", as: request)
```

You can also create a view with a [`QueryInterfaceRequest`](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/queryinterfacerequest):

```swift
// CREATE VIEW hero AS SELECT * FROM player WHERE isHero == 1
let request = Player.filter(Column("isHero") == true)
try db.create(view: "hero", as: request)
```

When creating views in [migrations](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/migrations), it is recommended to avoid using record types defined in the application. Instead of the `Player` record type, prefer `Table("player")`:

```swift
// RECOMMENDED IN MIGRATIONS
let request = Table("player").filter(Column("isHero") == true)
try db.create(view: "hero", as: request)
```

@mallman, what do you think? That should be enough, right?