### PR TITLE
Support for single value decoding

### DIFF
--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -506,15 +506,19 @@ private struct SingleValueRowDecoder<R: FetchableRecord>: SingleValueDecodingCon
     func decode(_ type: Int16.Type) throws -> Int16 { try columnDecoder.decode(type) }
     func decode(_ type: Int32.Type) throws -> Int32 { try columnDecoder.decode(type) }
     func decode(_ type: Int64.Type) throws -> Int64 { try columnDecoder.decode(type) }
+#if compiler(>=6)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func decode(_ type: Int128.Type) throws -> Int128 { try columnDecoder.decode(type) }
+#endif
     func decode(_ type: UInt.Type) throws -> UInt { try columnDecoder.decode(type) }
     func decode(_ type: UInt8.Type) throws -> UInt8 { try columnDecoder.decode(type) }
     func decode(_ type: UInt16.Type) throws -> UInt16 { try columnDecoder.decode(type) }
     func decode(_ type: UInt32.Type) throws -> UInt32 { try columnDecoder.decode(type) }
     func decode(_ type: UInt64.Type) throws -> UInt64 { try columnDecoder.decode(type) }
+#if compiler(>=6)
     @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
     func decode(_ type: UInt128.Type) throws -> UInt128 { try columnDecoder.decode(type) }
+#endif
 
     func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
         if let type = T.self as? any FetchableRecord.Type {

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -108,8 +108,12 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
     
     func singleValueContainer() throws -> SingleValueDecodingContainer {
         guard let key = codingPath.last else {
-            // Decoding an array of scalars from rows: pick the first column
-            return ColumnDecoder<R>(row: row, columnIndex: 0, codingPath: codingPath)
+            // Not yet sure what we are decoding, this will be decided in the SingleValueDecodingContainer functions.
+            // For decoding an array of scalars (in case of prefetched rows) we pick the first column.
+            return SingleValueRowDecoder(
+                columnDecoder: ColumnDecoder<R>(row: row, columnIndex: 0, codingPath: codingPath),
+                columnDecodingStrategy: columnDecodingStrategy
+            )
         }
         guard let index = row.index(forColumn: key.stringValue) else {
             // Don't use DecodingError.keyNotFound:
@@ -346,7 +350,7 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
             
             // Unknown key
             //
-            // Should be throw an error? Well... The use case is the following:
+            // Should we throw an error? Well... The use case is the following:
             //
             //      // SELECT book.*, author.* FROM book
             //      // JOIN author ON author.id = book.authorId
@@ -483,6 +487,46 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
                         .decode(type.self, from: data)
                 }
             }
+        }
+    }
+}
+
+private struct SingleValueRowDecoder<R: FetchableRecord>: SingleValueDecodingContainer {
+    var columnDecoder: ColumnDecoder<R>
+    var columnDecodingStrategy: DatabaseColumnDecodingStrategy
+    let codingPath: [any CodingKey] = []
+    
+    func decodeNil() -> Bool { columnDecoder.decodeNil() }
+    func decode(_ type: Bool.Type) throws -> Bool { try columnDecoder.decode(type) }
+    func decode(_ type: String.Type) throws -> String { try columnDecoder.decode(type) }
+    func decode(_ type: Double.Type) throws -> Double { try columnDecoder.decode(type) }
+    func decode(_ type: Float.Type) throws -> Float { try columnDecoder.decode(type) }
+    func decode(_ type: Int.Type) throws -> Int { try columnDecoder.decode(type) }
+    func decode(_ type: Int8.Type) throws -> Int8 { try columnDecoder.decode(type) }
+    func decode(_ type: Int16.Type) throws -> Int16 { try columnDecoder.decode(type) }
+    func decode(_ type: Int32.Type) throws -> Int32 { try columnDecoder.decode(type) }
+    func decode(_ type: Int64.Type) throws -> Int64 { try columnDecoder.decode(type) }
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func decode(_ type: Int128.Type) throws -> Int128 { try columnDecoder.decode(type) }
+    func decode(_ type: UInt.Type) throws -> UInt { try columnDecoder.decode(type) }
+    func decode(_ type: UInt8.Type) throws -> UInt8 { try columnDecoder.decode(type) }
+    func decode(_ type: UInt16.Type) throws -> UInt16 { try columnDecoder.decode(type) }
+    func decode(_ type: UInt32.Type) throws -> UInt32 { try columnDecoder.decode(type) }
+    func decode(_ type: UInt64.Type) throws -> UInt64 { try columnDecoder.decode(type) }
+    @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
+    func decode(_ type: UInt128.Type) throws -> UInt128 { try columnDecoder.decode(type) }
+
+    func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
+        if let type = T.self as? any FetchableRecord.Type {
+            // Prefer FetchableRecord decoding over Decodable.
+            return try type.init(row: columnDecoder.row) as! T
+        } else {
+            let decoder = _RowDecoder<R>(
+                row: columnDecoder.row,
+                codingPath: [],
+                columnDecodingStrategy: columnDecodingStrategy
+            )
+            return try T(from: decoder)
         }
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR addresses #1572, and has GRDB support generic decodable records that decode their base record from a singleValueContainer.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs ~without failure~.

I did get some random tests failing in the smoke test, but the failures were different per iOS simulator. This also happens when running from the development branch, so I guess that is not my doing.
