### PR TITLE
Fix error in CTE association documentation

### DIFF
--- a/Documentation/CommonTableExpressions.md
+++ b/Documentation/CommonTableExpressions.md
@@ -251,7 +251,7 @@ let rightCTE = ...
 let association = LeftRecord.association(
     to: rightCTE, 
     on: { left, right in
-        left[Column("x")] = right[Column("y")]
+        left[Column("x")] == right[Column("y")]
     })
 ```
 


### PR DESCRIPTION
This PR addresses a mistake in the code examples for creating Common Table Expression associations.

The example given won't compile; updating the assignment operator to an equality check corrects the snippet and matches the similar example further on in the doc.

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [ ] TESTS: Changes are tested.
- [ ] TESTS: The `make smokeTest` terminal command runs without failure.
