### PR TITLE
Add support for the FTS5 trigram tokenizer

### DIFF
--- a/Documentation/FTS5Tokenizers.md
+++ b/Documentation/FTS5Tokenizers.md
@@ -39,6 +39,8 @@ All SQLite [built-in tokenizers](https://www.sqlite.org/fts5.html#tokenizers) to
 
 - The [porter](https://www.sqlite.org/fts5.html#porter_tokenizer) tokenizer turns English words into their root: "database engine" gives the "databas" and "engin" tokens. The query "database engines" will match, because it produces the same tokens.
 
+- The [trigram](https://sqlite.org/fts5.html#the_trigram_tokenizer) tokenizer treats each contiguous sequence of three characters as a token to allow general substring matching. "Sequence" gives "seq", "equ", "que", "uen", "enc" and "nce". The queries "SEQUENCE", "SEQUEN", "QUENC" and "QUE" all match as they decompose into a subset of the same trigrams.
+
 However, built-in tokenizers don't match "first" with "1st", because they produce the different "first" and "1st" tokens.
 
 Nor do they match "Grossmann" with "Großmann", because they produce the different "grossmann" and "großmann" tokens.

--- a/Documentation/FullTextSearch.md
+++ b/Documentation/FullTextSearch.md
@@ -474,7 +474,7 @@ See below some examples of matches:
     
     Unlike the other tokenizers, it provides general substring matching, matching "Sequence" with "que" by splitting character sequences into overlapping 3 character tokens (trigrams).
     
-    It can also act as an index for GLOB and LIKE queries depending on the configuration.
+    It can also act as an index for GLOB and LIKE queries depending on the configuration (see the [SQLite Documentation](https://www.sqlite.org/fts5.html#the_trigram_tokenizer)).
 
 See [SQLite tokenizers](https://www.sqlite.org/fts5.html#tokenizers) for more information, and [custom FTS5 tokenizers](FTS5Tokenizers.md) in order to add your own tokenizers.
 

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -75,44 +75,82 @@ public struct FTS5 {
     }
     
     #if GRDBCUSTOMSQLITE || GRDBCIPHER
-    /// Options for trigram tokenizer character matching. Matches the raw
-    /// "case_sensitive" and "remove_diacritics" tokenizer arguments.
+    /// Case sensitivity options for the Trigram FTS5 tokenizer.
+    /// Matches the raw "case_sensitive" tokenizer argument.
     ///
-    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
-    public enum TrigramTokenizerMatching: Sendable {
-        /// Case insensitive matching without removing diacritics. This
-        /// option matches the raw "case_sensitive=0 remove_diacritics=0"
-        /// tokenizer argument.
-        case caseInsensitive
-        /// Case insensitive matching that removes diacritics before
-        /// matching. This option matches the raw
-        /// "case_sensitive=0 remove_diacritics=1" tokenizer argument.
-        case caseInsensitiveRemovingDiacritics
-        /// Case sensitive matching. Diacritics are not removed when
-        /// performing case sensitive matching. This option matches the raw
-        /// "case_sensitive=1 remove_diacritics=0" tokenizer argument.
-        case caseSensitive
+    /// Related SQLite documentation: <https://www.sqlite.org/fts5.html#the_trigram_tokenizer>
+    public struct TrigramCaseSensitiveOption: RawRepresentable, Sendable, ExpressibleByBooleanLiteral {
+        public var rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        /// When true, matches the "case_sensitive=1" trigram tokenizer argument.
+        /// When false, it is "case_sensitive=0".
+        public init(booleanLiteral value: Bool) {
+            self = value ? Self(rawValue: 1) : Self(rawValue: 0)
+        }
+    }
+    
+    /// Diacritics options for the Trigram FTS5 tokenizer.
+    /// Matches the raw "remove_diacritics" tokenizer argument.
+    ///
+    /// Related SQLite documentation: <https://www.sqlite.org/fts5.html#the_trigram_tokenizer>
+    public struct TrigramDiacriticsOption: RawRepresentable, Sendable {
+        public var rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        /// Do not remove diacritics. This option matches the raw
+        /// "remove_diacritics=0" trigram tokenizer argument.
+        public static let keep = Self(rawValue: 0)
+
+        /// Remove diacritics. This option matches the raw
+        /// "remove_diacritics=1" trigram tokenizer argument.
+        public static let remove = Self(rawValue: 1)
     }
     #else
-    /// Options for trigram tokenizer character matching. Matches the raw
-    /// "case_sensitive" and "remove_diacritics" tokenizer arguments.
+    /// Case sensitivity options for the Trigram FTS5 tokenizer.
+    /// Matches the raw "case_sensitive" tokenizer argument.
     ///
-    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
+    /// Related SQLite documentation: <https://www.sqlite.org/fts5.html#the_trigram_tokenizer>
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) // SQLite 3.35.0+ (3.34 actually)
-    public enum TrigramTokenizerMatching: Sendable {
-        /// Case insensitive matching without removing diacritics. This
-        /// option matches the raw "case_sensitive=0 remove_diacritics=0"
-        /// tokenizer argument.
-        case caseInsensitive
-        /// Case insensitive matching that removes diacritics before
-        /// matching. This option matches the raw
-        /// "case_sensitive=0 remove_diacritics=1" tokenizer argument.
-        @available(*, unavailable, message: "Requires a future OS release that includes SQLite >=3.45")
-        case caseInsensitiveRemovingDiacritics
-        /// Case sensitive matching. Diacritics are not removed when
-        /// performing case sensitive matching. This option matches the raw
-        /// "case_sensitive=1 remove_diacritics=0" tokenizer argument.
-        case caseSensitive
+    public struct TrigramCaseSensitiveOption: RawRepresentable, Sendable, ExpressibleByBooleanLiteral {
+        public var rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        /// When true, matches the "case_sensitive=1" trigram tokenizer argument.
+        /// When false, it is "case_sensitive=0".
+        public init(booleanLiteral value: Bool) {
+            self = value ? Self(rawValue: 1) : Self(rawValue: 0)
+        }
+    }
+
+    /// Diacritics options for the Trigram FTS5 tokenizer.
+    /// Matches the raw "remove_diacritics" tokenizer argument.
+    ///
+    /// Related SQLite documentation: <https://www.sqlite.org/fts5.html#the_trigram_tokenizer>
+    @available(*, unavailable, message: "Requires a future OS release that includes SQLite >=3.45")
+    public struct TrigramDiacriticsOption: RawRepresentable, Sendable {
+        public var rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        /// Do not remove diacritics. This option matches the raw
+        /// "remove_diacritics=0" trigram tokenizer argument.
+        public static let keep = Self(rawValue: 0)
+
+        /// Remove diacritics. This option matches the raw
+        /// "remove_diacritics=1" trigram tokenizer argument.
+        public static let remove = Self(rawValue: 1)
     }
     #endif
     

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -74,6 +74,48 @@ public struct FTS5 {
         #endif
     }
     
+    #if GRDBCUSTOMSQLITE || GRDBCIPHER
+    /// Options for trigram tokenizer character matching. Matches the raw
+    /// "case_sensitive" and "remove_diacritics" tokenizer arguments.
+    ///
+    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
+    public enum TrigramTokenizerMatching: Sendable {
+        /// Case insensitive matching without removing diacritics. This
+        /// option matches the raw "case_sensitive=0 remove_diacritics=0"
+        /// tokenizer argument.
+        case caseInsensitive
+        /// Case insensitive matching that removes diacritics before
+        /// matching. This option matches the raw
+        /// "case_sensitive=0 remove_diacritics=1" tokenizer argument.
+        case caseInsensitiveRemovingDiacritics
+        /// Case sensitive matching. Diacritics are not removed when
+        /// performing case sensitive matching. This option matches the raw
+        /// "case_sensitive=1 remove_diacritics=0" tokenizer argument.
+        case caseSensitive
+    }
+    #else
+    /// Options for trigram tokenizer character matching. Matches the raw
+    /// "case_sensitive" and "remove_diacritics" tokenizer arguments.
+    ///
+    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) // SQLite 3.35.0+ (3.34 actually)
+    public enum TrigramTokenizerMatching: Sendable {
+        /// Case insensitive matching without removing diacritics. This
+        /// option matches the raw "case_sensitive=0 remove_diacritics=0"
+        /// tokenizer argument.
+        case caseInsensitive
+        /// Case insensitive matching that removes diacritics before
+        /// matching. This option matches the raw
+        /// "case_sensitive=0 remove_diacritics=1" tokenizer argument.
+        @available(*, unavailable, message: "Requires a future OS release that includes SQLite >=3.45")
+        case caseInsensitiveRemovingDiacritics
+        /// Case sensitive matching. Diacritics are not removed when
+        /// performing case sensitive matching. This option matches the raw
+        /// "case_sensitive=1 remove_diacritics=0" tokenizer argument.
+        case caseSensitive
+    }
+    #endif
+    
     /// Creates an FTS5 module.
     ///
     /// For example:

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -148,11 +148,11 @@ extension FTS5Tokenizer {
     private func tokenize(_ string: String, for tokenization: FTS5Tokenization)
     throws -> [(token: String, flags: FTS5TokenFlags)]
     {
-        try ContiguousArray(string.utf8).withUnsafeBufferPointer { buffer -> [(String, FTS5TokenFlags)] in
+        try string.utf8CString.withUnsafeBufferPointer { buffer -> [(String, FTS5TokenFlags)] in
             guard let addr = buffer.baseAddress else {
                 return []
             }
-            let pText = UnsafeMutableRawPointer(mutating: addr).assumingMemoryBound(to: CChar.self)
+            let pText = addr
             let nText = CInt(buffer.count)
             
             var context = TokenizeContext()

--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -210,7 +210,7 @@ public struct FTS5TokenizerDescriptor: Sendable {
         }
         return FTS5TokenizerDescriptor(components: components)
     }
-
+    
     #if GRDBCUSTOMSQLITE || GRDBCIPHER
     /// The "trigram" tokenizer.
     ///
@@ -225,21 +225,25 @@ public struct FTS5TokenizerDescriptor: Sendable {
     /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
     ///
     /// - parameters:
-    ///     - matching: By default SQLite will perform case insensitive
-    ///     matching and not remove diacritics before matching.
+    ///     - caseSensitive: By default SQLite will perform case insensitive
+    ///     matching.
+    ///     - removeDiacritics: By default SQLite will not remove diacritics
+    ///     before matching.
     public static func trigram(
-        matching: FTS5.TrigramTokenizerMatching = .caseInsensitive
+        caseSensitive: FTS5.TrigramCaseSensitiveOption? = nil,
+        removeDiacritics: FTS5.TrigramDiacriticsOption? = nil
     ) -> FTS5TokenizerDescriptor {
         var components = ["trigram"]
-        switch matching {
-        case .caseInsensitive:
-            break
-        case .caseInsensitiveRemovingDiacritics:
-            components.append(contentsOf: ["remove_diacritics", "1"])
-        case .caseSensitive:
-            components.append(contentsOf: ["case_sensitive", "1"])
+        if let caseSensitive {
+            components.append(contentsOf: [
+                "case_sensitive", String(caseSensitive.rawValue)
+            ])
         }
-        
+        if let removeDiacritics {
+            components.append(contentsOf: [
+                "remove_diacritics", String(removeDiacritics.rawValue)
+            ])
+        }
         return FTS5TokenizerDescriptor(components: components)
     }
     #else
@@ -256,22 +260,54 @@ public struct FTS5TokenizerDescriptor: Sendable {
     /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
     ///
     /// - parameters:
-    ///     - matching: By default SQLite will perform case insensitive
-    ///     matching and not remove diacritics before matching.
+    ///     - caseSensitive: By default SQLite will perform case insensitive
+    ///     matching.
     @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) // SQLite 3.35.0+ (3.34 actually)
     public static func trigram(
-        matching: FTS5.TrigramTokenizerMatching = .caseInsensitive
+        caseSensitive: FTS5.TrigramCaseSensitiveOption? = nil
     ) -> FTS5TokenizerDescriptor {
         var components = ["trigram"]
-        switch matching {
-        case .caseInsensitive:
-            break
-        case .caseInsensitiveRemovingDiacritics:
-            components.append(contentsOf: ["remove_diacritics", "1"])
-        case .caseSensitive:
-            components.append(contentsOf: ["case_sensitive", "1"])
+        if let caseSensitive {
+            components.append(contentsOf: [
+                "case_sensitive", String(caseSensitive.rawValue)
+            ])
         }
-
+        return FTS5TokenizerDescriptor(components: components)
+    }
+    
+    /// The "trigram" tokenizer.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try db.create(virtualTable: "book", using: FTS5()) { t in
+    ///     t.tokenizer = .trigram()
+    /// }
+    /// ```
+    ///
+    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
+    ///
+    /// - parameters:
+    ///     - caseSensitive: By default SQLite will perform case insensitive
+    ///     matching.
+    ///     - removeDiacritics: By default SQLite will not remove diacritics
+    ///     before matching.
+    @available(*, unavailable, message: "Requires a future OS release that includes SQLite >=3.45")
+    public static func trigram(
+        caseSensitive: FTS5.TrigramCaseSensitiveOption? = nil,
+        removeDiacritics: FTS5.TrigramDiacriticsOption? = nil
+    ) -> FTS5TokenizerDescriptor {
+        var components = ["trigram"]
+        if let caseSensitive {
+            components.append(contentsOf: [
+                "case_sensitive", String(caseSensitive.rawValue)
+            ])
+        }
+        if let removeDiacritics {
+            components.append(contentsOf: [
+                "remove_diacritics", String(removeDiacritics.rawValue)
+            ])
+        }
         return FTS5TokenizerDescriptor(components: components)
     }
     #endif

--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -210,5 +210,70 @@ public struct FTS5TokenizerDescriptor: Sendable {
         }
         return FTS5TokenizerDescriptor(components: components)
     }
+
+    #if GRDBCUSTOMSQLITE || GRDBCIPHER
+    /// The "trigram" tokenizer.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try db.create(virtualTable: "book", using: FTS5()) { t in
+    ///     t.tokenizer = .trigram()
+    /// }
+    /// ```
+    ///
+    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
+    ///
+    /// - parameters:
+    ///     - matching: By default SQLite will perform case insensitive
+    ///     matching and not remove diacritics before matching.
+    public static func trigram(
+        matching: FTS5.TrigramTokenizerMatching = .caseInsensitive
+    ) -> FTS5TokenizerDescriptor {
+        var components = ["trigram"]
+        switch matching {
+        case .caseInsensitive:
+            break
+        case .caseInsensitiveRemovingDiacritics:
+            components.append(contentsOf: ["remove_diacritics", "1"])
+        case .caseSensitive:
+            components.append(contentsOf: ["case_sensitive", "1"])
+        }
+        
+        return FTS5TokenizerDescriptor(components: components)
+    }
+    #else
+    /// The "trigram" tokenizer.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// try db.create(virtualTable: "book", using: FTS5()) { t in
+    ///     t.tokenizer = .trigram()
+    /// }
+    /// ```
+    ///
+    /// Related SQLite documentation: <https://sqlite.org/fts5.html#the_trigram_tokenizer>
+    ///
+    /// - parameters:
+    ///     - matching: By default SQLite will perform case insensitive
+    ///     matching and not remove diacritics before matching.
+    @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) // SQLite 3.35.0+ (3.34 actually)
+    public static func trigram(
+        matching: FTS5.TrigramTokenizerMatching = .caseInsensitive
+    ) -> FTS5TokenizerDescriptor {
+        var components = ["trigram"]
+        switch matching {
+        case .caseInsensitive:
+            break
+        case .caseInsensitiveRemovingDiacritics:
+            components.append(contentsOf: ["remove_diacritics", "1"])
+        case .caseSensitive:
+            components.append(contentsOf: ["case_sensitive", "1"])
+        }
+
+        return FTS5TokenizerDescriptor(components: components)
+    }
+    #endif
 }
 #endif

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -166,7 +166,89 @@ class FTS5TableBuilderTests: GRDBTestCase {
             assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='''unicode61'' ''tokenchars'' ''-.''')")
         }
     }
+    
+    func testTrigramTokenizer() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3034000 else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .trigram()
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='''trigram''')")
+        }
+    }
+    
+    func testTrigramTokenizerCaseInsensitive() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3034000 else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .trigram(matching: .caseInsensitive)
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='''trigram''')")
+        }
+    }
 
+    func testTrigramTokenizerCaseSensitive() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3034000 else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .trigram(matching: .caseSensitive)
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='''trigram'' ''case_sensitive'' ''1''')")
+        }
+    }
+    
+    func testTrigramTokenizerCaseInsensitiveRemovingDiacritics() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3045000 else {
+            throw XCTSkip("FTS5 trigram tokenizer remove_diacritics is not available")
+        }
+                
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .trigram(matching: .caseInsensitiveRemovingDiacritics)
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE \"documents\" USING fts5(content, tokenize='''trigram'' ''remove_diacritics'' ''1''')")
+        }
+        #else
+        throw XCTSkip("FTS5 trigram tokenizer remove_diacritics is not available")
+        #endif
+    }
+    
     func testColumns() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/FTS5TokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5TokenizerTests.swift
