### PR TITLE
Avoid SQLite misuse when releasing memory on a closed database connection

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1575,7 +1575,9 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
     /// Frees as much memory as possible.
     public func releaseMemory() {
         SchedulingWatchdog.preconditionValidQueue(self)
-        sqlite3_db_release_memory(sqliteConnection)
+        if let sqliteConnection {
+            sqlite3_db_release_memory(sqliteConnection)
+        }
         schemaCache.clear()
         internalStatementCache.clear()
         publicStatementCache.clear()

--- a/Tests/GRDBTests/DatabasePoolTests.swift
+++ b/Tests/GRDBTests/DatabasePoolTests.swift
@@ -439,4 +439,12 @@ class DatabasePoolTests: GRDBTestCase {
         // In the zombie state, closing is a noop
         try dbPool.close()
     }
+    
+    // Regression test for <https://github.com/groue/GRDB.swift/issues/1612>
+    func test_releaseMemory_after_close() throws {
+        let dbPool = try makeDatabasePool()
+        try dbPool.read { _ in } // Create a reader
+        try dbPool.close()
+        dbPool.releaseMemory()
+    }
 }

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -467,4 +467,11 @@ class DatabaseQueueTests: GRDBTestCase {
             try db.execute(sql: "SELECT * FROM sqlite_master")
         }
     }
+    
+    // Regression test for <https://github.com/groue/GRDB.swift/issues/1612>
+    func test_releaseMemory_after_close() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.close()
+        dbQueue.releaseMemory()
+    }
 }


### PR DESCRIPTION
Fix #1612