### PR TITLE
Conform Database.ColumnType to Sendable

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1910,7 +1910,7 @@ extension Database {
     ///
     /// For more information, see
     /// [Datatypes In SQLite](https://www.sqlite.org/datatype3.html).
-    public struct ColumnType: RawRepresentable, Hashable {
+    public struct ColumnType: RawRepresentable, Hashable, Sendable {
         /// The SQL for the column type (`"TEXT"`, `"BLOB"`, etc.)
         public let rawValue: String
         


### PR DESCRIPTION
First up, thank you for making this! 🙏🏻 I have used GRDB in quite a few projects throughout my career now and it's a go-to tool for me. Making my first contribution to it a fairly minor improvement :)

This silences a (couple of, due to the static lets) warning when building GRDB with strict concurrency checking enabled. `Database.ColumnType` is `RawRepresentable` as a `String` (which also is `Sendable`) and its `rawValue` cannot change, making this a safe conformance.

Please let me know if there are things I have missed or if this can be done in a better way!

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
