### PR TITLE
Backport temporary copies from GRDBSnapshotTesting

### DIFF
--- a/GRDB.xcodeproj/project.pbxproj
+++ b/GRDB.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		562393601DEE06D300A6B01F /* CursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623935F1DEE06D300A6B01F /* CursorTests.swift */; };
 		562393691DEE0CD200A6B01F /* FlattenCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562393681DEE0CD200A6B01F /* FlattenCursorTests.swift */; };
 		562393721DEE104400A6B01F /* MapCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562393711DEE104400A6B01F /* MapCursorTests.swift */; };
+		5623B6142AED39A600436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6122AED39A600436239 /* DatabaseQueueInMemoryCopyTests.swift */; };
+		5623B6152AED39A600436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6132AED39A600436239 /* DatabaseQueueTemporaryCopyTests.swift */; };
 		56256ED025D1ACD0008C2BDD /* Table.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56256ECF25D1ACD0008C2BDD /* Table.swift */; };
 		56256ED925D1B316008C2BDD /* ForeignKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56256ED825D1B316008C2BDD /* ForeignKey.swift */; };
 		562756431E963AAC0035B653 /* DatabaseWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562756421E963AAC0035B653 /* DatabaseWriterTests.swift */; };
@@ -489,6 +491,8 @@
 		5623935F1DEE06D300A6B01F /* CursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CursorTests.swift; sourceTree = "<group>"; };
 		562393681DEE0CD200A6B01F /* FlattenCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlattenCursorTests.swift; sourceTree = "<group>"; };
 		562393711DEE104400A6B01F /* MapCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapCursorTests.swift; sourceTree = "<group>"; };
+		5623B6122AED39A600436239 /* DatabaseQueueInMemoryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueInMemoryCopyTests.swift; sourceTree = "<group>"; };
+		5623B6132AED39A600436239 /* DatabaseQueueTemporaryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTemporaryCopyTests.swift; sourceTree = "<group>"; };
 		5623E0901B4AFACC00B20B7F /* GRDBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GRDBTestCase.swift; sourceTree = "<group>"; };
 		56256ECF25D1ACD0008C2BDD /* Table.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Table.swift; sourceTree = "<group>"; };
 		56256ED825D1B316008C2BDD /* ForeignKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForeignKey.swift; sourceTree = "<group>"; };
@@ -1125,8 +1129,10 @@
 				5687359E1CEDE16C009B9116 /* Betty.jpeg */,
 				5672DE581CDB72520022BA81 /* DatabaseQueueBackupTests.swift */,
 				563363BC1C93FD5E000BE133 /* DatabaseQueueConcurrencyTests.swift */,
+				5623B6122AED39A600436239 /* DatabaseQueueInMemoryCopyTests.swift */,
 				56A238141B9C74A90082EB20 /* DatabaseQueueInMemoryTests.swift */,
 				567156151CB142AA007DC145 /* DatabaseQueueReadOnlyTests.swift */,
+				5623B6132AED39A600436239 /* DatabaseQueueTemporaryCopyTests.swift */,
 				569178451CED9B6000E179EA /* DatabaseQueueTests.swift */,
 			);
 			name = DatabaseQueue;
@@ -2006,6 +2012,7 @@
 				56419C6B24A519A2004967E1 /* Support.swift in Sources */,
 				56D496871D81316E008276D7 /* DatabaseTimestampTests.swift in Sources */,
 				5615B26A222AFE8F00061C1C /* AssociationHasOneThroughRowScopeTests.swift in Sources */,
+				5623B6152AED39A600436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */,
 				561CFA9C2376EC86000C8BAA /* AssociationHasManyOrderingTests.swift in Sources */,
 				56176C5A1EACCCC7000F3F2B /* FTS5PatternTests.swift in Sources */,
 				56D496581D81304E008276D7 /* FoundationDateTests.swift in Sources */,
@@ -2080,6 +2087,7 @@
 				56D496791D81309E008276D7 /* RecordWithColumnNameManglingTests.swift in Sources */,
 				56D4966C1D81309E008276D7 /* RecordMinimalPrimaryKeyRowIDTests.swift in Sources */,
 				564CE5BE21B8FFA300652B19 /* DatabaseRegionObservationTests.swift in Sources */,
+				5623B6142AED39A600436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */,
 				56AFEF372996B9DC00CA1E51 /* TransactionDateTests.swift in Sources */,
 				564F9C1E1F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
 				D263F40A26C613090038B07F /* DatabaseColumnEncodingStrategyTests.swift in Sources */,

--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -429,3 +429,96 @@ extension DatabaseQueue: DatabaseWriter {
         writer.async(updates)
     }
 }
