### PR TITLE
Add JSON functions to the query interface

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 		D263F40A26C613090038B07F /* DatabaseColumnEncodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263F40926C613090038B07F /* DatabaseColumnEncodingStrategyTests.swift */; };
 		DC2393C81ABE35F8003FF113 /* GRDB-Bridging.h in Headers */ = {isa = PBXBuildFile; fileRef = DC2393C61ABE35F8003FF113 /* GRDB-Bridging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC3773F919C8CBB3004FCF85 /* GRDB.h in Headers */ = {isa = PBXBuildFile; fileRef = DC3773F819C8CBB3004FCF85 /* GRDB.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7370F532A9899D0006DBC6C /* JSONFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7370F522A9899D0006DBC6C /* JSONFunctionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -821,6 +822,7 @@
 		DC3773F719C8CBB3004FCF85 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DC3773F819C8CBB3004FCF85 /* GRDB.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GRDB.h; sourceTree = "<group>"; };
 		DC37740419C8CBB3004FCF85 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E7370F522A9899D0006DBC6C /* JSONFunctionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONFunctionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1042,6 +1044,7 @@
 				563B5335267E2F90009549B5 /* TableTests.swift */,
 				5698AC7F1DA380A20056AF8C /* VirtualTableModuleTests.swift */,
 				5653EABF20944B1300F46237 /* Association */,
+				E7370F522A9899D0006DBC6C /* JSONFunctionTests.swift */,
 			);
 			name = QueryInterface;
 			sourceTree = "<group>";
@@ -1979,6 +1982,7 @@
 				56677C0D241CD0D00050755D /* ValueObservationRecorder.swift in Sources */,
 				5653EADA20944B4F00F46237 /* AssociationRowScopeSearchTests.swift in Sources */,
 				563B5336267E2F90009549B5 /* TableTests.swift in Sources */,
+				E7370F532A9899D0006DBC6C /* JSONFunctionTests.swift in Sources */,
 				56D4965A1D81304E008276D7 /* FoundationNSDataTests.swift in Sources */,
 				56D496791D81309E008276D7 /* RecordWithColumnNameManglingTests.swift in Sources */,
 				56D4966C1D81309E008276D7 /* RecordMinimalPrimaryKeyRowIDTests.swift in Sources */,

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -322,3 +322,49 @@ public func julianDay(_ value: some SQLSpecificExpressible, _ modifiers: SQLDate
 public func dateTime(_ value: some SQLSpecificExpressible, _ modifiers: SQLDateModifier...) -> SQLExpression {
     .function("DATETIME", [value.sqlExpression] + modifiers.map(\.sqlExpression))
 }
+
+// MARK: - JSON functions
+
+/// Verifies that the argument is valid JSON, and returns the minified version.
+///
+/// This function can be used to convert raw text into valid JSON
+/// that can be further used in other JSON functions so that it's interpreted as JSON and not text.
+///
+/// - Attention: This function is not appropriate for checking the validity of JSON.
+///
+/// Related SQLite documentation:<https://www.sqlite.org/json1.html#jmini>
+public func json(_ value: some SQLExpressible) -> SQLExpression {
+    .function("JSON", [value.sqlExpression])
+}
+
+/// Returns a well formed JSON array composed of the input parameters.
+///
+/// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarray>
+public func jsonArray(_ values: (any SQLExpressible)...) -> SQLExpression {
+    .function("JSON_ARRAY", values.map(\.sqlExpression))
+}
+
+/// Returns the length of a JSON array, or 0 if the input is not a JSON array.
+///
+/// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
+public func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
+    .function("JSON_ARRAY_LENGTH", [value.sqlExpression])
+}
+
+/// Returns the length of a JSON array located within the given path in the input,
+/// or 0 if the input is not a JSON array.
+///
+/// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
+public func jsonArrayLength(_ value: some SQLExpressible, _ path: String) -> SQLExpression {
+    .function("JSON_ARRAY_LENGTH", [value.sqlExpression, path.sqlExpression])
+}
+
+/// Extracts values from JSON at the given paths.
+///
+/// If a single path is provided, a corresponding SQL datatype or `NULL` is returned.
+/// If multiple paths are provided, returns a JSON array as text with the values.
+///
+/// Related SQLite documentation:<https://www.sqlite.org/json1.html#jex>
+public func jsonExtract(_ value: some SQLExpressible, _ paths: String...) -> SQLExpression {
+    .function("JSON_EXTRACT", [value.sqlExpression] + paths.map(\.sqlExpression))
+}

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -398,3 +398,27 @@ public func jsonArrayLength(_ value: some SQLSpecificExpressible, _ path: String
 public func jsonExtract(_ value: some SQLSpecificExpressible, _ paths: String...) -> SQLExpression {
     .function("JSON_EXTRACT", [value.sqlExpression] + paths.map(\.sqlExpression))
 }
+
+/// The `JSON_VALID` SQL function.
+///  
+/// Checks if the given expression is a well-formed,
+/// canonical [RFC-7159](https://datatracker.ietf.org/doc/html/rfc7159) JSON string
+/// without any JSON5 extensions.
+///
+/// For example:
+///  
+/// ``` swift
+/// // json_valid('{"x":35}')
+/// isJSONValid(#"{"x":35}"#.databaseValue) // 1
+///  
+/// // json_valid('{"x":35')
+/// isJSONValid(#"{"x":35"#.databaseValue) // 0
+/// ```
+///  
+/// Related SQLite documentation: <https://www.sqlite.org/json1.html#jvalid>
+/// - parameter value: JSON to be validated.
+/// - returns: ``SQLExpression`` returning `1` if the input was valid, and `0` if it was invalid.
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+public func isJSONValid(_ value: some SQLSpecificExpressible) -> SQLExpression {
+    .function("JSON_VALID", [value.sqlExpression])
+}

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -334,7 +334,7 @@ public func dateTime(_ value: some SQLSpecificExpressible, _ modifiers: SQLDateM
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jmini>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-public func json(_ value: some SQLExpressible) -> SQLExpression {
+public func json(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .function("JSON", [value.sqlExpression])
 }
 
@@ -342,7 +342,7 @@ public func json(_ value: some SQLExpressible) -> SQLExpression {
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarray>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-public func jsonArray(_ values: (any SQLExpressible)...) -> SQLExpression {
+public func jsonArray(_ values: (any SQLSpecificExpressible)...) -> SQLExpression {
     .function("JSON_ARRAY", values.map(\.sqlExpression))
 }
 
@@ -350,7 +350,7 @@ public func jsonArray(_ values: (any SQLExpressible)...) -> SQLExpression {
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-public func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
+public func jsonArrayLength(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .function("JSON_ARRAY_LENGTH", [value.sqlExpression])
 }
 
@@ -359,7 +359,7 @@ public func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-public func jsonArrayLength(_ value: some SQLExpressible, _ path: String) -> SQLExpression {
+public func jsonArrayLength(_ value: some SQLSpecificExpressible, _ path: String) -> SQLExpression {
     .function("JSON_ARRAY_LENGTH", [value.sqlExpression, path.sqlExpression])
 }
 
@@ -370,6 +370,6 @@ public func jsonArrayLength(_ value: some SQLExpressible, _ path: String) -> SQL
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jex>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-public func jsonExtract(_ value: some SQLExpressible, _ paths: String...) -> SQLExpression {
+public func jsonExtract(_ value: some SQLSpecificExpressible, _ paths: String...) -> SQLExpression {
     .function("JSON_EXTRACT", [value.sqlExpression] + paths.map(\.sqlExpression))
 }

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -325,12 +325,15 @@ public func dateTime(_ value: some SQLSpecificExpressible, _ modifiers: SQLDateM
 
 // MARK: - JSON functions
 
+/// The `JSON` SQL function.
+///
 /// Verifies that the argument is valid JSON, and returns the minified version.
 ///
 /// This function can be used to convert raw text into valid JSON
 /// that can be further used in other JSON functions so that it's interpreted as JSON and not text.
 ///
 /// - Attention: This function is not appropriate for checking the validity of JSON.
+/// Use ``isJSONValid(_:)`` instead.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jmini>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
@@ -338,6 +341,8 @@ public func json(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .function("JSON", [value.sqlExpression])
 }
 
+/// The `JSON_ARRAY` SQL function.
+///
 /// Returns a well formed JSON array composed of the input parameters.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarray>
@@ -346,6 +351,8 @@ public func jsonArray(_ values: (any SQLSpecificExpressible)...) -> SQLExpressio
     .function("JSON_ARRAY", values.map(\.sqlExpression))
 }
 
+/// The `JSON_ARRAY_LENGTH` SQL function.
+///
 /// Returns the length of a JSON array, or 0 if the input is not a JSON array.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
@@ -354,6 +361,8 @@ public func jsonArrayLength(_ value: some SQLSpecificExpressible) -> SQLExpressi
     .function("JSON_ARRAY_LENGTH", [value.sqlExpression])
 }
 
+/// The `JSON_ARRAY_LENGTH` SQL function.
+///
 /// Returns the length of a JSON array located within the given path in the input,
 /// or 0 if the input is not a JSON array.
 ///
@@ -363,10 +372,26 @@ public func jsonArrayLength(_ value: some SQLSpecificExpressible, _ path: String
     .function("JSON_ARRAY_LENGTH", [value.sqlExpression, path.sqlExpression])
 }
 
-/// Extracts values from JSON at the given paths.
+/// The `JSON_EXTRACT` SQL function.
 ///
-/// If a single path is provided, a corresponding SQL datatype or `NULL` is returned.
-/// If multiple paths are provided, returns a JSON array as text with the values.
+/// Extracts and returns one or more values from well-formed JSON.
+/// If multiple paths are provided, the function returns a JSON array holding the extracted values.
+///
+/// For example:
+///
+/// ```swift
+/// // JSON_EXTRACT(jsonData, '$')
+/// jsonExtract(Column("jsonData"), "$")
+///
+/// // JSON_EXTRACT(jsonData, '$.values')
+/// jsonExtract(Column("jsonData"), "$.values")
+///
+/// // JSON_EXTRACT(jsonData, '$.values[2]')
+/// jsonExtract(Column("jsonData"), "$.values[2]")
+///
+/// // JSON_EXTRACT(jsonData, '$.first_key', '$.second_key')
+/// jsonExtract(Column("jsonData"), "$.first_key", "$.second_key")
+/// ```
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jex>
 @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -333,6 +333,7 @@ public func dateTime(_ value: some SQLSpecificExpressible, _ modifiers: SQLDateM
 /// - Attention: This function is not appropriate for checking the validity of JSON.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jmini>
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 public func json(_ value: some SQLExpressible) -> SQLExpression {
     .function("JSON", [value.sqlExpression])
 }
@@ -340,6 +341,7 @@ public func json(_ value: some SQLExpressible) -> SQLExpression {
 /// Returns a well formed JSON array composed of the input parameters.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarray>
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 public func jsonArray(_ values: (any SQLExpressible)...) -> SQLExpression {
     .function("JSON_ARRAY", values.map(\.sqlExpression))
 }
@@ -347,6 +349,7 @@ public func jsonArray(_ values: (any SQLExpressible)...) -> SQLExpression {
 /// Returns the length of a JSON array, or 0 if the input is not a JSON array.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 public func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
     .function("JSON_ARRAY_LENGTH", [value.sqlExpression])
 }
@@ -355,6 +358,7 @@ public func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
 /// or 0 if the input is not a JSON array.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jarraylen>
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 public func jsonArrayLength(_ value: some SQLExpressible, _ path: String) -> SQLExpression {
     .function("JSON_ARRAY_LENGTH", [value.sqlExpression, path.sqlExpression])
 }
@@ -365,6 +369,7 @@ public func jsonArrayLength(_ value: some SQLExpressible, _ path: String) -> SQL
 /// If multiple paths are provided, returns a JSON array as text with the values.
 ///
 /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jex>
+@available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
 public func jsonExtract(_ value: some SQLExpressible, _ paths: String...) -> SQLExpression {
     .function("JSON_EXTRACT", [value.sqlExpression] + paths.map(\.sqlExpression))
 }

--- a/GRDB/QueryInterface/SQL/SQLOperators.swift
+++ b/GRDB/QueryInterface/SQL/SQLOperators.swift
@@ -535,6 +535,7 @@ extension SQLSpecificExpressible {
     /// Returns the value from the selected JSON path, or `NULL` if the path doesn't exist.
     ///
     /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jptr>
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
     public static func ->> (lhs: Self, rhs: String) -> SQLExpression {
         .literal("\(lhs) ->> \(rhs)")
     }

--- a/GRDB/QueryInterface/SQL/SQLOperators.swift
+++ b/GRDB/QueryInterface/SQL/SQLOperators.swift
@@ -523,3 +523,19 @@ extension SQLSpecificExpressible {
         .escapableBinary(.like, sqlExpression, pattern.sqlExpression, escape: escape?.sqlExpression)
     }
 }
+
+// MARK: - JSON operators
+
+infix operator ->>
+
+extension SQLSpecificExpressible {
+    
+    /// The `->>` SQL operator.
+    ///
+    /// Returns the value from the selected JSON path, or `NULL` if the path doesn't exist.
+    ///
+    /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jptr>
+    public static func ->> (lhs: Self, rhs: String) -> SQLExpression {
+        .literal("\(lhs) ->> \(rhs)")
+    }
+}

--- a/GRDB/QueryInterface/SQL/SQLOperators.swift
+++ b/GRDB/QueryInterface/SQL/SQLOperators.swift
@@ -526,17 +526,29 @@ extension SQLSpecificExpressible {
 
 // MARK: - JSON operators
 
-infix operator ->>
-
 extension SQLSpecificExpressible {
+    
+    /// The `->` SQL operator.
+    ///
+    /// Returns the object from the selected JSON path, or `NULL` if the path doesn't exist.
+    ///
+    /// For getting a JSON object, use ``subscript(valueAt:)`` instead.
+    ///
+    /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jptr>
+    @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
+    public subscript(objectAt jsonPath: String) -> SQLExpression {
+        .literal("\(self) -> \(jsonPath)")
+    }
     
     /// The `->>` SQL operator.
     ///
     /// Returns the value from the selected JSON path, or `NULL` if the path doesn't exist.
     ///
+    /// For getting a JSON object, use ``subscript(objectAt:)`` instead.
+    ///
     /// Related SQLite documentation:<https://www.sqlite.org/json1.html#jptr>
     @available(iOS 16, macOS 13, tvOS 16, watchOS 9, *)
-    public static func ->> (lhs: Self, rhs: String) -> SQLExpression {
-        .literal("\(lhs) ->> \(rhs)")
+    public subscript(valueAt jsonPath: String) -> SQLExpression {
+        .literal("\(self) ->> \(jsonPath)")
     }
 }

--- a/Tests/GRDBTests/JSONFunctionTests.swift
+++ b/Tests/GRDBTests/JSONFunctionTests.swift
@@ -24,7 +24,7 @@ final class JSONFunctionTests: GRDBTestCase {
             
             let input = """
              { "this" : "is", "a": [ "test" ] }
-            """
+            """.databaseValue
             
             let expected = """
             {"this":"is","a":["test"]}
@@ -41,11 +41,37 @@ final class JSONFunctionTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             
             try dbQueue.inDatabase { db in
-                try assert(db, jsonArray(1,2,"3",4), equal: "[1,2,\"3\",4]")
-                try assert(db, jsonArray(jsonArray(1, 2, "3", 4)), equal: "[[1,2,\"3\",4]]")
                 try assert(
                     db,
-                    jsonArray(1, DatabaseValue.null, "3", json("[4,5]"), json("{\"six\":7.7}")),
+                    jsonArray(
+                        1.databaseValue,
+                        2.databaseValue,
+                        "3".databaseValue,
+                        4.databaseValue
+                    ),
+                    equal: "[1,2,\"3\",4]"
+                )
+                try assert(
+                    db,
+                    jsonArray(
+                        jsonArray(
+                            1.databaseValue,
+                            2.databaseValue,
+                            "3".databaseValue,
+                            4.databaseValue
+                        )
+                    ),
+                    equal: "[[1,2,\"3\",4]]"
+                )
+                try assert(
+                    db,
+                    jsonArray(
+                        1.databaseValue,
+                        DatabaseValue.null,
+                        "3".databaseValue,
+                        json("[4,5]".databaseValue),
+                        json("{\"six\":7.7}".databaseValue)
+                    ),
                     equal: "[1,null,\"3\",[4,5],{\"six\":7.7}]"
                 )
             }
@@ -57,8 +83,8 @@ final class JSONFunctionTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             
             try dbQueue.inDatabase { db in
-                try assert(db, jsonArrayLength("[1,2,3,4]"), equal: 4)
-                try assert(db, jsonArrayLength("{\"one\":[1,2,3]}"), equal: 0)
+                try assert(db, jsonArrayLength("[1,2,3,4]".databaseValue), equal: 4)
+                try assert(db, jsonArrayLength("{\"one\":[1,2,3]}".databaseValue), equal: 0)
             }
         }
     }
@@ -68,8 +94,8 @@ final class JSONFunctionTests: GRDBTestCase {
             let dbQueue = try makeDatabaseQueue()
             
             try dbQueue.inDatabase { db in
-                try assert(db, jsonArrayLength("[1,2,3,4]", "$"), equal: 4)
-                try assert(db, jsonArrayLength("[1,2,3,4]", "$[2]"), equal: 0)
+                try assert(db, jsonArrayLength("[1,2,3,4]".databaseValue, "$"), equal: 4)
+                try assert(db, jsonArrayLength("[1,2,3,4]".databaseValue, "$[2]"), equal: 0)
             }
         }
     }
@@ -80,7 +106,7 @@ final class JSONFunctionTests: GRDBTestCase {
             
             let input = """
             {"a":2,"c":[4,5,{"f":7}]}
-            """
+            """.databaseValue
             
             try dbQueue.inDatabase { db in
                 try assert(db, jsonExtract(input, "$"), equal: input)

--- a/Tests/GRDBTests/JSONFunctionTests.swift
+++ b/Tests/GRDBTests/JSONFunctionTests.swift
@@ -118,4 +118,15 @@ final class JSONFunctionTests: GRDBTestCase {
             }
         }
     }
+    
+    func testIsJSONValid() throws {
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            let dbQueue = try makeDatabaseQueue()
+            
+            try dbQueue.inDatabase { db in
+                try assert(db, isJSONValid(#"{"x":35}"#.databaseValue), equal: 1)
+                try assert(db,  isJSONValid(#"{"x":35"#.databaseValue), equal: 0)
+            }
+        }
+    }
 }

--- a/Tests/GRDBTests/JSONFunctionTests.swift
+++ b/Tests/GRDBTests/JSONFunctionTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import GRDB
+
+final class JSONFunctionTests: GRDBTestCase {
+    
+    private func assert<Output: DatabaseValueConvertible & Equatable>(
+        _ db: Database,
+        _ expression: SQLExpression,
+        equal expectedOutput: Output,
+        file: StaticString = #file,
+        line: UInt = #line) throws
+    {
+        let request: SQLRequest<Output> = "SELECT \(expression)"
+        guard let json = try request.fetchOne(db) else {
+            XCTFail(file: file, line: line)
+            return
+        }
+        XCTAssertEqual(json, expectedOutput, file: file, line: line)
+    }
+    
+    func testJSON() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        let input = """
+         { "this" : "is", "a": [ "test" ] }
+        """
+        
+        let expected = """
+        {"this":"is","a":["test"]}
+        """
+        
+        try dbQueue.inDatabase { db in
+            try assert(db, json(input), equal: expected)
+        }
+    }
+    
+    func testJSONArray() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        try dbQueue.inDatabase { db in
+            try assert(db, jsonArray(1,2,"3",4), equal: "[1,2,\"3\",4]")
+            try assert(db, jsonArray(jsonArray(1, 2, "3", 4)), equal: "[[1,2,\"3\",4]]")
+            try assert(
+                db,
+                jsonArray(1, DatabaseValue.null, "3", json("[4,5]"), json("{\"six\":7.7}")),
+                equal: "[1,null,\"3\",[4,5],{\"six\":7.7}]"
+            )
+        }
+    }
+    
+    func testJSONArrayLength() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        try dbQueue.inDatabase { db in
+            try assert(db, jsonArrayLength("[1,2,3,4]"), equal: 4)
+            try assert(db, jsonArrayLength("{\"one\":[1,2,3]}"), equal: 0)
+        }
+    }
+    
+    func testJSONArrayLengthWithPath() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        try dbQueue.inDatabase { db in
+            try assert(db, jsonArrayLength("[1,2,3,4]", "$"), equal: 4)
+            try assert(db, jsonArrayLength("[1,2,3,4]", "$[2]"), equal: 0)
+        }
+    }
+    
+    func testJSONExtract() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        let input = """
+        {"a":2,"c":[4,5,{"f":7}]}
+        """
+        
+        try dbQueue.inDatabase { db in
+            try assert(db, jsonExtract(input, "$"), equal: input)
+            try assert(db, jsonExtract(input, "$.c"), equal: "[4,5,{\"f\":7}]")
+            try assert(db, jsonExtract(input, "$.c[2]"), equal: "{\"f\":7}")
+            try assert(db, jsonExtract(input, "$.c[2].f"), equal: 7)
+            try assert(db, jsonExtract(input, "$.x"), equal: DatabaseValue.null)
+            try assert(db, jsonExtract(input, "$.x", "$.a"), equal: "[null,2]")
+        }
+    }
+}

--- a/Tests/GRDBTests/JSONFunctionTests.swift
+++ b/Tests/GRDBTests/JSONFunctionTests.swift
@@ -19,67 +19,77 @@ final class JSONFunctionTests: GRDBTestCase {
     }
     
     func testJSON() throws {
-        let dbQueue = try makeDatabaseQueue()
-        
-        let input = """
-         { "this" : "is", "a": [ "test" ] }
-        """
-        
-        let expected = """
-        {"this":"is","a":["test"]}
-        """
-        
-        try dbQueue.inDatabase { db in
-            try assert(db, json(input), equal: expected)
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            let dbQueue = try makeDatabaseQueue()
+            
+            let input = """
+             { "this" : "is", "a": [ "test" ] }
+            """
+            
+            let expected = """
+            {"this":"is","a":["test"]}
+            """
+            
+            try dbQueue.inDatabase { db in
+                try assert(db, json(input), equal: expected)
+            }
         }
     }
     
     func testJSONArray() throws {
-        let dbQueue = try makeDatabaseQueue()
-        
-        try dbQueue.inDatabase { db in
-            try assert(db, jsonArray(1,2,"3",4), equal: "[1,2,\"3\",4]")
-            try assert(db, jsonArray(jsonArray(1, 2, "3", 4)), equal: "[[1,2,\"3\",4]]")
-            try assert(
-                db,
-                jsonArray(1, DatabaseValue.null, "3", json("[4,5]"), json("{\"six\":7.7}")),
-                equal: "[1,null,\"3\",[4,5],{\"six\":7.7}]"
-            )
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            let dbQueue = try makeDatabaseQueue()
+            
+            try dbQueue.inDatabase { db in
+                try assert(db, jsonArray(1,2,"3",4), equal: "[1,2,\"3\",4]")
+                try assert(db, jsonArray(jsonArray(1, 2, "3", 4)), equal: "[[1,2,\"3\",4]]")
+                try assert(
+                    db,
+                    jsonArray(1, DatabaseValue.null, "3", json("[4,5]"), json("{\"six\":7.7}")),
+                    equal: "[1,null,\"3\",[4,5],{\"six\":7.7}]"
+                )
+            }
         }
     }
     
     func testJSONArrayLength() throws {
-        let dbQueue = try makeDatabaseQueue()
-        
-        try dbQueue.inDatabase { db in
-            try assert(db, jsonArrayLength("[1,2,3,4]"), equal: 4)
-            try assert(db, jsonArrayLength("{\"one\":[1,2,3]}"), equal: 0)
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            let dbQueue = try makeDatabaseQueue()
+            
+            try dbQueue.inDatabase { db in
+                try assert(db, jsonArrayLength("[1,2,3,4]"), equal: 4)
+                try assert(db, jsonArrayLength("{\"one\":[1,2,3]}"), equal: 0)
+            }
         }
     }
     
     func testJSONArrayLengthWithPath() throws {
-        let dbQueue = try makeDatabaseQueue()
-        
-        try dbQueue.inDatabase { db in
-            try assert(db, jsonArrayLength("[1,2,3,4]", "$"), equal: 4)
-            try assert(db, jsonArrayLength("[1,2,3,4]", "$[2]"), equal: 0)
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            let dbQueue = try makeDatabaseQueue()
+            
+            try dbQueue.inDatabase { db in
+                try assert(db, jsonArrayLength("[1,2,3,4]", "$"), equal: 4)
+                try assert(db, jsonArrayLength("[1,2,3,4]", "$[2]"), equal: 0)
+            }
         }
     }
     
     func testJSONExtract() throws {
-        let dbQueue = try makeDatabaseQueue()
-        
-        let input = """
-        {"a":2,"c":[4,5,{"f":7}]}
-        """
-        
-        try dbQueue.inDatabase { db in
-            try assert(db, jsonExtract(input, "$"), equal: input)
-            try assert(db, jsonExtract(input, "$.c"), equal: "[4,5,{\"f\":7}]")
-            try assert(db, jsonExtract(input, "$.c[2]"), equal: "{\"f\":7}")
-            try assert(db, jsonExtract(input, "$.c[2].f"), equal: 7)
-            try assert(db, jsonExtract(input, "$.x"), equal: DatabaseValue.null)
-            try assert(db, jsonExtract(input, "$.x", "$.a"), equal: "[null,2]")
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            let dbQueue = try makeDatabaseQueue()
+            
+            let input = """
+            {"a":2,"c":[4,5,{"f":7}]}
+            """
+            
+            try dbQueue.inDatabase { db in
+                try assert(db, jsonExtract(input, "$"), equal: input)
+                try assert(db, jsonExtract(input, "$.c"), equal: "[4,5,{\"f\":7}]")
+                try assert(db, jsonExtract(input, "$.c[2]"), equal: "{\"f\":7}")
+                try assert(db, jsonExtract(input, "$.c[2].f"), equal: 7)
+                try assert(db, jsonExtract(input, "$.x"), equal: DatabaseValue.null)
+                try assert(db, jsonExtract(input, "$.x", "$.a"), equal: "[null,2]")
+            }
         }
     }
 }

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1678,4 +1678,16 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
                 """)
         }
     }
+    
+    // MARK: - JSON Operators
+    
+    func testJSONExtractOperator() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(Col.name ->> "$")),
+            """
+            SELECT "name" ->> '$' FROM "readers"
+            """)
+    }
 }

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1684,10 +1684,12 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testJSONExtractOperator() throws {
         let dbQueue = try makeDatabaseQueue()
         
-        XCTAssertEqual(
-            sql(dbQueue, tableRequest.select(Col.name ->> "$")),
-            """
-            SELECT "name" ->> '$' FROM "readers"
-            """)
+        if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.select(Col.name ->> "$")),
+                """
+                SELECT "name" ->> '$' FROM "readers"
+                """)
+        }
     }
 }

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1686,7 +1686,13 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         
         if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
             XCTAssertEqual(
-                sql(dbQueue, tableRequest.select(Col.name ->> "$")),
+                sql(dbQueue, tableRequest.select(Col.name[objectAt: "$"])),
+                """
+                SELECT "name" -> '$' FROM "readers"
+                """)
+            
+            XCTAssertEqual(
+                sql(dbQueue, tableRequest.select(Col.name[valueAt: "$"])),
                 """
                 SELECT "name" ->> '$' FROM "readers"
                 """)


