### PR TITLE
Linux compilation fixes

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -861,7 +861,7 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         
         if options.isEmpty || trace == nil {
             #if os(Linux)
-            sqlite3_trace(sqliteConnection, nil)
+            sqlite3_trace(sqliteConnection, nil, nil)
             #else
             sqlite3_trace_v2(sqliteConnection, 0, nil, nil)
             #endif

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -860,31 +860,16 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         self.trace = trace
         
         if options.isEmpty || trace == nil {
-            #if os(Linux)
-            sqlite3_trace(sqliteConnection, nil, nil)
-            #else
             sqlite3_trace_v2(sqliteConnection, 0, nil, nil)
-            #endif
             return
         }
         
-        // sqlite3_trace_v2 and sqlite3_expanded_sql were introduced in SQLite 3.14.0
-        // http://www.sqlite.org/changes.html#version_3_14
-        #if os(Linux)
-        let dbPointer = Unmanaged.passUnretained(self).toOpaque()
-        sqlite3_trace(sqliteConnection, { (dbPointer, sql) in
-            guard let sql = sql.map(String.init(cString:)) else { return }
-            let db = Unmanaged<Database>.fromOpaque(dbPointer!).takeUnretainedValue()
-            db.trace?(Database.TraceEvent.statement(TraceEvent.Statement(impl: .trace_v1(sql))))
-        }, dbPointer)
-        #else
         let dbPointer = Unmanaged.passUnretained(self).toOpaque()
         sqlite3_trace_v2(sqliteConnection, CUnsignedInt(bitPattern: options.rawValue), { (mask, dbPointer, p, x) in
             let db = Unmanaged<Database>.fromOpaque(dbPointer!).takeUnretainedValue()
             db.trace_v2(CInt(bitPattern: mask), p, x, sqlite3_expanded_sql)
             return SQLITE_OK
         }, dbPointer)
-        #endif
     }
     
     // Precondition: configuration.trace != nil
@@ -900,26 +885,22 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         case SQLITE_TRACE_STMT:
             if let sqliteStatement = p, let unexpandedSQL = x {
                 let statement = TraceEvent.Statement(
-                    impl: .trace_v2(
-                        sqliteStatement: OpaquePointer(sqliteStatement),
-                        unexpandedSQL: UnsafePointer(unexpandedSQL.assumingMemoryBound(to: CChar.self)),
-                        sqlite3_expanded_sql: sqlite3_expanded_sql,
-                        publicStatementArguments: configuration.publicStatementArguments))
+                    sqliteStatement: OpaquePointer(sqliteStatement),
+                    unexpandedSQL: UnsafePointer(unexpandedSQL.assumingMemoryBound(to: CChar.self)),
+                    sqlite3_expanded_sql: sqlite3_expanded_sql,
+                    publicStatementArguments: configuration.publicStatementArguments)
                 trace(TraceEvent.statement(statement))
             }
         case SQLITE_TRACE_PROFILE:
             if let sqliteStatement = p, let durationP = x?.assumingMemoryBound(to: Int64.self) {
                 let statement = TraceEvent.Statement(
-                    impl: .trace_v2(
-                        sqliteStatement: OpaquePointer(sqliteStatement),
-                        unexpandedSQL: nil,
-                        sqlite3_expanded_sql: sqlite3_expanded_sql,
-                        publicStatementArguments: configuration.publicStatementArguments))
+                    sqliteStatement: OpaquePointer(sqliteStatement),
+                    unexpandedSQL: nil,
+                    sqlite3_expanded_sql: sqlite3_expanded_sql,
+                    publicStatementArguments: configuration.publicStatementArguments)
                 let duration = TimeInterval(durationP.pointee) / 1.0e9
                 
-                #if !os(Linux)
                 trace(TraceEvent.profile(statement: statement, duration: duration))
-                #endif
             }
         default:
             break
@@ -1897,13 +1878,11 @@ extension Database {
         /// Trace event code: `SQLITE_TRACE_STMT`.
         public static let statement = TracingOptions(rawValue: SQLITE_TRACE_STMT)
         
-        #if !os(Linux)
         /// The option that reports executed statements and the estimated
         /// duration that the statement took to run.
         ///
         /// Trace event code: `SQLITE_TRACE_PROFILE`.
         public static let profile = TracingOptions(rawValue: SQLITE_TRACE_PROFILE)
-        #endif
     }
     
     /// A trace event.
