### PR TITLE
GRDB 7: enhance ergonomics of record methods that insert/save/upsert and fetch

### DIFF
--- a/GRDB/Record/MutablePersistableRecord+Insert.swift
+++ b/GRDB/Record/MutablePersistableRecord+Insert.swift
@@ -91,7 +91,6 @@ extension MutablePersistableRecord {
 
 extension MutablePersistableRecord {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-    // TODO: GRDB7 make it unable to return an optional
     /// Executes an `INSERT RETURNING` statement, and returns a new record built
     /// from the inserted row.
     ///
@@ -108,22 +107,22 @@ extension MutablePersistableRecord {
     /// - parameter conflictResolution: A policy for conflict resolution. If
     ///   nil, <doc:/MutablePersistableRecord/persistenceConflictPolicy-1isyv>
     ///   is used.
-    /// - returns: The inserted record, if any. The result can be nil when the
-    ///   conflict policy is `IGNORE`.
+    /// - returns: The inserted record.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type.
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` can be
+    ///   thrown if the insertion failed due to the IGNORE conflict policy.
     @inlinable // allow specialization so that empty callbacks are removed
     public func insertAndFetch(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil)
-    throws -> Self?
+    throws -> Self
     where Self: FetchableRecord
     {
         var result = self
         return try result.insertAndFetch(db, onConflict: conflictResolution, as: Self.self)
     }
     
-    // TODO: GRDB7 make it unable to return an optional
     /// Executes an `INSERT RETURNING` statement, and returns a new record built
     /// from the inserted row.
     ///
@@ -161,11 +160,10 @@ extension MutablePersistableRecord {
     ///     var partialPlayer = PartialPlayer(name: "Alice")
     ///
     ///     // INSERT INTO player (name) VALUES ('Alice') RETURNING *
-    ///     if let player = try partialPlayer.insertAndFetch(db, as: FullPlayer.self) {
-    ///         print(player.id)    // The inserted id
-    ///         print(player.name)  // The inserted name
-    ///         print(player.score) // The default score
-    ///     }
+    ///     let player = try partialPlayer.insertAndFetch(db, as: FullPlayer.self)
+    ///     print(player.id)    // The inserted id
+    ///     print(player.name)  // The inserted name
+    ///     print(player.score) // The default score
     /// }
     /// ```
     ///
@@ -174,19 +172,24 @@ extension MutablePersistableRecord {
     ///   nil, <doc:/MutablePersistableRecord/persistenceConflictPolicy-1isyv>
     ///   is used.
     /// - parameter returnedType: The type of the returned record.
-    /// - returns: A record of type `returnedType`, if any. The result can be
-    ///   nil when the conflict policy is `IGNORE`.
+    /// - returns: A record of type `returnedType`.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type.
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` can be
+    ///   thrown if the insertion failed due to the IGNORE conflict policy.
     @inlinable // allow specialization so that empty callbacks are removed
     public mutating func insertAndFetch<T: FetchableRecord & TableRecord>(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
         as returnedType: T.Type)
-    throws -> T?
+    throws -> T
     {
-        try insertAndFetch(db, onConflict: conflictResolution, selection: T.databaseSelection) {
-            try T.fetchOne($0)
+        let record = self
+        return try insertAndFetch(db, onConflict: conflictResolution, selection: T.databaseSelection) {
+            if let result = try T.fetchOne($0) {
+                return result
+            }
+            throw record.recordNotFound(db)
         }
     }
     
@@ -266,7 +269,6 @@ extension MutablePersistableRecord {
         return success.returned
     }
 #else
-    // TODO: GRDB7 make it unable to return an optional
     /// Executes an `INSERT RETURNING` statement, and returns a new record built
     /// from the inserted row.
     ///
@@ -283,23 +285,23 @@ extension MutablePersistableRecord {
     /// - parameter conflictResolution: A policy for conflict resolution. If
     ///   nil, <doc:/MutablePersistableRecord/persistenceConflictPolicy-1isyv>
     ///   is used.
-    /// - returns: The inserted record, if any. The result can be nil when the
-    ///   conflict policy is `IGNORE`.
+    /// - returns: The inserted record.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type.
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` can be
+    ///   thrown if the insertion failed due to the IGNORE conflict policy.
     @inlinable // allow specialization so that empty callbacks are removed
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) // SQLite 3.35.0+
     public func insertAndFetch(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil)
-    throws -> Self?
+    throws -> Self
     where Self: FetchableRecord
     {
         var result = self
         return try result.insertAndFetch(db, onConflict: conflictResolution, as: Self.self)
     }
     
-    // TODO: GRDB7 make it unable to return an optional
     /// Executes an `INSERT RETURNING` statement, and returns a new record built
     /// from the inserted row.
     ///
@@ -337,11 +339,10 @@ extension MutablePersistableRecord {
     ///     var partialPlayer = PartialPlayer(name: "Alice")
     ///
     ///     // INSERT INTO player (name) VALUES ('Alice') RETURNING *
-    ///     if let player = try partialPlayer.insertAndFetch(db, as: FullPlayer.self) {
-    ///         print(player.id)    // The inserted id
-    ///         print(player.name)  // The inserted name
-    ///         print(player.score) // The default score
-    ///     }
+    ///     let player = try partialPlayer.insertAndFetch(db, as: FullPlayer.self)
+    ///     print(player.id)    // The inserted id
+    ///     print(player.name)  // The inserted name
+    ///     print(player.score) // The default score
     /// }
     /// ```
     ///
@@ -350,20 +351,25 @@ extension MutablePersistableRecord {
     ///   nil, <doc:/MutablePersistableRecord/persistenceConflictPolicy-1isyv>
     ///   is used.
     /// - parameter returnedType: The type of the returned record.
-    /// - returns: A record of type `returnedType`, if any. The result can be
-    ///   nil when the conflict policy is `IGNORE`.
+    /// - returns: A record of type `returnedType`.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or any
     ///   error thrown by the persistence callbacks defined by the record type.
+    ///   ``RecordError/recordNotFound(databaseTableName:key:)`` can be
+    ///   thrown if the insertion failed due to the IGNORE conflict policy.
     @inlinable // allow specialization so that empty callbacks are removed
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) // SQLite 3.35.0+
     public mutating func insertAndFetch<T: FetchableRecord & TableRecord>(
         _ db: Database,
         onConflict conflictResolution: Database.ConflictResolution? = nil,
         as returnedType: T.Type)
-    throws -> T?
+    throws -> T
     {
-        try insertAndFetch(db, onConflict: conflictResolution, selection: T.databaseSelection) {
-            try T.fetchOne($0)
+        let record = self
+        return try insertAndFetch(db, onConflict: conflictResolution, selection: T.databaseSelection) {
+            if let result = try T.fetchOne($0) {
+                return result
+            }
+            throw record.recordNotFound(db)
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -2330,11 +2330,10 @@ try dbQueue.write { db in
     let partialPlayer = PartialPlayer(name: "Alice")
     
     // INSERT INTO player (name) VALUES ('Alice') RETURNING *
-    if let player = try partialPlayer.insertAndFetch(db, as: Player.self) {
-        print(player.id)    // The inserted id
-        print(player.name)  // The inserted name
-        print(player.score) // The default score
-    }
+    let player = try partialPlayer.insertAndFetch(db, as: Player.self)
+    print(player.id)    // The inserted id
+    print(player.name)  // The inserted name
+    print(player.score) // The default score
 }
 ```
 
@@ -3108,15 +3107,16 @@ struct Player : MutablePersistableRecord {
 try player.insert(db)
 ```
 
-> **Note**: If you specify the `ignore` policy for inserts, the [`didInsert`  callback](#persistence-callbacks) will be called with some random id in case of failed insert. You can detect failed insertions with `insertAndFetch`:
+> **Note**: If you specify the `ignore` policy for inserts, the [`didInsert` callback](#persistence-callbacks) will be called with some random id in case of failed insert. You can detect failed insertions with `insertAndFetch`:
 >     
 > ```swift
 > // How to detect failed `INSERT OR IGNORE`:
 > // INSERT OR IGNORE INTO player ... RETURNING *
-> if let insertedPlayer = try player.insertAndFetch(db) {
+> do {
+>     let insertedPlayer = try player.insertAndFetch(db) {
 >     // Succesful insertion
-> } else {
->     // Ignored failure
+> catch RecordError.recordNotFound {
+>     // Failed insertion due to IGNORE policy
 > }
 > ```
 >

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -1261,7 +1261,7 @@ extension MutablePersistableRecordTests {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let player = FullPlayer(id: nil, name: "Arthur", score: 1000)
-            let insertedPlayer = try XCTUnwrap(player.insertAndFetch(db))
+            let insertedPlayer = try player.insertAndFetch(db)
             XCTAssertEqual(insertedPlayer.id, 1)
             XCTAssertEqual(insertedPlayer.name, "Arthur")
             XCTAssertEqual(insertedPlayer.score, 1000)
@@ -1284,7 +1284,7 @@ extension MutablePersistableRecordTests {
             do {
                 sqlQueries.removeAll()
                 var partialPlayer = PartialPlayer(name: "Arthur")
-                let fullPlayer = try XCTUnwrap(partialPlayer.insertAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.insertAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.contains("""
                     INSERT INTO "player" ("id", "name") VALUES (NULL,'Arthur') RETURNING *
@@ -1423,7 +1423,7 @@ extension MutablePersistableRecordTests {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             let player = FullPlayer(id: nil, name: "Arthur", score: 1000)
-            let savedPlayer = try XCTUnwrap(player.saveAndFetch(db))
+            let savedPlayer = try player.saveAndFetch(db)
             XCTAssertEqual(savedPlayer.id, 1)
             XCTAssertEqual(savedPlayer.name, "Arthur")
             XCTAssertEqual(savedPlayer.score, 1000)
@@ -1446,7 +1446,7 @@ extension MutablePersistableRecordTests {
             do {
                 sqlQueries.removeAll()
                 var partialPlayer = PartialPlayer(name: "Arthur")
-                let fullPlayer = try XCTUnwrap(partialPlayer.saveAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.saveAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.allSatisfy { !$0.contains("UPDATE") })
                 XCTAssert(sqlQueries.contains("""
@@ -1483,7 +1483,7 @@ extension MutablePersistableRecordTests {
                 var partialPlayer = PartialPlayer(id: 1, name: "Arthur")
                 try partialPlayer.delete(db)
                 sqlQueries.removeAll()
-                let fullPlayer = try XCTUnwrap(partialPlayer.saveAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.saveAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.contains("""
                     UPDATE "player" SET "name"='Arthur' WHERE "id"=1 RETURNING *
@@ -1521,7 +1521,7 @@ extension MutablePersistableRecordTests {
             do {
                 sqlQueries.removeAll()
                 var partialPlayer = PartialPlayer(id: 1, name: "Arthur")
-                let fullPlayer = try XCTUnwrap(partialPlayer.saveAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.saveAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.allSatisfy { !$0.contains("INSERT") })
                 XCTAssert(sqlQueries.contains("""
@@ -1709,7 +1709,7 @@ extension MutablePersistableRecordTests {
             player.name = "Barbara"
             
             do {
-                let updatedPlayer = try XCTUnwrap(player.updateAndFetch(db))
+                let updatedPlayer = try player.updateAndFetch(db)
                 XCTAssertEqual(updatedPlayer.id, 1)
                 XCTAssertEqual(updatedPlayer.name, "Barbara")
                 XCTAssertEqual(updatedPlayer.score, 1000)
@@ -1760,7 +1760,7 @@ extension MutablePersistableRecordTests {
             player.name = "Barbara"
             
             do {
-                let updatedPlayer = try XCTUnwrap(player.updateAndFetch(db, as: PartialPlayer.self))
+                let updatedPlayer = try player.updateAndFetch(db, as: PartialPlayer.self)
                 XCTAssertEqual(updatedPlayer.id, 1)
                 XCTAssertEqual(updatedPlayer.name, "Barbara")
             }
@@ -2041,11 +2041,15 @@ extension MutablePersistableRecordTests {
             try player.insert(db)
             
             do {
-                let updatedRow = try player.updateChangesAndFetch(
+                // Update with no change
+                let update = try player.updateChangesAndFetch(
                     db, selection: [AllColumns()],
-                    fetch: { statement in try Row.fetchOne(statement) },
+                    fetch: { statement in
+                        XCTFail("Should not be called")
+                        return "ignored"
+                    },
                     modify: { $0.name = "Barbara" })
-                XCTAssertNil(updatedRow)
+                XCTAssertNil(update)
             }
             
             do {

--- a/Tests/GRDBTests/PersistableRecordTests.swift
+++ b/Tests/GRDBTests/PersistableRecordTests.swift
@@ -1342,7 +1342,7 @@ extension PersistableRecordTests {
             do {
                 sqlQueries.removeAll()
                 let partialPlayer = PartialPlayer(name: "Arthur")
-                let fullPlayer = try XCTUnwrap(partialPlayer.insertAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.insertAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.contains("""
                     INSERT INTO "player" ("id", "name") VALUES (NULL,'Arthur') RETURNING *
@@ -1444,7 +1444,7 @@ extension PersistableRecordTests {
             do {
                 sqlQueries.removeAll()
                 let partialPlayer = PartialPlayer(name: "Arthur")
-                let fullPlayer = try XCTUnwrap(partialPlayer.saveAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.saveAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.allSatisfy { !$0.contains("UPDATE") })
                 XCTAssert(sqlQueries.contains("""
@@ -1480,7 +1480,7 @@ extension PersistableRecordTests {
                 let partialPlayer = PartialPlayer(id: 1, name: "Arthur")
                 try partialPlayer.delete(db)
                 sqlQueries.removeAll()
-                let fullPlayer = try XCTUnwrap(partialPlayer.saveAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.saveAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.contains("""
                     UPDATE "player" SET "name"='Arthur' WHERE "id"=1 RETURNING *
@@ -1517,7 +1517,7 @@ extension PersistableRecordTests {
             do {
                 sqlQueries.removeAll()
                 let partialPlayer = PartialPlayer(id: 1, name: "Arthur")
-                let fullPlayer = try XCTUnwrap(partialPlayer.saveAndFetch(db, as: FullPlayer.self))
+                let fullPlayer = try partialPlayer.saveAndFetch(db, as: FullPlayer.self)
                 
                 XCTAssert(sqlQueries.allSatisfy { !$0.contains("INSERT") })
                 XCTAssert(sqlQueries.contains("""


### PR DESCRIPTION
The `insertAndFetch`, `saveAndFetch`, and `updateAndFetch` methods no longer return optionals.

When inserts and updates are performed with the `IGNORE` conflict policy, those methods can throw `RecordError.recordNotFound` (they used to return nil in case of conflict).