@@ -335,7 +335,7 @@ class FTS5TokenizerTests: GRDBTestCase {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.create(virtualTable: "documents", using: FTS5()) { t in
-                t.tokenizer = .trigram(matching: .caseSensitive)
+                t.tokenizer = .trigram(caseSensitive: true)
                 t.column("content")
             }
             
@@ -369,7 +369,7 @@ class FTS5TokenizerTests: GRDBTestCase {
         try dbQueue.inDatabase { db in
             do {
                 try db.create(virtualTable: "documents", using: FTS5()) { t in
-                    t.tokenizer = .trigram(matching: .caseInsensitiveRemovingDiacritics)
+                    t.tokenizer = .trigram(removeDiacritics: .remove)
                     t.column("content")
                 }
             } catch {

--- a/Tests/GRDBTests/FTS5TokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5TokenizerTests.swift
@@ -286,6 +286,121 @@ class FTS5TokenizerTests: GRDBTestCase {
         }
     }
     
+    func testTrigramTokenizer() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3034000 else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .trigram()
+                t.column("content")
+            }
+            
+            // simple match
+            XCTAssertTrue(match(db, "abcDÉF", "abcDÉF"))
+            
+            // English stemming
+            XCTAssertFalse(match(db, "database", "databases"))
+            
+            // diacritics in latin characters
+            XCTAssertFalse(match(db, "eéÉ", "Èèe"))
+            
+            // unicode case
+            XCTAssertTrue(match(db, "jérôme", "JÉRÔME"))
+            
+            // substring match
+            XCTAssertTrue(match(db, "sequence", "que"))
+        }
+    }
+    
+    func testTrigramTokenizerCaseSensitive() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3034000 else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", using: FTS5()) { t in
+                t.tokenizer = .trigram(matching: .caseSensitive)
+                t.column("content")
+            }
+            
+            // simple match
+            XCTAssertTrue(match(db, "abcDÉF", "abcDÉF"))
+            
+            // English stemming
+            XCTAssertFalse(match(db, "database", "databases"))
+            
+            // diacritics in latin characters
+            XCTAssertFalse(match(db, "eéÉ", "Èèe"))
+            
+            // unicode case
+            XCTAssertFalse(match(db, "jérôme", "JÉRÔME"))
+            
+            // substring match
+            XCTAssertTrue(match(db, "sequence", "que"))
+            
+            // substring match with too short query
+            XCTAssertFalse(match(db, "sequence", "qu"))
+        }
+    }
+    
+    func testTrigramTokenizerDiacriticsRemove() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3045000 else {
+            throw XCTSkip("FTS5 trigram tokenizer remove_diacritics is not available")
+        }
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                try db.create(virtualTable: "documents", using: FTS5()) { t in
+                    t.tokenizer = .trigram(matching: .caseInsensitiveRemovingDiacritics)
+                    t.column("content")
+                }
+            } catch {
+                print(error)
+                throw error
+            }
+            
+            
+            // simple match
+            XCTAssertTrue(match(db, "abcDÉF", "abcDÉF"))
+            
+            // English stemming
+            XCTAssertFalse(match(db, "database", "databases"))
+            
+            // diacritics in latin characters
+            XCTAssertTrue(match(db, "eéÉ", "Èèe"))
+            
+            // unicode case
+            XCTAssertTrue(match(db, "jérôme", "JÉRÔME"))
+            
+            // substring match
+            XCTAssertTrue(match(db, "sequence", "que"))
+            
+            // substring match with too short query
+            XCTAssertFalse(match(db, "sequence", "qu"))
+        }
+        #else
+        throw XCTSkip("FTS5 trigram tokenizer remove_diacritics is not available")
+        #endif
+    }
+    
     func testTokenize() throws {
         try makeDatabaseQueue().inDatabase { db in
             let ascii = try db.makeTokenizer(.ascii())
@@ -363,6 +478,47 @@ class FTS5TokenizerTests: GRDBTestCase {
             try XCTAssertEqual(porter.tokenize(query: "title:brest").map(\.token), ["titl", "brest"])
             try XCTAssertEqual(unicode61.tokenize(query: "title:brest").map(\.token), ["title", "brest"])
             try XCTAssertEqual(unicode61WithDiacritics.tokenize(query: "title:brest").map(\.token), ["title", "brest"])
+        }
+    }
+    
+    func testTokenizeTrigram() throws {
+        #if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3034000 else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("FTS5 trigram tokenizer is not available")
+        }
+        #endif
+        
+        try makeDatabaseQueue().inDatabase { db in
+            let trigram = try db.makeTokenizer(.trigram())
+            
+            // Empty query
+            try XCTAssertEqual(trigram.tokenize(query: "").map(\.token), [])
+            try XCTAssertEqual(trigram.tokenize(query: "?!").map(\.token), [])
+            
+            // Token queries
+            try XCTAssertEqual(trigram.tokenize(query: "Moby").map(\.token), ["mob", "oby"])
+            try XCTAssertEqual(trigram.tokenize(query: "écarlates").map(\.token), ["éca", "car", "arl", "rla", "lat", "ate", "tes"])
+            try XCTAssertEqual(trigram.tokenize(query: "fooéı👨👨🏿🇫🇷🇨🇮").map(\.token), ["foo", "ooé", "oéı", "éı👨", "ı👨👨", "👨👨🏿", "👨🏿🇫", "\u{0001F3FF}🇫🇷", "🇫🇷🇨", "🇷🇨🇮"])
+            try XCTAssertEqual(trigram.tokenize(query: "SQLite database").map(\.token), ["sql", "qli", "lit", "ite", "te ", "e d", " da", "dat", "ata", "tab", "aba", "bas", "ase"])
+            try XCTAssertEqual(trigram.tokenize(query: "Édouard Manet").map(\.token), ["édo", "dou", "oua", "uar", "ard", "rd ", "d m", " ma", "man", "ane", "net"])
+            
+            // Prefix queries
+            try XCTAssertEqual(trigram.tokenize(query: "*").map(\.token), [])
+            try XCTAssertEqual(trigram.tokenize(query: "Robin*").map(\.token), ["rob", "obi", "bin", "in*"])
+            
+            // Phrase queries
+            try XCTAssertEqual(trigram.tokenize(query: "\"foulent muscles\"").map(\.token), ["\"fo", "fou", "oul", "ule", "len", "ent", "nt ", "t m", " mu", "mus", "usc", "scl", "cle", "les", "es\""])
+            try XCTAssertEqual(trigram.tokenize(query: "\"Kim Stan* Robin*\"").map(\.token), ["\"ki", "kim", "im ", "m s", " st", "sta", "tan", "an*", "n* ", "* r", " ro", "rob", "obi", "bin", "in*", "n*\""])
+            
+            // Logical queries
+            try XCTAssertEqual(trigram.tokenize(query: "years AND months").map(\.token), ["yea", "ear", "ars", "rs ", "s a", " an", "and", "nd ", "d m", " mo", "mon", "ont", "nth", "ths"])
+            
+            // column queries
+            try XCTAssertEqual(trigram.tokenize(query: "title:brest").map(\.token), ["tit", "itl", "tle", "le:", "e:b", ":br", "bre", "res", "est"])
         }
     }
     


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I had added support for the newish FTS5 trigram tokenizer in my own project at some point. Upstreaming it here after some polish.

