### PR TITLE
Show trigger comments for expanded statement tracing

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -2103,7 +2103,7 @@ extension Database {
             public var expandedSQL: String {
                 if let unexpandedSQL {
                     let sql = String(cString: unexpandedSQL)
-                    if sql.hasSuffix("--") { return sql }
+                    if sql.hasPrefix("--") { return sql }
                 }
                 guard let cString = sqlite3_expanded_sql(sqliteStatement) else {
                     return ""

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -2101,6 +2101,10 @@ extension Database {
             ///   information from leaking in unexpected locations, so use this
             ///   property with care.
             public var expandedSQL: String {
+                if let unexpandedSQL {
+                    let sql = String(cString: unexpandedSQL)
+                    if sql.hasSuffix("--") { return sql }
+                }
                 guard let cString = sqlite3_expanded_sql(sqliteStatement) else {
                     return ""
                 }

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -2083,7 +2083,8 @@ extension Database {
             /// ```
             public var sql: String {
                 if let unexpandedSQL {
-                    return String(cString: unexpandedSQL).trimmedSQLStatement
+                    let sql = String(cString: unexpandedSQL)
+                    return sql.hasPrefix("--") ? sql : sql.trimmedSQLStatement
                 } else {
                     return String(cString: sqlite3_sql(sqliteStatement)).trimmedSQLStatement
                 }


### PR DESCRIPTION
When trace logs are enabled along with public statements, the output repeats the triggering statement for every table trigger rather than showing the trace trigger comment.

For example, if table `foo` has two triggers and I do
```sql
INSERT INTO foo (one, two) VALUES (1, 2)
```
the current implementation will log
```sql
INSERT INTO foo (one, two) VALUES (1, 2)
INSERT INTO foo (one, two) VALUES (1, 2)
INSERT INTO foo (one, two) VALUES (1, 2)
```
rather than
```sql
INSERT INTO foo (one, two) VALUES (1, 2)
— TRIGGER <trigger name>
— TRIGGER <trigger name>
```
I am not experienced with C interop so welcome a more efficient way to test for a SQL comment. Also, I didn’t see that this warranted particular documentation since it will just match the behavior of the non-expanded traces.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
