### PR TITLE
GRDB 7: ValueObservation async sequence is Sendable

### DIFF
--- a/GRDB/ValueObservation/ValueObservation.swift
+++ b/GRDB/ValueObservation/ValueObservation.swift
@@ -384,11 +384,13 @@ extension ValueObservation {
 ///
 /// You build an `AsyncValueObservation` from ``ValueObservation`` or
 /// ``SharedValueObservation``.
-public struct AsyncValueObservation<Element: Sendable>: AsyncSequence {
+public struct AsyncValueObservation<Element: Sendable>: AsyncSequence, Sendable {
     public typealias BufferingPolicy = AsyncThrowingStream<Element, Error>.Continuation.BufferingPolicy
     public typealias AsyncIterator = Iterator
     
-    var bufferingPolicy: BufferingPolicy
+    // AsyncThrowingStream.Continuation.BufferingPolicy is obviously
+    // Sendable, but lacks Sendable conformance.
+    nonisolated(unsafe) var bufferingPolicy: BufferingPolicy
     var start: ValueObservationStart<Element>
     
     public func makeAsyncIterator() -> Iterator {


### PR DESCRIPTION
Async sequences must be Sendable in order to play well with https://github.com/apple/swift-async-algorithms