### PR TITLE
Improve the documentation about the scheduling of ValueObservation fetches

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -820,6 +820,11 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     
     /// Reports the database region to ``ValueObservation``.
     ///
+    /// Calling this method does not fetch any database values. It just
+    /// helps optimizing `ValueObservation`. See
+    /// ``ValueObservation/trackingConstantRegion(_:)`` for more
+    /// information, and some examples of usage.
+    ///
     /// For example:
     ///
     /// ```swift
@@ -831,12 +836,9 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// }
     /// ```
     ///
-    /// See ``ValueObservation/trackingConstantRegion(_:)`` for some examples
-    /// of region reporting.
-    ///
-    /// This method has no effect on a ``ValueObservation`` created with an
-    /// explicit list of tracked regions. In the example below, only the
-    /// `player` table is tracked:
+    /// This method has no effect on a `ValueObservation` created with
+    /// ``ValueObservation/tracking(regions:fetch:)``. In the example below,
+    /// only the `player` table is tracked:
     ///
     /// ```swift
     /// // Observes the 'player' table only

--- a/GRDB/ValueObservation/ValueObservationScheduler.swift
+++ b/GRDB/ValueObservation/ValueObservationScheduler.swift
@@ -66,6 +66,10 @@ extension ValueObservationScheduler where Self == AsyncValueObservationScheduler
     ///         print("fresh players: \(players)")
     ///     })
     /// ```
+    ///
+    /// - warning: Make sure you provide a serial queue, because a
+    ///   concurrent one such as `DispachQueue.global(qos: .default)` would
+    ///   mess with the ordering of fresh value notifications.
     public static func async(onQueue queue: DispatchQueue) -> AsyncValueObservationScheduler {
         AsyncValueObservationScheduler(queue: queue)
     }


### PR DESCRIPTION
This pull request enhances the `ValueObservation` documentation with the topics explored in #1529.

In particular, it makes it explicit that `ValueObservation`, by default, fetches fresh values from the main thread, when the database is modified on the main thread. It also better explains how to configure an observation so that fresh values are never fetched from the main thread.

@kernandreas, thank you for opening #1529 👍 