### PR TITLE
Foundation: elide extensions on Windows to match Linux

### DIFF
--- a/GRDB/Core/Support/Foundation/NSNumber.swift
+++ b/GRDB/Core/Support/Foundation/NSNumber.swift
@@ -1,4 +1,4 @@
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 import Foundation
 
 private let integerRoundingBehavior = NSDecimalNumberHandler(

--- a/GRDB/Core/Support/Foundation/URL.swift
+++ b/GRDB/Core/Support/Foundation/URL.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 /// NSURL stores its absoluteString in the database.
 extension NSURL: DatabaseValueConvertible {
     

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -9,7 +9,7 @@ import SQLite3
 
 import Foundation
 
-#if !os(Linux)
+#if !os(Linux) && !os(Windows)
 /// NSUUID adopts DatabaseValueConvertible
 extension NSUUID: DatabaseValueConvertible {
     /// Returns a BLOB database value containing the uuid bytes.


### PR DESCRIPTION
Similar to Linux, elide some extensions on Windows. This is required to build this module on Windows.