* I kept the documentation basic, the trigram tokenizer is a bit different than the regular ones and has some caveats but probably best to leave it to the SQLite documentation to lists the details?

* The tokenizer (currently) has two boolean arguments but only 3 combinations are valid so I implemented the options as a single enum in Swift. I hope that is OK? Feedback welcome, especially on the enum and case naming.

* I tried to add `GRDBCUSTOMSQLITE`, `GRDBCIPHER` conditionals and availability annotations as needed. I would welcome if you had a look if they look sensible.

* One of the tokenizer options (`remove_diacritics`, e.g. `TrigramTokenizerMatching.caseInsensitiveRemovingDiacritics`) is available from SQLite `3.45` (according to an SQLite forum post, it's not mentioned in the release notes).
That is newer than what Apple currently ships so this option can't currently be used with the system provided SQLite. I was wondering if you have a preferred way of handling that.
For now I added an `@available(*, unavailable)` annotation with a message indicating that a future OS release is required.
Alternatively the stdlib approach with an `@available(macOS 9999, ...)` annotation could be used but I feel a custom message is maybe a bit more self-explanatory.
Finally we could just comment that option out (for the non-custom build) until Apple ships a release with SQLite `>3.45`.

* I made a minor adjustment in `FTS5Tokenizer.swift` to create a null-terminated C string when invoking a tokenizer from GRDB to work around a [bug with the trigram tokenizer](https://sqlite.org/forum/forumpost/b0a9475bbf) where it doesn't always handle non-null terminated strings correctly.
The string contents were also copied before so this shouldn't perform worse.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
