### PR TITLE
Make `SQL` able to feed SELECT statements, and deprecate redundant `CommonTableExpression` initializers

### DIFF
--- a/Documentation/CommonTableExpressions.md
+++ b/Documentation/CommonTableExpressions.md
@@ -42,12 +42,12 @@ let name = "O'Brien"
 // WITH playerName AS (SELECT 'O''Brien') ...
 let playerNameCTE = CommonTableExpression(
     named: "playerName",
-    sql: "SELECT ?", arguments: [name])
+    request: SQL(sql: "SELECT ?", arguments: [name]))
 
 // WITH playerName AS (SELECT 'O''Brien') ...
 let playerNameCTE = CommonTableExpression(
     named: "playerName",
-    literal: "SELECT \(name)")
+    request: SQL("SELECT \(name)"))
 
 // WITH playerName AS (SELECT 'O''Brien') ...
 let request = SQLRequest("SELECT \(name)")
@@ -63,7 +63,7 @@ All CTEs can be provided with explicit column names:
 let pairCTE = CommonTableExpression(
     named: "pair", 
     columns: ["a", "b"], 
-    sql: "SELECT 1, 2")
+    request: SQL("SELECT 1, 2"))
 ```
 
 Recursive CTEs need the `recursive` flag. The example below selects all integers between 1 and 1000:
@@ -75,11 +75,11 @@ let counterCTE = CommonTableExpression(
     recursive: true,
     named: "counter",
     columns: ["x"],
-    sql: """
+    request: SQL("""
         VALUES(1)
         UNION ALL
         SELECT x+1 FROM counter WHERE x<1000
-        """)
+        """))
 ```
 
 > **Note**: many recursive CTEs use the `UNION ALL` SQL operator. The query interface does not provide any Swift support for it, so you'll generally have to write SQL in your definitions of recursive CTEs.
@@ -103,7 +103,7 @@ We first build a `CommonTableExpression`:
 let name = "O'Brien"
 let playerNameCTE = CommonTableExpression(
     named: "playerName", 
-    literal: "SELECT \(name)")
+    request: SQL("SELECT \(name)"))
 ```
 
 We can then embed the definition of the CTE in a [query interface request] by calling the `with(_:)` method:

--- a/Documentation/QueryInterfaceOrganization.md
+++ b/Documentation/QueryInterfaceOrganization.md
@@ -304,15 +304,15 @@ let request = SQLRequest<Player>(literal: literal)
 let players: [Player] = try request.fetchAll(db)
 ```
 
-`SQL` conforms to [SQLSpecificExpressible], and thus behaves as an [SQLite expression](https://sqlite.org/syntax/expr.html) by default:
+`SQL` conforms to [SQLSubqueryable], and can be used wherever GRDB (and SQLite) expect a subquery, an expression, an ordering term, etc:
 
 ```swift
 let literal: SQL = "name = \("O'Brien")"
-let request = Player.filter(literal)
+let request = Player.filter(literal) // expression expected
 let players: [Player] = try request.fetchAll(db)
 ```
 
-:warning: **Warning**: Not all SQL snippets are expressions. It is not recommended to pass `SQL` literals around, or you may end up forgetting their content, and eventually generate invalid SQL. When possible, prefer building an explicit [SQLExpression], [SQLOrdering], [SQLSelection], [SQLRequest], or [SQLSubquery], depending on what you want to express:
+:warning: **Warning**: Not all SQL snippets are subqueries or expressions. It is not recommended to pass `SQL` literals around, or you may end up forgetting their content, and eventually generate invalid SQL. When possible, prefer building an explicit [SQLExpression], [SQLOrdering], [SQLSelection], [SQLRequest], or [SQLSubquery], depending on what you want to express:
 
 ```swift
 // SQLExpression
@@ -325,11 +325,11 @@ SQL("name DESC)").sqlOrdering
 SQL("score + bonus AS total)").sqlSelection
 SQL("*").sqlSelection
 
+// SQLSubquery
+SQL("SELECT * FROM player").sqlSubquery
+
 // SQLRequest
 SQLRequest<Player>(literal: "SELECT * FROM player")
-
-// SQLSubquery
-SQLRequest(literal: "SELECT * FROM player").sqlSubquery
 ```
 
 ### SQLExpression

--- a/GRDB/Core/SQL.swift
+++ b/GRDB/Core/SQL.swift
@@ -254,6 +254,15 @@ extension SQL {
     }
 }
 
