### PR TITLE
Remove shadow tables from database dump

### DIFF
--- a/GRDB/Dump/Database+Dump.swift
+++ b/GRDB/Dump/Database+Dump.swift
@@ -129,6 +129,9 @@ extension Database {
     ///
     /// > Note: Internal SQLite and GRDB schema objects are not recorded
     /// > (those with a name that starts with "sqlite_" or "grdb_").
+    /// >
+    /// > [Shadow tables](https://www.sqlite.org/vtab.html#xshadowname) are
+    /// > not recorded, starting SQLite 3.37+.
     ///
     /// - Parameters:
     ///   - format: The output format.

--- a/GRDB/Dump/Database+Dump.swift
+++ b/GRDB/Dump/Database+Dump.swift
@@ -252,7 +252,7 @@ extension Database {
             """)
         for row in sqlRows {
             let name: String = row[1]
-            if Database.isSQLiteInternalTable(name) || Database.isGRDBInternalTable(name) {
+            if try ignoresObject(named: name) {
                 continue
             }
             stream.writeln(row[0])
@@ -266,11 +266,41 @@ extension Database {
                 ORDER BY name COLLATE NOCASE
                 """)
             .filter {
-                !(Database.isSQLiteInternalTable($0) || Database.isGRDBInternalTable($0))
+                try !ignoresObject(named: $0)
             }
         if tables.isEmpty { return }
         stream.write("\n")
         try _dumpTables(tables, format: format, tableHeader: .always, stableOrder: true, to: &stream)
+    }
+    
+    private func ignoresObject(named name: String) throws -> Bool {
+        if Database.isSQLiteInternalTable(name) { return true }
+        if Database.isGRDBInternalTable(name) { return true }
+        if try isShadowTable(name) { return true }
+        return false
+    }
+    
+    private func isShadowTable(_ tableName: String) throws -> Bool {
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        // Maybe SQLCipher is too old: check actual version
+        if sqlite3_libversion_number() >= 3037000 {
+            guard let table = try table(tableName) else {
+                // Not a table
+                return false
+            }
+            return table.kind == .shadow
+        }
+#else
+        if #available(iOS 15.4, macOS 12.4, tvOS 15.4, watchOS 8.5, *) { // SQLite 3.37+
+            guard let table = try table(tableName) else {
+                // Not a table
+                return false
+            }
+            return table.kind == .shadow
+        }
+#endif
+        // Don't know
+        return false
     }
 }
 

--- a/GRDB/Dump/DatabaseReader+dump.swift
+++ b/GRDB/Dump/DatabaseReader+dump.swift
@@ -120,6 +120,9 @@ extension DatabaseReader {
     ///
     /// > Note: Internal SQLite and GRDB schema objects are not recorded
     /// > (those with a name that starts with "sqlite_" or "grdb_").
+    /// >
+    /// > [Shadow tables](https://www.sqlite.org/vtab.html#xshadowname) are
+    /// > not recorded, starting SQLite 3.37+.
     ///
     /// - Parameters:
     ///   - format: The output format.

--- a/Tests/GRDBTests/DatabaseDumpTests.swift
+++ b/Tests/GRDBTests/DatabaseDumpTests.swift
@@ -1337,6 +1337,10 @@ final class DatabaseDumpTests: GRDBTestCase {
     }
     
     func test_dumpContent_ignores_shadow_tables() throws {
+        guard sqlite3_libversion_number() >= 3037000 else {
+            throw XCTSkip("Can't detect shadow tables")
+        }
+        
         try makeDatabaseQueue().write { db in
             try db.create(table: "document") { t in
                 t.autoIncrementedPrimaryKey("id")


### PR DESCRIPTION
This pull request addresses #1464 by not recording shadow tables from [`dumpContent(format:to:)`](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/database/dumpcontent(format:to:)).

[Shadow tables](https://www.sqlite.org/vtab.html#xshadowname) are implementation details of virtual tables (FTS4, FTS5, ...) that do not provide useful information in database dumps.

---

**Caveat**: detection of shadow tables uses [PRAGMA table_list](https://www.sqlite.org/pragma.html#pragma_table_list) and requires SQLite 3.37+ (iOS 15.4, macOS 12.4, tvOS 15.4, watchOS 8.5). When run with older SQLite versions, shadow tables are still recorded.

This might bother applications that use the [GRDBSnapshotTesting](https://github.com/groue/GRDBSnapshotTesting) companion library, because the test results change, depending on the SQLite version 😬 

A possible solution is to skip those tests until SQLite 3.37+, as below:

```swift
import GRDB
import GRDBSnapshotTesting
import InlineSnapshotTesting
import XCTest

class MyDatabaseTests: XCTestCase {
    func test_full_database_content() throws {
        // Database snapshot contains undesired shadow tables
        // unless we run SQLite 3.37+.
        guard sqlite3_libversion_number() >= 3037000 else {
            throw XCTSkip("Can't snapshot database before SQLite 3.37")
        }
        
        let dbQueue = try makeMyDatabase()
        assertInlineSnapshot(of: dbQueue, as: .dumpContent()) {
            ...
        }
    }
}
```