### PR TITLE
Fix compilation issue with Xcode 16 beta 5 due to a missing import.

### DIFF
--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -2,6 +2,10 @@
 import Glibc
 #endif
 
+#if canImport(Darwin)
+import Darwin
+#endif
+
 /// `StatementAuthorizer` provides information about compiled database
 /// statements, and prevents the truncate optimization when row deletions are
 /// observed by transaction observers.


### PR DESCRIPTION
This is a fix for https://github.com/groue/GRDB.swift/issues/1588, a compilation issue with Xcode 16 beta 5.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
