### PR TITLE
Add support for stable ordering and dump of views.

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -70,7 +70,7 @@ let SQLITE_TRANSIENT = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_
 /// - ``dumpContent(format:to:)``
 /// - ``dumpRequest(_:format:to:)``
 /// - ``dumpSQL(_:format:to:)``
-/// - ``dumpTables(_:format:tableHeader:to:)``
+/// - ``dumpTables(_:format:tableHeader:stableOrder:to:)``
 /// - ``DumpFormat``
 /// - ``DumpTableHeaderOptions``
 ///

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -38,7 +38,7 @@ import Dispatch
 /// - ``dumpContent(format:to:)``
 /// - ``dumpRequest(_:format:to:)``
 /// - ``dumpSQL(_:format:to:)``
-/// - ``dumpTables(_:format:tableHeader:to:)``
+/// - ``dumpTables(_:format:tableHeader:stableOrder:to:)``
 /// - ``DumpFormat``
 /// - ``DumpTableHeaderOptions``
 ///

--- a/GRDB/Dump/DatabaseReader+dump.swift
+++ b/GRDB/Dump/DatabaseReader+dump.swift
@@ -53,7 +53,7 @@ extension DatabaseReader {
         }
     }
     
-    /// Prints the contents of the provided tables.
+    /// Prints the contents of the provided tables and views.
     ///
     /// For example:
     ///
@@ -72,17 +72,29 @@ extension DatabaseReader {
     ///   - tables: The table names.
     ///   - format: The output format.
     ///   - tableHeader: Options for printing table names.
+    ///   - stableOrder: A boolean value that controls the ordering of
+    ///     rows fetched from views. If false (the default), rows are
+    ///     printed in the order specified by the view (which may be
+    ///     undefined). It true, outputted rows are always printed in the
+    ///     same stable order. The purpose of this stable order is to make
+    ///     the output suitable for testing.
     ///   - stream: A stream for text output, which directs output to the
     ///     console by default.
     public func dumpTables(
         _ tables: [String],
         format: some DumpFormat = .debug(),
         tableHeader: DumpTableHeaderOptions = .automatic,
+        stableOrder: Bool = false,
         to stream: (any TextOutputStream)? = nil)
     throws
     {
         try unsafeReentrantRead { db in
-            try db.dumpTables(tables, format: format, tableHeader: tableHeader, to: stream)
+            try db.dumpTables(
+                tables,
+                format: format,
+                tableHeader: tableHeader,
+                stableOrder: stableOrder,
+                to: stream)
         }
     }
     

--- a/GRDB/QueryInterface/SQL/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQL/SQLRelation.swift
@@ -283,13 +283,20 @@ extension SQLRelation: Refinable {
     }
     
     func withStableOrder() -> Self {
-        with {
-            // Order by primary key. Don't order by rowid because those are
-            // not stable: rowids can change after a vacuum.
-            $0.ordering = $0.ordering.appending(Ordering(orderings: { db in
-                try db.primaryKey(source.tableName).columns.map { SQLExpression.column($0).sqlOrdering }
+        with { relation in
+            relation.ordering = relation.ordering.appending(Ordering(orderings: { [relation] db in
+                if try db.tableExists(source.tableName) {
+                    // Order by primary key. Don't order by rowid because those are
+                    // not stable: rowids can change after a vacuum.
+                    return try db.primaryKey(source.tableName).columns.map { SQLExpression.column($0).sqlOrdering }
+                } else {
+                    // Support for views: create a stable order from all columns:
+                    // ORDER BY 1, 2, 3, ...
+                    let columnCount = try SQLQueryGenerator(relation: relation).columnCount(db)
+                    return (1...columnCount).map { SQL(sql: $0.description).sqlOrdering }
+                }
             }))
-            $0.children = children.mapValues { child in
+            relation.children = children.mapValues { child in
                 child.with {
                     $0.relation = $0.relation.withStableOrder()
                 }


### PR DESCRIPTION
This pull request fixes two runtime errors regarding database views (`CREATE VIEW AS ...`).

Requests with stable ordering created with `request.withStableOrder()` no longer throw when used on views.

Dumping the content of views with `dbQueue.dumpTables()` introduced by #1439 no longer throws:

```swift
// NEW: dump tables or views
try dbQueue.dumpTables(["myTable", "myView"])
```

By default, the rows of views are printed in the order specified by the view, which may be undefined. Pass `stableOrder: true` in order to guarantee a stable order, suitable for testing:

```swift
try db.execute("""
  CREATE VIEW playerName1
  AS SELECT name FROM player;

  CREATE VIEW playerName2
  AS SELECT name FROM player ORDER BY name;
  """)

// playerName1 rows are printed in an unspecified order.
// playerName2 rows are printed sorted by name.
try dbQueue.dumpTables(["playerName1", "playerName2"])

// playerName1 rows are printed in a stable order.
// playerName2 rows are printed in a stable order.
try dbQueue.dumpTables(["playerName1", "playerName2"], stableOrder: true)
```
