### PR TITLE
Add schema name option to table introspection methods

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,6 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
-  checks: write
 
 jobs:
   Framework:
@@ -80,13 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: ${{ matrix.name }}
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project GRDB.xcodeproj -scheme GRDB -destination "${{ matrix.destination }}" -resultBundlePath TestResults.xcresult OTHER_SWIFT_FLAGS='$(inherited) -D SQLITE_ENABLE_FTS5 -D SQLITE_ENABLE_PREUPDATE_HOOK' GCC_PREPROCESSOR_DEFINITIONS='$(inherited) GRDB_SQLITE_ENABLE_PREUPDATE_HOOK=1' clean test
-      - uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: TestResults.xcresult
-          show-passed-tests: false
-          show-code-coverage: false
-        if: success() || failure()
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project GRDB.xcodeproj -scheme GRDB -destination "${{ matrix.destination }}" OTHER_SWIFT_FLAGS='$(inherited) -D SQLITE_ENABLE_FTS5 -D SQLITE_ENABLE_PREUPDATE_HOOK' GCC_PREPROCESSOR_DEFINITIONS='$(inherited) GRDB_SQLITE_ENABLE_PREUPDATE_HOOK=1' clean test
   SPM:
     name: SPM
     runs-on: ${{ matrix.runsOn }}
@@ -133,12 +126,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: ${{ matrix.name }}
         run: make test_framework_SQLCipher3Encrypted
-      - uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: Tests/CocoaPods/SQLCipher3/TestResults_encrypted.xcresult
-          show-passed-tests: false
-          show-code-coverage: false
-        if: success() || failure()
   SQLCipher4:
     name: SQLCipher4
     runs-on: ${{ matrix.runsOn }}
@@ -159,12 +146,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: ${{ matrix.name }}
         run: make test_framework_SQLCipher4Encrypted
-      - uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: Tests/CocoaPods/SQLCipher4/TestResults_encrypted.xcresult
-          show-passed-tests: false
-          show-code-coverage: false
-        if: success() || failure()
   CustomSQLite:
     name: CustomSQLite
     runs-on: ${{ matrix.runsOn }}
@@ -185,12 +166,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: ${{ matrix.name }}
         run: make test_framework_GRDBCustomSQLiteOSX
-      - uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: TestResults.xcresult
-          show-passed-tests: false
-          show-code-coverage: false
-        if: success() || failure()
   XCFramework:
     name: XCFramework
     runs-on: ${{ matrix.runsOn }}

--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,3 @@ Tests/SPM/Packages
 
 # Test products
 Tests/products
