### PR TITLE
Explicit change notifications

### DIFF
--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -57,6 +57,14 @@ extension Database {
             case let .attached(name): return "\(name).sqlite_master"
             }
         }
+        
+        /// The name of the master sqlite table, without the schema name.
+        var unqualifiedMasterTableName: String { // swiftlint:disable:this inclusive_language
+            switch self {
+            case .main, .attached: return "sqlite_master"
+            case .temp: return "sqlite_temp_master"
+            }
+        }
     }
     
     /// The identifier of a database table or view.
@@ -658,8 +666,16 @@ extension Database {
     /// attached database.
     func canonicalTableName(_ tableName: String) throws -> String? {
         for schemaIdentifier in try schemaIdentifiers() {
+            // Regular tables
             if let result = try schema(schemaIdentifier).canonicalName(tableName, ofType: .table) {
                 return result
+            }
+            
+            // Master table (sqlite_master, sqlite_temp_master)
+            // swiftlint:disable:next inclusive_language
+            let masterTableName = schemaIdentifier.unqualifiedMasterTableName
+            if tableName.lowercased() == masterTableName.lowercased() {
+                return masterTableName
             }
         }
         return nil

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -1367,7 +1367,7 @@ struct SchemaObject: Hashable, FetchableRecord {
 
 /// All objects in a database schema (tables, views, indexes, triggers).
 struct SchemaInfo: Equatable {
-    private var objects: Set<SchemaObject>
+    let objects: Set<SchemaObject>
     
     /// Returns whether there exists a object of given type with this name
     /// (case-insensitive).

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -838,10 +838,10 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     ///
     /// ```swift
     /// try dbQueue.write { db in
-    ///     // Notify all observers of regular tables
+    ///     // Notify observers that some changes were performed in the database
     ///     try db.notifyChanges(in: .fullDatabase)
     ///
-    ///     // Notify all observers of the player table
+    ///     // Notify observers that some changes were performed in the player table
     ///     try db.notifyChanges(in: Player.all())
     ///
     ///     // Equivalent alternative

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -820,6 +820,52 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         }
     }
     
+    /// Notifies that some changes were performed in the provided
+    /// database region.
+    ///
+    /// This method makes it possible to notify undetected changes, such as
+    /// changes performed by another process, changes performed by
+    /// direct calls to SQLite C functions, or changes to the
+    /// database schema.
+    /// See <doc:GRDB/TransactionObserver#Dealing-with-Undetected-Changes>
+    /// for a detailed list of undetected database modifications.
+    ///
+    /// It triggers active transaction observers (``TransactionObserver``).
+    /// In particular, ``ValueObservation`` that observe the input `region`
+    /// will fetch and notify a fresh value.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try dbQueue.write { db in
+    ///     // Notify all observers of regular tables
+    ///     try db.notifyChanges(in: .fullDatabase)
+    ///
+    ///     // Notify all observers of the player table
+    ///     try db.notifyChanges(in: Player.all())
+    ///
+    ///     // Equivalent alternative
+    ///     try db.notifyChanges(in: Table("player"))
+    /// }
+    /// ```
+    ///
+    /// This method has no effect when called from a read-only
+    /// database access.
+    ///
+    /// > Caveat: Individual rowids in the input region are ignored.
+    /// > Notifying a change to a specific rowid is the same as notifying a
+    /// > change in the whole table:
+    /// >
+    /// > ```swift
+    /// > try dbQueue.write { db in
+    /// >     // Equivalent
+    /// >     try db.notifyChanges(in: Player.all())
+    /// >     try db.notifyChanges(in: Player.filter(id: 1))
+    /// > }
+    /// > ```
+    public func notifyChanges(in region: some DatabaseRegionConvertible) throws {
+    }
+    
     /// Extends the `region` argument with the database region selected by all
     /// statements executed by the closure, and all regions explicitly tracked
     /// with the ``registerAccess(to:)`` method.

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -79,6 +79,7 @@ let SQLITE_TRANSIENT = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_
 /// - ``add(transactionObserver:extent:)``
 /// - ``remove(transactionObserver:)``
 /// - ``afterNextTransaction(onCommit:onRollback:)``
+/// - ``notifyChanges(in:)``
 /// - ``registerAccess(to:)``
 ///
 /// ### Collations

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -864,6 +864,12 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// > }
     /// > ```
     public func notifyChanges(in region: some DatabaseRegionConvertible) throws {
+        // Don't do anything when read-only, because read-only transactions
+        // are not notified. We don't want to notify transactions observers
+        // of changes, and have them wait for a commit that will never come!
+        if !isReadOnly {
+            try observationBroker?.notifyChanges(in: region.databaseRegion(self))
+        }
     }
     
     /// Extends the `region` argument with the database region selected by all

--- a/GRDB/Core/DatabaseRegionObservation.swift
+++ b/GRDB/Core/DatabaseRegionObservation.swift
@@ -161,6 +161,11 @@ private class DatabaseRegionObserver: TransactionObserver {
         region.isModified(byEventsOfKind: eventKind)
     }
     
+    func databaseDidChange() {
+        isChanged = true
+        stopObservingDatabaseChangesUntilNextTransaction()
+    }
+    
     func databaseDidChange(with event: DatabaseEvent) {
         if region.isModified(by: event) {
             isChanged = true

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -282,12 +282,7 @@ class DatabaseObservationBroker {
         }
     }
     
-    func notifyChanges(in region: DatabaseRegion) throws {
-        // Use canonical table names for case insensitivity of the input.
-        let eventKinds = try region
-            .canonicalTables(database)
-            .impactfulEventKinds(database)
-        
+    func notifyChanges(withEventsOfKind eventKinds: [DatabaseEventKind]) throws {
         // Support for stopObservingDatabaseChangesUntilNextTransaction()
         SchedulingWatchdog.current!.databaseObservationBroker = self
         defer {

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -782,6 +782,13 @@ public protocol TransactionObserver: AnyObject {
     /// from being applied on the observed tables.
     func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool
     
+    /// Called when the database was modified in some unspecified way.
+    ///
+    /// This method allows a transaction observer to handle changes that are
+    /// not automatically detected. See <doc:GRDB/TransactionObserver#Dealing-with-Undetected-Changes>
+    /// and ``Database/notifyChanges(in:)`` for more information.
+    func databaseDidChange()
+    
     /// Called when the database is changed by an insert, update, or
     /// delete event.
     ///
@@ -857,6 +864,9 @@ extension TransactionObserver {
     public func databaseWillChange(with event: DatabasePreUpdateEvent) { }
     #endif
     
+    /// The default implementation does nothing.
+    public func databaseDidChange() { }
+    
     /// Prevents the observer from receiving further change notifications until
     /// the next transaction.
     ///
@@ -889,7 +899,7 @@ extension TransactionObserver {
         guard let broker = SchedulingWatchdog.current?.databaseObservationBroker else {
             fatalError("""
                 stopObservingDatabaseChangesUntilNextTransaction must be called \
-                from the databaseDidChange method
+                from the databaseDidChange(with:) method
                 """)
         }
         broker.disableUntilNextTransaction(transactionObserver: self)

--- a/GRDB/Documentation.docc/DatabaseSharing.md
+++ b/GRDB/Documentation.docc/DatabaseSharing.md
@@ -228,9 +228,7 @@ In applications that use the background modes supported by iOS, post `resumeNoti
 
 <doc:DatabaseObservation> features are not able to detect database changes performed by other processes.
 
-Whenever you need to notify other processes that the database has been changed, you will have to use a cross-process notification mechanism such as [NSFileCoordinator] or [CFNotificationCenterGetDarwinNotifyCenter].
-
-You can trigger those notifications automatically with ``DatabaseRegionObservation``:
+Whenever you need to notify other processes that the database has been changed, you will have to use a cross-process notification mechanism such as [NSFileCoordinator] or [CFNotificationCenterGetDarwinNotifyCenter]. You can trigger those notifications automatically with ``DatabaseRegionObservation``:
 
 ```swift
 // Notify all changes made to the database
@@ -245,6 +243,8 @@ let observer = try observation.start(in: dbPool) { db in
     // Notify other processes
 }
 ```
+
+The processes that observe the database can catch those notifications, and deal with the notified changes. See <doc:GRDB/TransactionObserver#Dealing-with-Undetected-Changes> for some related techniques.
 
 [NSFileCoordinator]: https://developer.apple.com/documentation/foundation/nsfilecoordinator
 [CFNotificationCenterGetDarwinNotifyCenter]: https://developer.apple.com/documentation/corefoundation/1542572-cfnotificationcentergetdarwinnot

--- a/GRDB/Documentation.docc/Extension/DatabaseRegionObservation.md
+++ b/GRDB/Documentation.docc/Extension/DatabaseRegionObservation.md
@@ -9,6 +9,7 @@
 The only changes that are not notified are:
 
 - Changes performed by external database connections.
+- Changes performed by SQLite statements that are not compiled and executed by GRDB.
 - Changes to the database schema, changes to internal system tables such as `sqlite_master`.
 - Changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
 

--- a/GRDB/Documentation.docc/Extension/TransactionObserver.md
+++ b/GRDB/Documentation.docc/Extension/TransactionObserver.md
@@ -245,6 +245,7 @@ This extra API can be activated in two ways:
 
 ### Handling Database Changes
 
+- ``databaseDidChange()-7olv7``
 - ``databaseDidChange(with:)``
 - ``stopObservingDatabaseChangesUntilNextTransaction()``
 - ``DatabaseEvent``

--- a/GRDB/Documentation.docc/Extension/TransactionObserver.md
+++ b/GRDB/Documentation.docc/Extension/TransactionObserver.md
@@ -29,6 +29,7 @@ The only changes and transactions that are not notified are:
 
 - Read-only transactions.
 - Changes and transactions performed by external database connections.
+- Changes performed by SQLite statements that are not compiled and executed by GRDB.
 - Changes to the database schema, changes to internal system tables such as `sqlite_master`.
 - Changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
 - The deletion of duplicate rows triggered by [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) clauses (this last exception might change in a future release of SQLite).

--- a/GRDB/Documentation.docc/Extension/TransactionObserver.md
+++ b/GRDB/Documentation.docc/Extension/TransactionObserver.md
@@ -248,10 +248,10 @@ For example:
 
 ```swift
 try dbQueue.write { db in
-    // Notify all observers of regular tables
+    // Notify observers that some changes were performed in the database
     try db.notifyChanges(in: .fullDatabase)
 
-    // Notify all observers of the player table
+    // Notify observers that some changes were performed in the player table
     try db.notifyChanges(in: Player.all())
 
     // Equivalent alternative

--- a/GRDB/Documentation.docc/Extension/TransactionObserver.md
+++ b/GRDB/Documentation.docc/Extension/TransactionObserver.md
@@ -25,14 +25,7 @@ Database changes are notified to the ``databaseDidChange(with:)`` callback. This
 
 Transaction completions are notified to the ``databaseWillCommit()-7mksu``, ``databaseDidCommit(_:)`` and ``databaseDidRollback(_:)`` callbacks.
 
-The only changes and transactions that are not notified are:
-
-- Read-only transactions.
-- Changes and transactions performed by external database connections.
-- Changes performed by SQLite statements that are not compiled and executed by GRDB.
-- Changes to the database schema, changes to internal system tables such as `sqlite_master`.
-- Changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
-- The deletion of duplicate rows triggered by [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) clauses (this last exception might change in a future release of SQLite).
+> Important: Some changes and transactions are not automatically notified. See <doc:GRDB/TransactionObserver#Dealing-with-Undetected-Changes> below.
 
 Notified changes are not actually written to disk until the transaction commits, and the `databaseDidCommit` callback is called. On the other side, `databaseDidRollback` confirms their invalidation:
 
@@ -190,7 +183,7 @@ class PlayerObserver: TransactionObserver {
 }
 ```
 
-### Support for SQLite Pre-Update Hooks
+## Support for SQLite Pre-Update Hooks
 
 When SQLite is built with the `SQLITE_ENABLE_PREUPDATE_HOOK` option, `TransactionObserver` gets an extra callback which lets you observe individual column values in the rows modified by a transaction:
 
@@ -235,6 +228,45 @@ This extra API can be activated in two ways:
     **Note**: the `GRDB_SQLITE_ENABLE_PREUPDATE_HOOK=1` option in `GCC_PREPROCESSOR_DEFINITIONS` defines some C function prototypes that are lacking from the system `<sqlite3.h>` header. When Xcode eventually ships with an SDK that includes a complete header, you may get a compiler error about duplicate function definitions. When this happens, just remove this `GRDB_SQLITE_ENABLE_PREUPDATE_HOOK=1` option.
 
 2. Use a [custom SQLite build](http://github.com/groue/GRDB.swift/blob/master/Documentation/CustomSQLiteBuilds.md) and activate the `SQLITE_ENABLE_PREUPDATE_HOOK` compilation option.
+
+## Dealing with Undetected Changes
+
+Some changes and transactions are not automatically notified to transaction observers:
+
+- Read-only transactions.
+- Changes and transactions performed by external database connections.
+- Changes performed by SQLite statements that are not both compiled and executed through GRDB APIs.
+- Changes to the database schema, changes to internal system tables such as `sqlite_master`.
+- Changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
+- The deletion of duplicate rows triggered by [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) clauses (this last exception might change in a future release of SQLite).
+
+Undetected changes are notified to the ``databaseDidChange()-7olv7`` callback when you perform an explicit call to the ``Database/notifyChanges(in:)`` `Database` method.
+
+Event filtering described in <doc:GRDB/TransactionObserver#Filtering-Database-Events> still applies: the `databaseDidChange()` callback is not called for changes that are not observed. 
+
+For example:
+
+```swift
+try dbQueue.write { db in
+    // Notify all observers of regular tables
+    try db.notifyChanges(in: .fullDatabase)
+
+    // Notify all observers of the player table
+    try db.notifyChanges(in: Player.all())
+
+    // Equivalent alternative
+    try db.notifyChanges(in: Table("player"))
+}
+```
+
+To notify a change in the database schema, notify a change to the `sqlite_master` table:
+
+```swift
+try dbQueue.write { db in
+    // Notify all observers of the sqlite_master table
+    try db.notifyChanges(in: Table("sqlite_master"))
+}
+```
 
 ## Topics
 

--- a/GRDB/Documentation.docc/Extension/ValueObservation.md
+++ b/GRDB/Documentation.docc/Extension/ValueObservation.md
@@ -8,7 +8,8 @@
 
 The only changes that are not notified are:
 
-- Changes performed by external database connections. See <doc:DatabaseSharing#How-to-perform-cross-process-database-observation> for more information.
+- Changes performed by external database connections.
+- Changes performed by SQLite statements that are not compiled and executed by GRDB.
 - Changes to the database schema, changes to internal system tables such as `sqlite_master`.
 - Changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
 

--- a/GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift
+++ b/GRDB/ValueObservation/Observers/ValueConcurrentObserver.swift
@@ -710,6 +710,13 @@ extension ValueConcurrentObserver: TransactionObserver {
         }
     }
     
+    func databaseDidChange() {
+        // Database was modified!
+        observationState.isModified = true
+        // We can stop observing the current transaction
+        stopObservingDatabaseChangesUntilNextTransaction()
+    }
+    
     func databaseDidChange(with event: DatabaseEvent) {
         if let region = observationState.region, region.isModified(by: event) {
             // Database was modified!

--- a/GRDB/ValueObservation/Observers/ValueWriteOnlyObserver.swift
+++ b/GRDB/ValueObservation/Observers/ValueWriteOnlyObserver.swift
@@ -345,6 +345,13 @@ extension ValueWriteOnlyObserver: TransactionObserver {
         }
     }
     
+    func databaseDidChange() {
+        // Database was modified!
+        observationState.isModified = true
+        // We can stop observing the current transaction
+        stopObservingDatabaseChangesUntilNextTransaction()
+    }
+    
     func databaseDidChange(with event: DatabaseEvent) {
         if let region = observationState.region, region.isModified(by: event) {
             // Database was modified!

--- a/Tests/GRDBTests/TransactionObserverTests.swift
+++ b/Tests/GRDBTests/TransactionObserverTests.swift
@@ -21,13 +21,13 @@ private class Observer : TransactionObserver {
         }
     }
     
-    var didChangeCount: Int = 0
+    var didChangeWithEventCount: Int = 0
     var willCommitCount: Int = 0
     var didCommitCount: Int = 0
     var didRollbackCount: Int = 0
     
     func resetCounts() {
-        didChangeCount = 0
+        didChangeWithEventCount = 0
         willCommitCount = 0
         didCommitCount = 0
         didRollbackCount = 0
@@ -51,7 +51,7 @@ private class Observer : TransactionObserver {
     }
     
     func databaseDidChange(with event: DatabaseEvent) {
-        didChangeCount += 1
+        didChangeWithEventCount += 1
         events.append(event.copy())
     }
     
@@ -796,7 +796,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -826,7 +826,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 3) // 3 deletes
             #endif
-            XCTAssertEqual(observer.didChangeCount, 3) // 3 deletes
+            XCTAssertEqual(observer.didChangeWithEventCount, 3) // 3 deletes
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -894,7 +894,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -907,7 +907,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -917,7 +917,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -928,7 +928,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
-        XCTAssertEqual(observer.didChangeCount, 0)
+        XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 1)
         XCTAssertEqual(observer.didCommitCount, 1)
         XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1003,7 +1003,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 3) // 3 deletes
             #endif
-            XCTAssertEqual(observer.didChangeCount, 3) // 3 deletes
+            XCTAssertEqual(observer.didChangeWithEventCount, 3) // 3 deletes
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1014,7 +1014,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
-        XCTAssertEqual(observer.didChangeCount, 0)
+        XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 1)
         XCTAssertEqual(observer.didCommitCount, 1)
         XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1132,7 +1132,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
-        XCTAssertEqual(observer.didChangeCount, 0)
+        XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 0)
         XCTAssertEqual(observer.didCommitCount, 0)
         XCTAssertEqual(observer.didRollbackCount, 1)
@@ -1154,7 +1154,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
-                    XCTAssertEqual(observer.didChangeCount, 0)
+                    XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
                     XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1167,7 +1167,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 0)
+            XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1191,7 +1191,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
-                    XCTAssertEqual(observer.didChangeCount, 0)
+                    XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
                     XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1205,7 +1205,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 0)
+            XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 1)
@@ -1229,7 +1229,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 1)
                 #endif
-                XCTAssertEqual(observer.didChangeCount, 1)
+                XCTAssertEqual(observer.didChangeWithEventCount, 1)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 0)
                 XCTAssertEqual(observer.didRollbackCount, 1)
@@ -1260,7 +1260,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 1)
@@ -1284,7 +1284,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
-                    XCTAssertEqual(observer.didChangeCount, 0)
+                    XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
                     XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1297,7 +1297,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 0)
+            XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1322,7 +1322,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
-                    XCTAssertEqual(observer.didChangeCount, 0)
+                    XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
                     XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1336,7 +1336,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 0)
+            XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
             XCTAssertEqual(observer.didRollbackCount, 1)
@@ -1369,7 +1369,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1478,7 +1478,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
-        XCTAssertEqual(observer.didChangeCount, 0)
+        XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 0)
         XCTAssertEqual(observer.didCommitCount, 0)
         XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1503,7 +1503,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
-            XCTAssertEqual(observer.didChangeCount, 0)
+            XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1522,7 +1522,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
-            XCTAssertEqual(observer.didChangeCount, 3)
+            XCTAssertEqual(observer.didChangeWithEventCount, 3)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1550,7 +1550,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1578,7 +1578,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
-            XCTAssertEqual(observer.didChangeCount, 2)
+            XCTAssertEqual(observer.didChangeWithEventCount, 2)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1613,7 +1613,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1646,7 +1646,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
-            XCTAssertEqual(observer.didChangeCount, 1)
+            XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
             XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1659,13 +1659,13 @@ class TransactionObserverTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         
         class Observer: TransactionObserver {
-            var didChangeCount: Int = 0
+            var didChangeWithEventCount: Int = 0
             var willCommitCount: Int = 0
             var didCommitCount: Int = 0
             var didRollbackCount: Int = 0
 
             func resetCounts() {
-                didChangeCount = 0
+                didChangeWithEventCount = 0
                 willCommitCount = 0
                 didCommitCount = 0
                 didRollbackCount = 0
@@ -1682,7 +1682,7 @@ class TransactionObserverTests: GRDBTestCase {
             func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool { true }
             
             func databaseDidChange(with event: DatabaseEvent) {
-                didChangeCount += 1
+                didChangeWithEventCount += 1
                 if event.tableName == "ignore" {
                     stopObservingDatabaseChangesUntilNextTransaction()
                 }
@@ -1720,7 +1720,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 2)
                 #endif
-                XCTAssertEqual(observer.didChangeCount, 2)
+                XCTAssertEqual(observer.didChangeWithEventCount, 2)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
                 XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1739,7 +1739,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 1)
                 #endif
-                XCTAssertEqual(observer.didChangeCount, 1)
+                XCTAssertEqual(observer.didChangeWithEventCount, 1)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
                 XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1758,7 +1758,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 2)
                 #endif
-                XCTAssertEqual(observer.didChangeCount, 2)
+                XCTAssertEqual(observer.didChangeWithEventCount, 2)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
                 XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1777,7 +1777,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 3)
                 #endif
-                XCTAssertEqual(observer.didChangeCount, 3)
+                XCTAssertEqual(observer.didChangeWithEventCount, 3)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
                 XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1803,7 +1803,7 @@ class TransactionObserverTests: GRDBTestCase {
                     BEGIN;
                     COMMIT;
                     """)
-                XCTAssertEqual(observer.didChangeCount, 0)
+                XCTAssertEqual(observer.didChangeWithEventCount, 0)
                 XCTAssertEqual(observer.willCommitCount, 0)
                 XCTAssertEqual(observer.didCommitCount, 0)
                 XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1818,7 +1818,7 @@ class TransactionObserverTests: GRDBTestCase {
                     SELECT * FROM artists;
                     COMMIT;
                     """)
-                XCTAssertEqual(observer.didChangeCount, 0)
+                XCTAssertEqual(observer.didChangeWithEventCount, 0)
                 XCTAssertEqual(observer.willCommitCount, 0)
                 XCTAssertEqual(observer.didCommitCount, 0)
                 XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1843,7 +1843,7 @@ class TransactionObserverTests: GRDBTestCase {
                         BEGIN;
                         COMMIT;
                         """)
-                    XCTAssertEqual(observer.didChangeCount, 0)
+                    XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
                     XCTAssertEqual(observer.didRollbackCount, 0)
@@ -1858,7 +1858,7 @@ class TransactionObserverTests: GRDBTestCase {
                         SELECT * FROM artists;
                         COMMIT;
                         """)
-                    XCTAssertEqual(observer.didChangeCount, 0)
+                    XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
                     XCTAssertEqual(observer.didRollbackCount, 0)

--- a/Tests/GRDBTests/TransactionObserverTests.swift
+++ b/Tests/GRDBTests/TransactionObserverTests.swift
@@ -21,12 +21,14 @@ private class Observer : TransactionObserver {
         }
     }
     
+    var didChangeCount: Int = 0
     var didChangeWithEventCount: Int = 0
     var willCommitCount: Int = 0
     var didCommitCount: Int = 0
     var didRollbackCount: Int = 0
     
     func resetCounts() {
+        didChangeCount = 0
         didChangeWithEventCount = 0
         willCommitCount = 0
         didCommitCount = 0
@@ -48,6 +50,10 @@ private class Observer : TransactionObserver {
     
     func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool {
         observesBlock(eventKind)
+    }
+    
+    func databaseDidChange() {
+        didChangeCount += 1
     }
     
     func databaseDidChange(with event: DatabaseEvent) {
@@ -796,6 +802,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -826,6 +833,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 3) // 3 deletes
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 3) // 3 deletes
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -894,6 +902,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -907,6 +916,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -917,6 +927,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -928,6 +939,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
+        XCTAssertEqual(observer.didChangeCount, 0)
         XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 1)
         XCTAssertEqual(observer.didCommitCount, 1)
@@ -1003,6 +1015,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 3) // 3 deletes
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 3) // 3 deletes
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -1014,6 +1027,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
+        XCTAssertEqual(observer.didChangeCount, 0)
         XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 1)
         XCTAssertEqual(observer.didCommitCount, 1)
@@ -1132,6 +1146,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
+        XCTAssertEqual(observer.didChangeCount, 0)
         XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 0)
         XCTAssertEqual(observer.didCommitCount, 0)
@@ -1154,6 +1169,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
+                    XCTAssertEqual(observer.didChangeCount, 0)
                     XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
@@ -1167,6 +1183,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -1191,6 +1208,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
+                    XCTAssertEqual(observer.didChangeCount, 0)
                     XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
@@ -1205,6 +1223,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -1229,6 +1248,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 1)
                 #endif
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 1)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 0)
@@ -1260,6 +1280,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -1284,6 +1305,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
+                    XCTAssertEqual(observer.didChangeCount, 0)
                     XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
@@ -1297,6 +1319,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -1322,6 +1345,7 @@ class TransactionObserverTests: GRDBTestCase {
                     #if SQLITE_ENABLE_PREUPDATE_HOOK
                         XCTAssertEqual(observer.willChangeCount, 0)
                     #endif
+                    XCTAssertEqual(observer.didChangeCount, 0)
                     XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
@@ -1336,6 +1360,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 0)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 0)
             XCTAssertEqual(observer.didCommitCount, 0)
@@ -1369,6 +1394,7 @@ class TransactionObserverTests: GRDBTestCase {
             #if SQLITE_ENABLE_PREUPDATE_HOOK
                 XCTAssertEqual(observer.willChangeCount, 1)
             #endif
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1478,6 +1504,7 @@ class TransactionObserverTests: GRDBTestCase {
         #if SQLITE_ENABLE_PREUPDATE_HOOK
             XCTAssertEqual(observer.willChangeCount, 0)
         #endif
+        XCTAssertEqual(observer.didChangeCount, 0)
         XCTAssertEqual(observer.didChangeWithEventCount, 0)
         XCTAssertEqual(observer.willCommitCount, 0)
         XCTAssertEqual(observer.didCommitCount, 0)
@@ -1503,6 +1530,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 0)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1522,6 +1550,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 3)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1550,6 +1579,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1578,6 +1608,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 2)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1613,6 +1644,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1646,6 +1678,7 @@ class TransactionObserverTests: GRDBTestCase {
                 return .commit
             }
             
+            XCTAssertEqual(observer.didChangeCount, 0)
             XCTAssertEqual(observer.didChangeWithEventCount, 1)
             XCTAssertEqual(observer.willCommitCount, 1)
             XCTAssertEqual(observer.didCommitCount, 1)
@@ -1659,12 +1692,14 @@ class TransactionObserverTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         
         class Observer: TransactionObserver {
+            var didChangeCount: Int = 0
             var didChangeWithEventCount: Int = 0
             var willCommitCount: Int = 0
             var didCommitCount: Int = 0
             var didRollbackCount: Int = 0
 
             func resetCounts() {
+                didChangeCount = 0
                 didChangeWithEventCount = 0
                 willCommitCount = 0
                 didCommitCount = 0
@@ -1680,6 +1715,10 @@ class TransactionObserverTests: GRDBTestCase {
             #endif
             
             func observes(eventsOfKind eventKind: DatabaseEventKind) -> Bool { true }
+            
+            func databaseDidChange() {
+                didChangeCount += 1
+            }
             
             func databaseDidChange(with event: DatabaseEvent) {
                 didChangeWithEventCount += 1
@@ -1720,6 +1759,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 2)
                 #endif
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 2)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
@@ -1739,6 +1779,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 1)
                 #endif
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 1)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
@@ -1758,6 +1799,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 2)
                 #endif
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 2)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
@@ -1777,6 +1819,7 @@ class TransactionObserverTests: GRDBTestCase {
                 #if SQLITE_ENABLE_PREUPDATE_HOOK
                     XCTAssertEqual(observer.willChangeCount, 3)
                 #endif
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 3)
                 XCTAssertEqual(observer.willCommitCount, 1)
                 XCTAssertEqual(observer.didCommitCount, 1)
@@ -1803,6 +1846,7 @@ class TransactionObserverTests: GRDBTestCase {
                     BEGIN;
                     COMMIT;
                     """)
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 0)
                 XCTAssertEqual(observer.willCommitCount, 0)
                 XCTAssertEqual(observer.didCommitCount, 0)
@@ -1818,6 +1862,7 @@ class TransactionObserverTests: GRDBTestCase {
                     SELECT * FROM artists;
                     COMMIT;
                     """)
+                XCTAssertEqual(observer.didChangeCount, 0)
                 XCTAssertEqual(observer.didChangeWithEventCount, 0)
                 XCTAssertEqual(observer.willCommitCount, 0)
                 XCTAssertEqual(observer.didCommitCount, 0)
@@ -1843,6 +1888,7 @@ class TransactionObserverTests: GRDBTestCase {
                         BEGIN;
                         COMMIT;
                         """)
+                    XCTAssertEqual(observer.didChangeCount, 0)
                     XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)
@@ -1858,6 +1904,7 @@ class TransactionObserverTests: GRDBTestCase {
                         SELECT * FROM artists;
                         COMMIT;
                         """)
+                    XCTAssertEqual(observer.didChangeCount, 0)
                     XCTAssertEqual(observer.didChangeWithEventCount, 0)
                     XCTAssertEqual(observer.willCommitCount, 0)
                     XCTAssertEqual(observer.didCommitCount, 0)

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -523,6 +523,49 @@ class ValueObservationTests: GRDBTestCase {
     }
 #endif
     
+    // MARK: - Unspecified Changes
+    
+    func test_ValueObservation_is_triggered_by_explicit_change_notification() throws {
+        let dbQueue1 = try makeDatabaseQueue(filename: "test.sqlite")
+        try dbQueue1.write { db in
+            try db.execute(sql: "CREATE TABLE test(a)")
+        }
+        
+        let undetectedExpectation = expectation(description: "undetected")
+        undetectedExpectation.expectedFulfillmentCount = 2 // initial value and change
+        undetectedExpectation.isInverted = true
+
+        let detectedExpectation = expectation(description: "detected")
+        detectedExpectation.expectedFulfillmentCount = 2 // initial value and change
+        
+        let observation = ValueObservation.tracking { db in
+            try Table("test").fetchCount(db)
+        }
+        let cancellable = observation.start(
+            in: dbQueue1,
+            scheduling: .immediate,
+            onError: { error in XCTFail("Unexpected error: \(error)") },
+            onChange: { _ in
+                undetectedExpectation.fulfill()
+                detectedExpectation.fulfill()
+            })
+
+        try withExtendedLifetime(cancellable) {
+            // Change performed from external connection is not detected...
+            let dbQueue2 = try makeDatabaseQueue(filename: "test.sqlite")
+            try dbQueue2.write { db in
+                try db.execute(sql: "INSERT INTO test (a) VALUES (1)")
+            }
+            wait(for: [undetectedExpectation], timeout: 2)
+            
+            // ... until we perform an explicit change notification
+            try dbQueue1.write { db in
+                try db.notifyChanges(in: Table("test"))
+            }
+            wait(for: [detectedExpectation], timeout: 2)
+        }
+    }
+    
     // MARK: - Cancellation
     
     func testCancellableLifetime() throws {


### PR DESCRIPTION
This pull request addresses https://github.com/groue/GRDB.swift/discussions/1457 and adds a new API that helps applications deal with database changes that are not automatically detected by GRDB.

As a reminder, the changes that are not automatically detected are:

- Changes performed by external database connections.
- Changes performed by SQLite statements that are not both compiled and executed through GRDB APIs.
- Changes to the database schema, changes to internal system tables such as `sqlite_master`.
- Changes to [`WITHOUT ROWID`](https://www.sqlite.org/withoutrowid.html) tables.
- The deletion of duplicate rows triggered by [`ON CONFLICT REPLACE`](https://www.sqlite.org/lang_conflict.html) clauses (this last exception might change in a future release of SQLite).

Those changes are still undetected, but applications can explicitly notify them when appropriate, and trigger database observation tools (`ValueObservation`, `DatabaseRegionObservation`, and generally speaking all interested `TransactionObserver`):

```swift
try dbQueue.write { db in
    // Notify observers that some changes were performed in the database
    try db.notifyChanges(in: .fullDatabase)

    // Notify observers that some changes were performed in the player table
    try db.notifyChanges(in: Player.all())

    // Equivalent alternative
    try db.notifyChanges(in: Table("player"))
}
```
