### PR TITLE
GRDB 7: Remove DatabasePool.concurrentRead

### DIFF
--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -266,19 +266,6 @@ extension DatabaseQueue: DatabaseReader {
         try writer.reentrantSync(value)
     }
     
-    public func concurrentRead<T>(_ value: @escaping (Database) throws -> T) -> DatabaseFuture<T> {
-        // DatabaseQueue can't perform parallel reads.
-        // Perform a blocking read instead.
-        return DatabaseFuture(Result {
-            // Check that we're on the writer queue, as documented
-            try writer.execute { db in
-                try db.isolated(readOnly: true) {
-                    try value(db)
-                }
-            }
-        })
-    }
-    
     public func spawnConcurrentRead(_ value: @escaping (Result<Database, Error>) -> Void) {
         // Check that we're on the writer queue...
         writer.execute { db in

--- a/TODO.md
+++ b/TODO.md
@@ -102,7 +102,7 @@
 - [ ] GRDB7: Sendable: DatabaseDataDecodingStrategy (264d7fb5)
 - [ ] GRDB7: Sendable: DatabaseDateDecodingStrategy (264d7fb5)
 - [ ] GRDB7: Sendable: DatabaseColumnDecodingStrategy (264d7fb5)
-- [ ] GRDB7/BREAKING: Remove DatabaseFuture and concurrentRead (05f7d3c8)
+- [X] GRDB7/BREAKING: Remove DatabaseFuture and concurrentRead (05f7d3c8)
 - [ ] GRDB7: Sendable: DatabaseFunction (6e691fe7)
 - [ ] GRDB7: Sendable: DatabaseMigrator (22114ad4)
 - [ ] GRDB7: Not Sendable: FilterCursor (b26e9709)


### PR DESCRIPTION
This pull request removes the `DatabasePool.concurrentRead` method that returns a `DatabaseFuture`. Instead, use `DatabasePool.asyncConcurrentRead`.