+extension SQL: SQLSubqueryable {
+  /// Creates a literal SQL subquery.
+  ///
+  /// Use this property when you need an explicit `SQLSubquery`.
+  public var sqlSubquery: SQLSubquery {
+    .literal(self)
+  }
+}
+
 extension SQL: SQLSpecificExpressible {
     /// Creates a literal SQL expression.
     ///

--- a/GRDB/QueryInterface/Request/CommonTableExpression.swift
+++ b/GRDB/QueryInterface/Request/CommonTableExpression.swift
@@ -1,15 +1,50 @@
 /// A [common table expression](https://sqlite.org/lang_with.html) that can be
 /// used with the GRDB query interface.
+///
+/// For more information, see
+/// [Common Table Expressions](https://github.com/groue/GRDB.swift/blob/master/Documentation/CommonTableExpressions.md>).
+///
+/// - note: [**🔥 EXPERIMENTAL**](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features)
+///
+/// ## Topics
+///
+/// ### Creating a Common Table Expression
+///
+/// - ``init(recursive:named:columns:request:)-69rlb``
+/// - ``init(recursive:named:columns:request:)-35myd``
+/// - ``init(recursive:named:columns:literal:)-7vimx``
+/// - ``init(recursive:named:columns:literal:)-4nr63``
+/// - ``init(recursive:named:columns:sql:arguments:)-8hnp2``
+/// - ``init(recursive:named:columns:sql:arguments:)-1ft4x``
+///
+/// ### Building Requests from a Common Table Expression
+///
+/// - ``all()``
+///
+/// ### Building Expressions from a Common Table Expression
+///
+/// - ``contains(_:)``
+///
+/// ### Building Associations from a Common Table Expression
+///
+/// - ``association(to:)-8ymm1``
+/// - ``association(to:)-6p49n``
+/// - ``association(to:)-lpqk``
+/// - ``association(to:on:)-1gy8c``
+/// - ``association(to:on:)-3fns2``
+/// - ``association(to:on:)-3pqt9``
 public struct CommonTableExpression<RowDecoder> {
     /// The table name of the common table expression.
     ///
     /// For example:
     ///
-    ///     // WITH answer AS (SELECT 42) ...
-    ///     let answer = CommonTableExpression(
-    ///         named: "answer",
-    ///         sql: "SELECT 42")
-    ///     answer.tableName // "answer"
+    /// ```swift
+    /// // WITH answer AS (SELECT 42) ...
+    /// let answer = CommonTableExpression(
+    ///     named: "answer",
+    ///     request: SQLRequest("SELECT 42"))
+    /// answer.tableName // "answer"
+    /// ```
     public var tableName: String {
         cte.tableName
     }
@@ -20,17 +55,19 @@ public struct CommonTableExpression<RowDecoder> {
     ///
     /// For example:
     ///
-    ///     // WITH p AS (SELECT * FROM player) ...
-    ///     let p = CommonTableExpression(
-    ///         named: "p",
-    ///         request: Player.all(),
-    ///         type: Void.self)
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player) ...
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: Player.all(),
+    ///     type: Void.self)
     ///
-    ///     // WITH p AS (SELECT * FROM player) ...
-    ///     let p = CommonTableExpression(
-    ///         named: "p",
-    ///         request: SQLRequest<Player>(sql: "SELECT * FROM player"),
-    ///         type: Void.self)
+    /// // WITH p AS (SELECT * FROM player) ...
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: SQLRequest<Player>(sql: "SELECT * FROM player"),
+    ///     type: Void.self)
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -58,15 +95,17 @@ extension CommonTableExpression {
     ///
     /// For example:
     ///
-    ///     // WITH p AS (SELECT * FROM player) ...
-    ///     let p = CommonTableExpression<Void>(
-    ///         named: "p",
-    ///         request: Player.all())
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player) ...
+    /// let p = CommonTableExpression<Void>(
+    ///     named: "p",
+    ///     request: Player.all())
     ///
-    ///     // WITH p AS (SELECT * FROM player) ...
-    ///     let p = CommonTableExpression<Void>(
-    ///         named: "p",
-    ///         request: SQLRequest<Player>(sql: "SELECT * FROM player"))
+    /// // WITH p AS (SELECT * FROM player) ...
+    /// let p = CommonTableExpression<Void>(
+    ///     named: "p",
+    ///     request: SQLRequest<Player>(sql: "SELECT * FROM player"))
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -93,11 +132,26 @@ extension CommonTableExpression {
     ///
     /// For example:
     ///
-    ///     // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
-    ///     let p = CommonTableExpression<Void>(
-    ///         named: "p",
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let p = CommonTableExpression<Void>(
+    ///     named: "p",
+    ///     sql: "SELECT * FROM player WHERE name = ?",
+    ///     arguments: ["O'Brien"])
+    /// ```
+    ///
+    /// **This method is deprecated.** Use
+    /// ``init(recursive:named:columns:request:)-69rlb`` instead. For example:
+    ///
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let name = "O'Brien"
+    /// let p = CommonTableExpression<Void>(
+    ///     named: "p",
+    ///     request: SQLRequest(
     ///         sql: "SELECT * FROM player WHERE name = ?",
-    ///         arguments: ["O'Brien"])
+    ///         arguments: ["O'Brien"]))
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -106,6 +160,7 @@ extension CommonTableExpression {
     ///   the columns are the columns of the request.
     /// - parameter sql: An SQL string.
     /// - parameter arguments: Statement arguments.
+    @available(*, deprecated, message: "Use init(recursive:named:columns:request:) instead.")
     public init(
         recursive: Bool = false,
         named tableName: String,
@@ -126,11 +181,26 @@ extension CommonTableExpression {
     /// ``SQL`` literals allow you to safely embed raw values in your SQL,
     /// without any risk of syntax errors or SQL injection:
     ///
-    ///     // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
-    ///     let name = "O'Brien"
-    ///     let p = CommonTableExpression<Void>(
-    ///         named: "p",
-    ///         literal: "SELECT * FROM player WHERE name = \(name)")
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let name = "O'Brien"
+    /// let p = CommonTableExpression<Void>(
+    ///     named: "p",
+    ///     literal: "SELECT * FROM player WHERE name = \(name)")
+    /// ```
+    ///
+    /// **This method is deprecated.** Use
+    /// ``init(recursive:named:columns:request:)-69rlb`` instead. For example:
+    ///
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let name = "O'Brien"
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: SQLRequest<Void>("""
+    ///         SELECT * FROM player WHERE name = \(name)
+    ///         """))
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -138,6 +208,7 @@ extension CommonTableExpression {
     /// - parameter columns: The columns of the common table expression. If nil,
     ///   the columns are the columns of the request.
     /// - parameter sqlLiteral: An ``SQL`` literal.
+    @available(*, deprecated, message: "Use init(recursive:named:columns:request:) instead.")
     public init(
         recursive: Bool = false,
         named tableName: String,
@@ -158,15 +229,17 @@ extension CommonTableExpression<Row> {
     ///
     /// For example:
     ///
-    ///     // WITH p AS (SELECT * FROM player) ...
-    ///     let p = CommonTableExpression(
-    ///         named: "p",
-    ///         request: Player.all())
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player) ...
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: Player.all())
     ///
-    ///     // WITH p AS (SELECT * FROM player) ...
-    ///     let p = CommonTableExpression(
-    ///         named: "p",
-    ///         request: SQLRequest<Player>(sql: "SELECT * FROM player"))
+    /// // WITH p AS (SELECT * FROM player) ...
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: SQLRequest<Player>(sql: "SELECT * FROM player"))
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -193,11 +266,26 @@ extension CommonTableExpression<Row> {
     ///
     /// For example:
     ///
-    ///     // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
-    ///     let p = CommonTableExpression(
-    ///         named: "p",
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     sql: "SELECT * FROM player WHERE name = ?",
+    ///     arguments: ["O'Brien"])
+    /// ```
+    ///
+    /// **This method is deprecated.** Use
+    /// ``init(recursive:named:columns:request:)-35myd`` instead. For example:
+    ///
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let name = "O'Brien"
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: SQLRequest(
     ///         sql: "SELECT * FROM player WHERE name = ?",
-    ///         arguments: ["O'Brien"])
+    ///         arguments: ["O'Brien"]))
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -206,6 +294,7 @@ extension CommonTableExpression<Row> {
     ///   the columns are the columns of the request.
     /// - parameter sql: An SQL string.
     /// - parameter arguments: Statement arguments.
+    @available(*, deprecated, message: "Use init(recursive:named:columns:request:) instead.")
     public init(
         recursive: Bool = false,
         named tableName: String,
@@ -226,11 +315,24 @@ extension CommonTableExpression<Row> {
     /// ``SQL`` literals allow you to safely embed raw values in your SQL,
     /// without any risk of syntax errors or SQL injection:
     ///
-    ///     // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
-    ///     let name = "O'Brien"
-    ///     let p = CommonTableExpression(
-    ///         named: "p",
-    ///         literal: "SELECT * FROM player WHERE name = \(name)")
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let name = "O'Brien"
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     literal: "SELECT * FROM player WHERE name = \(name)")
+    /// ```
+    ///
+    /// **This method is deprecated.** Use
+    /// ``init(recursive:named:columns:request:)-35myd`` instead. For example:
+    ///
+    /// ```swift
+    /// // WITH p AS (SELECT * FROM player WHERE name = 'O''Brien') ...
+    /// let name = "O'Brien"
+    /// let p = CommonTableExpression(
+    ///     named: "p",
+    ///     request: SQLRequest("SELECT * FROM player WHERE name = \(name)"))
+    /// ```
     ///
     /// - parameter recursive: Whether this common table expression needs a
     ///   `WITH RECURSIVE` sql clause.
@@ -238,6 +340,7 @@ extension CommonTableExpression<Row> {
     /// - parameter columns: The columns of the common table expression. If nil,
     ///   the columns are the columns of the request.
     /// - parameter sqlLiteral: An ``SQL`` literal.
+    @available(*, deprecated, message: "Use init(recursive:named:columns:request:) instead.")
     public init(
         recursive: Bool = false,
         named tableName: String,
@@ -262,29 +365,33 @@ extension CommonTableExpression {
     ///
     /// You can fetch from this request:
     ///
-    ///     // WITH answer AS (SELECT 42 AS value)
-    ///     // SELECT * FROM answer
-    ///     struct Answer: Decodable, FetchableRecord {
-    ///         var value: Int
-    ///     }
-    ///     let cte = CommonTableExpression<Answer>(
-    ///         named: "answer",
-    ///         sql: "SELECT 42 AS value")
-    ///     let answer = try cte.all().with(cte).fetchOne(db)!
-    ///     print(answer.value) // prints 42
+    /// ```swift
+    /// // WITH answer AS (SELECT 42 AS value)
+    /// // SELECT * FROM answer
+    /// struct Answer: Decodable, FetchableRecord {
+    ///     var value: Int
+    /// }
+    /// let cte = CommonTableExpression<Answer>(
+    ///     named: "answer",
+    ///     sql: "SELECT 42 AS value")
+    /// let answer = try cte.all().with(cte).fetchOne(db)!
+    /// print(answer.value) // prints 42
+    /// ```
     ///
     /// You can embed this request as a subquery:
     ///
-    ///     // WITH answer AS (SELECT 42 AS value)
-    ///     // SELECT * FROM player
-    ///     // WHERE score = (SELECT * FROM answer)
-    ///     let answer = CommonTableExpression(
-    ///         named: "answer",
-    ///         sql: "SELECT 42 AS value")
-    ///     let players = try Player
-    ///         .filter(Column("score") == answer.all())
-    ///         .with(answer)
-    ///         .fetchAll(db)
+    /// ```
+    /// // WITH answer AS (SELECT 42 AS value)
+    /// // SELECT * FROM player
+    /// // WHERE score = (SELECT * FROM answer)
+    /// let answer = CommonTableExpression(
+    ///     named: "answer",
+    ///     sql: "SELECT 42 AS value")
+    /// let players = try Player
+    ///     .filter(Column("score") == answer.all())
+    ///     .with(answer)
+    ///     .fetchAll(db)
+    /// ```
     public func all() -> QueryInterfaceRequest<RowDecoder> {
         QueryInterfaceRequest(relation: relationForAll)
     }
@@ -292,12 +399,14 @@ extension CommonTableExpression {
     /// An SQL expression that checks the inclusion of an expression in a
     /// common table expression.
     ///
-    ///     let playerNameCTE = CommonTableExpression(
-    ///         named: "playerName",
-    ///         request: Player.select(Column("name"))
+    /// ```swift
+    /// let playerNameCTE = CommonTableExpression(
+    ///     named: "playerName",
+    ///     request: Player.select(Column("name"))
     ///
-    ///     // name IN playerName
-    ///     playerNameCTE.contains(Column("name"))
+    /// // name IN playerName
+    /// playerNameCTE.contains(Column("name"))
+    /// ```
     public func contains(_ element: some SQLExpressible) -> SQLExpression {
         SQLCollection.table(tableName).contains(element.sqlExpression)
     }

--- a/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingSQLTests.swift
@@ -1917,7 +1917,7 @@ class AssociationPrefetchingSQLTests: GRDBTestCase {
             
             do {
                 sqlQueries.removeAll()
-                let cte = CommonTableExpression(named: "cte", sql: "SELECT 42")
+                let cte = CommonTableExpression(named: "cte", request: SQL("SELECT 42"))
                 let association = Team.players.with(cte).filter(Column("playerId") == cte.all())
                 let request = Team.including(all: association)
                 _ = try Row.fetchAll(db, request)

--- a/Tests/GRDBTests/TableTests.swift
+++ b/Tests/GRDBTests/TableTests.swift
@@ -112,7 +112,7 @@ class TableTests: GRDBTestCase {
                 try assertEqualSQL(db, t.aliased(TableAlias(name: "p")), """
                     SELECT "p".* FROM "player" "p"
                     """)
-                try assertEqualSQL(db, t.with(CommonTableExpression(named: "cte", literal: "SELECT \("O'Brien")")), """
+                try assertEqualSQL(db, t.with(CommonTableExpression(named: "cte", request: SQL("SELECT \("O'Brien")"))), """
                     WITH "cte" AS (SELECT 'O''Brien') SELECT * FROM "player"
                     """)
             }


### PR DESCRIPTION
This pull request has `SQL`, the type that enables [SQL interpolation](https://github.com/groue/GRDB.swift/blob/master/Documentation/SQLInterpolation.md), conform to [`SQLSubqueryable`](https://swiftpackageindex.com/groue/grdb.swift/v6.15.1/documentation/grdb/sqlsubqueryable).

This protocol conformance makes `SQL` able to feed the [`select-stmt` SQLite grammar pattern](https://www.sqlite.org/syntax/select-stmt.html) in GRDB apis that need such a value.

This idea comes from #1398, as a way to make it easier to create views from `SQL` instances.

For consistency with #1398, and in order to simplify the api surface, the `CommonTableExpression` initializers that accepts a `literal` argument, or a `sql`/ `arguments` pair, have been deprecated:

```swift
// Deprecated
let playerNameCTE = CommonTableExpression(
    named: "playerName",
    literal: "SELECT ...")
```

Instead, use an `SQL` value with the `request` argument:

```swift
// Replacement
let playerNameCTE = CommonTableExpression(
    named: "playerName",
    request: SQL("SELECT ..."))
```

cc @mallman 

TODO:

- [ ] update the QueryInterfaceOrganization.md illustration
- [ ] Warning: check the impacts of this change. For example, `SQL` values that are turned into an expression via their `SQLSubqueryable` conformance trigger a different code path in `SQLExpression.qualified(with:)` and `SQLExpression.sql(_:wrappedInParenthesis:)`.