+
+// MARK: - Temp Copy
+
+extension DatabaseQueue {
+    /// Returns a connection to an in-memory copy of the database at `path`.
+    ///
+    /// Changes performed on the returned connection do not impact the
+    /// original database at `path`.
+    ///
+    /// The database memory is released when the returned connection
+    /// is deallocated.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let path = "/path/to/database.sqlite"
+    /// let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: path)
+    /// ```
+    public static func inMemoryCopy(
+        fromPath path: String,
+        configuration: Configuration = Configuration())
+    throws -> DatabaseQueue
+    {
+        var sourceConfig = configuration
+        sourceConfig.readonly = true
+        let source = try DatabaseQueue(path: path, configuration: sourceConfig)
+        
+        var copyConfig = configuration
+        copyConfig.readonly = false
+        let result = try DatabaseQueue(configuration: copyConfig)
+        
+        try source.backup(to: result)
+        
+        if configuration.readonly {
+            // Result was not opened read-only so that we could perform the
+            // copy. And SQLITE_OPEN_READONLY has no effect on in-memory
+            // databases anyway.
+            //
+            // So let's simulate read-only with PRAGMA query_only.
+            try result.inDatabase { db in
+                try db.beginReadOnly()
+            }
+        }
+        
+        return result
+    }
+    
+    /// Returns a connection to a private, temporary, on-disk copy of the
+    /// database at `path`.
+    ///
+    /// Changes performed on the returned connection do not impact the
+    /// original database at `path`.
+    ///
+    /// The on-disk copy will be automatically deleted from disk as soon as
+    /// the returned connection is closed or deallocated.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let path = "/path/to/database.sqlite"
+    /// let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: path)
+    /// ```
+    public static func temporaryCopy(
+        fromPath path: String,
+        configuration: Configuration = Configuration())
+    throws -> DatabaseQueue
+    {
+        var sourceConfig = configuration
+        sourceConfig.readonly = true
+        let source = try DatabaseQueue(path: path, configuration: sourceConfig)
+        
+        // <https://www.sqlite.org/c3ref/open.html>
+        // > If the filename is an empty string, then a private, temporary
+        // > on-disk database will be created. This private database will be
+        // > automatically deleted as soon as the database connection
+        // > is closed.
+        var copyConfig = configuration
+        copyConfig.readonly = false
+        let result = try DatabaseQueue(path: "", configuration: copyConfig)
+        
+        try source.backup(to: result)
+        
+        if configuration.readonly {
+            // Result was not opened read-only so that we could perform the
+            // copy. So let's simulate read-only with PRAGMA query_only.
+            try result.inDatabase { db in
+                try db.beginReadOnly()
+            }
+        }
+        
+        return result
+    }
+}

--- a/GRDB/Documentation.docc/Extension/DatabaseQueue.md
+++ b/GRDB/Documentation.docc/Extension/DatabaseQueue.md
@@ -88,6 +88,8 @@ A `DatabaseQueue` needs your application to follow rules in order to deliver its
 
 - ``init(named:configuration:)``
 - ``init(path:configuration:)``
+- ``inMemoryCopy(fromPath:configuration:)``
+- ``temporaryCopy(fromPath:configuration:)``
 
 ### Accessing the Database
 

--- a/GRDBCustom.xcodeproj/project.pbxproj
+++ b/GRDBCustom.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		562393631DEE06D300A6B01F /* CursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623935F1DEE06D300A6B01F /* CursorTests.swift */; };
 		5623936C1DEE0CD200A6B01F /* FlattenCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562393681DEE0CD200A6B01F /* FlattenCursorTests.swift */; };
 		562393751DEE104400A6B01F /* MapCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562393711DEE104400A6B01F /* MapCursorTests.swift */; };
+		5623B6192AED39C300436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6162AED39C200436239 /* DatabaseQueueInMemoryCopyTests.swift */; };
+		5623B61A2AED39C300436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6182AED39C200436239 /* DatabaseQueueTemporaryCopyTests.swift */; };
 		56256EDE25D1BC07008C2BDD /* ForeignKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56256EDD25D1BC07008C2BDD /* ForeignKey.swift */; };
 		562756461E963AAC0035B653 /* DatabaseWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562756421E963AAC0035B653 /* DatabaseWriterTests.swift */; };
 		562B58CE2A29BC0700E8C75D /* Issue1383.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = 562B58CC2A29BC0700E8C75D /* Issue1383.sqlite */; };
@@ -503,6 +505,8 @@
 		5623935F1DEE06D300A6B01F /* CursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CursorTests.swift; sourceTree = "<group>"; };
 		562393681DEE0CD200A6B01F /* FlattenCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlattenCursorTests.swift; sourceTree = "<group>"; };
 		562393711DEE104400A6B01F /* MapCursorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapCursorTests.swift; sourceTree = "<group>"; };
+		5623B6162AED39C200436239 /* DatabaseQueueInMemoryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueInMemoryCopyTests.swift; sourceTree = "<group>"; };
+		5623B6182AED39C200436239 /* DatabaseQueueTemporaryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTemporaryCopyTests.swift; sourceTree = "<group>"; };
 		5623E0901B4AFACC00B20B7F /* GRDBTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GRDBTestCase.swift; sourceTree = "<group>"; };
 		56256EDD25D1BC07008C2BDD /* ForeignKey.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForeignKey.swift; sourceTree = "<group>"; };
 		562756421E963AAC0035B653 /* DatabaseWriterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseWriterTests.swift; sourceTree = "<group>"; };
@@ -1129,8 +1133,10 @@
 				5687359E1CEDE16C009B9116 /* Betty.jpeg */,
 				5672DE581CDB72520022BA81 /* DatabaseQueueBackupTests.swift */,
 				563363BC1C93FD5E000BE133 /* DatabaseQueueConcurrencyTests.swift */,
