### PR TITLE
Add `DatabaseValueConvertible` tip for JSON columns

### DIFF
--- a/GRDB/Documentation.docc/JSON.md
+++ b/GRDB/Documentation.docc/JSON.md
@@ -101,14 +101,17 @@ extension Team: FetchableRecord, PersistableRecord {
 > Tip: Conform your `Codable` property to `DatabaseValueConvertible` if you want to be able to filter on specific values of it:
 >
 > ```swift
+> struct Address: Codable { ... }
 > extension Address: DatabaseValueConvertible {}
 >
 > // SELECT * FROM player
-> // WHERE "address" = '{"street": "...", "city": "...",  "country": "..."}'
+> // WHERE address = '{"street": "...", "city": "...", "country": "..."}'
 > let players = try Player
 >     .filter(JSONColumn("address") == Address(...))
 >     .fetchAll(db)
 > ```
+>
+> Take care that SQLite will compare strings, not JSON objects: white-space and key ordering matter. For this comparison to succeed, make sure that the database contains values that are formatted exactly like a serialized `Address`.
 
 ## Manipulate JSON values at the database level
 

--- a/GRDB/Documentation.docc/JSON.md
+++ b/GRDB/Documentation.docc/JSON.md
@@ -98,6 +98,18 @@ extension Team: FetchableRecord, PersistableRecord {
 }
 ```
 
+> Tip: Conform your `Codable` property to `DatabaseValueConvertible` if you want to be able to filter on specific values of it:
+>
+> ```swift
+> extension Address: DatabaseValueConvertible {}
+>
+> // SELECT * FROM player
+> // WHERE "address" = '{"street": "...", "city": "...",  "country": "..."}'
+> let players = try Player
+>     .filter(JSONColumn("address") == Address(...))
+>     .fetchAll(db)
+> ```
+
 ## Manipulate JSON values at the database level
 
 [SQLite JSON functions and operators](https://www.sqlite.org/json1.html) are available starting iOS 16+, macOS 10.15+, tvOS 17+, and watchOS 9+.


### PR DESCRIPTION
This PR adds a tip to the JSON page of the DocC docs about conforming your JSON column's Codable property to `DatabaseValueConvertible` for filtering. Adding my first JSON column and this would have saved me a couple of hours of digging.

Please feel free to rewrite if it doesn't match the tone or intent of existing documentation.

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- ~TESTS: Changes are tested.~
- ~TESTS: The `make smokeTest` terminal command runs without failure.~
