### PR TITLE
Fix DatabaseMigrator.hasSchemaChanges failing for readonly connections

### DIFF
--- a/GRDB/Migration/DatabaseMigrator.swift
+++ b/GRDB/Migration/DatabaseMigrator.swift
@@ -333,6 +333,7 @@ public struct DatabaseMigrator: Sendable {
                 // Make sure the temporary database is configured
                 // just as the migrated database
                 var tmpConfig = db.configuration
+                tmpConfig.readonly = false // We need write access
                 tmpConfig.targetQueue = nil // Avoid deadlocks
                 tmpConfig.writeTargetQueue = nil // Avoid deadlocks
                 tmpConfig.label = "GRDB.DatabaseMigrator.temporary"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

`DatabaseMigrator.hasSchemaChanges` currently fails for readonly database configurations. This wasn't an issue before since the migrator needed write access to perform migrations anyway.

With the introduction of `hasSchemaChanges` this becomes an issue when:
 * one tries to use it with a readonly database
 * using `DatabasePool.read` which always uses a readonly connection even when the DB is opened as writeable

This PR fixes that issue by adjusting the database configuration used by the migrator to create the temporary database in `hasSchemaChanges`.

---

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