+				5623B6162AED39C200436239 /* DatabaseQueueInMemoryCopyTests.swift */,
 				56A238141B9C74A90082EB20 /* DatabaseQueueInMemoryTests.swift */,
 				567156151CB142AA007DC145 /* DatabaseQueueReadOnlyTests.swift */,
+				5623B6182AED39C200436239 /* DatabaseQueueTemporaryCopyTests.swift */,
 				569178451CED9B6000E179EA /* DatabaseQueueTests.swift */,
 			);
 			name = DatabaseQueue;
@@ -2250,6 +2256,7 @@
 				564E73F3203DA2AC000C443C /* JoinSupportTests.swift in Sources */,
 				563B071B21862F5600B38F35 /* ValueObservationDatabaseValueConvertibleTests.swift in Sources */,
 				5674A70C1F3087710095F066 /* DatabaseValueConvertibleEncodableTests.swift in Sources */,
+				5623B61A2AED39C300436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */,
 				5698AC8C1DA389380056AF8C /* FTS3TableBuilderTests.swift in Sources */,
 				5665F868203EF4640084C6C0 /* ColumnInfoTests.swift in Sources */,
 				F3BA81391CFB3064003DC1BA /* RecordWithColumnNameManglingTests.swift in Sources */,
@@ -2324,6 +2331,7 @@
 				F3BA80E11CFB300F003DC1BA /* DatabaseValueConversionTests.swift in Sources */,
 				5623931B1DECC02000A6B01F /* RowFetchTests.swift in Sources */,
 				564F9C211F069B4E00877A00 /* DatabaseAggregateTests.swift in Sources */,
+				5623B6192AED39C300436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */,
 				F3BA80ED1CFB3017003DC1BA /* RowFromDictionaryTests.swift in Sources */,
 				5690C3291D23E6D800E59934 /* FoundationDateComponentsTests.swift in Sources */,
 				5657AB391D108BA9006283EF /* FoundationDataTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher3/GRDBTests.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		561F38FA2AC9CE6D0051EEE9 /* DatabaseDataDecodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561F38F72AC9CE6D0051EEE9 /* DatabaseDataDecodingStrategyTests.swift */; };
 		561F38FB2AC9CE6D0051EEE9 /* DatabaseDataEncodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561F38F82AC9CE6D0051EEE9 /* DatabaseDataEncodingStrategyTests.swift */; };
 		561F38FC2AC9CE6D0051EEE9 /* DatabaseDataEncodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561F38F82AC9CE6D0051EEE9 /* DatabaseDataEncodingStrategyTests.swift */; };
+		5623B61D2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B61B2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift */; };
+		5623B61E2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B61B2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift */; };
+		5623B61F2AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B61C2AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift */; };
+		5623B6202AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B61C2AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift */; };
 		56419D6724A54062004967E1 /* DatabasePoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56419C9C24A54053004967E1 /* DatabasePoolTests.swift */; };
 		56419D6824A54062004967E1 /* DatabasePoolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56419C9C24A54053004967E1 /* DatabasePoolTests.swift */; };
 		56419D6924A54062004967E1 /* ResultCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56419C9D24A54053004967E1 /* ResultCodeTests.swift */; };
@@ -501,6 +505,8 @@
 		561F38DC2AC891710051EEE9 /* JSONColumnTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONColumnTests.swift; sourceTree = "<group>"; };
 		561F38F72AC9CE6D0051EEE9 /* DatabaseDataDecodingStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDataDecodingStrategyTests.swift; sourceTree = "<group>"; };
 		561F38F82AC9CE6D0051EEE9 /* DatabaseDataEncodingStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDataEncodingStrategyTests.swift; sourceTree = "<group>"; };
+		5623B61B2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTemporaryCopyTests.swift; sourceTree = "<group>"; };
+		5623B61C2AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueInMemoryCopyTests.swift; sourceTree = "<group>"; };
 		56419C9C24A54053004967E1 /* DatabasePoolTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabasePoolTests.swift; sourceTree = "<group>"; };
 		56419C9D24A54053004967E1 /* ResultCodeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultCodeTests.swift; sourceTree = "<group>"; };
 		56419C9E24A54053004967E1 /* DatabaseQueueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTests.swift; sourceTree = "<group>"; };
@@ -907,10 +913,12 @@
 				56419C9C24A54053004967E1 /* DatabasePoolTests.swift */,
 				56419D4924A54060004967E1 /* DatabaseQueueBackupTests.swift */,
 				56419D2824A5405D004967E1 /* DatabaseQueueConcurrencyTests.swift */,