### PR DESCRIPTION
**Adds query interface wrappers for a subset of the SQLite [JSON functions](https://www.sqlite.org/json1.html).**

Sometimes it's near impossible to design a nice database schema due to external factors, and I've found myself needing the JSON functions quite a bit. They are a bit awkward to use without wrappers in the query interface (but otherwise work perfectly, which speaks a lot about the API design), so I wanted to start a discussion of how best to include them by making a PR that implements the read-only subset of JSON functions, and the `->>` operator. I'm looking to implement the editing functions as well, but they'll be in another PR for multiple reasons.

Some notes/considerations:

Since SQLite has the concept of JSON paths, I thought about making a key path based API for the functions. But I then remembered that they can't be converted to `String`s anyway, so I dropped the idea. And building any other DSL for it, while nice, would probably be quite overkill as it would basically mean building the `jq` query language in Swift… And if I remember correctly, you had some good reasons for not using key paths in the query APIs, so I'm assuming that this isn't something you'd want to pursue in the future either. Also, anything lighter would probably just end up wrapping `.joined(separator: ".")` in an overcomplicated way, so now all the paths are simply `String`s.

This might be out of scope since the PR is only a change to the query interface, but returning JSON `String`s seems a bit funny to me. I don't know of a nice native way to handle a lot of arbitrary JSON in Swift, so handling the returned data is currently left to users and the likes of [`AnyCodable`](https://github.com/Flight-School/AnyCodable). But I'd like to figure out something for this.

The tests are currently a reflection of SQLite's JSON examples since that was the easiest way to confirm that they were working, but since that's testing SQLite in addition to the query interface, should they be changed to just check the generated output? They are also in a separate file, which I don't think is the correct place, so I'd appreciate help organizing them.

Regarding the `->>` operator, I'm not sure whether it should actually be included, but I wanted to try to implement it (with questionable success) and start the discussion of whether custom operators are something that should be in GRDB. I think my biggest issue is that we can't implement (at least to my knowledge) the `->` operator, so it feels weird to only have the other one. Especially since it's not technically needed, as the functionality heavily overlaps the JSON functions.

JSON support is quite new, so all the functions will likely need OS version constraints. Can this be validated on simulators?

Lastly, despite reading the docs on `SQLSpecificExpressible` and `SQLExpressible`, and understanding the point of them from the compiler's point of view, I don't think I really grasped how they should be used in the APIs. So I'm assuming all of that needs to be refactored.

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure. *(couldn't run it fully yet due to a few stupid issues on my side, but the unit tests pass. Will double-check the whole thing before undrafting the PR)*
