### PR TITLE
Extend `DatabaseValueConvertible` JSON parsing format customization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ How you can Contribute
     - Get familiar with the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
     - Spaces, not tabs.
     - Whitespace-only lines are not trimmed.
-    - Documentation comments are hard-wrapped at column 80 (Xcode > Preferences > Text Editing > Display > [X] Page guide at column: 80).
+    - Documentation comments are hard-wrapped at column 76 (Xcode > Preferences > Text Editing > Display > [X] Page guide at column: 76).
     - No Swiftlint warning after a build.
 
 

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -62,13 +62,13 @@ public protocol DatabaseValueConvertible: SQLExpressible, StatementBinding {
     /// - returns: A decoded value, or, if decoding is impossible, nil.
     static func fromMissingColumn() -> Self?
     
-    /// Returns the `JSONDecoder` that decodes the value for a given column.
+    /// Returns the `JSONDecoder` that decodes the value.
     ///
     /// This method is dedicated to ``DatabaseValueConvertible`` types that 
     /// also conform to the standard `Decodable` protocol.
     static func databaseJSONDecoder() -> JSONDecoder
     
-    /// Returns the `JSONEncoder` that encodes the value for a given column.
+    /// Returns the `JSONEncoder` that encodes the value.
     ///
     /// This method is dedicated to ``DatabaseValueConvertible`` types that
     /// also conform to the standard `Encodable` protocol.

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // Standard collections `Array`, `Set`, and `Dictionary` do not conform to
 // `DatabaseValueConvertible`, on purpose.
 //

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -62,14 +62,14 @@ public protocol DatabaseValueConvertible: SQLExpressible, StatementBinding {
     
     /// Returns the `JSONDecoder` that decodes the value for a given column.
     ///
-    /// This method is dedicated to ``DatabaseValueConvertible`` types that also conform
-    /// to the standard `Decodable` protocol.
+    /// This method is dedicated to ``DatabaseValueConvertible`` types that 
+    /// also conform to the standard `Decodable` protocol.
     static func databaseJSONDecoder() -> JSONDecoder
     
     /// Returns the `JSONEncoder` that encodes the value for a given column.
     ///
-    /// This method is dedicated to ``DatabaseValueConvertible`` types that also conform
-    /// to the standard `Encodable` protocol.
+    /// This method is dedicated to ``DatabaseValueConvertible`` types that
+    /// also conform to the standard `Encodable` protocol.
     static func databaseJSONEncoder() -> JSONEncoder
 }
 

--- a/GRDB/Core/DatabaseValueConvertible.swift
+++ b/GRDB/Core/DatabaseValueConvertible.swift
@@ -59,6 +59,18 @@ public protocol DatabaseValueConvertible: SQLExpressible, StatementBinding {
     ///
     /// - returns: A decoded value, or, if decoding is impossible, nil.
     static func fromMissingColumn() -> Self?
+    
+    /// Returns the `JSONDecoder` that decodes the value for a given column.
+    ///
+    /// This method is dedicated to ``DatabaseValueConvertible`` types that also conform
+    /// to the standard `Decodable` protocol.
+    static func databaseJSONDecoder() -> JSONDecoder
+    
+    /// Returns the `JSONEncoder` that encodes the value for a given column.
+    ///
+    /// This method is dedicated to ``DatabaseValueConvertible`` types that also conform
+    /// to the standard `Encodable` protocol.
+    static func databaseJSONEncoder() -> JSONEncoder
 }
 
 extension DatabaseValueConvertible {
@@ -74,6 +86,41 @@ extension DatabaseValueConvertible {
     /// Default implementation fails to decode a value from a missing column.
     public static func fromMissingColumn() -> Self? {
         nil // failure.
+    }
+    
+    /// Returns the `JSONDecoder` that decodes the value.
+    ///
+    /// The default implementation returns a `JSONDecoder` with the
+    /// following properties:
+    ///
+    /// - `dataDecodingStrategy`: `.base64`
+    /// - `dateDecodingStrategy`: `.millisecondsSince1970`
+    /// - `nonConformingFloatDecodingStrategy`: `.throw`
+    public static func databaseJSONDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dataDecodingStrategy = .base64
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        decoder.nonConformingFloatDecodingStrategy = .throw
+        return decoder
+    }
+    
+    /// Returns the `JSONEncoder` that encodes the value.
+    ///
+    /// The default implementation returns a `JSONEncoder` with the
+    /// following properties:
+    ///
+    /// - `dataEncodingStrategy`: `.base64`
+    /// - `dateEncodingStrategy`: `.millisecondsSince1970`
+    /// - `nonConformingFloatEncodingStrategy`: `.throw`
+    /// - `outputFormatting`: `.sortedKeys`
+    public static func databaseJSONEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dataEncodingStrategy = .base64
+        encoder.dateEncodingStrategy = .millisecondsSince1970
+        encoder.nonConformingFloatEncodingStrategy = .throw
+        // guarantee some stability in order to ease value comparison
+        encoder.outputFormatting = .sortedKeys
+        return encoder
     }
 }
 