+				5623B61C2AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift */,
 				56419CA024A54054004967E1 /* DatabaseQueueInMemoryTests.swift */,
 				56419CCF24A54057004967E1 /* DatabaseQueueReadOnlyTests.swift */,
 				56419D0A24A5405B004967E1 /* DatabaseQueueReleaseMemoryTests.swift */,
 				56419CEF24A54059004967E1 /* DatabaseQueueSchemaCacheTests.swift */,
+				5623B61B2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift */,
 				56419C9E24A54053004967E1 /* DatabaseQueueTests.swift */,
 				567B5C4A2AD32F7000629622 /* DatabaseReaderDumpTests.swift */,
 				56419D2924A5405D004967E1 /* DatabaseReaderTests.swift */,
@@ -1278,6 +1286,7 @@
 				56419E0724A54062004967E1 /* DatabasePoolBackupTests.swift in Sources */,
 				56419DAF24A54062004967E1 /* DatabaseMigratorTests.swift in Sources */,
 				56419E7924A54062004967E1 /* RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
+				5623B61D2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */,
 				56419EA124A54063004967E1 /* QueryInterfaceExtensibilityTests.swift in Sources */,
 				56419D8724A54062004967E1 /* RecordPrimaryKeyHiddenRowIDTests.swift in Sources */,
 				567B5C352AD32A2D00629622 /* DatabaseSnapshotPoolTests.swift in Sources */,
@@ -1344,6 +1353,7 @@
 				56F61DF0283D484700AF9884 /* getThreadsCount.c in Sources */,
 				56419EC724A54063004967E1 /* RecordPrimaryKeyMultipleTests.swift in Sources */,
 				56419DF724A54062004967E1 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
+				5623B61F2AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */,
 				56419EB724A54063004967E1 /* MutablePersistableRecordPersistenceConflictPolicyTests.swift in Sources */,
 				56419E7524A54062004967E1 /* AssociationAggregateTests.swift in Sources */,
 				56419DD924A54062004967E1 /* AssociationBelongsToSQLTests.swift in Sources */,
@@ -1523,6 +1533,7 @@
 				56419E0824A54062004967E1 /* DatabasePoolBackupTests.swift in Sources */,
 				56419DB024A54062004967E1 /* DatabaseMigratorTests.swift in Sources */,
 				56419E7A24A54062004967E1 /* RecordPrimaryKeySingleWithReplaceConflictResolutionTests.swift in Sources */,
+				5623B61E2AED39F700436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */,
 				56419EA224A54063004967E1 /* QueryInterfaceExtensibilityTests.swift in Sources */,
 				56419D8824A54062004967E1 /* RecordPrimaryKeyHiddenRowIDTests.swift in Sources */,
 				567B5C362AD32A2D00629622 /* DatabaseSnapshotPoolTests.swift in Sources */,
@@ -1589,6 +1600,7 @@
 				56F61DF1283D484700AF9884 /* getThreadsCount.c in Sources */,
 				56419EC824A54063004967E1 /* RecordPrimaryKeyMultipleTests.swift in Sources */,
 				56419DF824A54062004967E1 /* DatabaseDateEncodingStrategyTests.swift in Sources */,
+				5623B6202AED39F700436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */,
 				56419EB824A54063004967E1 /* MutablePersistableRecordPersistenceConflictPolicyTests.swift in Sources */,
 				56419E7624A54062004967E1 /* AssociationAggregateTests.swift in Sources */,
 				56419DDA24A54062004967E1 /* AssociationBelongsToSQLTests.swift in Sources */,

--- a/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaPods/SQLCipher4/GRDBTests.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		561F39002AC9CE870051EEE9 /* DatabaseDataEncodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561F38FD2AC9CE870051EEE9 /* DatabaseDataEncodingStrategyTests.swift */; };
 		561F39012AC9CE870051EEE9 /* DatabaseDataDecodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561F38FE2AC9CE870051EEE9 /* DatabaseDataDecodingStrategyTests.swift */; };
 		561F39022AC9CE870051EEE9 /* DatabaseDataDecodingStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561F38FE2AC9CE870051EEE9 /* DatabaseDataDecodingStrategyTests.swift */; };
+		5623B6232AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6212AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift */; };
+		5623B6242AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6212AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift */; };
+		5623B6252AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6222AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift */; };
+		5623B6262AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5623B6222AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift */; };
 		56419FC824A540A1004967E1 /* FetchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56419EFD24A54093004967E1 /* FetchRequestTests.swift */; };
 		56419FC924A540A1004967E1 /* FetchRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56419EFD24A54093004967E1 /* FetchRequestTests.swift */; };
 		56419FCA24A540A1004967E1 /* DatabasePoolBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56419EFE24A54093004967E1 /* DatabasePoolBackupTests.swift */; };