-
-# CI
-*.xcresult

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -454,10 +454,18 @@ extension Database {
     /// the columns contain the primary key or a unique index, use
     /// ``table(_:hasUniqueKey:)``.
     ///
-    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or if no
-    /// such table exists in the main or temp schema, or in an
-    /// attached database.
-    public func indexes(on tableName: String) throws -> [IndexInfo] {
+    /// When `schemaName` is not specified, known schemas are iterated in
+    /// SQLite resolution order and the first matching result is returned.
+    ///
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, if
+    /// the specified schema does not exist, or if no such table or view
+    /// with this name exists in the main or temp schema, or in an attached
+    /// database.
+    public func indexes(on tableName: String, in schemaName: String? = nil) throws -> [IndexInfo] {
+        if let schemaName {
+            return try introspect(tableNamed: tableName, inSchemaNamed: schemaName, using: indexes(on:))
+        }
+        
         for schemaIdentifier in try schemaIdentifiers() {
             if let result = try indexes(on: TableIdentifier(schemaID: schemaIdentifier, name: tableName)) {
                 return result
@@ -998,7 +1006,7 @@ public struct ColumnInfo: FetchableRecord {
 
 /// Information about an index.
 ///
-/// You get `IndexInfo` instances with the ``Database/indexes(on:)``
+/// You get `IndexInfo` instances with the ``Database/indexes(on:in:)``
 /// `Database` method.
 ///
 /// Related SQLite documentation:

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -396,6 +396,10 @@ public struct DatabaseError: Error {
     static func noSuchTable(_ tableName: String) -> Self {
         DatabaseError(message: "no such table: \(tableName)")
     }
+    
+    static func noSuchSchema(_ schemaName: String) -> Self {
+        DatabaseError(message: "no such schema: \(schemaName)")
+    }
 }
 
 extension DatabaseError {

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -410,9 +410,9 @@ extension Team: TableRecord {
 ### Integrity Checks
 
 - ``Database/checkForeignKeys()``
-- ``Database/checkForeignKeys(in:)``
+- ``Database/checkForeignKeys(in:in:)``
 - ``Database/foreignKeyViolations()``
-- ``Database/foreignKeyViolations(in:)``
+- ``Database/foreignKeyViolations(in:in:)``
 - ``ForeignKeyViolation``
 
 ### Sunsetted Methods

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -392,7 +392,7 @@ extension Team: TableRecord {
 ### Querying the Database Schema
 
 - ``Database/columns(in:in:)``
-- ``Database/foreignKeys(on:)``
+- ``Database/foreignKeys(on:in:)``
 - ``Database/indexes(on:)``
 - ``Database/isGRDBInternalTable(_:)``
 - ``Database/isSQLiteInternalTable(_:)``

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -399,9 +399,9 @@ extension Team: TableRecord {
 - ``Database/primaryKey(_:in:)``
 - ``Database/schemaVersion()``
 - ``Database/table(_:hasUniqueKey:)``
-- ``Database/tableExists(_:)``
-- ``Database/triggerExists(_:)``
-- ``Database/viewExists(_:)``
+- ``Database/tableExists(_:in:)``
+- ``Database/triggerExists(_:in:)``
+- ``Database/viewExists(_:in:)``
 - ``ColumnInfo``
 - ``ForeignKeyInfo``
 - ``IndexInfo``

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -391,7 +391,7 @@ extension Team: TableRecord {
 
 ### Querying the Database Schema
 
-- ``Database/columns(in:)``
+- ``Database/columns(in:in:)``
 - ``Database/foreignKeys(on:)``
 - ``Database/indexes(on:)``
 - ``Database/isGRDBInternalTable(_:)``

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -393,7 +393,7 @@ extension Team: TableRecord {
 
 - ``Database/columns(in:in:)``
 - ``Database/foreignKeys(on:in:)``
-- ``Database/indexes(on:)``
+- ``Database/indexes(on:in:)``
 - ``Database/isGRDBInternalTable(_:)``
 - ``Database/isSQLiteInternalTable(_:)``
 - ``Database/primaryKey(_:in:)``

--- a/GRDB/Documentation.docc/DatabaseSchema.md
+++ b/GRDB/Documentation.docc/DatabaseSchema.md
@@ -396,7 +396,7 @@ extension Team: TableRecord {
 - ``Database/indexes(on:)``
 - ``Database/isGRDBInternalTable(_:)``
 - ``Database/isSQLiteInternalTable(_:)``
-- ``Database/primaryKey(_:)``
+- ``Database/primaryKey(_:in:)``
 - ``Database/schemaVersion()``
 - ``Database/table(_:hasUniqueKey:)``
 - ``Database/tableExists(_:)``

--- a/GRDB/Documentation.docc/Migrations.md
+++ b/GRDB/Documentation.docc/Migrations.md
@@ -233,7 +233,7 @@ To prevent a migration from committing foreign key violations on disk, you can:
     }
     ```
 
-As in the above example, check for foreign key violations with the ``Database/checkForeignKeys()`` and ``Database/checkForeignKeys(in:)`` methods. They throw a nicely detailed ``DatabaseError`` that contains a lot of debugging information:
+As in the above example, check for foreign key violations with the ``Database/checkForeignKeys()`` and ``Database/checkForeignKeys(in:in:)`` methods. They throw a nicely detailed ``DatabaseError`` that contains a lot of debugging information:
 
 ```swift
 // SQLite error 19: FOREIGN KEY constraint violation - from book(authorId) to author(id),

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -50,7 +50,7 @@ public struct DatabaseMigrator {
         /// ``DatabaseMigrator/disablingDeferredForeignKeyChecks()``.
         ///
         /// In this case, you can perform your own deferred foreign key checks
-        /// with ``Database/checkForeignKeys(in:)`` or
+        /// with ``Database/checkForeignKeys(in:in:)`` or
         /// ``Database/checkForeignKeys()``:
         /// 
         /// ```swift
@@ -118,7 +118,7 @@ public struct DatabaseMigrator {
     /// The returned migrator is _unsafe_, because it no longer guarantees the
     /// integrity of the database. It is now _your_ responsibility to register
     /// migrations that do not break foreign key constraints. See
-    /// ``Database/checkForeignKeys()`` and ``Database/checkForeignKeys(in:)``.
+    /// ``Database/checkForeignKeys()`` and ``Database/checkForeignKeys(in:in:)``.
     ///
     /// Running migrations without foreign key checks can improve migration
     /// performance on huge databases.

--- a/Makefile
+++ b/Makefile
@@ -81,12 +81,10 @@ test_CocoaPodsLint: test_CocoaPodsLint_GRDB
 test_demo_apps: test_GRDBDemoiOS test_GRDBCombineDemo test_GRDBAsyncDemo
 
 test_framework_GRDBOSX:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDB.xcodeproj \
 	  -scheme GRDB \
 	  -destination "platform=macOS" \
-	  -resultBundlePath TestResults.xcresult \
 	  OTHER_SWIFT_FLAGS=$(OTHER_SWIFT_FLAGS) \
 	  GCC_PREPROCESSOR_DEFINITIONS=$(GCC_PREPROCESSOR_DEFINITIONS) \
 	  $(TEST_ACTIONS) \
@@ -95,92 +93,76 @@ test_framework_GRDBOSX:
 test_framework_GRDBiOS: test_framework_GRDBiOS_maxTarget test_framework_GRDBiOS_minTarget
 
 test_framework_GRDBiOS_maxTarget:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDB.xcodeproj \
 	  -scheme GRDB \
 	  -destination $(MAX_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  OTHER_SWIFT_FLAGS=$(OTHER_SWIFT_FLAGS) \
 	  GCC_PREPROCESSOR_DEFINITIONS=$(GCC_PREPROCESSOR_DEFINITIONS) \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_GRDBiOS_minTarget:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDB.xcodeproj \
 	  -scheme GRDB \
 	  -destination $(MIN_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_GRDBtvOS: test_framework_GRDBtvOS_maxTarget test_framework_GRDBtvOS_minTarget
 
 test_framework_GRDBtvOS_maxTarget:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDB.xcodeproj \
 	  -scheme GRDB \
 	  -destination $(MAX_TVOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  OTHER_SWIFT_FLAGS=$(OTHER_SWIFT_FLAGS) \
 	  GCC_PREPROCESSOR_DEFINITIONS=$(GCC_PREPROCESSOR_DEFINITIONS) \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_GRDBtvOS_minTarget:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDB.xcodeproj \
 	  -scheme GRDB \
 	  -destination $(MIN_TVOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_GRDBCustomSQLiteOSX: SQLiteCustom
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDBCustom.xcodeproj \
 	  -scheme GRDBCustom \
 	  -destination "platform=macOS" \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_GRDBCustomSQLiteiOS: test_framework_GRDBCustomSQLiteiOS_maxTarget test_framework_GRDBCustomSQLiteiOS_minTarget
 
 test_framework_GRDBCustomSQLiteiOS_maxTarget: SQLiteCustom
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDBCustom.xcodeproj \
 	  -scheme GRDBCustom \
 	  -destination $(MAX_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_GRDBCustomSQLiteiOS_minTarget: SQLiteCustom
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project GRDBCustom.xcodeproj \
 	  -scheme GRDBCustom \
 	  -destination $(MIN_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_framework_SQLCipher3:
 ifdef POD
 	cd Tests/CocoaPods/SQLCipher3 && \
-	rm -rf TestResults.xcresult && \
 	$(POD) install && \
 	$(XCODEBUILD) \
 	  -workspace GRDBTests.xcworkspace \
 	  -scheme GRDBTests \
-	  -resultBundlePath TestResults.xcresult \
 	  build-for-testing test-without-building \
 	  $(XCPRETTY)
 else
@@ -191,12 +173,10 @@ endif
 test_framework_SQLCipher3Encrypted:
 ifdef POD
 	cd Tests/CocoaPods/SQLCipher3 && \
-	rm -rf TestResults_encrypted.xcresult && \
 	$(POD) install && \
 	$(XCODEBUILD) \
 	  -workspace GRDBTests.xcworkspace \
 	  -scheme GRDBEncryptedTests \
-	  -resultBundlePath TestResults_encrypted.xcresult \
 	  build-for-testing test-without-building \
 	  $(XCPRETTY)
 else
@@ -207,12 +187,10 @@ endif
 test_framework_SQLCipher4:
 ifdef POD
 	cd Tests/CocoaPods/SQLCipher4 && \
-	rm -rf TestResults.xcresult && \
 	$(POD) install && \
 	$(XCODEBUILD) \
 	  -workspace GRDBTests.xcworkspace \
 	  -scheme GRDBTests \
-	  -resultBundlePath TestResults.xcresult \
 	  build-for-testing test-without-building \
 	  $(XCPRETTY)
 else
@@ -223,12 +201,10 @@ endif
 test_framework_SQLCipher4Encrypted:
 ifdef POD
 	cd Tests/CocoaPods/SQLCipher4 && \
-	rm -rf TestResults_encrypted.xcresult && \
 	$(POD) install && \
 	$(XCODEBUILD) \
 	  -workspace GRDBTests.xcworkspace \
 	  -scheme GRDBEncryptedTests \
-	  -resultBundlePath TestResults_encrypted.xcresult \
 	  build-for-testing test-without-building \
 	  $(XCPRETTY)
 else
@@ -393,32 +369,26 @@ else
 endif
 
 test_GRDBDemoiOS:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project Documentation/DemoApps/GRDBDemoiOS/GRDBDemoiOS.xcodeproj \
 	  -scheme GRDBDemoiOS \
 	  -destination $(MAX_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_GRDBCombineDemo:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project Documentation/DemoApps/GRDBCombineDemo/GRDBCombineDemo.xcodeproj \
 	  -scheme GRDBCombineDemo \
 	  -destination $(MAX_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 
 test_GRDBAsyncDemo:
-	rm -rf TestResults.xcresult
 	$(XCODEBUILD) \
 	  -project Documentation/DemoApps/GRDBAsyncDemo/GRDBAsyncDemo.xcodeproj \
 	  -scheme GRDBAsyncDemo \
 	  -destination $(MAX_IOS_DESTINATION) \
-	  -resultBundlePath TestResults.xcresult \
 	  $(TEST_ACTIONS) \
 	  $(XCPRETTY)
 

--- a/Tests/GRDBTests/ColumnInfoTests.swift
+++ b/Tests/GRDBTests/ColumnInfoTests.swift
@@ -317,6 +317,12 @@ class ColumnInfoTests: GRDBTestCase {
     }
     
     func testSpecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE t (id2 TEXT)")
@@ -342,6 +348,12 @@ class ColumnInfoTests: GRDBTestCase {
     // be found unless explicitly specified as it is after
     // `main.t` in resolution order.
     func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE t (id2 TEXT)")
@@ -359,6 +371,12 @@ class ColumnInfoTests: GRDBTestCase {
     }
     
     func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE t (id2 TEXT)")

--- a/Tests/GRDBTests/ColumnInfoTests.swift
+++ b/Tests/GRDBTests/ColumnInfoTests.swift
@@ -289,4 +289,88 @@ class ColumnInfoTests: GRDBTestCase {
             _ = try db.columns(in: "t1")
         }
     }
+    
+    func testUnknownSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id INTEGER)")
+            do {
+                _ = try db.columns(in: "t", in: "invalid")
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.message, "no such schema: invalid")
+                XCTAssertEqual(error.description, "SQLite error 1: no such schema: invalid")
+            }
+        }
+    }
+    
+    func testSpecifiedMainSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id INTEGER)")
+            let columns = try db.columns(in: "t")
+            XCTAssertEqual(columns.count, 1)
+            XCTAssertEqual(columns[0].name, "id")
+            XCTAssertEqual(columns[0].type, "INTEGER")
+        }
+    }
+    
+    func testSpecifiedSchemaWithTableNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id2 TEXT)")
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id1 INTEGER)")
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            let columnsMain = try db.columns(in: "t", in: "main")
+            XCTAssertEqual(columnsMain.count, 1)
+            XCTAssertEqual(columnsMain[0].name, "id1")
+            XCTAssertEqual(columnsMain[0].type, "INTEGER")
+            
+            let columnsAttached = try db.columns(in: "t", in: "attached")
+            XCTAssertEqual(columnsAttached.count, 1)
+            XCTAssertEqual(columnsAttached[0].name, "id2")
+            XCTAssertEqual(columnsAttached[0].type, "TEXT")
+        }
+    }
+    
+    // The `t` table in the attached database should never
+    // be found unless explicitly specified as it is after
+    // `main.t` in resolution order.
+    func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id2 TEXT)")
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id1 INTEGER)")
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            let columnsMain = try db.columns(in: "t")
+            XCTAssertEqual(columnsMain.count, 1)
+            XCTAssertEqual(columnsMain[0].name, "id1")
+            XCTAssertEqual(columnsMain[0].type, "INTEGER")
+        }
+    }
+    
+    func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t (id2 TEXT)")
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            let columnsMain = try db.columns(in: "t")
+            XCTAssertEqual(columnsMain.count, 1)
+            XCTAssertEqual(columnsMain[0].name, "id2")
+            XCTAssertEqual(columnsMain[0].type, "TEXT")
+        }
+    }
 }

--- a/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
@@ -229,4 +229,153 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
             try XCTAssertFalse(db.tableExists("item"))
         }
     }
+    
+    func testTableExistsThrowsWhenUnknownSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+            do {
+                _ = try db.tableExists("t", in: "invalid")
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.message, "no such schema: invalid")
+                XCTAssertEqual(error.description, "SQLite error 1: no such schema: invalid")
+            }
+            do {
+                _ = try db.viewExists("v", in: "invalid")
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.message, "no such schema: invalid")
+                XCTAssertEqual(error.description, "SQLite error 1: no such schema: invalid")
+            }
+            do {
+                _ = try db.triggerExists("tr", in: "invalid")
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.message, "no such schema: invalid")
+                XCTAssertEqual(error.description, "SQLite error 1: no such schema: invalid")
+            }
+        }
+    }
+    
+    func testExistsWithSpecifiedMainSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+            let tableExists = try db.tableExists("t", in: "main")
+            let viewExists = try db.viewExists("v", in: "main")
+            let triggerExists = try db.triggerExists("tr", in: "main")
+            XCTAssertTrue(tableExists)
+            XCTAssertTrue(viewExists)
+            XCTAssertTrue(triggerExists)
+        }
+    }
+    
+    func testNotExistsWithSpecifiedMainSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let tableExists = try db.tableExists("t", in: "main")
+            let viewExists = try db.viewExists("v", in: "main")
+            let triggerExists = try db.triggerExists("tr", in: "main")
+            XCTAssertFalse(tableExists)
+            XCTAssertFalse(viewExists)
+            XCTAssertFalse(triggerExists)
+        }
+    }
+    
+    func testExistsWithSpecifiedSchemaWithEntityNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached")
+        try attached.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            let tableExistsInMain = try db.tableExists("t", in: "main")
+            let viewExistsInMain = try db.viewExists("v", in: "main")
+            let triggerExistsInMain = try db.triggerExists("tr", in: "main")
+            XCTAssertTrue(tableExistsInMain)
+            XCTAssertTrue(viewExistsInMain)
+            XCTAssertTrue(triggerExistsInMain)
+            
+            let tableExistsInAttached = try db.tableExists("t", in: "attached")
+            let viewExistsInAttached = try db.viewExists("v", in: "attached")
+            let triggerExistsInAttached = try db.triggerExists("tr", in: "attached")
+            XCTAssertTrue(tableExistsInAttached)
+            XCTAssertTrue(viewExistsInAttached)
+            XCTAssertTrue(triggerExistsInAttached)
+        }
+    }
+    
+    func testExistsWithUnspecifiedSchemaWithEntityNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached")
+        try attached.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            // Some entity with the name exists, but we can't prove from this information which one
+            // it's getting. `true` is still the correct result.
+            let tableExists = try db.tableExists("t")
+            let viewExists = try db.viewExists("v")
+            let triggerExists = try db.triggerExists("tr")
+            XCTAssertTrue(tableExists)
+            XCTAssertTrue(viewExists)
+            XCTAssertTrue(triggerExists)
+        }
+    }
+    
+    func testExistsWithUnspecifiedSchemaFindsAttachedDatabase() throws {
+        let attached = try makeDatabaseQueue(filename: "attached")
+        try attached.inDatabase { db in
+            try db.execute(sql: """
+               CREATE TABLE t (id INTEGER);
+               CREATE VIEW v AS SELECT * FROM t;
+               CREATE TRIGGER tr AFTER INSERT ON t BEGIN SELECT 1; END;
+               """)
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            let tableExists = try db.tableExists("t")
+            let viewExists = try db.viewExists("v")
+            let triggerExists = try db.triggerExists("tr")
+            XCTAssertTrue(tableExists)
+            XCTAssertTrue(viewExists)
+            XCTAssertTrue(triggerExists)
+        }
+    }
 }

