### PR TITLE
Extend the macOS availability of JSON functions

### DIFF
--- a/GRDB/Documentation.docc/JSON.md
+++ b/GRDB/Documentation.docc/JSON.md
@@ -4,7 +4,7 @@ Store and use JSON values in SQLite databases.
 
 ## Overview
 
-SQLite and GRDB can store and fetch JSON values in database columns. Starting SQLite 3.38.0 (iOS 16+, macOS 13.2+, tvOS 17+, and watchOS 9+), JSON values can be manipulated at the database level.
+SQLite and GRDB can store and fetch JSON values in database columns. Starting iOS 16+, macOS 10.15+, tvOS 17+, and watchOS 9+, JSON values can be manipulated at the database level.
 
 ## Store and fetch JSON values
 
@@ -98,7 +98,7 @@ extension Team: FetchableRecord, PersistableRecord {
 
 ## Manipulate JSON values at the database level
 
-[SQLite JSON functions and operators](https://www.sqlite.org/json1.html) are available starting SQLite 3.38.0 (iOS 16+, macOS 13.2+, tvOS 17+, and watchOS 9+).
+[SQLite JSON functions and operators](https://www.sqlite.org/json1.html) are available starting iOS 16+, macOS 10.15+, tvOS 17+, and watchOS 9+.
 
 Functions such as `JSON`, `JSON_EXTRACT`, `JSON_PATCH` and others are available as static methods on `Database`: ``Database/json(_:)``, ``Database/jsonExtract(_:atPath:)``, ``Database/jsonPatch(_:with:)``, etc.
 

--- a/GRDB/JSON/SQLJSONExpressible.swift
+++ b/GRDB/JSON/SQLJSONExpressible.swift
@@ -259,7 +259,6 @@ extension SQLJSONExpressible {
     }
 }
 #else
-@available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
 extension SQLJSONExpressible {
     /// The `->>` SQL operator.
     ///
@@ -285,6 +284,7 @@ extension SQLJSONExpressible {
     ///
     /// - parameter path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments),
     ///   or an JSON object field label, or an array index.
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public subscript(_ path: some SQLExpressible) -> SQLExpression {
         .binary(.jsonExtractSQL, sqlExpression, path.sqlExpression)
     }
@@ -312,6 +312,7 @@ extension SQLJSONExpressible {
     /// Related SQL documentation: <https://www.sqlite.org/json1.html#jex>
     ///
     /// - parameter path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public func jsonExtract(atPath path: some SQLExpressible) -> SQLExpression {
         Database.jsonExtract(self, atPath: path)
     }
@@ -333,6 +334,7 @@ extension SQLJSONExpressible {
     /// Related SQL documentation: <https://www.sqlite.org/json1.html#jex>
     ///
     /// - parameter paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public func jsonExtract<C>(atPaths paths: C) -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
     {
@@ -363,13 +365,13 @@ extension SQLJSONExpressible {
     ///
     /// - parameter path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments),
     ///   or an JSON object field label, or an array index.
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public func jsonRepresentation(atPath path: some SQLExpressible) -> SQLExpression {
         .binary(.jsonExtractJSON, sqlExpression, path.sqlExpression)
     }
 }
 
 // TODO: Enable when those apis are ready.
-// @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
 // extension ColumnExpression where Self: SQLJSONExpressible {
 //     /// Updates a columns with the `JSON_PATCH` SQL function.
 //     ///
@@ -383,6 +385,7 @@ extension SQLJSONExpressible {
 //     /// ```
 //     ///
 //     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jpatch>
+//     @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
 //     public func jsonPatch(
 //         with patch: some SQLExpressible)
 //     -> ColumnAssignment
@@ -405,6 +408,7 @@ extension SQLJSONExpressible {
 //     ///
 //     /// - Parameters:
 //     ///   - paths: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
+//     @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
 //     public func jsonRemove(atPath path: some SQLExpressible) -> ColumnAssignment {
 //         .init(columnName: name, value: Database.jsonRemove(self, atPath: path))
 //     }
@@ -424,6 +428,7 @@ extension SQLJSONExpressible {
 //     ///
 //     /// - Parameters:
 //     ///   - paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+//     @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
 //     public func jsonRemove<C>(atPaths paths: C)
 //     -> ColumnAssignment
 //     where C: Collection, C.Element: SQLExpressible

--- a/GRDB/JSON/SQLJSONExpressible.swift
+++ b/GRDB/JSON/SQLJSONExpressible.swift
@@ -312,7 +312,7 @@ extension SQLJSONExpressible {
     /// Related SQL documentation: <https://www.sqlite.org/json1.html#jex>
     ///
     /// - parameter path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public func jsonExtract(atPath path: some SQLExpressible) -> SQLExpression {
         Database.jsonExtract(self, atPath: path)
     }
@@ -334,7 +334,7 @@ extension SQLJSONExpressible {
     /// Related SQL documentation: <https://www.sqlite.org/json1.html#jex>
     ///
     /// - parameter paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public func jsonExtract<C>(atPaths paths: C) -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
     {
@@ -385,7 +385,7 @@ extension SQLJSONExpressible {
 //     /// ```
 //     ///
 //     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jpatch>
-//     @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+//     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
 //     public func jsonPatch(
 //         with patch: some SQLExpressible)
 //     -> ColumnAssignment
@@ -408,7 +408,7 @@ extension SQLJSONExpressible {
 //     ///
 //     /// - Parameters:
 //     ///   - paths: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
-//     @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+//     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
 //     public func jsonRemove(atPath path: some SQLExpressible) -> ColumnAssignment {
 //         .init(columnName: name, value: Database.jsonRemove(self, atPath: path))
 //     }
@@ -428,7 +428,7 @@ extension SQLJSONExpressible {
 //     ///
 //     /// - Parameters:
 //     ///   - paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-//     @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+//     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
 //     public func jsonRemove<C>(atPaths paths: C)
 //     -> ColumnAssignment
 //     where C: Collection, C.Element: SQLExpressible

--- a/GRDB/JSON/SQLJSONFunctions.swift
+++ b/GRDB/JSON/SQLJSONFunctions.swift
@@ -397,7 +397,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jmini>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func json(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON", [value.sqlExpression])
     }
@@ -412,7 +412,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jarray>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonArray<C>(_ values: C) -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
     {
@@ -429,7 +429,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jarray>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonArray<C>(_ values: C) -> SQLExpression
     where C: Collection, C.Element == any SQLExpressible
     {
@@ -447,7 +447,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jarraylen>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_ARRAY_LENGTH", [value.sqlExpression])
     }
@@ -467,7 +467,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON array.
     ///   - path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonArrayLength(
         _ value: some SQLExpressible,
         atPath path: some SQLExpressible)
@@ -505,7 +505,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonExtract(_ value: some SQLExpressible, atPath path: some SQLExpressible) -> SQLExpression {
         .function("JSON_EXTRACT", [value.sqlExpression, path.sqlExpression])
     }
@@ -524,7 +524,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonExtract<C>(_ value: some SQLExpressible, atPaths paths: C)
     -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
@@ -547,7 +547,7 @@ extension Database {
     ///   - value: A JSON value.
     ///   - assignments: A collection of key/value pairs, where keys are
     ///     [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonInsert<C>(
         _ value: some SQLExpressible,
         _ assignments: C)
@@ -575,7 +575,7 @@ extension Database {
     ///   - value: A JSON value.
     ///   - assignments: A collection of key/value pairs, where keys are
     ///     [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonReplace<C>(
         _ value: some SQLExpressible,
         _ assignments: C)
@@ -603,7 +603,7 @@ extension Database {
     ///   - value: A JSON value.
     ///   - assignments: A collection of key/value pairs, where keys are
     ///     [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonSet<C>(
         _ value: some SQLExpressible,
         _ assignments: C)
@@ -639,7 +639,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jobj>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonObject<C>(_ elements: C)
     -> SQLExpression
     where C: Collection,
@@ -660,7 +660,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jpatch>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonPatch(
         _ value: some SQLExpressible,
         with patch: some SQLExpressible)
@@ -683,7 +683,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonRemove(_ value: some SQLExpressible, atPath path: some SQLExpressible) -> SQLExpression {
         .function("JSON_REMOVE", [value.sqlExpression, path.sqlExpression])
     }
@@ -702,7 +702,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonRemove<C>(_ value: some SQLExpressible, atPaths paths: C)
     -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
@@ -720,7 +720,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jtype>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonType(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_TYPE", [value.sqlExpression])
     }
@@ -739,7 +739,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonType(_ value: some SQLExpressible, atPath path: some SQLExpressible) -> SQLExpression {
         .function("JSON_TYPE", [value.sqlExpression, path.sqlExpression])
     }
@@ -754,7 +754,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jvalid>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonIsValid(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_VALID", [value.sqlExpression])
     }
@@ -772,7 +772,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jquote>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonQuote(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_QUOTE", [value.sqlExpression.jsonBuilderExpression])
     }
@@ -780,7 +780,7 @@ extension Database {
     /// The `JSON_GROUP_ARRAY` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonGroupArray(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_GROUP_ARRAY", [value.sqlExpression.jsonBuilderExpression])
     }
@@ -788,7 +788,7 @@ extension Database {
     /// The `JSON_GROUP_OBJECT` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonGroupObject(key: some SQLExpressible, value: some SQLExpressible) -> SQLExpression {
         .function("JSON_GROUP_OBJECT", [key.sqlExpression, value.sqlExpression.jsonBuilderExpression])
     }

--- a/GRDB/JSON/SQLJSONFunctions.swift
+++ b/GRDB/JSON/SQLJSONFunctions.swift
@@ -386,7 +386,6 @@ extension Database {
     }
 }
 #else
-@available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
 extension Database {
     /// Validates and minifies a JSON string, with the `JSON` SQL function.
     ///
@@ -398,6 +397,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jmini>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func json(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON", [value.sqlExpression])
     }
@@ -412,6 +412,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jarray>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonArray<C>(_ values: C) -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
     {
@@ -428,6 +429,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jarray>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonArray<C>(_ values: C) -> SQLExpression
     where C: Collection, C.Element == any SQLExpressible
     {
@@ -445,6 +447,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jarraylen>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonArrayLength(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_ARRAY_LENGTH", [value.sqlExpression])
     }
@@ -464,6 +467,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON array.
     ///   - path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonArrayLength(
         _ value: some SQLExpressible,
         atPath path: some SQLExpressible)
@@ -501,6 +505,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - path: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonExtract(_ value: some SQLExpressible, atPath path: some SQLExpressible) -> SQLExpression {
         .function("JSON_EXTRACT", [value.sqlExpression, path.sqlExpression])
     }
@@ -519,6 +524,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonExtract<C>(_ value: some SQLExpressible, atPaths paths: C)
     -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
@@ -541,6 +547,7 @@ extension Database {
     ///   - value: A JSON value.
     ///   - assignments: A collection of key/value pairs, where keys are
     ///     [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonInsert<C>(
         _ value: some SQLExpressible,
         _ assignments: C)
@@ -568,6 +575,7 @@ extension Database {
     ///   - value: A JSON value.
     ///   - assignments: A collection of key/value pairs, where keys are
     ///     [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonReplace<C>(
         _ value: some SQLExpressible,
         _ assignments: C)
@@ -595,6 +603,7 @@ extension Database {
     ///   - value: A JSON value.
     ///   - assignments: A collection of key/value pairs, where keys are
     ///     [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonSet<C>(
         _ value: some SQLExpressible,
         _ assignments: C)
@@ -630,6 +639,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jobj>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonObject<C>(_ elements: C)
     -> SQLExpression
     where C: Collection,
@@ -650,6 +660,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jpatch>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonPatch(
         _ value: some SQLExpressible,
         with patch: some SQLExpressible)
@@ -672,6 +683,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonRemove(_ value: some SQLExpressible, atPath path: some SQLExpressible) -> SQLExpression {
         .function("JSON_REMOVE", [value.sqlExpression, path.sqlExpression])
     }
@@ -690,6 +702,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A collection of [JSON paths](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonRemove<C>(_ value: some SQLExpressible, atPaths paths: C)
     -> SQLExpression
     where C: Collection, C.Element: SQLExpressible
@@ -707,6 +720,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jtype>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonType(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_TYPE", [value.sqlExpression])
     }
@@ -725,6 +739,7 @@ extension Database {
     /// - Parameters:
     ///   - value: A JSON value.
     ///   - paths: A [JSON path](https://www.sqlite.org/json1.html#path_arguments).
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonType(_ value: some SQLExpressible, atPath path: some SQLExpressible) -> SQLExpression {
         .function("JSON_TYPE", [value.sqlExpression, path.sqlExpression])
     }
@@ -739,6 +754,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jvalid>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonIsValid(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_VALID", [value.sqlExpression])
     }
@@ -756,6 +772,7 @@ extension Database {
     /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jquote>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonQuote(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_QUOTE", [value.sqlExpression.jsonBuilderExpression])
     }
@@ -763,6 +780,7 @@ extension Database {
     /// The `JSON_GROUP_ARRAY` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonGroupArray(_ value: some SQLExpressible) -> SQLExpression {
         .function("JSON_GROUP_ARRAY", [value.sqlExpression.jsonBuilderExpression])
     }
@@ -770,6 +788,7 @@ extension Database {
     /// The `JSON_GROUP_OBJECT` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
+    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
     public static func jsonGroupObject(key: some SQLExpressible, value: some SQLExpressible) -> SQLExpression {
         .function("JSON_GROUP_OBJECT", [key.sqlExpression, value.sqlExpression.jsonBuilderExpression])
     }

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -492,13 +492,21 @@ public struct SQLExpression {
         /// The `>>` bitwise right shift operator
         static let rightShift = BinaryOperator(">>")
         
-        // Not guarded by availability checks, but only available for SQLite 3.38+
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
         /// The `->` SQL operator
         static let jsonExtractJSON = BinaryOperator("->", isJSONValue: true)
         
-        // Not guarded by availability checks, but only available for SQLite 3.38+
         /// The `->>` SQL operator
         static let jsonExtractSQL = BinaryOperator("->>")
+#else
+        /// The `->` SQL operator
+        @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+        static let jsonExtractJSON = BinaryOperator("->", isJSONValue: true)
+        
+        /// The `->>` SQL operator
+        @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+        static let jsonExtractSQL = BinaryOperator("->>")
+#endif
     }
     
     /// `EscapableBinaryOperator` is an SQLite binary operator that accepts an
@@ -1977,7 +1985,7 @@ extension SQLExpression {
         }
     }
 #else
-    @available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) // SQLite 3.38+
+    @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     /// Returns an expression suitable in JSON building contexts.
     var jsonBuilderExpression: SQLExpression {
         switch preferredJSONInterpretation {

--- a/Tests/GRDBTests/JSONExpressionsTests.swift
+++ b/Tests/GRDBTests/JSONExpressionsTests.swift
@@ -9,7 +9,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -44,7 +44,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -105,7 +105,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -130,6 +130,49 @@ final class JSONExpressionsTests: GRDBTestCase {
             try assertEqualSQL(db, Database.jsonArray([1, 2, "3", 4]), """
                 JSON_ARRAY(1, 2, '3', 4)
                 """)
+            
+            // Note: this JSON(JSON_EXTRACT(...)) is useful, when the extracted value is a string that contains JSON
+            try assertEqualSQL(db, player
+                .select(
+                    Database.jsonArray([
+                        nameColumn,
+                        nameColumn.asJSON,
+                        infoColumn,
+                        infoColumn.jsonExtract(atPath: "address"),
+                        infoColumn.jsonExtract(atPath: "address").asJSON,
+                    ] as [any SQLExpressible])
+                ), """
+                SELECT JSON_ARRAY(\
+                "name", \
+                JSON("name"), \
+                JSON("info"), \
+                JSON_EXTRACT("info", 'address'), \
+                JSON(JSON_EXTRACT("info", 'address'))\
+                ) FROM "player"
+                """)
+        }
+    }
+    
+    func test_Database_jsonArray_from_SQLJSONExpressible() throws {
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3038000 else {
+            throw XCTSkip("JSON support is not available")
+        }
+#else
+        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+            throw XCTSkip("JSON support is not available")
+        }
+#endif
+        
+        try makeDatabaseQueue().inDatabase { db in
+            try db.create(table: "player") { t in
+                t.column("name", .text)
+                t.column("info", .jsonText)
+            }
+            let player = Table("player")
+            let nameColumn = Column("name")
+            let infoColumn = JSONColumn("info")
             
             // Note: this JSON(JSON_EXTRACT(...)) is useful, when the extracted value is a string that contains JSON
             try assertEqualSQL(db, player
@@ -238,7 +281,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -273,7 +316,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -351,7 +394,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -394,7 +437,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -429,7 +472,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -484,7 +527,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -539,7 +582,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -594,7 +637,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -697,7 +740,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -780,7 +823,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -863,7 +906,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -906,7 +949,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -949,7 +992,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -984,7 +1027,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -1019,7 +1062,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -1062,7 +1105,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -1097,7 +1140,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -1144,7 +1187,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -1175,7 +1218,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+        guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
             throw XCTSkip("JSON support is not available")
         }
 #endif
@@ -1202,9 +1245,10 @@ final class JSONExpressionsTests: GRDBTestCase {
             throw XCTSkip("JSON support is not available")
         }
 #else
-        guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
-            throw XCTSkip("JSON support is not available")
+        guard #available(iOS 16, macOS 12, tvOS 17, watchOS 9, *) else {
+            throw XCTSkip("JSON support or generated columns are not available")
         }
+        
 #endif
         
         try makeDatabaseQueue().inDatabase { db in
@@ -1212,27 +1256,35 @@ final class JSONExpressionsTests: GRDBTestCase {
                 t.primaryKey("id", .integer)
                 t.column("address", .jsonText)
                 t.column("country", .text)
-                    .generatedAs(JSONColumn("address")["country"])
+                    .generatedAs(JSONColumn("address").jsonExtract(atPath: "$.country"))
                     .indexed()
             }
             
             XCTAssertEqual(Array(sqlQueries.suffix(2)), [
                 """
-                CREATE TABLE "player" ("id" INTEGER PRIMARY KEY, "address" TEXT, "country" TEXT GENERATED ALWAYS AS ("address" ->> 'country') VIRTUAL)
+                CREATE TABLE "player" (\
+                "id" INTEGER PRIMARY KEY, \
+                "address" TEXT, \
+                "country" TEXT GENERATED ALWAYS AS (JSON_EXTRACT("address", '$.country')) VIRTUAL\
+                )
                 """,
                 """
                 CREATE INDEX "player_on_country" ON "player"("country")
                 """,
-                ])
+            ])
             
             try db.create(index: "player_on_address", on: "player", expressions: [
-                JSONColumn("address")["country"],
-                JSONColumn("address")["city"],
-                JSONColumn("address")["street"],
+                JSONColumn("address").jsonExtract(atPath: "$.country"),
+                JSONColumn("address").jsonExtract(atPath: "$.city"),
+                JSONColumn("address").jsonExtract(atPath: "$.street"),
             ])
             
             XCTAssertEqual(lastSQLQuery, """
-                CREATE INDEX "player_on_address" ON "player"("address" ->> 'country', "address" ->> 'city', "address" ->> 'street')
+                CREATE INDEX "player_on_address" ON "player"(\
+                JSON_EXTRACT("address", '$.country'), \
+                JSON_EXTRACT("address", '$.city'), \
+                JSON_EXTRACT("address", '$.street')\
+                )
                 """)
             
             try db.execute(literal: """
@@ -1245,7 +1297,7 @@ final class JSONExpressionsTests: GRDBTestCase {
             try XCTAssertEqual(String.fetchOne(db, sql: "SELECT country FROM player"), "France")
         }
     }
-
+    
 // TODO: Enable when those apis are ready.
 //     func test_ColumnAssignment() throws {
 // #if GRDBCUSTOMSQLITE || GRDBCIPHER
@@ -1254,7 +1306,7 @@ final class JSONExpressionsTests: GRDBTestCase {
 //             throw XCTSkip("JSON support is not available")
 //         }
 // #else
-//         guard #available(iOS 16, macOS 13.2, tvOS 17, watchOS 9, *) else {
+//         guard #available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) else {
 //             throw XCTSkip("JSON support is not available")
 //         }
 // #endif
@@ -1277,7 +1329,6 @@ final class JSONExpressionsTests: GRDBTestCase {
 //             try Player.updateAll(db, [
 //                 JSONColumn("info").jsonRemove(atPath: "$.country")
 //             ])
-//             print(lastSQLQuery!)
 //             XCTAssertEqual(lastSQLQuery, """
 //                 UPDATE "player" SET "info" = JSON_REMOVE("info", '$.country')
 //                 """)
@@ -1285,7 +1336,6 @@ final class JSONExpressionsTests: GRDBTestCase {
 //             try Player.updateAll(db, [
 //                 JSONColumn("info").jsonRemove(atPaths: ["$.country", "$.city"])
 //             ])
-//             print(lastSQLQuery!)
 //             XCTAssertEqual(lastSQLQuery, """
 //                 UPDATE "player" SET "info" = JSON_REMOVE("info", '$.country', '$.city')
 //                 """)


### PR DESCRIPTION
All SQLite JSON functions, but the `->` and `->>` operators, were already available on macOS 10.15, as reported by @martindufort in https://gist.github.com/groue/046ebddb4a410304094c022d756081c8.

This pull request updates the availability condition of the matching Swift APIs.