--- a/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+Decodable.swift
+++ b/GRDB/Core/Support/StandardLibrary/DatabaseValueConvertible+Decodable.swift
@@ -179,11 +179,7 @@ extension DatabaseValueConvertible where Self: Decodable {
             guard let data = Data.fromDatabaseValue(databaseValue) else {
                 return nil
             }
-            let decoder = JSONDecoder()
-            decoder.dataDecodingStrategy = .base64
-            decoder.dateDecodingStrategy = .millisecondsSince1970
-            decoder.nonConformingFloatDecodingStrategy = .throw
-            return try? decoder.decode(Self.self, from: data)
+            return try? databaseJSONDecoder().decode(Self.self, from: data)
         } catch {
             return nil
         }

--- a/GRDB/Documentation.docc/Extension/DatabaseValueConvertible.md
+++ b/GRDB/Documentation.docc/Extension/DatabaseValueConvertible.md
@@ -151,6 +151,11 @@ This extra conformance is not required: only aim at the low-level C interface if
 
 - ``databaseValue-1ob9k``
 
+### Configuring the JSON format for the standard Decodable protocol
+
+- ``databaseJSONDecoder()-7zou9``
+- ``databaseJSONEncoder()-37sff``
+
 ### Fetching Values from Raw SQL
 
 - ``fetchCursor(_:sql:arguments:adapter:)-6elcz``

--- a/GRDB/Documentation.docc/Extension/DatabaseValueConvertible.md
+++ b/GRDB/Documentation.docc/Extension/DatabaseValueConvertible.md
@@ -74,7 +74,15 @@ extension Color: DatabaseValueConvertible { }
 
 By default, such codable value types are encoded and decoded with the standard [JSONEncoder](https://developer.apple.com/documentation/foundation/jsonencoder) and [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder). `Data` values are handled with the `.base64` strategy, `Date` with the `.millisecondsSince1970` strategy, and non conforming floats with the `.throw` strategy.
 
-To customize the JSON format, provide an explicit implementation for the `DatabaseValueConvertible` requirements.
+To customize the JSON format, provide an explicit implementation for the `DatabaseValueConvertible` requirements,
+or implement these two methods:
+
+```swift
+protocol DatabaseValueConvertible {
+    static func databaseJSONDecoder() -> JSONDecoder
+    static func databaseJSONEncoder() -> JSONEncoder
+}
+```
 
 ### Adding support for the Tagged library
 

--- a/GRDB/Documentation.docc/Extension/DatabaseValueConvertible.md
+++ b/GRDB/Documentation.docc/Extension/DatabaseValueConvertible.md
@@ -74,8 +74,7 @@ extension Color: DatabaseValueConvertible { }
 
 By default, such codable value types are encoded and decoded with the standard [JSONEncoder](https://developer.apple.com/documentation/foundation/jsonencoder) and [JSONDecoder](https://developer.apple.com/documentation/foundation/jsondecoder). `Data` values are handled with the `.base64` strategy, `Date` with the `.millisecondsSince1970` strategy, and non conforming floats with the `.throw` strategy.
 
-To customize the JSON format, provide an explicit implementation for the `DatabaseValueConvertible` requirements,
-or implement these two methods:
+To customize the JSON format, provide an explicit implementation for the `DatabaseValueConvertible` requirements, or implement these two methods:
 
 ```swift
 protocol DatabaseValueConvertible {


### PR DESCRIPTION
### Summary

Fixes #1428.

Brings `DatabaseValueConvertible` to parity with `FetchableRecord` and `EncodableRecord` by allowing users to customize their JSON encoding and decoding using these two added methods:
- `static func databaseJSONDecoder() -> JSONDecoder`
- `static func databaseJSONEncoder() -> JSONEncoder`

This work follows the existing implementation for Records, but with the caveat of having to introduce an optional `jsonEncoder` property in `DatabaseValueEncoder`. Let me know if we should handle this differently, or if things like these just make expanding this protocol not worth it and keep encouraging users to just implement the required methods.

---

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