--- a/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueSchemaCacheTests.swift
@@ -150,7 +150,7 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
     }
     
     func testMainShadowedByAttachedDatabase() throws {
-        #if SQLITE_HAS_CODEC
+        #if GRDBCIPHER_USE_ENCRYPTION
         // Avoid error due to key not being provided:
         // file is not a database - while executing `ATTACH DATABASE...`
         throw XCTSkip("This test does not support encrypted databases")
@@ -295,6 +295,12 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
     }
     
     func testExistsWithSpecifiedSchemaWithEntityNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached")
         try attached.inDatabase { db in
             try db.execute(sql: """
@@ -329,6 +335,12 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
     }
     
     func testExistsWithUnspecifiedSchemaWithEntityNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached")
         try attached.inDatabase { db in
             try db.execute(sql: """
@@ -358,6 +370,12 @@ class DatabaseQueueSchemaCacheTests : GRDBTestCase {
     }
     
     func testExistsWithUnspecifiedSchemaFindsAttachedDatabase() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached")
         try attached.inDatabase { db in
             try db.execute(sql: """

--- a/Tests/GRDBTests/ForeignKeyInfoTests.swift
+++ b/Tests/GRDBTests/ForeignKeyInfoTests.swift
@@ -101,6 +101,12 @@ class ForeignKeyInfoTests: GRDBTestCase {
     }
     
     func testSpecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE parents2 (id PRIMARY KEY)")
@@ -124,6 +130,12 @@ class ForeignKeyInfoTests: GRDBTestCase {
     // be found unless explicitly specified as it is after
     // `main.children` in resolution order.
     func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE parents2 (id PRIMARY KEY)")
@@ -144,6 +156,12 @@ class ForeignKeyInfoTests: GRDBTestCase {
     }
     
     func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE parents2 (id PRIMARY KEY)")
@@ -368,6 +386,12 @@ class ForeignKeyInfoTests: GRDBTestCase {
     }
     
     func testForeignKeyViolationsInSpecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: """
@@ -411,6 +435,12 @@ class ForeignKeyInfoTests: GRDBTestCase {
     // be found unless explicitly specified as it is after
     // `main.child` in resolution order.
     func testForeignKeyViolationsInUnspecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: """
@@ -451,6 +481,12 @@ class ForeignKeyInfoTests: GRDBTestCase {
     }
     
     func testForeignKeyViolationsInUnspecifiedSchemaFindsAttachedDatabase() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: """

--- a/Tests/GRDBTests/IndexInfoTests.swift
+++ b/Tests/GRDBTests/IndexInfoTests.swift
@@ -126,6 +126,12 @@ class IndexInfoTests: GRDBTestCase {
     }
     
     func testSpecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: """
@@ -154,6 +160,12 @@ class IndexInfoTests: GRDBTestCase {
     // be found unless explicitly specified as it is after
     // `main.player` in resolution order.
     func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: """
@@ -175,6 +187,12 @@ class IndexInfoTests: GRDBTestCase {
     }
     
     func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: """

--- a/Tests/GRDBTests/IndexInfoTests.swift
+++ b/Tests/GRDBTests/IndexInfoTests.swift
@@ -93,4 +93,101 @@ class IndexInfoTests: GRDBTestCase {
             }
         }
     }
+    
+    func testUnknownSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndex ON player (name);
+                """)
+            do {
+                _ = try db.indexes(on: "player", in: "invalid")
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.message, "no such schema: invalid")
+                XCTAssertEqual(error.description, "SQLite error 1: no such schema: invalid")
+            }
+        }
+    }
+    
+    func testSpecifiedMainSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndex ON player (name);
+                """)
+            let indexes = try db.indexes(on: "player", in: "main")
+            XCTAssertEqual(indexes.count, 1)
+            XCTAssertEqual(indexes[0].name, "columnIndex")
+        }
+    }
+    
+    func testSpecifiedSchemaWithTableNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndexAttached ON player (name);
+                """)
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndex ON player (name);
+                """)
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            let mainIndexes = try db.indexes(on: "player", in: "main")
+            XCTAssertEqual(mainIndexes.count, 1)
+            XCTAssertEqual(mainIndexes[0].name, "columnIndex")
+            
+            let attachedIndexes = try db.indexes(on: "player", in: "attached")
+            XCTAssertEqual(attachedIndexes.count, 1)
+            XCTAssertEqual(attachedIndexes[0].name, "columnIndexAttached")
+        }
+    }
+    
+    // The `player` table in the attached database should never
+    // be found unless explicitly specified as it is after
+    // `main.player` in resolution order.
+    func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndexAttached ON player (name);
+                """)
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndex ON player (name);
+                """)
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            let mainIndexes = try db.indexes(on: "player")
+            XCTAssertEqual(mainIndexes.count, 1)
+            XCTAssertEqual(mainIndexes[0].name, "columnIndex")
+        }
+    }
+    
+    func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: """
+                CREATE TABLE player (id INTEGER PRIMARY KEY, name TEXT);
+                CREATE INDEX columnIndexAttached ON player (name);
+                """)
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            let attachedIndexes = try db.indexes(on: "player", in: "attached")
+            XCTAssertEqual(attachedIndexes.count, 1)
+            XCTAssertEqual(attachedIndexes[0].name, "columnIndexAttached")
+        }
+    }
 }

--- a/Tests/GRDBTests/PrimaryKeyInfoTests.swift
+++ b/Tests/GRDBTests/PrimaryKeyInfoTests.swift
@@ -158,6 +158,12 @@ class PrimaryKeyInfoTests: GRDBTestCase {
     }
     
     func testSpecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE items (id2 INTEGER PRIMARY KEY)")
@@ -189,6 +195,12 @@ class PrimaryKeyInfoTests: GRDBTestCase {
     // be found unless explicitly specified as it is after
     // `main.items` in resolution order.
     func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE items (id2 INTEGER PRIMARY KEY)")
@@ -208,6 +220,12 @@ class PrimaryKeyInfoTests: GRDBTestCase {
     }
     
     func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        #if GRDBCIPHER_USE_ENCRYPTION
+        // Avoid error due to key not being provided:
+        // file is not a database - while executing `ATTACH DATABASE...`
+        throw XCTSkip("This test does not support encrypted databases")
+        #endif
+        
         let attached = try makeDatabaseQueue(filename: "attached1")
         try attached.inDatabase { db in
             try db.execute(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")

--- a/Tests/GRDBTests/PrimaryKeyInfoTests.swift
+++ b/Tests/GRDBTests/PrimaryKeyInfoTests.swift
@@ -128,4 +128,100 @@ class PrimaryKeyInfoTests: GRDBTestCase {
             XCTAssertFalse(primaryKey.tableHasRowID)
         }
     }
+    
+    func testUnknownSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (name TEXT)")
+            do {
+                _ = try db.primaryKey("items", in: "invalid")
+                XCTFail("Expected Error")
+            } catch let error as DatabaseError {
+                XCTAssertEqual(error.resultCode, .SQLITE_ERROR)
+                XCTAssertEqual(error.message, "no such schema: invalid")
+                XCTAssertEqual(error.description, "SQLite error 1: no such schema: invalid")
+            }
+        }
+    }
+    
+    func testSpecifiedMainSchema() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (name TEXT)")
+            let primaryKey = try db.primaryKey("items", in: "main")
+            XCTAssertNil(primaryKey.columnInfos)
+            XCTAssertEqual(primaryKey.columns, [Column.rowID.name])
+            XCTAssertNil(primaryKey.rowIDColumn)
+            XCTAssertTrue(primaryKey.isRowID)
+            XCTAssertTrue(primaryKey.tableHasRowID)
+        }
+    }
+    
+    func testSpecifiedSchemaWithTableNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (id2 INTEGER PRIMARY KEY)")
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (id1 INTEGER PRIMARY KEY)")
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            
+            let primaryKeyMain = try db.primaryKey("items", in: "main")
+            XCTAssertEqual(primaryKeyMain.columnInfos?.map(\.name), ["id1"])
+            XCTAssertEqual(primaryKeyMain.columnInfos?.map(\.type), ["INTEGER"])
+            XCTAssertEqual(primaryKeyMain.columns, ["id1"])
+            XCTAssertEqual(primaryKeyMain.rowIDColumn, "id1")
+            XCTAssertTrue(primaryKeyMain.isRowID)
+            XCTAssertTrue(primaryKeyMain.tableHasRowID)
+            
+            let primaryKeyAttached = try db.primaryKey("items", in: "attached")
+            XCTAssertEqual(primaryKeyAttached.columnInfos?.map(\.name), ["id2"])
+            XCTAssertEqual(primaryKeyAttached.columnInfos?.map(\.type), ["INTEGER"])
+            XCTAssertEqual(primaryKeyAttached.columns, ["id2"])
+            XCTAssertEqual(primaryKeyAttached.rowIDColumn, "id2")
+            XCTAssertTrue(primaryKeyAttached.isRowID)
+            XCTAssertTrue(primaryKeyAttached.tableHasRowID)
+        }
+    }
+    
+    // The `items` table in the attached database should never
+    // be found unless explicitly specified as it is after
+    // `main.items` in resolution order.
+    func testUnspecifiedSchemaWithTableNameCollisions() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (id2 INTEGER PRIMARY KEY)")
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (id1 INTEGER PRIMARY KEY)")
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            let primaryKey = try db.primaryKey("items")
+            XCTAssertEqual(primaryKey.columnInfos?.map(\.name), ["id1"])
+            XCTAssertEqual(primaryKey.columnInfos?.map(\.type), ["INTEGER"])
+            XCTAssertEqual(primaryKey.columns, ["id1"])
+            XCTAssertEqual(primaryKey.rowIDColumn, "id1")
+            XCTAssertTrue(primaryKey.isRowID)
+            XCTAssertTrue(primaryKey.tableHasRowID)
+        }
+    }
+    
+    func testUnspecifiedSchemaFindsAttachedDatabase() throws {
+        let attached = try makeDatabaseQueue(filename: "attached1")
+        try attached.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE items (id INTEGER PRIMARY KEY)")
+        }
+        let main = try makeDatabaseQueue(filename: "main")
+        try main.inDatabase { db in
+            try db.execute(literal: "ATTACH DATABASE \(attached.path) AS attached")
+            let primaryKey = try db.primaryKey("items")
+            XCTAssertEqual(primaryKey.columnInfos?.map(\.name), ["id"])
+            XCTAssertEqual(primaryKey.columnInfos?.map(\.type), ["INTEGER"])
+            XCTAssertEqual(primaryKey.columns, ["id"])
+            XCTAssertEqual(primaryKey.rowIDColumn, "id")
+            XCTAssertTrue(primaryKey.isRowID)
+            XCTAssertTrue(primaryKey.tableHasRowID)
+        }
+    }
 }

--- a/Tests/GRDBTests/TableRecordTests.swift
+++ b/Tests/GRDBTests/TableRecordTests.swift
@@ -127,7 +127,7 @@ class TableRecordTests: GRDBTestCase {
     }
     
     func testRecordInAttachedDatabase() throws {
-        #if SQLITE_HAS_CODEC
+        #if GRDBCIPHER_USE_ENCRYPTION
         // Avoid error due to key not being provided:
         // file is not a database - while executing `ATTACH DATABASE...`
         throw XCTSkip("This test does not support encrypted databases")
@@ -185,7 +185,7 @@ class TableRecordTests: GRDBTestCase {
     }
     
     func testCrossAttachedDatabaseAssociation() throws {
-        #if SQLITE_HAS_CODEC
+        #if GRDBCIPHER_USE_ENCRYPTION
         // Avoid error due to key not being provided:
         // file is not a database - while executing `ATTACH DATABASE...`
         throw XCTSkip("This test does not support encrypted databases")


### PR DESCRIPTION
Adds an optional `schemaName` parameter to table introspection methods as discussed in #1463.

I have added the extra parameter to `foreignKeyViolations()` since that does support checking in other schemas - it then follows to also update `checkForeignKeys()`. I'm not totally happy with the doc comments on `checkForeignKeys()`, but I think they makes sense.

Commits in this PR are mostly grouped by which function they're updating, so are hopefully easy to review.

I have not updated the sample code in the README since the code in there still works and doesn't really need to show this optional addition.

One problem is that `make smokeTest` persistently fails on `DatabaseCursorTests.testFastDatabaseValueCursorStep()`. This is the first profiling test to run and takes about 3x longer than others in the same file. It appears unrelated to any of the code that I've touched with this PR. Other tests all pass.

Any and all critiques welcome!

---
### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [ ] TESTS: The `make smokeTest` terminal command runs without failure.
