### PR TITLE
Recommend IMMEDIATE transactions when a database is shared between multiple processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ GRDB adheres to [Semantic Versioning](https://semver.org/), with one exception: 
 
 ## Next Release
 
+- **Documentation Update**: The [Sharing a Database](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/databasesharing) guide was updated with a new recommendation. When an SQLite database is shared between multiple processes, writers should always perform IMMEDIATE transactions in order to avoid the `SQLITE_BUSY` error that can occur when transactions overlap. The new recommendation fits in a single line of code: `configuration.defaultTransactionKind = .immediate`.
 - **New**: Associations that involve views instead of tables are supported, but they require an explicit `ForeignKey` in their definition. Now a clear diagnostic message is emitted, instead of a unhelpful "no such table" runtime error.
 
 ## 6.24.1

--- a/GRDB/Documentation.docc/DatabaseSharing.md
+++ b/GRDB/Documentation.docc/DatabaseSharing.md
@@ -152,11 +152,14 @@ If several processes want to write in the database, configure the database pool 
 
 ```swift
 var configuration = Configuration()
+configuration.defaultTransactionKind = .immediate
 configuration.busyMode = .timeout(/* a TimeInterval */)
 let dbPool = try DatabasePool(path: ..., configuration: configuration)
 ```
 
-With such a setup, you may still get `SQLITE_BUSY` errors from all write operations. They will occur if the database remains locked by another process for longer than the specified timeout. You can catch those errors:
+Both the `defaultTransactionKind` and `busyMode` are important for preventing `SQLITE_BUSY`. The `immediate` transaction kind prevents write transactions from overlapping, and the busy timeout has write transactions wait, instead of throwing `SQLITE_BUSY`, whenever another process is writing.
+
+With such a setup, you will still get `SQLITE_BUSY` errors if the database remains locked by another process for longer than the specified timeout. You can catch those errors:
 
 ```swift
 do {


### PR DESCRIPTION
This pull request addresses #1483 by recommending to add a single line of code in applications that share a database across multiple processes:

```swift
configuration.defaultTransactionKind = .immediate
```
