### PR TITLE
GRDB 7: prefer any DatabaseReader and DatabaseWriter

### DIFF
--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -472,7 +472,7 @@ extension DatabaseReader {
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs, or the
     ///   error thrown by `progress`.
     public func backup(
-        to writer: some DatabaseWriter,
+        to writer: any DatabaseWriter,
         pagesPerStep: CInt = -1,
         progress: ((DatabaseBackupProgress) throws -> Void)? = nil)
     throws
@@ -628,7 +628,7 @@ public final class AnyDatabaseReader {
     
     /// Creates a new database reader that wraps and forwards operations
     /// to `base`.
-    public init(_ base: some DatabaseReader) {
+    public init(_ base: any DatabaseReader) {
         self.base = base
     }
 }

--- a/GRDB/Core/DatabaseRegionObservation.swift
+++ b/GRDB/Core/DatabaseRegionObservation.swift
@@ -84,7 +84,7 @@ extension DatabaseRegionObservation {
     ///   modified the observed region.
     /// - returns: A DatabaseCancellable that can stop the observation.
     public func start(
-        in writer: some DatabaseWriter,
+        in writer: any DatabaseWriter,
         onError: @escaping @Sendable (Error) -> Void,
         onChange: @escaping @Sendable (Database) -> Void)
     -> AnyDatabaseCancellable
@@ -139,7 +139,7 @@ extension DatabaseRegionObservation {
     ///
     /// Do not reschedule the publisher with `receive(on:options:)` or any
     /// `Publisher` method that schedules publisher elements.
-    public func publisher(in writer: some DatabaseWriter) -> DatabasePublishers.DatabaseRegion {
+    public func publisher(in writer: any DatabaseWriter) -> DatabasePublishers.DatabaseRegion {
         DatabasePublishers.DatabaseRegion(self, in: writer)
     }
 }
@@ -195,7 +195,7 @@ extension DatabasePublishers {
         let writer: any DatabaseWriter
         let observation: DatabaseRegionObservation
         
-        init(_ observation: DatabaseRegionObservation, in writer: some DatabaseWriter) {
+        init(_ observation: DatabaseRegionObservation, in writer: any DatabaseWriter) {
             self.writer = writer
             self.observation = observation
         }
@@ -247,7 +247,7 @@ extension DatabasePublishers {
         private var lock = NSRecursiveLock() // Allow re-entrancy
         
         init(
-            writer: some DatabaseWriter,
+            writer: any DatabaseWriter,
             observation: DatabaseRegionObservation,
             downstream: Downstream)
         {

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -873,7 +873,7 @@ public final class AnyDatabaseWriter {
     
     /// Creates a new database reader that wraps and forwards operations
     /// to `base`.
-    public init(_ base: some DatabaseWriter) {
+    public init(_ base: any DatabaseWriter) {
         self.base = base
     }
 }

--- a/GRDB/Documentation.docc/Extension/ValueObservation.md
+++ b/GRDB/Documentation.docc/Extension/ValueObservation.md
@@ -311,9 +311,9 @@ When needed, you can help GRDB optimize observations and reduce database content
 
 ### Accessing Observed Values
 
+- ``start(in:scheduling:onError:onChange:)-t62r``
+- ``start(in:scheduling:onError:onChange:)-4mqbs``
 - ``publisher(in:scheduling:)``
-- ``start(in:scheduling:onError:onChange:)-10vwf``
-- ``start(in:scheduling:onError:onChange:)-7z197``
 - ``values(in:scheduling:bufferingPolicy:)``
 - ``DatabaseCancellable``
 - ``ValueObservationScheduler``

--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -230,7 +230,7 @@ public struct DatabaseMigrator: Sendable {
     ///
     /// - parameter writer: A DatabaseWriter.
     /// - throws: The error thrown by the first failed migration.
-    public func migrate(_ writer: some DatabaseWriter) throws {
+    public func migrate(_ writer: any DatabaseWriter) throws {
         guard let lastMigration = _migrations.last else {
             return
         }
@@ -249,7 +249,7 @@ public struct DatabaseMigrator: Sendable {
     /// - parameter writer: A DatabaseWriter.
     /// - parameter targetIdentifier: A migration identifier.
     /// - throws: The error thrown by the first failed migration.
-    public func migrate(_ writer: some DatabaseWriter, upTo targetIdentifier: String) throws {
+    public func migrate(_ writer: any DatabaseWriter, upTo targetIdentifier: String) throws {
         try writer.barrierWriteWithoutTransaction { db in
             try migrate(db, upTo: targetIdentifier)
         }
@@ -263,7 +263,7 @@ public struct DatabaseMigrator: Sendable {
     ///   database, or the failure that prevented the migrations
     ///   from succeeding.
     public func asyncMigrate(
-        _ writer: some DatabaseWriter,
+        _ writer: any DatabaseWriter,
         completion: @escaping @Sendable (Result<Database, Error>) -> Void)
     {
         writer.asyncBarrierWriteWithoutTransaction { dbResult in
@@ -497,7 +497,7 @@ extension DatabaseMigrator {
     ///   where migrations should apply.
     /// - parameter scheduler: A Combine Scheduler.
     public func migratePublisher(
-        _ writer: some DatabaseWriter,
+        _ writer: any DatabaseWriter,
         receiveOn scheduler: some Combine.Scheduler = DispatchQueue.main)
     -> DatabasePublishers.Migrate
     {

--- a/GRDB/ValueObservation/SharedValueObservation.swift
+++ b/GRDB/ValueObservation/SharedValueObservation.swift
@@ -117,7 +117,7 @@ extension ValueObservation {
     /// - parameter extent: The extent of the shared database observation.
     /// - returns: A `SharedValueObservation`
     public func shared(
-        in reader: some DatabaseReader,
+        in reader: any DatabaseReader,
         scheduling scheduler: some ValueObservationScheduler = .async(onQueue: .main),
         extent: SharedValueObservationExtent = .whileObserved)
     -> SharedValueObservation<Reducer.Value>

--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -120,7 +120,7 @@ extension ValueObservation: Refinable {
     ///   fresh value.
     /// - returns: A DatabaseCancellable that can stop the observation.
     @preconcurrency public func start(
-        in reader: some DatabaseReader,
+        in reader: any DatabaseReader,
         scheduling scheduler: some ValueObservationScheduler,
         onError: @escaping @Sendable (Error) -> Void,
         onChange: @escaping @Sendable (Reducer.Value) -> Void)
@@ -180,7 +180,7 @@ extension ValueObservation: Refinable {
     ///   fresh value.
     /// - returns: A DatabaseCancellable that can stop the observation.
     @preconcurrency @MainActor public func start(
-        in reader: some DatabaseReader,
+        in reader: any DatabaseReader,
         scheduling scheduler: some ValueObservationMainActorScheduler = .mainActor,
         onError: @escaping @MainActor (Error) -> Void,
         onChange: @escaping @MainActor (Reducer.Value) -> Void)
@@ -350,7 +350,7 @@ extension ValueObservation {
     /// - parameter bufferingPolicy: see the documntation
     ///   of `AsyncThrowingStream`.
     public func values(
-        in reader: some DatabaseReader,
+        in reader: any DatabaseReader,
         scheduling scheduler: some ValueObservationScheduler = .task,
         bufferingPolicy: AsyncValueObservation<Reducer.Value>.BufferingPolicy = .unbounded)
     -> AsyncValueObservation<Reducer.Value>
@@ -486,7 +486,7 @@ extension ValueObservation {
     ///   values are dispatched asynchronously on the main dispatch queue.
     /// - returns: A Combine publisher
     public func publisher(
-        in reader: some DatabaseReader,
+        in reader: any DatabaseReader,
         scheduling scheduler: some ValueObservationScheduler = .async(onQueue: .main))
     -> DatabasePublishers.Value<Reducer.Value>
     where Reducer: ValueReducer


### PR DESCRIPTION
APIs that used to accept `some DatabaseReader` or `some DatabaseWriter` arguments now accept `any DatabaseReader` or `any DatabaseWriter`. This better matches the most frequent GRDB usage (DatabasePool in app, DatabaseQueue in tests and previews), and avoids compiler quirks with existential opening.