### PR TITLE
Core: import `ucrt` on Windows for `strcmp`

### DIFF
--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -13,6 +13,8 @@ import string_h
 import Glibc
 #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
+#elseif os(Windows)
+import ucrt
 #endif
 
 /// `StatementAuthorizer` provides information about compiled database


### PR DESCRIPTION
This uses the deprecated `strcmp` interface on Windows, which requires the C library to be imported. Add the missing import to allow building on Windows.