@@ -503,6 +507,8 @@
 		561F38E02AC891890051EEE9 /* JSONColumnTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONColumnTests.swift; sourceTree = "<group>"; };
 		561F38FD2AC9CE870051EEE9 /* DatabaseDataEncodingStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDataEncodingStrategyTests.swift; sourceTree = "<group>"; };
 		561F38FE2AC9CE870051EEE9 /* DatabaseDataDecodingStrategyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseDataDecodingStrategyTests.swift; sourceTree = "<group>"; };
+		5623B6212AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueInMemoryCopyTests.swift; sourceTree = "<group>"; };
+		5623B6222AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabaseQueueTemporaryCopyTests.swift; sourceTree = "<group>"; };
 		56419EFD24A54093004967E1 /* FetchRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FetchRequestTests.swift; sourceTree = "<group>"; };
 		56419EFE24A54093004967E1 /* DatabasePoolBackupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DatabasePoolBackupTests.swift; sourceTree = "<group>"; };
 		56419EFF24A54093004967E1 /* TableRecordDeleteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableRecordDeleteTests.swift; sourceTree = "<group>"; };
@@ -911,10 +917,12 @@
 				56419F7424A5409A004967E1 /* DatabasePoolTests.swift */,
 				56419F1324A54093004967E1 /* DatabaseQueueBackupTests.swift */,
 				56419F7F24A5409B004967E1 /* DatabaseQueueConcurrencyTests.swift */,
+				5623B6212AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift */,
 				56419FC424A540A0004967E1 /* DatabaseQueueInMemoryTests.swift */,
 				56419F8424A5409B004967E1 /* DatabaseQueueReadOnlyTests.swift */,
 				56419F3424A54096004967E1 /* DatabaseQueueReleaseMemoryTests.swift */,
 				56419F3224A54096004967E1 /* DatabaseQueueSchemaCacheTests.swift */,
+				5623B6222AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift */,
 				56419F9924A5409D004967E1 /* DatabaseQueueTests.swift */,
 				567B5C442AD32F5900629622 /* DatabaseReaderDumpTests.swift */,
 				56419F5C24A54099004967E1 /* DatabaseReaderTests.swift */,
@@ -1387,6 +1395,7 @@
 				5641A03824A540A1004967E1 /* VirtualTableModuleTests.swift in Sources */,
 				5641A02024A540A1004967E1 /* UpdateStatementTests.swift in Sources */,
 				5641A0E424A540A1004967E1 /* TransactionObserverSavepointsTests.swift in Sources */,
+				5623B6252AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */,
 				5641A00C24A540A1004967E1 /* DatabaseValueConversionErrorTests.swift in Sources */,
 				56419FD224A540A1004967E1 /* MutablePersistableRecordEncodableTests.swift in Sources */,
 				56419FD024A540A1004967E1 /* MutablePersistableRecordTests.swift in Sources */,
@@ -1461,6 +1470,7 @@
 				56419FEC24A540A1004967E1 /* FTS4TableBuilderTests.swift in Sources */,
 				567B5C122AD32A0000629622 /* SharedValueObservationTests.swift in Sources */,
 				5641A18A24A540C7004967E1 /* DatabaseRegionObservationPublisherTests.swift in Sources */,
+				5623B6232AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */,
 				5641A05C24A540A1004967E1 /* ValueObservationRecordTests.swift in Sources */,
 				5641A18424A540C7004967E1 /* DatabaseWriterWritePublisherTests.swift in Sources */,
 				5641A00024A540A1004967E1 /* StatementArguments+FoundationTests.swift in Sources */,
@@ -1632,6 +1642,7 @@
 				5641A03924A540A1004967E1 /* VirtualTableModuleTests.swift in Sources */,
 				5641A02124A540A1004967E1 /* UpdateStatementTests.swift in Sources */,
 				5641A0E524A540A1004967E1 /* TransactionObserverSavepointsTests.swift in Sources */,
+				5623B6262AED3A2200436239 /* DatabaseQueueTemporaryCopyTests.swift in Sources */,
 				5641A00D24A540A1004967E1 /* DatabaseValueConversionErrorTests.swift in Sources */,
 				56419FD324A540A1004967E1 /* MutablePersistableRecordEncodableTests.swift in Sources */,
 				56419FD124A540A1004967E1 /* MutablePersistableRecordTests.swift in Sources */,
@@ -1706,6 +1717,7 @@
 				56419FED24A540A1004967E1 /* FTS4TableBuilderTests.swift in Sources */,
 				567B5C132AD32A0000629622 /* SharedValueObservationTests.swift in Sources */,
 				5641A18B24A540C7004967E1 /* DatabaseRegionObservationPublisherTests.swift in Sources */,
