### PR TITLE
SQLite 3.44.0, FILTER and ORDER BY clauses in aggregate functions

### DIFF
--- a/Documentation/CustomSQLiteBuilds.md
+++ b/Documentation/CustomSQLiteBuilds.md
@@ -3,7 +3,7 @@ Custom SQLite Builds
 
 By default, GRDB uses the version of SQLite that ships with the target operating system.
 
-**You can build GRDB with a custom build of [SQLite 3.42.0](https://www.sqlite.org/changes.html).**
+**You can build GRDB with a custom build of [SQLite 3.44.0](https://www.sqlite.org/changes.html).**
 
 A custom SQLite build can activate extra SQLite features, and extra GRDB features as well, such as support for the [FTS5 full-text search engine](../../../#full-text-search), and [SQLite Pre-Update Hooks](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/transactionobserver).
 

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -144,6 +144,7 @@ public final class DatabaseFunction: Hashable {
         self.kind = .aggregate { Aggregate() }
     }
     
+    // TODO: GRDB7 -> expose ORDER BY and FILTER when we have distinct types for simple functions and aggregates.
     /// Returns an SQL expression that applies the function.
     ///
     /// You can use a `DatabaseFunction` as a regular Swift function. It returns

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -34,19 +34,6 @@ public final class DatabaseFunction: Hashable {
     private let kind: Kind
     private var eTextRep: CInt { (SQLITE_UTF8 | (isPure ? SQLITE_DETERMINISTIC : 0)) }
     
-    var functionFlags: SQLFunctionFlags {
-        var flags = SQLFunctionFlags(isPure: isPure)
-        
-        switch kind {
-        case .function:
-            break
-        case .aggregate:
-            flags.isAggregate = true
-        }
-        
-        return flags
-    }
-    
     /// Creates an SQL function.
     ///
     /// For example:
@@ -183,9 +170,24 @@ public final class DatabaseFunction: Hashable {
     /// }
     /// ```
     public func callAsFunction(_ arguments: any SQLExpressible...) -> SQLExpression {
-        .function(name, arguments.map(\.sqlExpression), flags: functionFlags)
+        switch kind {
+        case .function:
+            return .simpleFunction(
+                name,
+                arguments.map(\.sqlExpression),
+                isPure: isPure,
+                isJSONValue: false)
+        case .aggregate:
+            return .aggregateFunction(
+                name,
+                arguments.map(\.sqlExpression),
+                isDistinct: false,
+                ordering: nil,
+                filter: nil,
+                isJSONValue: false)
+        }
     }
-
+    
     /// Calls sqlite3_create_function_v2
     /// See <https://sqlite.org/c3ref/create_function.html>
     func install(in db: Database) {

--- a/GRDB/Documentation.docc/JSON.md
+++ b/GRDB/Documentation.docc/JSON.md
@@ -133,8 +133,8 @@ The `->` and `->>` SQL operators are available on the ``SQLJSONExpressible`` pro
 - ``Database/jsonArray(_:)-469db``
 - ``Database/jsonObject(_:)``
 - ``Database/jsonQuote(_:)``
-- ``Database/jsonGroupArray(_:)``
-- ``Database/jsonGroupObject(key:value:)``
+- ``Database/jsonGroupArray(_:filter:)``
+- ``Database/jsonGroupObject(key:value:filter:)``
 
 ### Modify JSON values at the SQL level
 

--- a/GRDB/JSON/SQLJSONFunctions.swift
+++ b/GRDB/JSON/SQLJSONFunctions.swift
@@ -374,15 +374,32 @@ extension Database {
     /// The `JSON_GROUP_ARRAY` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
-    public static func jsonGroupArray(_ value: some SQLExpressible) -> SQLExpression {
-        .function("JSON_GROUP_ARRAY", [value.sqlExpression.jsonBuilderExpression])
+    public static func jsonGroupArray(
+        _ value: some SQLExpressible,
+        orderBy ordering: (any SQLOrderingTerm)? = nil,
+        filter: (any SQLSpecificExpressible)? = nil)
+    -> SQLExpression {
+        .aggregateFunction(
+            "JSON_GROUP_ARRAY",
+            [value.sqlExpression.jsonBuilderExpression],
+            ordering: ordering?.sqlOrdering,
+            filter: filter?.sqlExpression,
+            isJSONValue: true)
     }
     
     /// The `JSON_GROUP_OBJECT` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
-    public static func jsonGroupObject(key: some SQLExpressible, value: some SQLExpressible) -> SQLExpression {
-        .function("JSON_GROUP_OBJECT", [key.sqlExpression, value.sqlExpression.jsonBuilderExpression])
+    public static func jsonGroupObject(
+        key: some SQLExpressible,
+        value: some SQLExpressible,
+        filter: (any SQLSpecificExpressible)? = nil
+    ) -> SQLExpression {
+        .aggregateFunction(
+            "JSON_GROUP_OBJECT",
+            [key.sqlExpression, value.sqlExpression.jsonBuilderExpression],
+            filter: filter?.sqlExpression,
+            isJSONValue: true)
     }
 }
 #else
@@ -781,16 +798,31 @@ extension Database {
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
-    public static func jsonGroupArray(_ value: some SQLExpressible) -> SQLExpression {
-        .function("JSON_GROUP_ARRAY", [value.sqlExpression.jsonBuilderExpression])
+    public static func jsonGroupArray(
+        _ value: some SQLExpressible,
+        filter: (any SQLSpecificExpressible)? = nil)
+    -> SQLExpression {
+        .aggregateFunction(
+            "JSON_GROUP_ARRAY",
+            [value.sqlExpression.jsonBuilderExpression],
+            filter: filter?.sqlExpression,
+            isJSONValue: true)
     }
     
     /// The `JSON_GROUP_OBJECT` SQL function.
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
-    public static func jsonGroupObject(key: some SQLExpressible, value: some SQLExpressible) -> SQLExpression {
-        .function("JSON_GROUP_OBJECT", [key.sqlExpression, value.sqlExpression.jsonBuilderExpression])
+    public static func jsonGroupObject(
+        key: some SQLExpressible,
+        value: some SQLExpressible,
+        filter: (any SQLSpecificExpressible)? = nil
+    ) -> SQLExpression {
+        .aggregateFunction(
+            "JSON_GROUP_OBJECT",
+            [key.sqlExpression, value.sqlExpression.jsonBuilderExpression],
+            filter: filter?.sqlExpression,
+            isJSONValue: true)
     }
 }
 #endif

--- a/GRDB/JSON/SQLJSONFunctions.swift
+++ b/GRDB/JSON/SQLJSONFunctions.swift
@@ -373,6 +373,19 @@ extension Database {
     
     /// The `JSON_GROUP_ARRAY` SQL function.
     ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT JSON_GROUP_ARRAY(name) FROM player
+    /// Player.select(Database.jsonGroupArray(Column("name")))
+    ///
+    /// // SELECT JSON_GROUP_ARRAY(name) FILTER (WHERE score > 0) FROM player
+    /// Player.select(Database.jsonGroupArray(Column("name"), filter: Column("score") > 0))
+    ///
+    /// // SELECT JSON_GROUP_ARRAY(name ORDER BY name) FROM player
+    /// Player.select(Database.jsonGroupArray(Column("name"), orderBy: Column("name")))
+    /// ```
+    ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
     public static func jsonGroupArray(
         _ value: some SQLExpressible,
@@ -388,6 +401,21 @@ extension Database {
     }
     
     /// The `JSON_GROUP_OBJECT` SQL function.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT JSON_GROUP_OBJECT(name, score) FROM player
+    /// Player.select(Database.jsonGroupObject(
+    ///     key: Column("name"),
+    ///     value: Column("score")))
+    ///
+    /// // SELECT JSON_GROUP_OBJECT(name, score) FILTER (WHERE score > 0) FROM player
+    /// Player.select(Database.jsonGroupObject(
+    ///     key: Column("name"),
+    ///     value: Column("score"),
+    ///     filter: Column("score") > 0))
+    /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
     public static func jsonGroupObject(
@@ -796,6 +824,16 @@ extension Database {
     
     /// The `JSON_GROUP_ARRAY` SQL function.
     ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT JSON_GROUP_ARRAY(name) FROM player
+    /// Player.select(Database.jsonGroupArray(Column("name")))
+    ///
+    /// // SELECT JSON_GROUP_ARRAY(name) FILTER (WHERE score > 0) FROM player
+    /// Player.select(Database.jsonGroupArray(Column("name"), filter: Column("score") > 0))
+    /// ```
+    ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS
     public static func jsonGroupArray(
@@ -810,6 +848,21 @@ extension Database {
     }
     
     /// The `JSON_GROUP_OBJECT` SQL function.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT JSON_GROUP_OBJECT(name, score) FROM player
+    /// Player.select(Database.jsonGroupObject(
+    ///     key: Column("name"),
+    ///     value: Column("score")))
+    ///
+    /// // SELECT JSON_GROUP_OBJECT(name, score) FILTER (WHERE score > 0) FROM player
+    /// Player.select(Database.jsonGroupObject(
+    ///     key: Column("name"),
+    ///     value: Column("score"),
+    ///     filter: Column("score") > 0))
+    /// ```
     ///
     /// Related SQLite documentation: <https://www.sqlite.org/json1.html#jgrouparray>
     @available(iOS 16, macOS 10.15, tvOS 17, watchOS 9, *) // SQLite 3.38+ with exceptions for macOS

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -2144,6 +2144,7 @@ extension SQLExpressible where Self == Column {
 ///
 /// - ``abs(_:)-5l6xp``
 /// - ``average(_:)``
+/// - ``average(_:filter:)``
 /// - ``capitalized``
 /// - ``count(_:)``
 /// - ``count(distinct:)``
@@ -2156,9 +2157,13 @@ extension SQLExpressible where Self == Column {
 /// - ``localizedUppercased``
 /// - ``lowercased``
 /// - ``min(_:)``
+/// - ``min(_:filter:)``
 /// - ``max(_:)``
+/// - ``max(_:filter:)``
 /// - ``sum(_:)``
+/// - ``sum(_:filter:)``
 /// - ``total(_:)``
+/// - ``total(_:filter:)``
 /// - ``uppercased``
 /// - ``SQLDateModifier``
 ///

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -10,6 +10,40 @@ public func abs(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .function("ABS", [value.sqlExpression])
 }
 
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// The `AVG` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // AVG(length)
+/// average(Column("length"))
+/// ```
+public func average(
+    _ value: some SQLSpecificExpressible,
+    filter: (any SQLSpecificExpressible)? = nil)
+-> SQLExpression {
+    .aggregateFunction("AVG", [value.sqlExpression], filter: filter?.sqlExpression)
+}
+#else
+/// The `AVG` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // AVG(length) FILTER (WHERE length > 0)
+/// average(Column("length"), filter: Column("length") > 0)
+/// ```
+@available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) // SQLite 3.30+
+public func average(
+    _ value: some SQLSpecificExpressible,
+    filter: some SQLSpecificExpressible)
+-> SQLExpression {
+    .aggregateFunction(
+        "AVG", [value.sqlExpression],
+        filter: filter.sqlExpression)
+}
+
 /// The `AVG` SQL function.
 ///
 /// For example:
@@ -19,8 +53,9 @@ public func abs(_ value: some SQLSpecificExpressible) -> SQLExpression {
 /// average(Column("length"))
 /// ```
 public func average(_ value: some SQLSpecificExpressible) -> SQLExpression {
-    .function("AVG", [value.sqlExpression])
+    .aggregateFunction("AVG", [value.sqlExpression])
 }
+#endif
 
 /// The `COUNT` SQL function.
 ///
@@ -72,6 +107,38 @@ public func length(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .function("LENGTH", [value.sqlExpression])
 }
 
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// The `MAX` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // MAX(score)
+/// max(Column("score"))
+/// ```
+public func max(
+    _ value: some SQLSpecificExpressible,
+    filter: (any SQLSpecificExpressible)? = nil)
+-> SQLExpression {
+    .aggregateFunction("MAX", [value.sqlExpression], filter: filter?.sqlExpression)
+}
+#else
+/// The `MAX` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // MAX(score) FILTER (WHERE score < 0)
+/// max(Column("score"), filter: Column("score") < 0)
+/// ```
+@available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) // SQLite 3.30+
+public func max(
+    _ value: some SQLSpecificExpressible,
+    filter: some SQLSpecificExpressible)
+-> SQLExpression {
+    .aggregateFunction("MAX", [value.sqlExpression], filter: filter.sqlExpression)
+}
+
 /// The `MAX` SQL function.
 ///
 /// For example:
@@ -81,7 +148,40 @@ public func length(_ value: some SQLSpecificExpressible) -> SQLExpression {
 /// max(Column("score"))
 /// ```
 public func max(_ value: some SQLSpecificExpressible) -> SQLExpression {
-    .function("MAX", [value.sqlExpression])
+    .aggregateFunction("MAX", [value.sqlExpression])
+}
+#endif
+
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// The `MIN` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // MIN(score)
+/// min(Column("score"))
+/// ```
+public func min(
+    _ value: some SQLSpecificExpressible,
+    filter: (any SQLSpecificExpressible)? = nil) 
+-> SQLExpression {
+    .aggregateFunction("MIN", [value.sqlExpression], filter: filter?.sqlExpression)
+}
+#else
+/// The `MIN` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // MIN(score) FILTER (WHERE score > 0)
+/// min(Column("score"), filter: Column("score") > 0)
+/// ```
+@available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) // SQLite 3.30+
+public func min(
+    _ value: some SQLSpecificExpressible,
+    filter: some SQLSpecificExpressible)
+-> SQLExpression {
+    .aggregateFunction("MIN", [value.sqlExpression], filter: filter.sqlExpression)
 }
 
 /// The `MIN` SQL function.
@@ -93,7 +193,55 @@ public func max(_ value: some SQLSpecificExpressible) -> SQLExpression {
 /// min(Column("score"))
 /// ```
 public func min(_ value: some SQLSpecificExpressible) -> SQLExpression {
-    .function("MIN", [value.sqlExpression])
+    .aggregateFunction("MIN", [value.sqlExpression])
+}
+#endif
+
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// The `SUM` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // SUM(amount)
+/// sum(Column("amount"))
+/// ```
+///
+/// See also ``total(_:)``.
+///
+/// Related SQLite documentation: <https://www.sqlite.org/lang_aggfunc.html#sumunc>.
+public func sum(
+    _ value: some SQLSpecificExpressible,
+    orderBy ordering: (any SQLOrderingTerm)? = nil,
+    filter: (any SQLSpecificExpressible)? = nil)
+-> SQLExpression
+{
+    .aggregateFunction(
+        "SUM", [value.sqlExpression],
+        ordering: ordering?.sqlOrdering,
+        filter: filter?.sqlExpression)
+}
+#else
+/// The `SUM` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // SUM(amount) FILTER (WHERE amount > 0)
+/// sum(Column("amount"), filter: Column("amount") > 0)
+/// ```
+///
+/// See also ``total(_:)``.
+///
+/// Related SQLite documentation: <https://www.sqlite.org/lang_aggfunc.html#sumunc>.
+@available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) // SQLite 3.30+
+public func sum(
+    _ value: some SQLSpecificExpressible,
+    filter: some SQLSpecificExpressible)
+-> SQLExpression {
+    .aggregateFunction(
+        "SUM", [value.sqlExpression],
+        filter: filter.sqlExpression)
 }
 
 /// The `SUM` SQL function.
@@ -109,7 +257,55 @@ public func min(_ value: some SQLSpecificExpressible) -> SQLExpression {
 ///
 /// Related SQLite documentation: <https://www.sqlite.org/lang_aggfunc.html#sumunc>.
 public func sum(_ value: some SQLSpecificExpressible) -> SQLExpression {
-    .function("SUM", [value.sqlExpression])
+    .aggregateFunction("SUM", [value.sqlExpression])
+}
+#endif
+
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+/// The `TOTAL` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // TOTAL(amount)
+/// total(Column("amount"))
+/// ```
+///
+/// See also ``sum(_:)``.
+///
+/// Related SQLite documentation: <https://www.sqlite.org/lang_aggfunc.html#sumunc>.
+public func total(
+    _ value: some SQLSpecificExpressible,
+    orderBy ordering: (any SQLOrderingTerm)? = nil,
+    filter: (any SQLSpecificExpressible)? = nil)
+-> SQLExpression
+{
+    .aggregateFunction(
+        "TOTAL", [value.sqlExpression],
+        ordering: ordering?.sqlOrdering,
+        filter: filter?.sqlExpression)
+}
+#else
+/// The `TOTAL` SQL function.
+///
+/// For example:
+///
+/// ```swift
+/// // TOTAL(amount) FILTER (WHERE amount > 0)
+/// total(Column("amount"), filter: Column("amount") > 0)
+/// ```
+///
+/// See also ``total(_:)``.
+///
+/// Related SQLite documentation: <https://www.sqlite.org/lang_aggfunc.html#sumunc>.
+@available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) // SQLite 3.30+
+public func total(
+    _ value: some SQLSpecificExpressible,
+    filter: some SQLSpecificExpressible)
+-> SQLExpression {
+    .aggregateFunction(
+        "TOTAL", [value.sqlExpression],
+        filter: filter.sqlExpression)
 }
 
 /// The `TOTAL` SQL function.
@@ -125,8 +321,9 @@ public func sum(_ value: some SQLSpecificExpressible) -> SQLExpression {
 ///
 /// Related SQLite documentation: <https://www.sqlite.org/lang_aggfunc.html#sumunc>.
 public func total(_ value: some SQLSpecificExpressible) -> SQLExpression {
-    .function("TOTAL", [value.sqlExpression])
+    .aggregateFunction("TOTAL", [value.sqlExpression])
 }
+#endif
 
 // MARK: - String functions
 

--- a/Tests/GRDBTests/JSONExpressionsTests.swift
+++ b/Tests/GRDBTests/JSONExpressionsTests.swift
@@ -1245,7 +1245,7 @@ final class JSONExpressionsTests: GRDBTestCase {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
     func test_Database_jsonGroupArray_order() throws {
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard sqlite3_libversion_number() >= 3044000 else {
             throw XCTSkip("JSON support is not available")
         }
         

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1505,6 +1505,28 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT AVG(\"age\" / 2) FROM \"readers\"")
     }
     
+    func testAvgExpression_filter() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3030000 else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #else
+        guard #available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(average(Col.age, filter: Col.age > 0))),
+            "SELECT AVG(\"age\") FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(average(Col.age / 2, filter: Col.age > 0))),
+            "SELECT AVG(\"age\" / 2) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+    }
+
     func testLengthExpression() throws {
         let dbQueue = try makeDatabaseQueue()
         
@@ -1524,6 +1546,28 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT MIN(\"age\" / 2) FROM \"readers\"")
     }
     
+    func testMinExpression_filter() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3030000 else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #else
+        guard #available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(min(Col.age, filter: Col.age > 0))),
+            "SELECT MIN(\"age\") FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(min(Col.age / 2, filter: Col.age > 0))),
+            "SELECT MIN(\"age\" / 2) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+    }
+    
     func testMaxExpression() throws {
         let dbQueue = try makeDatabaseQueue()
         
@@ -1533,6 +1577,28 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
         XCTAssertEqual(
             sql(dbQueue, tableRequest.select(max(Col.age / 2))),
             "SELECT MAX(\"age\" / 2) FROM \"readers\"")
+    }
+    
+    func testMaxExpression_filter() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3030000 else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #else
+        guard #available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(max(Col.age, filter: Col.age < 0))),
+            "SELECT MAX(\"age\") FILTER (WHERE \"age\" < 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(max(Col.age / 2, filter: Col.age < 0))),
+            "SELECT MAX(\"age\" / 2) FILTER (WHERE \"age\" < 0) FROM \"readers\"")
     }
     
     func testSumExpression() throws {
@@ -1546,6 +1612,52 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT SUM(\"age\" / 2) FROM \"readers\"")
     }
     
+    func testSumExpression_filter() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3030000 else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #else
+        guard #available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(sum(Col.age, filter: Col.age > 0))),
+            "SELECT SUM(\"age\") FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(sum(Col.age / 2, filter: Col.age > 0))),
+            "SELECT SUM(\"age\" / 2) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+    }
+    
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+    func testSumExpression_order() throws {
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3044000 else {
+            throw XCTSkip("ORDER BY clause on aggregate functions is not available")
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(sum(Col.age, orderBy: Col.age))),
+            "SELECT SUM(\"age\" ORDER BY \"age\") FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(sum(Col.age / 2, orderBy: Col.age.desc))),
+            "SELECT SUM(\"age\" / 2 ORDER BY \"age\" DESC) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(sum(Col.age, orderBy: Col.age, filter: Col.age > 0))),
+            "SELECT SUM(\"age\" ORDER BY \"age\") FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(sum(Col.age / 2, orderBy: Col.age.desc, filter: Col.age > 0))),
+            "SELECT SUM(\"age\" / 2 ORDER BY \"age\" DESC) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+    }
+#endif
+    
     func testTotalExpression() throws {
         let dbQueue = try makeDatabaseQueue()
         
@@ -1557,6 +1669,51 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT TOTAL(\"age\" / 2) FROM \"readers\"")
     }
     
+    func testTotalExpression_filter() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3030000 else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #else
+        guard #available(iOS 14, macOS 10.16, tvOS 14, watchOS 7, *) else {
+            throw XCTSkip("FILTER clause on aggregate functions is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(total(Col.age, filter: Col.age > 0))),
+            "SELECT TOTAL(\"age\") FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(total(Col.age / 2, filter: Col.age > 0))),
+            "SELECT TOTAL(\"age\" / 2) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+    }
+    
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+    func testTotalExpression_order() throws {
+        // Prevent SQLCipher failures
+        guard sqlite3_libversion_number() >= 3044000 else {
+            throw XCTSkip("ORDER BY clause on aggregate functions is not available")
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(total(Col.age, orderBy: Col.age))),
+            "SELECT TOTAL(\"age\" ORDER BY \"age\") FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(total(Col.age / 2, orderBy: Col.age.desc))),
+            "SELECT TOTAL(\"age\" / 2 ORDER BY \"age\" DESC) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(total(Col.age, orderBy: Col.age, filter: Col.age > 0))),
+            "SELECT TOTAL(\"age\" ORDER BY \"age\") FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(total(Col.age / 2, orderBy: Col.age.desc, filter: Col.age > 0))),
+            "SELECT TOTAL(\"age\" / 2 ORDER BY \"age\" DESC) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
+    }
+#endif
     
     // MARK: - LIKE operator
     


### PR DESCRIPTION
This pull request bumps custom SQLite builds to [SQLite 3.44.0](https://www.sqlite.org/releaselog/3_44_0.html).

It also brings support for `FILTER` and `ORDER BY` clauses in aggregate functions, with the `filter` and `orderBy` arguments (available depending on the SQLite and operating system versions).

For example:

```swift
// SELECT JSON_GROUP_ARRAY(name) FROM player
Player.select(Database.jsonGroupArray(Column("name")))

// SELECT JSON_GROUP_ARRAY(name) FILTER (WHERE score > 0) FROM player
Player.select(Database.jsonGroupArray(Column("name"), filter: Column("score") > 0))

// SELECT JSON_GROUP_ARRAY(name ORDER BY name) FROM player
Player.select(Database.jsonGroupArray(Column("name"), orderBy: Column("name")))
```
