### PR TITLE
GRDB 7: coding strategies depend on the column

### DIFF
--- a/GRDB/Documentation.docc/JSON.md
+++ b/GRDB/Documentation.docc/JSON.md
@@ -92,7 +92,9 @@ struct Team: Codable {
 extension Team: FetchableRecord, PersistableRecord {
     // Support SQLite JSON functions and operators
     // by storing JSON data as database text:
-    static let databaseDataEncodingStrategy = DatabaseDataEncodingStrategy.text
+    static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy {
+        .text
+    }
 }
 ```
 

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -443,45 +443,64 @@ extension TableRequest where Self: FilteredRequest, Self: TypedRequest {
         // `deleteAll(_:ids:)` etc.
         if let recordType = RowDecoder.self as? any EncodableRecord.Type {
             if Sequence.Element.self == Data.self || Sequence.Element.self == Optional<Data>.self {
-                let strategy = recordType.databaseDataEncodingStrategy
-                let keys = keys.compactMap { ($0 as! Data?).flatMap(strategy.encode)?.databaseValue }
-                return filter(rawKeys: keys)
+                let datas = keys.compactMap { ($0 as! Data?) }
+                if datas.isEmpty {
+                    // Don't hit the database
+                    return none()
+                }
+                
+                return filterWhenConnected(keys: { [databaseTableName] db in
+                    let primaryKey = try db.primaryKey(databaseTableName)
+                    GRDBPrecondition(
+                        primaryKey.columns.count == 1,
+                        "Requesting by key requires a single-column primary key in the table \(databaseTableName)")
+                    let column = primaryKey.columns[0]
+                    let strategy = recordType.databaseDataEncodingStrategy(for: column)
+                    let expressions = datas.map { strategy.encode($0).sqlExpression }
+                    return expressions
+                })
             } else if Sequence.Element.self == Date.self || Sequence.Element.self == Optional<Date>.self {
+                let dates = keys.compactMap { ($0 as! Date?) }
+                if dates.isEmpty {
+                    // Don't hit the database
+                    return none()
+                }
                 let strategy = recordType.databaseDateEncodingStrategy
-                let keys = keys.compactMap { ($0 as! Date?).flatMap(strategy.encode)?.databaseValue }
-                return filter(rawKeys: keys)
+                let expressions = dates.map { strategy.encode($0).sqlExpression }
+                return filterWhenConnected(keys: { _ in expressions })
             } else if Sequence.Element.self == UUID.self || Sequence.Element.self == Optional<UUID>.self {
+                let uuids = keys.compactMap { ($0 as! UUID?) }
+                if uuids.isEmpty {
+                    // Don't hit the database
+                    return none()
+                }
                 let strategy = recordType.databaseUUIDEncodingStrategy
-                let keys = keys.map { ($0 as! UUID?).map(strategy.encode)?.databaseValue }
-                return filter(rawKeys: keys)
+                let expressions = uuids.map { strategy.encode($0).sqlExpression }
+                return filterWhenConnected(keys: { _ in expressions })
             }
         }
         
-        return filter(rawKeys: keys)
+        let expressions = keys.map { $0.sqlExpression }
+        if expressions.isEmpty {
+            // Don't hit the database
+            return none()
+        }
+        return filterWhenConnected(keys: { _ in expressions })
     }
     
     /// Creates a request filtered by primary key.
     ///
     ///     // SELECT * FROM player WHERE ... id IN (1, 2, 3)
-    ///     let request = try Player...filter(rawKeys: [1, 2, 3])
+    ///     let request = try Player...filterWhenConnected(keys: { db in [1, 2, 3] })
     ///
     /// - parameter keys: A collection of primary keys
-    func filter<Keys>(rawKeys: Keys) -> Self
-    where Keys: Sequence, Keys.Element: DatabaseValueConvertible
-    {
-        // Don't bother removing NULLs. We'd lose CPU cycles, and this does not
-        // change the SQLite results anyway.
-        let expressions = rawKeys.map {
-            $0.databaseValue.sqlExpression
-        }
-        
-        if expressions.isEmpty {
-            // Don't hit the database
-            return none()
-        }
-        
+    fileprivate func filterWhenConnected(keys: @escaping @Sendable (Database) throws -> [SQLExpression]) -> Self {
         let databaseTableName = self.databaseTableName
         return filterWhenConnected { db in
+            // Don't bother removing NULLs. We'd lose CPU cycles, and this does not
+            // change the SQLite results anyway.
+            let expressions = try keys(db)
+            
             let primaryKey = try db.primaryKey(databaseTableName)
             GRDBPrecondition(
                 primaryKey.columns.count == 1,

--- a/GRDB/QueryInterface/Request/RequestProtocols.swift
+++ b/GRDB/QueryInterface/Request/RequestProtocols.swift
@@ -482,9 +482,17 @@ extension TableRequest where Self: FilteredRequest, Self: TypedRequest {
                     // Don't hit the database
                     return none()
                 }
-                let strategy = recordType.databaseUUIDEncodingStrategy
-                let expressions = uuids.map { strategy.encode($0).sqlExpression }
-                return filterWhenConnected(keys: { _ in expressions })
+                
+                return filterWhenConnected(keys: { [databaseTableName] db in
+                    let primaryKey = try db.primaryKey(databaseTableName)
+                    GRDBPrecondition(
+                        primaryKey.columns.count == 1,
+                        "Requesting by key requires a single-column primary key in the table \(databaseTableName)")
+                    let column = primaryKey.columns[0]
+                    let strategy = recordType.databaseUUIDEncodingStrategy(for: column)
+                    let expressions = uuids.map { strategy.encode($0).sqlExpression }
+                    return expressions
+                })
             }
         }
         

--- a/GRDB/Record/EncodableRecord+Encodable.swift
+++ b/GRDB/Record/EncodableRecord+Encodable.swift
@@ -122,7 +122,9 @@ private class RecordEncoder<Record: EncodableRecord>: Encoder {
             let dbValue = Record.databaseDataEncodingStrategy(for: column).encode(data)
             _persistenceContainer[column] = dbValue
         } else if let date = value as? Date {
-            persist(Record.databaseDateEncodingStrategy.encode(date), forKey: key)
+            let column = keyEncodingStrategy.column(forKey: key)
+            let dbValue = Record.databaseDateEncodingStrategy(for: column).encode(date)
+            _persistenceContainer[column] = dbValue
         } else if let uuid = value as? UUID {
             persist(Record.databaseUUIDEncodingStrategy.encode(uuid), forKey: key)
         } else if let value = value as? any DatabaseValueConvertible {

--- a/GRDB/Record/EncodableRecord+Encodable.swift
+++ b/GRDB/Record/EncodableRecord+Encodable.swift
@@ -126,7 +126,9 @@ private class RecordEncoder<Record: EncodableRecord>: Encoder {
             let dbValue = Record.databaseDateEncodingStrategy(for: column).encode(date)
             _persistenceContainer[column] = dbValue
         } else if let uuid = value as? UUID {
-            persist(Record.databaseUUIDEncodingStrategy.encode(uuid), forKey: key)
+            let column = keyEncodingStrategy.column(forKey: key)
+            let dbValue = Record.databaseUUIDEncodingStrategy(for: column).encode(uuid)
+            _persistenceContainer[column] = dbValue
         } else if let value = value as? any DatabaseValueConvertible {
             // Prefer DatabaseValueConvertible encoding over Decodable.
             persist(value.databaseValue, forKey: key)

--- a/GRDB/Record/EncodableRecord+Encodable.swift
+++ b/GRDB/Record/EncodableRecord+Encodable.swift
@@ -118,7 +118,9 @@ private class RecordEncoder<Record: EncodableRecord>: Encoder {
     
     fileprivate func encode<T>(_ value: T, forKey key: any CodingKey) throws where T: Encodable {
         if let data = value as? Data {
-            persist(Record.databaseDataEncodingStrategy.encode(data), forKey: key)
+            let column = keyEncodingStrategy.column(forKey: key)
+            let dbValue = Record.databaseDataEncodingStrategy(for: column).encode(data)
+            _persistenceContainer[column] = dbValue
         } else if let date = value as? Date {
             persist(Record.databaseDateEncodingStrategy.encode(date), forKey: key)
         } else if let uuid = value as? UUID {

--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -22,9 +22,9 @@ import Foundation // For JSONEncoder
 /// - ``databaseColumnEncodingStrategy-5sx4v``
 /// - ``databaseDataEncodingStrategy(for:)``
 /// - ``databaseDateEncodingStrategy(for:)``
-/// - ``databaseEncodingUserInfo-8upii``
 /// - ``databaseJSONEncoder(for:)-6x62c``
-/// - ``databaseUUIDEncodingStrategy-2t96q``
+/// - ``databaseUUIDEncodingStrategy(for:)``
+/// - ``databaseEncodingUserInfo-8upii``
 /// - ``DatabaseColumnEncodingStrategy``
 /// - ``DatabaseDataEncodingStrategy``
 /// - ``DatabaseDateEncodingStrategy``
@@ -167,13 +167,15 @@ public protocol EncodableRecord {
     ///
     /// ```swift
     /// struct Player: EncodableRecord, Encodable {
-    ///     static let databaseUUIDEncodingStrategy = DatabaseUUIDEncodingStrategy.uppercaseString
+    ///     static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy {
+    ///         .uppercaseString
+    ///     }
     ///
     ///     // Encoded in a string like "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
     ///     var uuid: UUID
     /// }
     /// ```
-    static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy { get }
+    static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy
     
     /// The strategy for converting coding keys to column names.
     ///
@@ -237,7 +239,7 @@ extension EncodableRecord {
     
     /// Returns the default strategy for encoding `UUID` columns:
     /// ``DatabaseUUIDEncodingStrategy/deferredToUUID``.
-    public static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy {
+    public static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy {
         .deferredToUUID
     }
     
@@ -587,7 +589,9 @@ public enum DatabaseDateEncodingStrategy {
 ///
 /// ```swift
 /// struct Player: EncodableRecord, Encodable {
-///     static let databaseUUIDEncodingStrategy = DatabaseUUIDEncodingStrategy.uppercaseString
+///     static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy {`
+///         .uppercaseString
+///     }
 ///
 ///     // Encoded in a string like "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
 ///     var uuid: UUID

--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -21,6 +21,7 @@ import Foundation // For JSONEncoder
 ///
 /// - ``databaseColumnEncodingStrategy-5sx4v``
 /// - ``databaseDataEncodingStrategy(for:)``
+/// - ``databaseDateEncodingStrategy(for:)``
 /// - ``databaseEncodingUserInfo-8upii``
 /// - ``databaseJSONEncoder(for:)-6x62c``
 /// - ``databaseUUIDEncodingStrategy-2t96q``
@@ -146,13 +147,15 @@ public protocol EncodableRecord {
     ///
     /// ```swift
     /// struct Player: EncodableRecord, Encodable {
-    ///     static let databaseDateEncodingStrategy = DatabaseDateEncodingStrategy.timeIntervalSince1970
+    ///     static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
+    ///         .timeIntervalSince1970
+    ///     }
     ///
     ///     // Encoded as an epoch timestamp
     ///     var creationDate: Date
     /// }
     /// ```
-    static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy { get }
+    static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy
     
     /// The strategy for encoding `UUID` columns.
     ///
@@ -228,7 +231,7 @@ extension EncodableRecord {
     
     /// Returns the default strategy for encoding `Date` columns:
     /// ``DatabaseDateEncodingStrategy/deferredToDate``.
-    public static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy {
+    public static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
         .deferredToDate
     }
     
@@ -505,7 +508,9 @@ public enum DatabaseDataEncodingStrategy {
 ///
 /// ```swift
 /// struct Player: EncodableRecord, Encodable {
-///     static let databaseDateEncodingStrategy = DatabaseDateEncodingStrategy.timeIntervalSince1970
+///     static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {`
+///         .timeIntervalSince1970
+///     }
 ///
 ///     // Encoded as an epoch timestamp
 ///     var creationDate: Date

--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -20,8 +20,7 @@ import Foundation // For JSONEncoder
 /// ### Configuring Persistence for the Standard Encodable Protocol
 ///
 /// - ``databaseColumnEncodingStrategy-5sx4v``
-/// - ``databaseDataEncodingStrategy-9y0c7``
-/// - ``databaseDateEncodingStrategy-2gtc1``
+/// - ``databaseDataEncodingStrategy(for:)``
 /// - ``databaseEncodingUserInfo-8upii``
 /// - ``databaseJSONEncoder(for:)-6x62c``
 /// - ``databaseUUIDEncodingStrategy-2t96q``
@@ -127,13 +126,15 @@ public protocol EncodableRecord {
     ///
     /// ```swift
     /// struct Player: EncodableRecord, Encodable {
-    ///     static let databaseDataEncodingStrategy = DatabaseDataEncodingStrategy.text
+    ///     static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy {
+    ///         .text
+    ///     }
     ///
     ///     // Encoded as SQL text. Data must contain valid UTF8 bytes.
     ///     var jsonData: Data
     /// }
     /// ```
-    static var databaseDataEncodingStrategy: DatabaseDataEncodingStrategy { get }
+    static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy
     
     /// The strategy for encoding `Date` columns.
     ///
@@ -221,7 +222,7 @@ extension EncodableRecord {
     
     /// Returns the default strategy for encoding `Data` columns:
     /// ``DatabaseDataEncodingStrategy/deferredToData``.
-    public static var databaseDataEncodingStrategy: DatabaseDataEncodingStrategy {
+    public static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy {
         .deferredToData
     }
     
@@ -460,7 +461,9 @@ extension Row {
 ///
 /// ```swift
 /// struct Player: EncodableRecord, Encodable {
-///     static let databaseDataEncodingStrategy = DatabaseDataEncodingStrategy.text
+///     static func databaseDataEncodingStrategy(for column: Column) -> DatabaseDataEncodingStrategy {
+///         .text
+///     }
 ///
 ///     // Encoded as SQL text. Data must contain valid UTF8 bytes.
 ///     var jsonData: Data

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -62,7 +62,7 @@ extension FetchableRecord where Self: Decodable {
 ///
 /// - ``FetchableRecord/databaseColumnDecodingStrategy-6uefz``
 /// - ``FetchableRecord/databaseDataDecodingStrategy(for:)``
-/// - ``FetchableRecord/databaseDateDecodingStrategy-78y03``
+/// - ``FetchableRecord/databaseDateDecodingStrategy(for:)``
 /// - ``FetchableRecord/databaseDecodingUserInfo-77jim``
 /// - ``FetchableRecord/databaseJSONDecoder(for:)-7lmxd``
 public class FetchableRecordDecoder {
@@ -289,9 +289,9 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
                         .databaseDataDecodingStrategy(for: column)
                         .decodeIfPresent(fromRow: row, atUncheckedIndex: index) as! T?
                 } else if type == Date.self {
-                    return try R.databaseDateDecodingStrategy.decodeIfPresent(
-                        fromRow: row,
-                        atUncheckedIndex: index) as! T?
+                    return try R
+                        .databaseDateDecodingStrategy(for: column)
+                        .decodeIfPresent(fromRow: row, atUncheckedIndex: index) as! T?
                 } else if let type = T.self as? any (DatabaseValueConvertible & StatementColumnConvertible).Type {
                     return try type.fastDecodeIfPresent(fromRow: row, atUncheckedIndex: index) as! T?
                 } else if let type = T.self as? any DatabaseValueConvertible.Type {
@@ -338,7 +338,9 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
                         .databaseDataDecodingStrategy(for: column)
                         .decode(fromRow: row, atUncheckedIndex: index) as! T
                 } else if type == Date.self {
-                    return try R.databaseDateDecodingStrategy.decode(fromRow: row, atUncheckedIndex: index) as! T
+                    return try R
+                        .databaseDateDecodingStrategy(for: column)
+                        .decode(fromRow: row, atUncheckedIndex: index) as! T
                 } else if let type = T.self as? any (DatabaseValueConvertible & StatementColumnConvertible).Type {
                     return try type.fastDecode(fromRow: row, atUncheckedIndex: index) as! T
                 } else if let type = T.self as? any DatabaseValueConvertible.Type {
@@ -660,7 +662,10 @@ extension ColumnDecoder: SingleValueDecodingContainer {
                 .databaseDataDecodingStrategy(for: columnName)
                 .decode(fromRow: row, atUncheckedIndex: columnIndex) as! T
         } else if type == Date.self {
-            return try R.databaseDateDecodingStrategy.decode(fromRow: row, atUncheckedIndex: columnIndex) as! T
+            let columnName = row.impl.columnName(atUncheckedIndex: columnIndex)
+            return try R
+                .databaseDateDecodingStrategy(for: columnName)
+                .decode(fromRow: row, atUncheckedIndex: columnIndex) as! T
         } else if let type = T.self as? any (DatabaseValueConvertible & StatementColumnConvertible).Type {
             return try type.fastDecode(fromRow: row, atUncheckedIndex: columnIndex) as! T
         } else if let type = T.self as? any DatabaseValueConvertible.Type {

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -61,7 +61,7 @@ extension FetchableRecord where Self: Decodable {
 /// The behavior of the decoder depends on the decoded type. See:
 ///
 /// - ``FetchableRecord/databaseColumnDecodingStrategy-6uefz``
-/// - ``FetchableRecord/databaseDataDecodingStrategy-71bh1``
+/// - ``FetchableRecord/databaseDataDecodingStrategy(for:)``
 /// - ``FetchableRecord/databaseDateDecodingStrategy-78y03``
 /// - ``FetchableRecord/databaseDecodingUserInfo-77jim``
 /// - ``FetchableRecord/databaseJSONDecoder(for:)-7lmxd``
@@ -285,9 +285,9 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
                 // Prefer DatabaseValueConvertible decoding over Decodable.
                 // This allows decoding Date from String, or DatabaseValue from NULL.
                 if type == Data.self {
-                    return try R.databaseDataDecodingStrategy.decodeIfPresent(
-                        fromRow: row,
-                        atUncheckedIndex: index) as! T?
+                    return try R
+                        .databaseDataDecodingStrategy(for: column)
+                        .decodeIfPresent(fromRow: row, atUncheckedIndex: index) as! T?
                 } else if type == Date.self {
                     return try R.databaseDateDecodingStrategy.decodeIfPresent(
                         fromRow: row,
@@ -334,7 +334,9 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
                 // Prefer DatabaseValueConvertible decoding over Decodable.
                 // This allows decoding Date from String, or DatabaseValue from NULL.
                 if type == Data.self {
-                    return try R.databaseDataDecodingStrategy.decode(fromRow: row, atUncheckedIndex: index) as! T
+                    return try R
+                        .databaseDataDecodingStrategy(for: column)
+                        .decode(fromRow: row, atUncheckedIndex: index) as! T
                 } else if type == Date.self {
                     return try R.databaseDateDecodingStrategy.decode(fromRow: row, atUncheckedIndex: index) as! T
                 } else if let type = T.self as? any (DatabaseValueConvertible & StatementColumnConvertible).Type {
@@ -652,9 +654,11 @@ extension ColumnDecoder: SingleValueDecodingContainer {
     func decode(_ type: String.Type) throws -> String { try row.decode(atIndex: columnIndex) }
     
     func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
-        // TODO: not tested
         if type == Data.self {
-            return try R.databaseDataDecodingStrategy.decode(fromRow: row, atUncheckedIndex: columnIndex) as! T
+            let columnName = row.impl.columnName(atUncheckedIndex: columnIndex)
+            return try R
+                .databaseDataDecodingStrategy(for: columnName)
+                .decode(fromRow: row, atUncheckedIndex: columnIndex) as! T
         } else if type == Date.self {
             return try R.databaseDateDecodingStrategy.decode(fromRow: row, atUncheckedIndex: columnIndex) as! T
         } else if let type = T.self as? any (DatabaseValueConvertible & StatementColumnConvertible).Type {

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -90,7 +90,7 @@ import Foundation
 ///
 /// - ``databaseColumnDecodingStrategy-6uefz``
 /// - ``databaseDataDecodingStrategy(for:)``
-/// - ``databaseDateDecodingStrategy-78y03``
+/// - ``databaseDateDecodingStrategy(for:)``
 /// - ``databaseJSONDecoder(for:)-7lmxd``
 /// - ``databaseDecodingUserInfo-77jim``
 /// - ``DatabaseColumnDecodingStrategy``
@@ -190,13 +190,15 @@ public protocol FetchableRecord {
     ///
     /// ```swift
     /// struct Player: FetchableRecord, Decodable {
-    ///     static let databaseDateDecodingStrategy = DatabaseDateDecodingStrategy.timeIntervalSince1970
+    ///     static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
+    ///         .timeIntervalSince1970
+    ///     }
     ///
     ///     // Decoded from an epoch timestamp
     ///     var creationDate: Date
     /// }
     /// ```
-    static var databaseDateDecodingStrategy: DatabaseDateDecodingStrategy { get }
+    static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy
     
     /// The strategy for converting column names to coding keys.
     ///
@@ -251,7 +253,7 @@ extension FetchableRecord {
     
     /// The default strategy for decoding `Date` columns is
     /// ``DatabaseDateDecodingStrategy/deferredToDate``.
-    public static var databaseDateDecodingStrategy: DatabaseDateDecodingStrategy {
+    public static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
         .deferredToDate
     }
     
@@ -901,7 +903,9 @@ public enum DatabaseDataDecodingStrategy {
 /// For example:
 ///
 ///     struct Player: FetchableRecord, Decodable {
-///         static let databaseDateDecodingStrategy = DatabaseDateDecodingStrategy.timeIntervalSince1970
+///         static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
+///             .timeIntervalSince1970
+///         }
 ///
 ///         var name: String
 ///         var registrationDate: Date // decoded from epoch timestamp

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -89,10 +89,10 @@ import Foundation
 /// ### Configuring Row Decoding for the Standard Decodable Protocol
 ///
 /// - ``databaseColumnDecodingStrategy-6uefz``
-/// - ``databaseDataDecodingStrategy-71bh1``
+/// - ``databaseDataDecodingStrategy(for:)``
 /// - ``databaseDateDecodingStrategy-78y03``
-/// - ``databaseDecodingUserInfo-77jim``
 /// - ``databaseJSONDecoder(for:)-7lmxd``
+/// - ``databaseDecodingUserInfo-77jim``
 /// - ``DatabaseColumnDecodingStrategy``
 /// - ``DatabaseDataDecodingStrategy``
 /// - ``DatabaseDateDecodingStrategy``
@@ -165,18 +165,20 @@ public protocol FetchableRecord {
     ///
     /// ```swift
     /// struct Player: FetchableRecord, Decodable {
-    ///     static let databaseDataDecodingStrategy = DatabaseDataDecodingStrategy.custom { dbValue
-    ///         guard let base64Data = Data.fromDatabaseValue(dbValue) else {
-    ///             return nil
+    ///     static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy {
+    ///         .custom { dbValue
+    ///             guard let base64Data = Data.fromDatabaseValue(dbValue) else {
+    ///                 return nil
+    ///             }
+    ///             return Data(base64Encoded: base64Data)
     ///         }
-    ///         return Data(base64Encoded: base64Data)
     ///     }
     ///
     ///     // Decoded from both database base64 strings and blobs
     ///     var myData: Data
     /// }
     /// ```
-    static var databaseDataDecodingStrategy: DatabaseDataDecodingStrategy { get }
+    static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy
 
     /// The strategy for decoding `Date` columns.
     ///
@@ -243,7 +245,7 @@ extension FetchableRecord {
     
     /// The default strategy for decoding `Data` columns is
     /// ``DatabaseDataDecodingStrategy/deferredToData``.
-    public static var databaseDataDecodingStrategy: DatabaseDataDecodingStrategy {
+    public static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy {
         .deferredToData
     }
     
@@ -865,11 +867,13 @@ extension RecordCursor: Sendable { }
 ///
 /// ```swift
 /// struct Player: FetchableRecord, Decodable {
-///     static let databaseDataDecodingStrategy = DatabaseDataDecodingStrategy.custom { dbValue
-///         guard let base64Data = Data.fromDatabaseValue(dbValue) else {
-///             return nil
+///     static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy {
+///         .custom { dbValue
+///             guard let base64Data = Data.fromDatabaseValue(dbValue) else {
+///                 return nil
+///             }
+///             return Data(base64Encoded: base64Data)
 ///         }
-///         return Data(base64Encoded: base64Data)
 ///     }
 ///
 ///     // Decoded from both database base64 strings and blobs

--- a/README.md
+++ b/README.md
@@ -2701,7 +2701,7 @@ Those behaviors can be overridden:
 ```swift
 protocol FetchableRecord {
     static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy
-    static var databaseDateDecodingStrategy: DatabaseDateDecodingStrategy { get }
+    static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy
 }
 
 protocol EncodableRecord {

--- a/README.md
+++ b/README.md
@@ -2706,7 +2706,7 @@ protocol FetchableRecord {
 
 protocol EncodableRecord {
     static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy
-    static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy { get }
+    static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy
     static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy { get }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2700,7 +2700,7 @@ Those behaviors can be overridden:
 
 ```swift
 protocol FetchableRecord {
-    static var databaseDataDecodingStrategy: DatabaseDataDecodingStrategy { get }
+    static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy
     static var databaseDateDecodingStrategy: DatabaseDateDecodingStrategy { get }
 }
 

--- a/README.md
+++ b/README.md
@@ -2707,7 +2707,7 @@ protocol FetchableRecord {
 protocol EncodableRecord {
     static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy
     static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy
-    static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy { get }
+    static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy
 }
 ```
 
@@ -2727,7 +2727,10 @@ So make sure that those are properly encoded in your requests. For example:
 ```swift
 struct Player: Codable, FetchableRecord, PersistableRecord, Identifiable {
     // UUIDs are stored as strings
-    static let databaseUUIDEncodingStrategy = DatabaseUUIDEncodingStrategy.uppercaseString
+    static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy {
+        .uppercaseString
+    }
+    
     var id: UUID
     ...
 }

--- a/README.md
+++ b/README.md
@@ -2705,7 +2705,7 @@ protocol FetchableRecord {
 }
 
 protocol EncodableRecord {
-    static var databaseDataEncodingStrategy: DatabaseDataEncodingStrategy { get }
+    static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy
     static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy { get }
     static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy { get }
 }

--- a/Tests/GRDBTests/DatabaseDataDecodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDataDecodingStrategyTests.swift
@@ -20,12 +20,18 @@ private enum StrategyCustom: StrategyProvider {
 }
 
 private struct RecordWithData<Strategy: StrategyProvider>: FetchableRecord, Decodable {
-    static var databaseDataDecodingStrategy: DatabaseDataDecodingStrategy { Strategy.strategy }
+    static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy {
+        Strategy.strategy
+    }
+    
     var data: Data
 }
 
 private struct RecordWithOptionalData<Strategy: StrategyProvider>: FetchableRecord, Decodable {
-    static var databaseDataDecodingStrategy: DatabaseDataDecodingStrategy { Strategy.strategy }
+    static func databaseDataDecodingStrategy(for column: String) -> DatabaseDataDecodingStrategy {
+        Strategy.strategy
+    }
+    
     var data: Data?
 }
 

--- a/Tests/GRDBTests/DatabaseDataEncodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDataEncodingStrategyTests.swift
@@ -19,7 +19,9 @@ private enum StrategyCustom: StrategyProvider {
 }
 
 private struct RecordWithData<Strategy: StrategyProvider>: EncodableRecord, Encodable {
-    static var databaseDataEncodingStrategy: DatabaseDataEncodingStrategy { Strategy.strategy }
+    static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy {
+        Strategy.strategy
+    }
     var data: Data
 }
 
@@ -29,7 +31,9 @@ extension RecordWithData: Identifiable {
 }
 
 private struct RecordWithOptionalData<Strategy: StrategyProvider>: EncodableRecord, Encodable {
-    static var databaseDataEncodingStrategy: DatabaseDataEncodingStrategy { Strategy.strategy }
+    static func databaseDataEncodingStrategy(for column: String) -> DatabaseDataEncodingStrategy {
+        Strategy.strategy
+    }
     var data: Data?
 }
 

--- a/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
@@ -47,12 +47,18 @@ private enum StrategyCustom: StrategyProvider {
 }
 
 private struct RecordWithDate<Strategy: StrategyProvider>: FetchableRecord, Decodable {
-    static var databaseDateDecodingStrategy: DatabaseDateDecodingStrategy { Strategy.strategy }
+    static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
+        Strategy.strategy
+    }
+    
     var date: Date
 }
 
 private struct RecordWithOptionalDate<Strategy: StrategyProvider>: FetchableRecord, Decodable {
-    static var databaseDateDecodingStrategy: DatabaseDateDecodingStrategy { Strategy.strategy }
+    static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
+        Strategy.strategy
+    }
+    
     var date: Date?
 }
 

--- a/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
@@ -46,7 +46,9 @@ private enum StrategyCustom: StrategyProvider {
 }
 
 private struct RecordWithDate<Strategy: StrategyProvider>: EncodableRecord, Encodable {
-    static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy { Strategy.strategy }
+    static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
+        Strategy.strategy
+    }
     var date: Date
 }
 
@@ -56,7 +58,9 @@ extension RecordWithDate: Identifiable {
 }
 
 private struct RecordWithOptionalDate<Strategy: StrategyProvider>: EncodableRecord, Encodable {
-    static var databaseDateEncodingStrategy: DatabaseDateEncodingStrategy { Strategy.strategy }
+    static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
+        Strategy.strategy
+    }
     var date: Date?
 }
 

--- a/Tests/GRDBTests/DatabaseUUIDEncodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseUUIDEncodingStrategyTests.swift
@@ -19,7 +19,10 @@ private enum StrategyLowercaseString: StrategyProvider {
 }
 
 private struct RecordWithUUID<Strategy: StrategyProvider>: EncodableRecord, Encodable {
-    static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy { Strategy.strategy }
+    static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy {
+        Strategy.strategy
+    }
+    
     var uuid: UUID
 }
 
@@ -29,7 +32,10 @@ extension RecordWithUUID: Identifiable {
 }
 
 private struct RecordWithOptionalUUID<Strategy: StrategyProvider>: EncodableRecord, Encodable {
-    static var databaseUUIDEncodingStrategy: DatabaseUUIDEncodingStrategy { Strategy.strategy }
+    static func databaseUUIDEncodingStrategy(for column: String) -> DatabaseUUIDEncodingStrategy {
+        Strategy.strategy
+    }
+    
     var uuid: UUID?
 }
 

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -164,6 +164,49 @@ extension FetchableRecordDecodableTests {
         }
     }
     
+    func testSingleValueDateProperty() throws {
+        struct Value : Decodable {
+            let date: Date
+            
+            init(from decoder: Decoder) throws {
+                date = try decoder.singleValueContainer().decode(Date.self)
+            }
+        }
+        
+        struct Struct : FetchableRecord, Decodable {
+            static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
+                if column == "value" {
+                    return .custom { _ in Date(timeIntervalSince1970: 0) }
+                } else {
+                    return .deferredToDate
+                }
+            }
+            let value: Value
+            let optionalValue: Value?
+        }
+        
+        do {
+            // No null values
+            let s = try Struct(row: ["value": "foo", "optionalValue": "2001-01-01 00:00:00"])
+            XCTAssertEqual(s.value.date, Date(timeIntervalSince1970: 0))
+            XCTAssertEqual(s.optionalValue?.date, Date(timeIntervalSinceReferenceDate: 0))
+        }
+        
+        do {
+            // Null values
+            let s = try Struct(row: ["value": "foo", "optionalValue": nil])
+            XCTAssertEqual(s.value.date, Date(timeIntervalSince1970: 0))
+            XCTAssertNil(s.optionalValue)
+        }
+        
+        do {
+            // Missing and extra values
+            let s = try Struct(row: ["value": "foo", "ignored": "?"])
+            XCTAssertEqual(s.value.date, Date(timeIntervalSince1970: 0))
+            XCTAssertNil(s.optionalValue)
+        }
+    }
+
     func testNonTrivialSingleValueDecodableProperty() throws {
         struct NestedValue : Decodable {
             let string: String


### PR DESCRIPTION
This pull request allows record types to customize the coding strategy of `Data`, `Date`, and `UUID` for individual columns.