+				5623B6242AED3A2200436239 /* DatabaseQueueInMemoryCopyTests.swift in Sources */,
 				5641A05D24A540A1004967E1 /* ValueObservationRecordTests.swift in Sources */,
 				5641A18524A540C7004967E1 /* DatabaseWriterWritePublisherTests.swift in Sources */,
 				5641A00124A540A1004967E1 /* StatementArguments+FoundationTests.swift in Sources */,

--- a/Tests/GRDBTests/DatabaseQueueInMemoryCopyTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueInMemoryCopyTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+import GRDB
+
+private final class TestStream: TextOutputStream {
+    var output: String
+    
+    init() {
+        output = ""
+    }
+    
+    func write(_ string: String) {
+        output.append(string)
+    }
+}
+
+final class DatabaseQueueInMemoryCopyTests: GRDBTestCase {
+    private func makeSourceDatabase() throws -> DatabaseQueue {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("name", .text)
+                t.column("score", .integer)
+            }
+            try db.execute(sql: "INSERT INTO player VALUES (NULL, 'Arthur', 500)")
+            try db.execute(sql: "INSERT INTO player VALUES (NULL, 'Barbara', 1000)")
+        }
+        return dbQueue
+    }
+    
+    func test_inMemoryCopy() throws {
+        let source = try makeSourceDatabase()
+        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path)
+        
+        // Test that content was faithfully copied
+        let stream = TestStream()
+        try dbQueue.dumpContent(format: .quote(), to: stream)
+        XCTAssertEqual(stream.output, """
+            sqlite_master
+            CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+            
+            player
+            1,'Arthur',500
+            2,'Barbara',1000
+            
+            """)
+    }
+    
+    func test_inMemoryCopy_write() throws {
+        let source = try makeSourceDatabase()
+        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path)
+        
+        // The in-memory copy is writable (necessary for testing migrations)
+        try dbQueue.write { db in
+            try db.execute(sql: "INSERT INTO player VALUES (NULL, 'Craig', 200)")
+        }
+        let stream = TestStream()
+        try dbQueue.dumpContent(format: .quote(), to: stream)
+        XCTAssertEqual(stream.output, """
+            sqlite_master
+            CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+            
+            player
+            1,'Arthur',500
+            2,'Barbara',1000
+            3,'Craig',200
+            
+            """)
+    }
+    
+    func test_inMemoryCopy_readOnly() throws {
+        let source = try makeSourceDatabase()
+        var config = Configuration()
+        config.readonly = true
+        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path, configuration: config)
+        
+        // Test that the copy is read-only
+        XCTAssertThrowsError(try dbQueue.write { try $0.execute(sql: "DROP TABLE player") }) { error in
+            guard let dbError = error as? DatabaseError else {
+                XCTFail("Expected DatabaseError")
+                return
+            }
+            XCTAssertEqual(dbError.message, "attempt to write a readonly database")
+        }
+        
+        // Test that the copy is still read-only after a read
+        try dbQueue.read { _ in }
+        XCTAssertThrowsError(try dbQueue.write { try $0.execute(sql: "DROP TABLE player") }) { error in
+            guard let dbError = error as? DatabaseError else {
+                XCTFail("Expected DatabaseError")
+                return
+            }
+            XCTAssertEqual(dbError.message, "attempt to write a readonly database")
+        }
+        
+        // Test that content was faithfully copied
+        let stream = TestStream()
+        try dbQueue.dumpContent(format: .quote(), to: stream)
+        XCTAssertEqual(stream.output, """
+            sqlite_master
+            CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+            
+            player
+            1,'Arthur',500
+            2,'Barbara',1000
+            
+            """)
+    }
+    
+    func test_migrations_are_testable() throws {
+        // Given a migrator…
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("v1") { try $0.create(table: "team") { $0.autoIncrementedPrimaryKey("id") } }
+        migrator.registerMigration("v2") { try $0.create(table: "match") { $0.autoIncrementedPrimaryKey("id") } }
+        migrator.registerMigration("v3") { try $0.drop(table: "match") }
+        
+        // …GRDB users can test the migrator on fixtures
+        let source = try makeSourceDatabase()
+        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path)
+        
+        try migrator.migrate(dbQueue, upTo: "v2")
+        do {
+            let stream = TestStream()
+            try dbQueue.dumpContent(format: .quote(), to: stream)
+            XCTAssertEqual(stream.output, """
+                sqlite_master
+                CREATE TABLE "match" ("id" INTEGER PRIMARY KEY AUTOINCREMENT);
+                CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+                CREATE TABLE "team" ("id" INTEGER PRIMARY KEY AUTOINCREMENT);
+                
+                match
+                
+                player
+                1,'Arthur',500
+                2,'Barbara',1000
+                
+                team
+                
+                """)
+        }
+        
+        try migrator.migrate(dbQueue, upTo: "v3")
+        do {
+            let stream = TestStream()
+            try dbQueue.dumpContent(format: .quote(), to: stream)
+            XCTAssertEqual(stream.output, """
+                sqlite_master
+                CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+                CREATE TABLE "team" ("id" INTEGER PRIMARY KEY AUTOINCREMENT);
+                
+                player
+                1,'Arthur',500
+                2,'Barbara',1000
+                
+                team
+                
+                """)
+        }
+    }
+}

