### PR TITLE
docs: fixes typos "FST"->"FTS"

### DIFF
--- a/Documentation/FTS5Tokenizers.md
+++ b/Documentation/FTS5Tokenizers.md
@@ -3,7 +3,7 @@ FTS5 Tokenizers
 
 **[FTS5](https://www.sqlite.org/fts5.html) is an extensible full-text search engine.**
 
-GRDB lets you define your own custom FST5 tokenizers, and extend SQLite built-in tokenizers. Possible use cases are:
+GRDB lets you define your own custom FTS5 tokenizers, and extend SQLite built-in tokenizers. Possible use cases are:
 
 - Have "fi" match the ligature "&#xfb01;" (U+FB01)
 - Have "first" match "1st"
@@ -95,7 +95,7 @@ let documents = try Document.matching(pattern).fetchAll(db)
 
 ## FTS5Tokenizer
 
-**FST5Tokenizer** is the protocol for all FTS5 tokenizers.
+**FTS5Tokenizer** is the protocol for all FTS5 tokenizers.
 
 It only requires a tokenization method that matches the low-level `xTokenize` C function documented at https://www.sqlite.org/fts5.html#custom_tokenizers. We'll discuss it more when describing custom tokenizers.
 

--- a/Documentation/FullTextSearch.md
+++ b/Documentation/FullTextSearch.md
@@ -82,7 +82,7 @@ Generally speaking, FTS5 is better than FTS4 which improves on FTS3. But this do
 
 - **The location of the indexed text in your database schema.** Only FTS4 and FTS5 support "contentless" and "external content" tables.
 
-- See [FST3 vs. FTS4](https://www.sqlite.org/fts3.html#differences_between_fts3_and_fts4) and [FTS5 vs. FTS3/4](https://www.sqlite.org/fts5.html#appendix_a) for more differences.
+- See [FTS3 vs. FTS4](https://www.sqlite.org/fts3.html#differences_between_fts3_and_fts4) and [FTS5 vs. FTS3/4](https://www.sqlite.org/fts5.html#appendix_a) for more differences.
 
 > **Note**: In case you were still wondering, it is recommended to read the SQLite documentation: [FTS3 & FTS4](https://www.sqlite.org/fts3.html) and [FTS5](https://www.sqlite.org/fts5.html).
 


### PR DESCRIPTION
Just some typos I've found while reading the docs on full-text search (should fix all instances of FST* typos)

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [ ] TESTS: Changes are tested.
- [ ] TESTS: The `make smokeTest` terminal command runs without failure.
