### PR TITLE
Temporary read-only access

### DIFF
--- a/Tests/GRDBTests/DatabaseTests.swift
+++ b/Tests/GRDBTests/DatabaseTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import GRDB
+import GRDB
 
 class DatabaseTests : GRDBTestCase {
     
@@ -520,7 +520,6 @@ class DatabaseTests : GRDBTestCase {
         }
     }
     
-    // Test an internal API
     func testReadOnly() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in


### PR DESCRIPTION
This pull request exposes a new `Database.readOnly(_:)` method that provides a scoped, temporary read-only access:

```swift
try dbQueue.write { db in
    // <- Writes allowed
    try db.readOnly {
        // <- Attempts to write throw SQLITE_READONLY
    }
    // <- Writes allowed
}
```

This new API can help applications define custom transactions that allow unrestricted reads while strictly controlling the possible writes.

<details><summary>Example of a "custom transaction"</summary>

```swift
public struct PlayerStore {
    // Not public: client can only write through public apis.
    let writer: any DatabaseWriter
    
    /// Perform multiple modifications in a single transaction
    public func write<T>(_ updates: (PlayerTransaction) throws -> T) throws -> T {
        try writer.write { db in
            let transaction = PlayerTransaction(db: db)
            return updates(transaction)
        }
    }
}

/// A transaction in a PlayerStore 
public struct PlayerTransaction {
    // Not public: client can only write through public apis.
    let db: Database

    /// Increments the player score
    public func incrementScore(_ player: inout Player) throws {
        try player.updateChanges(db) { $0.score += 1 }
    }

    /// Read database values
    public func read(_ value: (Database) throws -> T) throws -> T {
        try db.readOnly {
            try value(db)
        }
    }
}
```

Usage:

```swift
let store: PlayerStore = ...

// Increment score of player 42 and fetch maximum score
let maxScore = try store.write { transaction -> Int in
    var player = try transaction.read { db in
        try Player.find(db, id: 42)
    }
    try transaction.incrementScore(&player)
    
    return try transaction.read { db in
         try Player.select(max(Column("score")).fetchOne(db)!
    }
}
```

</details>