--- a/Tests/GRDBTests/DatabaseQueueInMemoryCopyTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueInMemoryCopyTests.swift
@@ -30,7 +30,9 @@ final class DatabaseQueueInMemoryCopyTests: GRDBTestCase {
     
     func test_inMemoryCopy() throws {
         let source = try makeSourceDatabase()
-        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path)
+        let dbQueue = try DatabaseQueue.inMemoryCopy(
+            fromPath: source.path,
+            configuration: dbConfiguration)
         
         // Test that content was faithfully copied
         let stream = TestStream()
@@ -48,7 +50,9 @@ final class DatabaseQueueInMemoryCopyTests: GRDBTestCase {
     
     func test_inMemoryCopy_write() throws {
         let source = try makeSourceDatabase()
-        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path)
+        let dbQueue = try DatabaseQueue.inMemoryCopy(
+            fromPath: source.path,
+            configuration: dbConfiguration)
         
         // The in-memory copy is writable (necessary for testing migrations)
         try dbQueue.write { db in
@@ -70,7 +74,7 @@ final class DatabaseQueueInMemoryCopyTests: GRDBTestCase {
     
     func test_inMemoryCopy_readOnly() throws {
         let source = try makeSourceDatabase()
-        var config = Configuration()
+        var config = dbConfiguration!
         config.readonly = true
         let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path, configuration: config)
         
@@ -116,7 +120,9 @@ final class DatabaseQueueInMemoryCopyTests: GRDBTestCase {
         
         // …GRDB users can test the migrator on fixtures
         let source = try makeSourceDatabase()
-        let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: source.path)
+        let dbQueue = try DatabaseQueue.inMemoryCopy(
+            fromPath: source.path,
+            configuration: dbConfiguration)
         
         try migrator.migrate(dbQueue, upTo: "v2")
         do {

--- a/Tests/GRDBTests/DatabaseQueueTemporaryCopyTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTemporaryCopyTests.swift
@@ -1,0 +1,160 @@
+import XCTest
+import GRDB
+
+private final class TestStream: TextOutputStream {
+    var output: String
+    
+    init() {
+        output = ""
+    }
+    
+    func write(_ string: String) {
+        output.append(string)
+    }
+}
+
+final class DatabaseQueueTemporaryCopyTests: GRDBTestCase {
+    private func makeSourceDatabase() throws -> DatabaseQueue {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.write { db in
+            try db.create(table: "player") { t in
+                t.autoIncrementedPrimaryKey("id")
+                t.column("name", .text)
+                t.column("score", .integer)
+            }
+            try db.execute(sql: "INSERT INTO player VALUES (NULL, 'Arthur', 500)")
+            try db.execute(sql: "INSERT INTO player VALUES (NULL, 'Barbara', 1000)")
+        }
+        return dbQueue
+    }
+    
+    func test_temporaryCopy() throws {
+        let source = try makeSourceDatabase()
+        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path)
+        
+        // Test that content was faithfully copied
+        let stream = TestStream()
+        try dbQueue.dumpContent(format: .quote(), to: stream)
+        XCTAssertEqual(stream.output, """
+            sqlite_master
+            CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+            
+            player
+            1,'Arthur',500
+            2,'Barbara',1000
+            
+            """)
+    }
+    
+    func test_temporaryCopy_write() throws {
+        let source = try makeSourceDatabase()
+        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path)
+        
+        // The in-memory copy is writable (necessary for testing migrations)
+        try dbQueue.write { db in
+            try db.execute(sql: "INSERT INTO player VALUES (NULL, 'Craig', 200)")
+        }
+        let stream = TestStream()
+        try dbQueue.dumpContent(format: .quote(), to: stream)
+        XCTAssertEqual(stream.output, """
+            sqlite_master
+            CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+            
+            player
+            1,'Arthur',500
+            2,'Barbara',1000
+            3,'Craig',200
+            
+            """)
+    }
+    
+    func test_temporaryCopy_readOnly() throws {
+        let source = try makeSourceDatabase()
+        var config = Configuration()
+        config.readonly = true
+        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path, configuration: config)
+        
+        // Test that the copy is read-only
+        XCTAssertThrowsError(try dbQueue.write { try $0.execute(sql: "DROP TABLE player") }) { error in
+            guard let dbError = error as? DatabaseError else {
+                XCTFail("Expected DatabaseError")
+                return
+            }
+            XCTAssertEqual(dbError.message, "attempt to write a readonly database")
+        }
+        
+        // Test that the copy is still read-only after a read
+        try dbQueue.read { _ in }
+        XCTAssertThrowsError(try dbQueue.write { try $0.execute(sql: "DROP TABLE player") }) { error in
+            guard let dbError = error as? DatabaseError else {
+                XCTFail("Expected DatabaseError")
+                return
+            }
+            XCTAssertEqual(dbError.message, "attempt to write a readonly database")
+        }
+        
+        // Test that content was faithfully copied
+        let stream = TestStream()
+        try dbQueue.dumpContent(format: .quote(), to: stream)
+        XCTAssertEqual(stream.output, """
+            sqlite_master
+            CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+            
+            player
+            1,'Arthur',500
+            2,'Barbara',1000
+            
+            """)
+    }
+    
+    func test_migrations_are_testable() throws {
+        // Given a migrator…
+        var migrator = DatabaseMigrator()
+        migrator.registerMigration("v1") { try $0.create(table: "team") { $0.autoIncrementedPrimaryKey("id") } }
+        migrator.registerMigration("v2") { try $0.create(table: "match") { $0.autoIncrementedPrimaryKey("id") } }
+        migrator.registerMigration("v3") { try $0.drop(table: "match") }
+        
+        // …GRDB users can test the migrator on fixtures
+        let source = try makeSourceDatabase()
+        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path)
+        
+        try migrator.migrate(dbQueue, upTo: "v2")
+        do {
+            let stream = TestStream()
+            try dbQueue.dumpContent(format: .quote(), to: stream)
+            XCTAssertEqual(stream.output, """
+                sqlite_master
+                CREATE TABLE "match" ("id" INTEGER PRIMARY KEY AUTOINCREMENT);
+                CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+                CREATE TABLE "team" ("id" INTEGER PRIMARY KEY AUTOINCREMENT);
+                
+                match
+                
+                player
+                1,'Arthur',500
+                2,'Barbara',1000
+                
+                team
+                
+                """)
+        }
+        
+        try migrator.migrate(dbQueue, upTo: "v3")
+        do {
+            let stream = TestStream()
+            try dbQueue.dumpContent(format: .quote(), to: stream)
+            XCTAssertEqual(stream.output, """
+                sqlite_master
+                CREATE TABLE "player" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "score" INTEGER);
+                CREATE TABLE "team" ("id" INTEGER PRIMARY KEY AUTOINCREMENT);
+                
+                player
+                1,'Arthur',500
+                2,'Barbara',1000
+                
+                team
+                
+                """)
+        }
+    }
+}

--- a/Tests/GRDBTests/DatabaseQueueTemporaryCopyTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTemporaryCopyTests.swift
@@ -30,7 +30,9 @@ final class DatabaseQueueTemporaryCopyTests: GRDBTestCase {
     
     func test_temporaryCopy() throws {
         let source = try makeSourceDatabase()
-        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path)
+        let dbQueue = try DatabaseQueue.temporaryCopy(
+            fromPath: source.path,
+            configuration: dbConfiguration)
         
         // Test that content was faithfully copied
         let stream = TestStream()
@@ -48,7 +50,9 @@ final class DatabaseQueueTemporaryCopyTests: GRDBTestCase {
     
     func test_temporaryCopy_write() throws {
         let source = try makeSourceDatabase()
-        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path)
+        let dbQueue = try DatabaseQueue.temporaryCopy(
+            fromPath: source.path,
+            configuration: dbConfiguration)
         
         // The in-memory copy is writable (necessary for testing migrations)
         try dbQueue.write { db in
@@ -70,7 +74,7 @@ final class DatabaseQueueTemporaryCopyTests: GRDBTestCase {
     
     func test_temporaryCopy_readOnly() throws {
         let source = try makeSourceDatabase()
-        var config = Configuration()
+        var config = dbConfiguration!
         config.readonly = true
         let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path, configuration: config)
         
@@ -116,7 +120,9 @@ final class DatabaseQueueTemporaryCopyTests: GRDBTestCase {
         
         // …GRDB users can test the migrator on fixtures
         let source = try makeSourceDatabase()
-        let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: source.path)
+        let dbQueue = try DatabaseQueue.temporaryCopy(
+            fromPath: source.path,
+            configuration: dbConfiguration)
         
         try migrator.migrate(dbQueue, upTo: "v2")
         do {


### PR DESCRIPTION
This pull requests adds two convenience methods that create temporary copies of databases:

```swift
let path = "/path/to/database.sqlite"
let dbQueue = try DatabaseQueue.inMemoryCopy(fromPath: path)
let dbQueue = try DatabaseQueue.temporaryCopy(fromPath: path)
```

Those have originally lived in [GRDBSnapshotTesting](http://github.com/groue/GRDBSnapshotTesting), but people who want to test databases without GRDBSnapshotTesting might like those methods. Their implementation is more robust as well, with better support for the `readonly` configuration flag.