@@ -1914,17 +1893,11 @@ extension Database {
         
         /// Information about an executed statement.
         public struct Statement: CustomStringConvertible {
-            enum Impl {
-                case trace_v1(String)
-                case trace_v2(
-                    sqliteStatement: SQLiteStatement,
-                    unexpandedSQL: UnsafePointer<CChar>?,
-                    sqlite3_expanded_sql: @convention(c) (OpaquePointer?) -> UnsafeMutablePointer<Int8>?,
-                    publicStatementArguments: Bool) // See Configuration.publicStatementArguments
-            }
-            var impl: Impl
+            var sqliteStatement: SQLiteStatement
+            var unexpandedSQL: UnsafePointer<CChar>?
+            var sqlite3_expanded_sql: @convention(c) (OpaquePointer?) -> UnsafeMutablePointer<Int8>?
+            var publicStatementArguments: Bool // See Configuration.publicStatementArguments
             
-            #if !os(Linux)
             /// The executed SQL, where bound parameters are not expanded.
             ///
             /// For example:
@@ -1932,21 +1905,11 @@ extension Database {
             /// ```sql
             /// SELECT * FROM player WHERE email = ?
             /// ```
-            public var sql: String { _sql }
-            #endif
-            
-            var _sql: String {
-                switch impl {
-                case .trace_v1:
-                    // Likely a GRDB bug: this api is not supposed to be available
-                    fatalError("Unavailable statement SQL")
-                    
-                case let .trace_v2(sqliteStatement, unexpandedSQL, _, _):
-                    if let unexpandedSQL {
-                        return String(cString: unexpandedSQL).trimmedSQLStatement
-                    } else {
-                        return String(cString: sqlite3_sql(sqliteStatement)).trimmedSQLStatement
-                    }
+            public var sql: String {
+                if let unexpandedSQL {
+                    return String(cString: unexpandedSQL).trimmedSQLStatement
+                } else {
+                    return String(cString: sqlite3_sql(sqliteStatement)).trimmedSQLStatement
                 }
             }
             
@@ -1962,30 +1925,18 @@ extension Database {
             ///   information from leaking in unexpected locations, so use this
             ///   property with care.
             public var expandedSQL: String {
-                switch impl {
-                case let .trace_v1(expandedSQL):
-                    return expandedSQL
-                    
-                case let .trace_v2(sqliteStatement, _, sqlite3_expanded_sql, _):
-                    guard let cString = sqlite3_expanded_sql(sqliteStatement) else {
-                        return ""
-                    }
-                    defer { sqlite3_free(cString) }
-                    return String(cString: cString).trimmedSQLStatement
+                guard let cString = sqlite3_expanded_sql(sqliteStatement) else {
+                    return ""
                 }
+                defer { sqlite3_free(cString) }
+                return String(cString: cString).trimmedSQLStatement
             }
             
             public var description: String {
-                switch impl {
-                case let .trace_v1(expandedSQL):
+                if publicStatementArguments {
                     return expandedSQL
-                    
-                case let .trace_v2(_, _, _, publicStatementArguments):
-                    if publicStatementArguments {
-                        return expandedSQL
-                    } else {
-                        return _sql
-                    }
+                } else {
+                    return sql
                 }
             }
         }

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -446,7 +446,7 @@ public struct DatabaseMigrator {
                         //
                         // So let's create a "regular" temporary database:
                         let tmpURL = URL(fileURLWithPath: NSTemporaryDirectory())
-                            .appendingPathComponent(ProcessInfo().globallyUniqueString)
+                            .appendingPathComponent(ProcessInfo.processInfo.globallyUniqueString)
                         defer {
                             try? FileManager().removeItem(at: tmpURL)
                         }

--- a/GRDB/Utils/Utils.swift
+++ b/GRDB/Utils/Utils.swift
@@ -190,3 +190,7 @@ extension NSLocking {
         sideEffect?()
     }
 }
+
+#if !canImport(ObjectiveC)
+@inlinable func autoreleasepool<Result>(invoking body: () throws -> Result) rethrows -> Result { try body() }
+#endif


### PR DESCRIPTION
Hello,

I'd like to fix the compilation errors of GRDB 6.15.x on Linux. I've read that it's not officially supported, but that one-off PRs are welcome.

This PR gets the repo to the point where GRDB compiles on Linux with SQLite 3.20.0. Additionally, please find below some of my findings while working on this.

#### SQLite 3.20.0 conditional compilations

Several places in the code use the following pattern.
```swift
#if GRDBCUSTOMSQLITE || GRDBCIPHER
    // new version of the code (1)
#else
    if #available(iOS 12, macOS 10.14, tvOS 12, watchOS 5, *) { // SQLite 3.20+
        // new version of the code (2)
        // same as (1)
    } else {
        // old version of the code
    }
#endif
```

When compiling on Linux with SQLite 3.19.3 installed in the system, compilation chooses `new version of the code (2)`. I wonder how to fix this pattern to choose according to the actual SQLite version available.
However, this is not a critical issue, as I can just choose to compile using SQLite 3.20.0.

#### Outdated code?

There's some `#if os(Linux)` blocks around this line: https://github.com/groue/GRDB.swift/blob/284a4ee1acf9bf6c8b3d045494d0a7e3046ebf92/GRDB/Core/Database.swift#L871
I guess this logic assumes that any Linux builds will run SQLite < 3.14.0, but the docs state that the minimum supported SQLite version is 3.19.3, so this logic seems outdated.

### Dockerfile for testing

With SQLite 3.19.3. (GRDB doesn't compile with this setup, see above.)
```Dockerfile
FROM swift:5.7-amazonlinux2

RUN yum -y install make && \
    yum clean all

ARG sqlite_year=2017
ARG sqlite_version=3190300

RUN curl -O --output-dir . https://www.sqlite.org/${sqlite_year}/sqlite-autoconf-${sqlite_version}.tar.gz && \
    tar xvzf sqlite-autoconf-${sqlite_version}.tar.gz && \
    cd sqlite-autoconf-${sqlite_version} && \
    CFLAGS="-Os" ./configure --prefix=/usr && \
    make && \
    make install && \
    cd .. && rm -rf sqlite-autoconf-${sqlite_version}*
```

To test with SQLite 3.20.0, just set `ARG sqlite_version` to `3200000`. (Which compiles for me.)

Build the image - copy-paste the above Dockerfile somewhere, and run from the same folder:
`docker rmi -f grdb-build && docker build . -t grdb-build`

Then from the repo root, run:
`docker run --rm -t -v ".:/src" -w "/src/" grdb-build bash -c "swift package clean && swift build"`

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [ ] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
