### PR TITLE
Select all columns but a few ones

### DIFF
--- a/Documentation/QueryInterfaceOrganization.md
+++ b/Documentation/QueryInterfaceOrganization.md
@@ -497,7 +497,7 @@ protocol SQLSelectable {
 SQLSelectable feeds the `select()` method of the query interface:
 
 ```swift
-Player.select(AllColumns())
+Player.select(.allColumns)
 Player.select(Column("name"), Column("score"))
 ```
 
@@ -505,7 +505,7 @@ All [SQLSpecificExpressible] values are selectable. Other selectable values are:
 
 ```swift
 // SELECT * FROM player
-Player.select(AllColumns())
+Player.select(.allColumns)
 
 // SELECT MAX(score) AS maxScore FROM player
 Player.select(max(Column("score")).forKey("maxScore"))

--- a/GRDB/Documentation.docc/DatabaseSchemaRecommendations.md
+++ b/GRDB/Documentation.docc/DatabaseSchemaRecommendations.md
@@ -151,7 +151,7 @@ extension Player: FetchableRecord, MutablePersistableRecord {
     // Required because the primary key
     // is the hidden rowid column.
     static var databaseSelection: [any SQLSelectable] {
-        [AllColumns(), Column.rowID]
+        [.allColumns, .rowID]
     }
 
     // Update id upon successful insertion

--- a/GRDB/QueryInterface/SQL/Column.swift
+++ b/GRDB/QueryInterface/SQL/Column.swift
@@ -61,6 +61,13 @@ extension ColumnExpression {
 
 extension ColumnExpression where Self == Column {
     /// The hidden rowID column.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT rowid FROM player
+    /// let rowids = try Player.select(.rowID).fetchSet(db)
+    /// ```
     public static var rowID: Self { Column.rowID }
 }
 

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -2136,7 +2136,14 @@ public protocol SQLExpressible {
 }
 
 extension SQLExpressible where Self == Column {
-    /// The hidden rowID column
+    /// The hidden rowID column.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT rowid FROM player
+    /// let rowids = try Player.select(.rowID).fetchSet(db)
+    /// ```
     public static var rowID: Self { Column.rowID }
 }
 

--- a/GRDB/QueryInterface/SQL/SQLRelation.swift
+++ b/GRDB/QueryInterface/SQL/SQLRelation.swift
@@ -636,7 +636,7 @@ extension SQLRelation {
             }
             
             // <https://github.com/groue/GRDB.swift/issues/1357>
-            guard selection.allSatisfy(\.isTriviallyCountable) else {
+            if selection.contains(where: \.requiresTrivialCount) {
                 return try fetchTrivialCount(db)
             }
             

--- a/GRDB/QueryInterface/SQL/SQLSelection.swift
+++ b/GRDB/QueryInterface/SQL/SQLSelection.swift
@@ -440,7 +440,7 @@ extension SQLSelectable where Self == AllColumns {
 /// ```swift
 /// struct Player: TableRecord {
 ///     static var databaseSelection: [any SQLSelectable] {
-///         [.allColumns(excluding: ["computedColumn"])]
+///         [.allColumns(excluding: ["generatedColumn"])]
 ///     }
 /// }
 ///
@@ -471,7 +471,7 @@ extension SQLSelectable where Self == AllColumnsExcluding {
     /// ```swift
     /// struct Player: TableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
-    ///         [.allColumns(excluding: ["computedColumn"])]
+    ///         [.allColumns(excluding: ["generatedColumn"])]
     ///     }
     /// }
     ///
@@ -489,7 +489,7 @@ extension SQLSelectable where Self == AllColumnsExcluding {
     /// ```swift
     /// struct Player: TableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
-    ///         [.allColumns(excluding: [Column("computedColumn")])]
+    ///         [.allColumns(excluding: [Column("generatedColumn")])]
     ///     }
     /// }
     ///

--- a/GRDB/QueryInterface/SQL/SQLSelection.swift
+++ b/GRDB/QueryInterface/SQL/SQLSelection.swift
@@ -126,41 +126,6 @@ extension SQLSelection {
         }
     }
     
-    /// Returns the SQL that feeds the argument of the `COUNT` function.
-    ///
-    /// For example:
-    ///
-    ///     COUNT(*)
-    ///     COUNT(id)
-    ///           ^---- countedSQL
-    ///
-    /// - parameter context: An SQL generation context which accepts
-    ///   statement arguments.
-    func countedSQL(_ context: SQLGenerationContext) throws -> String {
-        switch impl {
-        case .allColumns:
-            return "*"
-            
-        case let .qualifiedAllColumns(alias):
-            if context.qualifier(for: alias) != nil {
-                // SELECT COUNT(t.*) is invalid SQL
-                fatalError("Not implemented, or invalid query")
-            }
-            return "*"
-            
-        case let .expression(expression),
-             let .aliasedExpression(expression, _):
-            return try expression.sql(context)
-            
-        case .literal:
-            fatalError("""
-                Selection literals can't be counted. \
-                To resolve this error, select one or several literal expressions instead. \
-                See SQL.sqlExpression.
-                """)
-        }
-    }
-    
     /// Returns the SQL that feeds the selection of a `SELECT` statement.
     ///
     /// For example:

--- a/GRDB/QueryInterface/SQL/SQLSelection.swift
+++ b/GRDB/QueryInterface/SQL/SQLSelection.swift
@@ -245,15 +245,25 @@ extension SQLSelection {
         }
     }
     
+    /// Returns whether this selection MUST be counted with a "trivial"
+    /// count: `SELECT COUNT(*) FROM (SELECT ...)`.
+    ///
     /// Supports SQLRelation.fetchCount.
     ///
     /// See <https://github.com/groue/GRDB.swift/issues/1357>
-    var isTriviallyCountable: Bool {
+    var requiresTrivialCount: Bool {
         switch impl {
         case .aliasedExpression, .literal:
-            return false
-        case .allColumns, .qualifiedAllColumns, .expression:
+            // Trivial count is required.
+            //
+            // For example, the WHERE clause here requires the aliased
+            // column to be preserved in the counting request:
+            // SELECT *, column AS alt FROM player WHERE alt
             return true
+        case .allColumns, .qualifiedAllColumns:
+            return false
+        case .expression:
+            return false
         }
     }
 }

--- a/GRDB/QueryInterface/SQL/SQLSelection.swift
+++ b/GRDB/QueryInterface/SQL/SQLSelection.swift
@@ -26,6 +26,12 @@ public struct SQLSelection: Sendable {
         /// All columns, qualified: `player.*`
         case qualifiedAllColumns(TableAlias)
         
+        /// All columns but the specified ones
+        case allColumnsExcluding(Set<CaseInsensitiveIdentifier>)
+        
+        /// All columns but the specified ones, qualified.
+        case qualifiedAllColumnsExcluding(TableAlias, Set<CaseInsensitiveIdentifier>)
+
         /// An expression
         case expression(SQLExpression)
         
@@ -41,9 +47,19 @@ public struct SQLSelection: Sendable {
     /// All columns: `*`
     static let allColumns = SQLSelection(impl: .allColumns)
     
+    /// All columns but the specified ones.
+    static func allColumnsExcluding(_ excludedColumns: Set<CaseInsensitiveIdentifier>) -> Self {
+        SQLSelection(impl: .allColumnsExcluding(excludedColumns))
+    }
+    
     /// All columns, qualified: `player.*`
     static func qualifiedAllColumns(_ alias: TableAlias) -> Self {
         self.init(impl: .qualifiedAllColumns(alias))
+    }
+    
+    /// All columns but the specified ones, qualified.
+    static func qualifiedAllColumnsExcluding(_ alias: TableAlias, _ excludedColumns: Set<CaseInsensitiveIdentifier>) -> Self {
+        self.init(impl: .qualifiedAllColumnsExcluding(alias, excludedColumns))
     }
     
     /// An expression
@@ -70,13 +86,16 @@ extension SQLSelection {
     /// Returns nil when the number of columns is unknown.
     func columnCount(_ context: SQLGenerationContext) throws -> Int? {
         switch impl {
-        case .allColumns:
+        case .allColumns, .allColumnsExcluding:
             // Likely a GRDB bug: we can't count the number of columns in an
             // unqualified table.
             return nil
             
         case let .qualifiedAllColumns(alias):
-            return try context.columnCount(in: alias.tableName)
+            return try context.columnCount(in: alias.tableName, excluding: [])
+            
+        case let .qualifiedAllColumnsExcluding(alias, excludedColumns):
+            return try context.columnCount(in: alias.tableName, excluding: excludedColumns)
             
         case .expression,
              .aliasedExpression:
@@ -104,7 +123,28 @@ extension SQLSelection {
             // SELECT COUNT(*) FROM tableName ...
             return .all
             
-        case .qualifiedAllColumns:
+        case .allColumnsExcluding:
+            // SELECT DISTINCT a, b, c FROM tableName ...
+            if distinct {
+                // TODO: if the selection were qualified, and if we had a
+                // database connection, we could detect the case where there
+                // remains only one column, and we could perform a
+                // SELECT COUNT(DISTINCT remainingColumn) FROM tableName
+                //
+                // Since most people will not use `.allColumns(excluding:)`
+                // when they want to select only one column, I guess that
+                // this optimization has little chance to be needed.
+                //
+                // Can't count
+                return nil
+            }
+            
+            // SELECT a, b, c FROM tableName ...
+            // ->
+            // SELECT COUNT(*) FROM tableName ...
+            return .all
+            
+        case .qualifiedAllColumns, .qualifiedAllColumnsExcluding:
             return nil
             
         case let .expression(expression),
@@ -144,11 +184,38 @@ extension SQLSelection {
         case .allColumns:
             return "*"
             
+        case .allColumnsExcluding:
+            // Likely a GRDB bug: we don't know the table name so we can't
+            // load remaining columns. This selection should have been
+            // turned into a `.qualifiedAllColumnsExcluding`.
+            fatalError("Not implemented, or invalid query")
+            
         case let .qualifiedAllColumns(alias):
             if let qualifier = context.qualifier(for: alias) {
                 return qualifier.quotedDatabaseIdentifier + ".*"
             }
             return "*"
+        
+        case let .qualifiedAllColumnsExcluding(alias, excludedColumns):
+            let columnsNames = try context.columnNames(in: alias.tableName)
+            let remainingColumnsNames = if excludedColumns.isEmpty {
+                columnsNames
+            } else {
+                columnsNames.filter {
+                    !excludedColumns.contains(CaseInsensitiveIdentifier(rawValue: $0))
+                }
+            }
+            if columnsNames.count == remainingColumnsNames.count {
+                // We're not excluding anything
+                if let qualifier = context.qualifier(for: alias) {
+                    return qualifier.quotedDatabaseIdentifier + ".*"
+                }
+                return "*"
+            } else {
+                return try remainingColumnsNames
+                    .map { try SQLExpression.column($0).qualified(with: alias).sql(context) }
+                    .joined(separator: ", ")
+            }
             
         case let .expression(expression):
             return try expression.sql(context)
@@ -193,11 +260,14 @@ extension SQLSelection {
     /// Returns a qualified selection
     func qualified(with alias: TableAlias) -> SQLSelection {
         switch impl {
-        case .qualifiedAllColumns:
+        case .qualifiedAllColumns, .qualifiedAllColumnsExcluding:
             return self
             
         case .allColumns:
             return .qualifiedAllColumns(alias)
+            
+        case let .allColumnsExcluding(excludedColumns):
+            return .qualifiedAllColumnsExcluding(alias, excludedColumns)
             
         case let .expression(expression):
             return .expression(expression.qualified(with: alias))
@@ -226,6 +296,8 @@ extension SQLSelection {
             // SELECT *, column AS alt FROM player WHERE alt
             return true
         case .allColumns, .qualifiedAllColumns:
+            return false
+        case .allColumnsExcluding, .qualifiedAllColumnsExcluding:
             return false
         case .expression:
             return false
@@ -272,13 +344,39 @@ enum SQLCount {
 ///
 /// ## Topics
 ///
+/// ### Standard Selections
+///
+/// - ``rowID``
+/// - ``allColumns``
+/// - ``allColumns(excluding:)-3sg4w``
+/// - ``allColumns(excluding:)-3blq4``
+///
 /// ### Supporting Types
 ///
 /// - ``AllColumns``
+/// - ``AllColumnsExcluding``
 /// - ``SQLSelection``
 public protocol SQLSelectable {
     /// Returns an SQL selection.
     var sqlSelection: SQLSelection { get }
+}
+
+extension SQLSelectable where Self == Column {
+    /// The hidden rowID column.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// struct Player: FetchableRecord, TableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns, .rowID]
+    ///     }
+    /// }
+    ///
+    /// // SELECT *, rowid FROM player
+    /// Player.fetchAll(db)
+    /// ```
+    public static var rowID: Self { Column.rowID }
 }
 
 extension SQLSelection: SQLSelectable {
@@ -294,10 +392,14 @@ extension SQLSelection: SQLSelectable {
 /// For example:
 ///
 /// ```swift
-/// try dbQueue.read { db in
-///     // SELECT * FROM player
-///     let players = try Player.select(AllColumns()).fetchAll(db)
+/// struct Player: FetchableRecord, TableRecord {
+///     static var databaseSelection: [any SQLSelectable] {
+///         [.allColumns, .rowID]
+///     }
 /// }
+///
+/// // SELECT *, rowid FROM player
+/// Player.fetchAll(db)
 /// ```
 public struct AllColumns: Sendable {
     /// The `*` selection.
@@ -307,5 +409,94 @@ public struct AllColumns: Sendable {
 extension AllColumns: SQLSelectable {
     public var sqlSelection: SQLSelection {
         .allColumns
+    }
+}
+
+extension SQLSelectable where Self == AllColumns {
+    /// All columns of the requested table.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// struct Player: FetchableRecord, TableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns, .rowID]
+    ///     }
+    /// }
+    ///
+    /// // SELECT *, rowid FROM player
+    /// Player.fetchAll(db)
+    /// ```
+    public static var allColumns: AllColumns { AllColumns() }
+}
+
+// MARK: - AllColumnsExcluding
+
+/// `AllColumnsExcluding` selects all columns in a database table, but the
+/// ones you specify.
+///
+/// For example:
+///
+/// ```swift
+/// struct Player: TableRecord {
+///     static var databaseSelection: [any SQLSelectable] {
+///         [.allColumns(excluding: ["computedColumn"])]
+///     }
+/// }
+///
+/// // SELECT id, name, score FROM player
+/// Player.fetchAll(db)
+/// ```
+public struct AllColumnsExcluding: Sendable {
+    var excludedColumns: Set<CaseInsensitiveIdentifier>
+    
+    public init(_ excludedColumns: some Collection<String>) {
+        self.excludedColumns = Set(excludedColumns.lazy.map {
+            CaseInsensitiveIdentifier(rawValue: $0)
+        })
+    }
+}
+
+extension AllColumnsExcluding: SQLSelectable {
+    public var sqlSelection: SQLSelection {
+        .allColumnsExcluding(excludedColumns)
+    }
+}
+
+extension SQLSelectable where Self == AllColumnsExcluding {
+    /// All columns of the requested table, excluding the provided columns.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// struct Player: TableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: ["computedColumn"])]
+    ///     }
+    /// }
+    ///
+    /// // SELECT id, name, score FROM player
+    /// Player.fetchAll(db)
+    /// ```
+    public static func allColumns(excluding excludedColumns: some Collection<String>) -> Self {
+        AllColumnsExcluding(excludedColumns)
+    }
+    
+    /// All columns of the requested table, excluding the provided columns.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// struct Player: TableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: [Column("computedColumn")])]
+    ///     }
+    /// }
+    ///
+    /// // SELECT id, name, score FROM player
+    /// Player.fetchAll(db)
+    /// ```
+    public static func allColumns(excluding excludedColumns: some Collection<any ColumnExpression>) -> Self {
+        AllColumnsExcluding(excludedColumns.map(\.name))
     }
 }

--- a/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
+++ b/GRDB/QueryInterface/SQLGeneration/SQLQueryGenerator.swift
@@ -235,7 +235,11 @@ struct SQLQueryGenerator: Refinable {
                 sql += " LIMIT " + limit.sql
             }
             
-            return try makeStatement(db, sql: sql, arguments: context.arguments, returning: selection)
+            return try makeStatement(
+                db, sql: sql,
+                arguments: context.arguments,
+                returning: selection,
+                from: relation.source.tableName)
             
         case .unique:
             return try makeTrivialDeleteStatement(db, selection: selection)
@@ -264,7 +268,11 @@ struct SQLQueryGenerator: Refinable {
         sql += try selectPrimaryKey.requestSQL(subqueryContext)
         sql += ")"
         
-        return try makeStatement(db, sql: sql, arguments: context.arguments, returning: selection)
+        return try makeStatement(
+            db, sql: sql,
+            arguments: context.arguments,
+            returning: selection,
+            from: tableName)
     }
     
     /// Returns an `UPDATE` statement, with `RETURNING` clause if `selection`
@@ -323,7 +331,11 @@ struct SQLQueryGenerator: Refinable {
                 sql += " LIMIT " + limit.sql
             }
             
-            return try makeStatement(db, sql: sql, arguments: context.arguments, returning: selection)
+            return try makeStatement(
+                db, sql: sql,
+                arguments: context.arguments,
+                returning: selection,
+                from: relation.source.tableName)
             
         case .unique:
             return try makeTrivialUpdateStatement(
@@ -380,7 +392,11 @@ struct SQLQueryGenerator: Refinable {
         sql += try selectPrimaryKey.requestSQL(subqueryContext)
         sql += ")"
         
-        return try makeStatement(db, sql: sql, arguments: context.arguments, returning: selection)
+        return try makeStatement(
+            db, sql: sql,
+            arguments: context.arguments,
+            returning: selection,
+            from: tableName)
     }
     
     // Support for the RETURNING clause
@@ -388,7 +404,8 @@ struct SQLQueryGenerator: Refinable {
         _ db: Database,
         sql: String,
         arguments: StatementArguments,
-        returning selection: [any SQLSelectable])
+        returning selection: [any SQLSelectable],
+        from tableName: String)
     throws -> Statement
     {
         if selection.isEmpty {
@@ -396,12 +413,17 @@ struct SQLQueryGenerator: Refinable {
             statement.arguments = arguments
             return statement
         } else {
-            let context = SQLGenerationContext(db)
+            // Generate the RETURNING clause by turning selection into SQL.
+            // Make sure the selection is qualified with a table alias, so
+            // that selectables such as `.allColumns(excluding:)` can query
+            // the database about the database table.
+            let alias = TableAlias(tableName: tableName)
+            let context = SQLGenerationContext(db, aliases: [alias])
             var sql = sql
             var arguments = arguments
             sql += " RETURNING "
             sql += try selection
-                .map { try $0.sqlSelection.sql(context) }
+                .map { try $0.sqlSelection.qualified(with: alias).sql(context) }
                 .joined(separator: ", ")
             arguments += context.arguments
             let statement = try db.makeStatement(sql: sql)

--- a/GRDB/QueryInterface/Schema/ColumnDefinition.swift
+++ b/GRDB/QueryInterface/Schema/ColumnDefinition.swift
@@ -370,8 +370,8 @@ public final class ColumnDefinition {
     /// }
     /// ```
     ///
-    /// When you want to ignore generated columns in record types, instruct
-    /// GRDB not to select them:
+    /// To remove the generated columns from the selection of record types,
+    /// define their `databaseSelection`:
     ///
     /// ```swift
     /// struct Player: Codable {
@@ -383,6 +383,9 @@ public final class ColumnDefinition {
     ///
     /// extension Player: FetchableRecord, PersistableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
+    ///         // Option 1
+    ///         [Column("id"), Column("score"), Column("bonus")]
+    ///         // Option 2
     ///         [.allColumns(excluding: ["totalScore"])]
     ///     }
     /// }
@@ -432,8 +435,8 @@ public final class ColumnDefinition {
     /// }
     /// ```
     ///
-    /// When you want to ignore generated columns in record types, instruct
-    /// GRDB not to select them:
+    /// To remove the generated columns from the selection of record types,
+    /// define their `databaseSelection`:
     ///
     /// ```swift
     /// struct Player: Codable {
@@ -445,6 +448,9 @@ public final class ColumnDefinition {
     ///
     /// extension Player: FetchableRecord, PersistableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
+    ///         // Option 1
+    ///         [Column("id"), Column("score"), Column("bonus")]
+    ///         // Option 2
     ///         [.allColumns(excluding: ["totalScore"])]
     ///     }
     /// }
@@ -493,8 +499,8 @@ public final class ColumnDefinition {
     /// }
     /// ```
     ///
-    /// When you want to ignore generated columns in record types, instruct
-    /// GRDB not to select them:
+    /// To remove the generated columns from the selection of record types,
+    /// define their `databaseSelection`:
     ///
     /// ```swift
     /// struct Player: Codable {
@@ -506,6 +512,9 @@ public final class ColumnDefinition {
     ///
     /// extension Player: FetchableRecord, PersistableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
+    ///         // Option 1
+    ///         [Column("id"), Column("score"), Column("bonus")]
+    ///         // Option 2
     ///         [.allColumns(excluding: ["totalScore"])]
     ///     }
     /// }
@@ -556,8 +565,8 @@ public final class ColumnDefinition {
     /// }
     /// ```
     ///
-    /// When you want to ignore generated columns in record types, instruct
-    /// GRDB not to select them:
+    /// To remove the generated columns from the selection of record types,
+    /// define their `databaseSelection`:
     ///
     /// ```swift
     /// struct Player: Codable {
@@ -569,6 +578,9 @@ public final class ColumnDefinition {
     ///
     /// extension Player: FetchableRecord, PersistableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
+    ///         // Option 1
+    ///         [Column("id"), Column("score"), Column("bonus")]
+    ///         // Option 2
     ///         [.allColumns(excluding: ["totalScore"])]
     ///     }
     /// }

--- a/GRDB/QueryInterface/Schema/ColumnDefinition.swift
+++ b/GRDB/QueryInterface/Schema/ColumnDefinition.swift
@@ -370,6 +370,29 @@ public final class ColumnDefinition {
     /// }
     /// ```
     ///
+    /// When you want to ignore generated columns in record types, instruct
+    /// GRDB not to select them:
+    ///
+    /// ```swift
+    /// struct Player: Codable {
+    ///     // No property for `totalScore`
+    ///     var id: Int64
+    ///     var score: Int
+    ///     var bonus: Int
+    /// }
+    ///
+    /// extension Player: FetchableRecord, PersistableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: ["totalScore"])]
+    ///     }
+    /// }
+    ///
+    /// // SELECT id, score, bonus FROM player
+    /// let players = try dbQueue.read { db in
+    ///     try Player.fetchAll(db)
+    /// }
+    /// ```
+    ///
     /// Related SQLite documentation: <https://sqlite.org/gencol.html>
     ///
     /// - parameters:
@@ -406,6 +429,29 @@ public final class ColumnDefinition {
     ///     t.column("score", .integer).notNull()
     ///     t.column("bonus", .integer).notNull()
     ///     t.column("totalScore", .integer).generatedAs(Column("score") + Column("bonus"))
+    /// }
+    /// ```
+    ///
+    /// When you want to ignore generated columns in record types, instruct
+    /// GRDB not to select them:
+    ///
+    /// ```swift
+    /// struct Player: Codable {
+    ///     // No property for `totalScore`
+    ///     var id: Int64
+    ///     var score: Int
+    ///     var bonus: Int
+    /// }
+    ///
+    /// extension Player: FetchableRecord, PersistableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: ["totalScore"])]
+    ///     }
+    /// }
+    ///
+    /// // SELECT id, score, bonus FROM player
+    /// let players = try dbQueue.read { db in
+    ///     try Player.fetchAll(db)
     /// }
     /// ```
     ///
@@ -447,6 +493,29 @@ public final class ColumnDefinition {
     /// }
     /// ```
     ///
+    /// When you want to ignore generated columns in record types, instruct
+    /// GRDB not to select them:
+    ///
+    /// ```swift
+    /// struct Player: Codable {
+    ///     // No property for `totalScore`
+    ///     var id: Int64
+    ///     var score: Int
+    ///     var bonus: Int
+    /// }
+    ///
+    /// extension Player: FetchableRecord, PersistableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: ["totalScore"])]
+    ///     }
+    /// }
+    ///
+    /// // SELECT id, score, bonus FROM player
+    /// let players = try dbQueue.read { db in
+    ///     try Player.fetchAll(db)
+    /// }
+    /// ```
+    ///
     /// Related SQLite documentation: <https://sqlite.org/gencol.html>
     ///
     /// - parameters:
@@ -484,6 +553,29 @@ public final class ColumnDefinition {
     ///     t.column("score", .integer).notNull()
     ///     t.column("bonus", .integer).notNull()
     ///     t.column("totalScore", .integer).generatedAs(Column("score") + Column("bonus"))
+    /// }
+    /// ```
+    ///
+    /// When you want to ignore generated columns in record types, instruct
+    /// GRDB not to select them:
+    ///
+    /// ```swift
+    /// struct Player: Codable {
+    ///     // No property for `totalScore`
+    ///     var id: Int64
+    ///     var score: Int
+    ///     var bonus: Int
+    /// }
+    ///
+    /// extension Player: FetchableRecord, PersistableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: ["totalScore"])]
+    ///     }
+    /// }
+    ///
+    /// // SELECT id, score, bonus FROM player
+    /// let players = try dbQueue.read { db in
+    ///     try Player.fetchAll(db)
     /// }
     /// ```
     ///

--- a/GRDB/Record/Record.swift
+++ b/GRDB/Record/Record.swift
@@ -107,7 +107,7 @@ open class Record {
     /// try PartialPlayer.fetchAll(db)
     /// ```
     open class var databaseSelection: [any SQLSelectable] {
-        [AllColumns()]
+        [.allColumns]
     }
     
     /// Encodes the record into the provided persistence container.

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -135,7 +135,7 @@ public protocol TableRecord {
     /// ```swift
     /// struct Player: TableRecord {
     ///     static var databaseSelection: [any SQLSelectable] {
-    ///         [AllColumns()]
+    ///         [.allColumns]
     ///     }
     /// }
     ///
@@ -168,7 +168,7 @@ public protocol TableRecord {
     /// > // concurrency-safe because non-'Sendable' type
     /// > // '[any SQLSelectable]' may have shared
     /// > // mutable state.
-    /// > static let databaseSelection: [any SQLSelectable] = [AllColumns()]
+    /// > static let databaseSelection: [any SQLSelectable] = [.allColumns]
     /// > ```
     static var databaseSelection: [any SQLSelectable] { get }
 }
@@ -215,9 +215,9 @@ extension TableRecord {
         defaultDatabaseTableName
     }
     
-    /// The default selection is all columns: `[AllColumns()]`.
+    /// The default selection is all columns: `[.allColumns]`.
     public static var databaseSelection: [any SQLSelectable] {
-        [AllColumns()]
+        [.allColumns]
     }
 }
 

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -134,6 +134,7 @@ public protocol TableRecord {
     ///
     /// ```swift
     /// struct Player: TableRecord {
+    ///     // This is the default
     ///     static var databaseSelection: [any SQLSelectable] {
     ///         [.allColumns]
     ///     }
@@ -146,11 +147,20 @@ public protocol TableRecord {
     ///     }
     /// }
     ///
+    /// struct Team: TableRecord {
+    ///     static var databaseSelection: [any SQLSelectable] {
+    ///         [.allColumns(excluding: ["generatedColumn"])]
+    ///     }
+    /// }
+    ///
     /// // SELECT * FROM player
     /// try Player.fetchAll(db)
     ///
     /// // SELECT id, name FROM player
     /// try PartialPlayer.fetchAll(db)
+    ///
+    /// // SELECT id, name, color FROM team
+    /// try Team.fetchAll(db)
     /// ```
     ///
     /// > Important: Make sure the `databaseSelection` property is

--- a/README.md
+++ b/README.md
@@ -3604,21 +3604,41 @@ let request = Player.select(max(Column("score")), as: Int.self)
 let maxScore = try request.fetchOne(db)      // Int?
 ```
 
-The default selection for a record type is controlled by the `databaseSelection` property:
+The default selection for a record type is controlled by the `databaseSelection` property. For example:
 
 ```swift
+// Select a limited set of columns
 struct RestrictedPlayer : TableRecord {
     static let databaseTableName = "player"
-    static var databaseSelection: [any SQLSelectable] { [Column("id"), Column("name")] }
-}
-
-struct ExtendedPlayer : TableRecord {
-    static let databaseTableName = "player"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] {
+        [Column("id"), Column("name")]
+    }
 }
 
 // SELECT id, name FROM player
 let request = RestrictedPlayer.all()
+```
+
+```swift
+// Select all but a few columns
+struct Player : TableRecord {
+    static var databaseSelection: [any SQLSelectable] { 
+        [.allColumns(excluding: ["generatedColumn"])]
+    }
+}
+
+// SELECT id, name FROM player
+let request = RestrictedPlayer.all()
+```
+
+```swift
+// Select all columns are more
+struct ExtendedPlayer : TableRecord {
+    static let databaseTableName = "player"
+    static var databaseSelection: [any SQLSelectable] {
+        [.allColumns, .rowID]
+    }
+}
 
 // SELECT *, rowid FROM player
 let request = ExtendedPlayer.all()

--- a/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToRowScopeTests.swift
@@ -66,6 +66,16 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
     }
     
+    func testDefaultScopeIncludingRequiredRestrictedSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.select(.allColumns(excluding: ["name"])).including(required: Player.defaultTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].unscoped, ["id":1, "teamId":1])
+        XCTAssertEqual(Set(rows[0].scopes.names), ["team"])
+        XCTAssertEqual(rows[0].scopes["team"]!, ["id":1, "name":"Reds"])
+    }
+    
     func testDefaultScopeAnnotatedWithRequired() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.annotated(withRequired: Player.defaultTeam)
@@ -80,6 +90,14 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
+    }
+    
+    func testDefaultScopeAnnotatedWithRequiredRestrictedSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withRequired: Player.defaultTeam.select(.allColumns(excluding: ["name"])))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1])
     }
     
     func testDefaultScopeIncludingOptional() throws {
@@ -113,6 +131,15 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "teamName":nil])
     }
 
+    func testDefaultScopeAnnotatedWithOptionalRestrictedSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withOptional: Player.defaultTeam.select(.allColumns(excluding: ["name"])))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1])
+        XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "id":nil])
+    }
+    
     func testDefaultScopeJoiningRequired() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.joining(required: Player.defaultTeam)
@@ -153,6 +180,16 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows[0].scopes["customTeam"]!, ["id":1, "name":"Reds"])
     }
     
+    func testCustomScopeIncludingRequiredRestrictedSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.select(.allColumns(excluding: ["name"])).including(required: Player.customTeam)
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].unscoped, ["id":1, "teamId":1])
+        XCTAssertEqual(Set(rows[0].scopes.names), ["customTeam"])
+        XCTAssertEqual(rows[0].scopes["customTeam"]!, ["id":1, "name":"Reds"])
+    }
+    
     func testCustomScopeAnnotatedWithRequired() throws {
         let dbQueue = try makeDatabaseQueue()
         let request = Player.annotated(withRequired: Player.customTeam)
@@ -167,6 +204,14 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
+    }
+    
+    func testCustomScopeAnnotatedWithRequiredRestrictedSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withRequired: Player.customTeam.select(.allColumns(excluding: ["name"])))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1])
     }
     
     func testCustomScopeIncludingOptional() throws {
@@ -198,6 +243,15 @@ class AssociationBelongsToRowScopeTests: GRDBTestCase {
         XCTAssertEqual(rows.count, 2)
         XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "teamName":"Reds"])
         XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "teamName":nil])
+    }
+    
+    func testCustomScopeAnnotatedWithOptionalRestrictedSelection() throws {
+        let dbQueue = try makeDatabaseQueue()
+        let request = Player.annotated(withOptional: Player.customTeam.select(.allColumns(excluding: ["name"])))
+        let rows = try dbQueue.inDatabase { try Row.fetchAll($0, request) }
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0], ["id":1, "teamId":1, "name":"Arthur", "id":1])
+        XCTAssertEqual(rows[1], ["id":2, "teamId":nil, "name":"Barbara", "id":nil])
     }
     
     func testCustomPluralScopeIncludingRequired() throws {

--- a/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLDerivationTests.swift
@@ -21,7 +21,7 @@ private struct RestrictedB : TableRecord {
 
 private struct ExtendedB : TableRecord {
     static let databaseTableName = "b"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
 }
 
 /// Test SQL generation
@@ -76,8 +76,8 @@ class AssociationBelongsToSQLDerivationTests: GRDBTestCase {
             do {
                 let request = A.including(required: A.b
                     .select(
-                        AllColumns(),
-                        Column.rowID))
+                        .allColumns,
+                        .rowID))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".*, "b"."rowid" \
                     FROM "a" \

--- a/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToSQLTests.swift
@@ -76,6 +76,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."rowid" = "children"."parentId"
+                    """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "rowid" = 1
@@ -136,6 +146,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
                     SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
@@ -229,6 +249,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -289,6 +319,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
                     SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
@@ -380,6 +420,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -443,6 +493,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -503,6 +563,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
                     SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parentId"
                     """)
@@ -599,6 +669,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
                 
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -662,6 +742,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent1Id"
+                    """)
                 
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 1
@@ -725,7 +815,17 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
-
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                
                 try assertEqualSQL(db, Child(parent1ID: 1, parent2ID: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE "id" = 2
                     """)
@@ -785,6 +885,16 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
                     SELECT "children".*, "parents"."id" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns)), """
+                    SELECT "children".*, "parents".* \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "children".*, "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON "parents"."id" = "children"."parent2Id"
                     """)
@@ -879,6 +989,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
                     SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
@@ -991,6 +1106,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
                 
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -1065,6 +1185,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
                     SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
@@ -1176,6 +1301,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
                 
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -1253,6 +1383,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
                 
                 try assertEqualSQL(db, Child(parentA: 1, parentB: 2).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -1327,6 +1462,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
                     SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parentA") AND ("parents"."b" = "children"."parentB")
                     """)
@@ -1447,6 +1587,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
                 
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -1524,6 +1669,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent1A") AND ("parents"."b" = "children"."parent1B")
+                    """)
                 
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 1) AND ("b" = 2)
@@ -1598,6 +1748,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("a"), Column("b"))), """
                     SELECT "children".*, "parents"."a", "parents"."b" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
@@ -1678,6 +1833,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "children" \
                     LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["a"]))), """
+                    SELECT "children".*, "parents"."b", "parents"."name" \
+                    FROM "children" \
+                    LEFT JOIN "parents" ON ("parents"."a" = "children"."parent2A") AND ("parents"."b" = "children"."parent2B")
+                    """)
                 
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: 3, parent2B: 4).request(for: association), """
                     SELECT * FROM "parents" WHERE ("a" = 3) AND ("b" = 4)
@@ -1699,7 +1859,7 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: nil, parent2B: 4).request(for: association).aliased(TableAlias(name: "custom")), """
                     SELECT "custom".* FROM "parents" "custom" WHERE 0
                     """)
-
+                
                 try assertEqualSQL(db, Child(parent1A: 1, parent1B: 2, parent2A: nil, parent2B: nil).request(for: association), """
                     SELECT * FROM "parents" WHERE 0
                     """)
@@ -1896,6 +2056,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "CHILDREN" \
                     LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "CHILDREN".*, "PARENTS"."name" \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "PARENTS" WHERE "id" = 1
@@ -1959,6 +2124,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     FROM "CHILDREN" \
                     LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
                     """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "CHILDREN".*, "PARENTS"."name" \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."id" = "CHILDREN"."parentId"
+                    """)
                 
                 try assertEqualSQL(db, Child(parentID: 1).request(for: association), """
                     SELECT * FROM "PARENTS" WHERE "id" = 1
@@ -2019,6 +2189,11 @@ class AssociationBelongsToSQLTests: GRDBTestCase {
                     """)
                 try assertEqualSQL(db, Child.annotated(withOptional: association.select(Column("id"))), """
                     SELECT "CHILDREN".*, "PARENTS"."id" \
+                    FROM "CHILDREN" \
+                    LEFT JOIN "PARENTS" ON "PARENTS"."ID" = "CHILDREN"."PARENTID"
+                    """)
+                try assertEqualSQL(db, Child.annotated(withOptional: association.select(.allColumns(excluding: ["id"]))), """
+                    SELECT "CHILDREN".*, "PARENTS"."name" \
                     FROM "CHILDREN" \
                     LEFT JOIN "PARENTS" ON "PARENTS"."ID" = "CHILDREN"."PARENTID"
                     """)

--- a/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
@@ -5,7 +5,8 @@ import GRDB
 private struct A : TableRecord {
     static let databaseTableName = "a"
     static let b = hasOne(B.self)
-    static let restrictedB = hasOne(RestrictedB.self)
+    static let restrictedB1 = hasOne(RestrictedB1.self)
+    static let restrictedB2 = hasOne(RestrictedB2.self)
     static let extendedB = hasOne(ExtendedB.self)
 }
 
@@ -14,9 +15,14 @@ private struct B : TableRecord {
     static let databaseTableName = "b"
 }
 
-private struct RestrictedB : TableRecord {
+private struct RestrictedB1 : TableRecord {
     static let databaseTableName = "b"
     static var databaseSelection: [any SQLSelectable] { [Column("name")] }
+}
+
+private struct RestrictedB2 : TableRecord {
+    static let databaseTableName = "b"
+    static var databaseSelection: [any SQLSelectable] { [.allColumns(excluding: ["id"])] }
 }
 
 private struct ExtendedB : TableRecord {
@@ -48,8 +54,13 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 FROM "a" \
                 JOIN "b" ON "b"."aid" = "a"."id"
                 """)
-            try assertEqualSQL(db, A.including(required: A.restrictedB), """
+            try assertEqualSQL(db, A.including(required: A.restrictedB1), """
                 SELECT "a".*, "b"."name" \
+                FROM "a" \
+                JOIN "b" ON "b"."aid" = "a"."id"
+                """)
+            try assertEqualSQL(db, A.including(required: A.restrictedB2), """
+                SELECT "a".*, "b"."aid", "b"."name" \
                 FROM "a" \
                 JOIN "b" ON "b"."aid" = "a"."id"
                 """)
@@ -89,9 +100,9 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
                 let request = A
                     .aliased(aAlias)
                     .including(required: A.b
-                    .select(
-                        Column("name"),
-                        (Column("id") + aAlias[Column("id")]).forKey("foo")))
+                        .select(
+                            Column("name"),
+                            (Column("id") + aAlias[Column("id")]).forKey("foo")))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b"."name", "b"."id" + "a"."id" AS "foo" \
                     FROM "a" \

--- a/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneSQLDerivationTests.swift
@@ -21,7 +21,7 @@ private struct RestrictedB : TableRecord {
 
 private struct ExtendedB : TableRecord {
     static let databaseTableName = "b"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
 }
 
 /// Test SQL generation
@@ -76,8 +76,8 @@ class AssociationHasOneSQLDerivationTests: GRDBTestCase {
             do {
                 let request = A.including(required: A.b
                     .select(
-                        AllColumns(),
-                        Column.rowID))
+                        .allColumns,
+                        .rowID))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "b".*, "b"."rowid" \
                     FROM "a" \

--- a/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
+++ b/Tests/GRDBTests/AssociationHasOneThroughSQLDerivationTests.swift
@@ -24,7 +24,7 @@ private struct RestrictedC : TableRecord {
 
 private struct ExtendedC : TableRecord {
     static let databaseTableName = "c"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
 }
 
 /// Test SQL generation
@@ -87,8 +87,8 @@ class AssociationHasOneThroughSQLDerivationTests: GRDBTestCase {
             do {
                 let request = A.including(required: A.c
                     .select(
-                        AllColumns(),
-                        Column.rowID))
+                        .allColumns,
+                        .rowID))
                 try assertEqualSQL(db, request, """
                     SELECT "a".*, "c".*, "c"."rowid" \
                     FROM "a" \

--- a/Tests/GRDBTests/DerivableRequestTests.swift
+++ b/Tests/GRDBTests/DerivableRequestTests.swift
@@ -174,11 +174,11 @@ class DerivableRequestTests: GRDBTestCase {
         try libraryMigrator.migrate(dbQueue)
         try dbQueue.inDatabase { db in
             try db.create(view: "authorView", as: Author.select(
-                AllColumns(),
+                .allColumns,
                 [Column("firstName"), Column("lastName")]
                     .joined(operator: .concat)
                     .forKey("fullName")))
-                          
+            
             // ... for one table
             clearSQLQueries()
             let authorNames = try Author.all()
@@ -221,7 +221,7 @@ class DerivableRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, """
                 SELECT * FROM "author" ORDER BY "id"
                 """)
-
+            
             clearSQLQueries()
             _ /* stableOrderAuthors */ = try Author.all()
                 .orderByFullName()
@@ -267,7 +267,7 @@ class DerivableRequestTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, """
                 SELECT * FROM "authorView" ORDER BY 1, 2, 3, 4, 5
                 """)
-
+            
             clearSQLQueries()
             _ /* stableOrderAuthorViews */ = try Table("authorView").all()
                 .order(Column("fullName"))

--- a/Tests/GRDBTests/FTS3RecordTests.swift
+++ b/Tests/GRDBTests/FTS3RecordTests.swift
@@ -19,7 +19,7 @@ extension Book : FetchableRecord {
 
 extension Book : MutablePersistableRecord {
     static let databaseTableName = "books"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
     
     func encode(to container: inout PersistenceContainer) {
         container[.rowID] = id

--- a/Tests/GRDBTests/FTS4RecordTests.swift
+++ b/Tests/GRDBTests/FTS4RecordTests.swift
@@ -19,7 +19,7 @@ extension Book : FetchableRecord {
 
 extension Book : MutablePersistableRecord {
     static let databaseTableName = "books"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
 
     func encode(to container: inout PersistenceContainer) {
         container[.rowID] = id

--- a/Tests/GRDBTests/FTS5RecordTests.swift
+++ b/Tests/GRDBTests/FTS5RecordTests.swift
@@ -20,7 +20,7 @@ extension Book : FetchableRecord {
 
 extension Book : MutablePersistableRecord {
     static let databaseTableName = "books"
-    static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+    static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
     
     func encode(to container: inout PersistenceContainer) {
         container[.rowID] = id

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -1802,7 +1802,7 @@ extension MutablePersistableRecordTests {
         try dbQueue.inDatabase { db in
             var player = FullPlayer(id: 1, name: "Arthur", score: 1000)
             do {
-                _ = try player.updateAndFetch(db, selection: [AllColumns()]) { statement in
+                _ = try player.updateAndFetch(db, selection: [.allColumns]) { statement in
                     try Row.fetchOne(statement)
                 }
                 XCTFail("Expected RecordError")
@@ -1813,7 +1813,7 @@ extension MutablePersistableRecordTests {
             player.score = 0
 
             do {
-                let row = try player.updateAndFetch(db, selection: [AllColumns()]) { statement in
+                let row = try player.updateAndFetch(db, selection: [.allColumns]) { statement in
                     try Row.fetchOne(statement)
                 }
                 XCTAssertEqual(row, ["id": 1, "name": "Barbara", "score": 0])
@@ -1856,7 +1856,7 @@ extension MutablePersistableRecordTests {
         try dbQueue.inDatabase { db in
             var player = FullPlayer(id: 1, name: "Arthur", score: 1000)
             do {
-                _ = try player.updateAndFetch(db, columns: [Column("score")], selection: [AllColumns()]) { statement in
+                _ = try player.updateAndFetch(db, columns: [Column("score")], selection: [.allColumns]) { statement in
                     try Row.fetchOne(statement)
                 }
                 XCTFail("Expected RecordError")
@@ -1867,7 +1867,7 @@ extension MutablePersistableRecordTests {
             player.score = 0
 
             do {
-                let row = try player.updateAndFetch(db, columns: [Column("score")], selection: [AllColumns()]) { statement in
+                let row = try player.updateAndFetch(db, columns: [Column("score")], selection: [.allColumns]) { statement in
                     try Row.fetchOne(statement)
                 }
                 XCTAssertEqual(row, ["id": 1, "name": "Arthur", "score": 0])
@@ -2032,7 +2032,7 @@ extension MutablePersistableRecordTests {
             var player = FullPlayer(id: 1, name: "Arthur", score: 1000)
             do {
                 _ = try player.updateChangesAndFetch(
-                    db, selection: [AllColumns()],
+                    db, selection: [.allColumns],
                     fetch: { statement in try Row.fetchOne(statement) },
                     modify: { $0.name = "Barbara" })
                 XCTFail("Expected RecordError")
@@ -2043,7 +2043,7 @@ extension MutablePersistableRecordTests {
             do {
                 // Update with no change
                 let update = try player.updateChangesAndFetch(
-                    db, selection: [AllColumns()],
+                    db, selection: [.allColumns],
                     fetch: { statement in
                         XCTFail("Should not be called")
                         return "ignored"
@@ -2054,7 +2054,7 @@ extension MutablePersistableRecordTests {
             
             do {
                 let updatedRow = try player.updateChangesAndFetch(
-                    db, selection: [AllColumns()],
+                    db, selection: [.allColumns],
                     fetch: { statement in try Row.fetchOne(statement) },
                     modify: { $0.name = "Craig" })
                 XCTAssertEqual(updatedRow, ["id": 1, "name": "Craig", "score": 1000])

--- a/Tests/GRDBTests/PersistableRecordTests.swift
+++ b/Tests/GRDBTests/PersistableRecordTests.swift
@@ -1375,7 +1375,7 @@ extension PersistableRecordTests {
         }
     }
     
-    func test_insertAndFetch_selection_fetch() throws {
+    func test_insertAndFetch_selection_fetch_column() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         guard sqlite3_libversion_number() >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
@@ -1400,6 +1400,104 @@ extension PersistableRecordTests {
                     """), sqlQueries.joined(separator: "\n"))
                 
                 XCTAssertEqual(score, 1000)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 0)
+            }
+        }
+    }
+    
+    func test_insertAndFetch_selection_fetch_allColumns() throws {
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3035000 else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                clearSQLQueries()
+                let partialPlayer = PartialPlayer(name: "Arthur")
+                let row = try partialPlayer.insertAndFetch(db, selection: [.allColumns]) { (statement: Statement) in
+                    try Row.fetchOne(statement)!
+                }
+                
+                XCTAssert(sqlQueries.contains("""
+                    INSERT INTO "player" ("id", "name") VALUES (NULL,'Arthur') RETURNING *
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur", "score": 1000])
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 0)
+            }
+        }
+    }
+    
+    func test_insertAndFetch_selection_fetch_allColumns_excluding() throws {
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3035000 else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                clearSQLQueries()
+                let partialPlayer = PartialPlayer(name: "Arthur")
+                let row = try partialPlayer.insertAndFetch(db, selection: [.allColumns(excluding: ["score"])]) { (statement: Statement) in
+                    try Row.fetchOne(statement)!
+                }
+                
+                XCTAssert(sqlQueries.contains("""
+                    INSERT INTO "player" ("id", "name") VALUES (NULL,'Arthur') RETURNING "id", "name"
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
                 
                 XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
                 XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
@@ -1551,7 +1649,7 @@ extension PersistableRecordTests {
         }
     }
     
-    func test_saveAndFetch_selection_fetch() throws {
+    func test_saveAndFetch_selection_fetch_column() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         guard sqlite3_libversion_number() >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
@@ -1650,6 +1748,256 @@ extension PersistableRecordTests {
                     """), sqlQueries.joined(separator: "\n"))
                 
                 XCTAssertEqual(score, 1000)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 0)
+            }
+        }
+    }
+    
+    func test_saveAndFetch_selection_fetch_allColumns() throws {
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3035000 else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                clearSQLQueries()
+                let partialPlayer = PartialPlayer(name: "Arthur")
+                let row = try partialPlayer.saveAndFetch(db, selection: [.allColumns]) { (
+                    statement: Statement
+                ) in
+                    try Row.fetchOne(statement)
+                }
+                
+                XCTAssert(sqlQueries.allSatisfy { !$0.contains("UPDATE") })
+                XCTAssert(sqlQueries.contains("""
+                    INSERT INTO "player" ("id", "name") VALUES (NULL,'Arthur') RETURNING *
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur", "score": 1000])
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 0)
+            }
+            
+            do {
+                let partialPlayer = PartialPlayer(id: 1, name: "Arthur")
+                try partialPlayer.delete(db)
+                clearSQLQueries()
+                let row = try partialPlayer.saveAndFetch(db, selection: [.allColumns]) { (statement: Statement) in
+                    try Row.fetchOne(statement)
+                }
+                
+                XCTAssert(sqlQueries.contains("""
+                    UPDATE "player" SET "name"='Arthur' WHERE "id"=1 RETURNING *
+                    """), sqlQueries.joined(separator: "\n"))
+                XCTAssert(sqlQueries.contains("""
+                    INSERT INTO "player" ("id", "name") VALUES (1,'Arthur') RETURNING *
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur", "score": 1000])
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 1)
+            }
+            
+            do {
+                clearSQLQueries()
+                let partialPlayer = PartialPlayer(id: 1, name: "Arthur")
+                let row = try partialPlayer.saveAndFetch(db, selection: [.allColumns]) { (statement: Statement) in
+                    try Row.fetchOne(statement)
+                }
+                
+                XCTAssert(sqlQueries.allSatisfy { !$0.contains("INSERT") })
+                XCTAssert(sqlQueries.contains("""
+                    UPDATE "player" SET "name"='Arthur' WHERE "id"=1 RETURNING *
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur", "score": 1000])
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 0)
+            }
+        }
+    }
+    
+    func test_saveAndFetch_selection_fetch_allColumns_excluding() throws {
+#if GRDBCUSTOMSQLITE || GRDBCIPHER
+        guard sqlite3_libversion_number() >= 3035000 else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#else
+        guard #available(iOS 15, macOS 12, tvOS 15, watchOS 8, *) else {
+            throw XCTSkip("RETURNING clause is not available")
+        }
+#endif
+        
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            do {
+                clearSQLQueries()
+                let partialPlayer = PartialPlayer(name: "Arthur")
+                let row = try partialPlayer.saveAndFetch(db, selection: [.allColumns(excluding: ["score"])]) { (
+                    statement: Statement
+                ) in
+                    try Row.fetchOne(statement)
+                }
+                
+                XCTAssert(sqlQueries.allSatisfy { !$0.contains("UPDATE") })
+                XCTAssert(sqlQueries.contains("""
+                    INSERT INTO "player" ("id", "name") VALUES (NULL,'Arthur') RETURNING "id", "name"
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 0)
+            }
+            
+            do {
+                let partialPlayer = PartialPlayer(id: 1, name: "Arthur")
+                try partialPlayer.delete(db)
+                clearSQLQueries()
+                let row = try partialPlayer.saveAndFetch(db, selection: [.allColumns(excluding: ["score"])]) { (statement: Statement) in
+                    try Row.fetchOne(statement)
+                }
+                
+                XCTAssert(sqlQueries.contains("""
+                    UPDATE "player" SET "name"='Arthur' WHERE "id"=1 RETURNING "id", "name"
+                    """), sqlQueries.joined(separator: "\n"))
+                XCTAssert(sqlQueries.contains("""
+                    INSERT INTO "player" ("id", "name") VALUES (1,'Arthur') RETURNING "id", "name"
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
+                
+                XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundInsertExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didInsertCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willUpdateCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundUpdateExitCount, 0)
+                XCTAssertEqual(partialPlayer.callbacks.didUpdateCount, 0)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willSaveCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundSaveExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didSaveCount, 1)
+                
+                XCTAssertEqual(partialPlayer.callbacks.willDeleteCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteEnterCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.aroundDeleteExitCount, 1)
+                XCTAssertEqual(partialPlayer.callbacks.didDeleteCount, 1)
+            }
+            
+            do {
+                clearSQLQueries()
+                let partialPlayer = PartialPlayer(id: 1, name: "Arthur")
+                let row = try partialPlayer.saveAndFetch(db, selection: [.allColumns(excluding: ["score"])]) { (statement: Statement) in
+                    try Row.fetchOne(statement)
+                }
+                
+                XCTAssert(sqlQueries.allSatisfy { !$0.contains("INSERT") })
+                XCTAssert(sqlQueries.contains("""
+                    UPDATE "player" SET "name"='Arthur' WHERE "id"=1 RETURNING "id", "name"
+                    """), sqlQueries.joined(separator: "\n"))
+                
+                XCTAssertEqual(row, ["id": 1, "name": "Arthur"])
                 
                 XCTAssertEqual(partialPlayer.callbacks.willInsertCount, 0)
                 XCTAssertEqual(partialPlayer.callbacks.aroundInsertEnterCount, 0)

--- a/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
+++ b/Tests/GRDBTests/RecordPrimaryKeyHiddenRowIDTests.swift
@@ -28,7 +28,7 @@ private class Person : Record, Hashable {
     // Record
     
     override static var databaseSelection: [any SQLSelectable] {
-        [AllColumns(), Column.rowID]
+        [.allColumns, .rowID]
     }
     
     override class var databaseTableName: String {

--- a/Tests/GRDBTests/SQLLiteralTests.swift
+++ b/Tests/GRDBTests/SQLLiteralTests.swift
@@ -640,7 +640,7 @@ extension SQLLiteralTests {
     
     func testPlusOperatorWithInterpolation() throws {
         try makeDatabaseQueue().inDatabase { db in
-            var query: SQL = "SELECT \(AllColumns()) "
+            var query: SQL = "SELECT \(.allColumns) "
             query = query + "FROM player "
             query = query + "WHERE id = \(1)"
             
@@ -654,7 +654,7 @@ extension SQLLiteralTests {
     
     func testPlusEqualOperatorWithInterpolation() throws {
         try makeDatabaseQueue().inDatabase { db in
-            var query: SQL = "SELECT \(AllColumns()) "
+            var query: SQL = "SELECT \(.allColumns) "
             query += "FROM player "
             query += "WHERE id = \(1)"
             
@@ -668,7 +668,7 @@ extension SQLLiteralTests {
     
     func testAppendLiteralWithInterpolation() throws {
         try makeDatabaseQueue().inDatabase { db in
-            var query: SQL = "SELECT \(AllColumns()) "
+            var query: SQL = "SELECT \(.allColumns) "
             query.append(literal: "FROM player ")
             query.append(literal: "WHERE id = \(1)")
             
@@ -682,7 +682,7 @@ extension SQLLiteralTests {
     
     func testAppendRawSQLWithInterpolation() throws {
         try makeDatabaseQueue().inDatabase { db in
-            var query: SQL = "SELECT \(AllColumns()) "
+            var query: SQL = "SELECT \(.allColumns) "
             query.append(sql: "FROM player ")
             query.append(sql: "WHERE score > \(1000) ")
             query.append(sql: "AND \("name") = :name", arguments: ["name": "Arthur"])

--- a/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
+++ b/Tests/GRDBTests/TableRecord+QueryInterfaceRequestTests.swift
@@ -71,6 +71,32 @@ class TableRecordQueryInterfaceRequestTests: GRDBTestCase {
             
             XCTAssertEqual(try Reader.select(max(Col.age)).group(Col.name).fetchCount(db), 0)
             XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT MAX(\"age\") FROM \"readers\" GROUP BY \"name\")")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: [] as [String])).fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\"")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: [] as [String])).distinct().fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT DISTINCT * FROM \"readers\")")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: ["name"])).fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\"")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: ["name"])).distinct().fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT DISTINCT \"id\", \"age\" FROM \"readers\")")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: ["id", "name"])).fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\"")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: ["id", "name"])).distinct().fetchCount(db), 0)
+            // This test tests for a missed optimization, because
+            // SELECT COUNT(DISTINCT age) FROM readers would be correct as well.
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT DISTINCT \"age\" FROM \"readers\")")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: ["unknown"])).fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM \"readers\"")
+            
+            XCTAssertEqual(try Reader.select(.allColumns(excluding: ["unknown"])).distinct().fetchCount(db), 0)
+            XCTAssertEqual(lastSQLQuery, "SELECT COUNT(*) FROM (SELECT DISTINCT * FROM \"readers\")")
         }
     }
 

--- a/Tests/GRDBTests/TableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/TableRecordDeleteTests.swift
@@ -238,10 +238,24 @@ class TableRecordDeleteTests: GRDBTestCase {
         
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
-            let request = Person.all()
-            let statement = try request.deleteAndFetchStatement(db, selection: [AllColumns()])
-            XCTAssertEqual(statement.sql, "DELETE FROM \"persons\" RETURNING *")
-            XCTAssertEqual(statement.columnNames, ["id", "name", "email"])
+            do {
+                let request = Person.all()
+                let statement = try request.deleteAndFetchStatement(db, selection: [Column("name")])
+                XCTAssertEqual(statement.sql, "DELETE FROM \"persons\" RETURNING \"name\"")
+                XCTAssertEqual(statement.columnNames, ["name"])
+            }
+            do {
+                let request = Person.all()
+                let statement = try request.deleteAndFetchStatement(db, selection: [.allColumns])
+                XCTAssertEqual(statement.sql, "DELETE FROM \"persons\" RETURNING *")
+                XCTAssertEqual(statement.columnNames, ["id", "name", "email"])
+            }
+            do {
+                let request = Person.all()
+                let statement = try request.deleteAndFetchStatement(db, selection: [.allColumns(excluding: ["name"])])
+                XCTAssertEqual(statement.sql, "DELETE FROM \"persons\" RETURNING \"id\", \"email\"")
+                XCTAssertEqual(statement.columnNames, ["id", "email"])
+            }
         }
     }
     

--- a/Tests/GRDBTests/TableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/TableRecordDeleteTests.swift
@@ -479,7 +479,7 @@ class TableRecordDeleteTests: GRDBTestCase {
             
             do {
                 let request = Player.including(required: Player.team)
-                let statement = try request.deleteAndFetchStatement(db, selection: [AllColumns()])
+                let statement = try request.deleteAndFetchStatement(db, selection: [.allColumns])
                 XCTAssertEqual(statement.sql, """
                     DELETE FROM "player" WHERE "id" IN (\
                     SELECT "player"."id" \
@@ -511,7 +511,7 @@ class TableRecordDeleteTests: GRDBTestCase {
             }
             do {
                 let request = Team.having(Team.players.isEmpty)
-                let statement = try request.deleteAndFetchStatement(db, selection: [AllColumns()])
+                let statement = try request.deleteAndFetchStatement(db, selection: [.allColumns])
                 XCTAssertEqual(statement.sql, """
                     DELETE FROM "team" WHERE "id" IN (\
                     SELECT "team"."id" \

--- a/Tests/GRDBTests/TableRecordTests.swift
+++ b/Tests/GRDBTests/TableRecordTests.swift
@@ -128,6 +128,21 @@ class TableRecordTests: GRDBTestCase {
         }
     }
     
+    func testRestrictedDatabaseSelectionWithAllColumnsExcluding() throws {
+        struct Record: TableRecord {
+            static let databaseTableName = "t1"
+            static var databaseSelection: [any SQLSelectable] {
+                [.allColumns(excluding: ["C"])]
+            }
+        }
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.execute(sql: "CREATE TABLE t1(a,b,c)")
+            _ = try Row.fetchAll(db, Record.all())
+            XCTAssertEqual(lastSQLQuery, "SELECT \"a\", \"b\" FROM \"t1\"")
+        }
+    }
+    
     func testRecordInAttachedDatabase() throws {
         #if GRDBCIPHER_USE_ENCRYPTION
         // Avoid error due to key not being provided:

--- a/Tests/GRDBTests/TableRecordTests.swift
+++ b/Tests/GRDBTests/TableRecordTests.swift
@@ -103,7 +103,7 @@ class TableRecordTests: GRDBTestCase {
     func testExtendedDatabaseSelection() throws {
         struct Record: TableRecord {
             static let databaseTableName = "t1"
-            static var databaseSelection: [any SQLSelectable] { [AllColumns(), Column.rowID] }
+            static var databaseSelection: [any SQLSelectable] { [.allColumns, .rowID] }
         }
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/TableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/TableRecordUpdateTests.swift
@@ -129,11 +129,27 @@ class TableRecordUpdateTests: GRDBTestCase {
             try Player.createTable(db)
             let assignment = Columns.score.set(to: 0)
             
-            let request = Player.all()
-            let statement = try request.updateAndFetchStatement(db, [assignment], selection: [AllColumns()])
-            XCTAssertEqual(statement.sql, "UPDATE \"player\" SET \"score\" = ? RETURNING *")
-            XCTAssertEqual(statement.arguments, [0])
-            XCTAssertEqual(statement.columnNames, ["id", "name", "score", "bonus"])
+            do {
+                let request = Player.all()
+                let statement = try request.updateAndFetchStatement(db, [assignment], selection: [Column("score")])
+                XCTAssertEqual(statement.sql, "UPDATE \"player\" SET \"score\" = ? RETURNING \"score\"")
+                XCTAssertEqual(statement.arguments, [0])
+                XCTAssertEqual(statement.columnNames, ["score"])
+            }
+            do {
+                let request = Player.all()
+                let statement = try request.updateAndFetchStatement(db, [assignment], selection: [.allColumns])
+                XCTAssertEqual(statement.sql, "UPDATE \"player\" SET \"score\" = ? RETURNING *")
+                XCTAssertEqual(statement.arguments, [0])
+                XCTAssertEqual(statement.columnNames, ["id", "name", "score", "bonus"])
+            }
+            do {
+                let request = Player.all()
+                let statement = try request.updateAndFetchStatement(db, [assignment], selection: [.allColumns(excluding: ["name"])])
+                XCTAssertEqual(statement.sql, "UPDATE \"player\" SET \"score\" = ? RETURNING \"id\", \"score\", \"bonus\"")
+                XCTAssertEqual(statement.arguments, [0])
+                XCTAssertEqual(statement.columnNames, ["id", "score", "bonus"])
+            }
         }
     }
     

--- a/Tests/GRDBTests/TableTests.swift
+++ b/Tests/GRDBTests/TableTests.swift
@@ -44,6 +44,12 @@ class TableTests: GRDBTestCase {
                 try assertEqualSQL(db, t.select([Column("id"), Column("name")]), """
                     SELECT "id", "name" FROM "player"
                     """)
+                try assertEqualSQL(db, t.select(.allColumns), """
+                    SELECT * FROM "player"
+                    """)
+                try assertEqualSQL(db, t.select(.allColumns(excluding: ["name"])), """
+                    SELECT "id" FROM "player"
+                    """)
                 try assertEqualSQL(db, t.select(sql: "id, ?", arguments: ["O'Brien"]), """
                     SELECT id, 'O''Brien' FROM "player"
                     """)


### PR DESCRIPTION
This pull request makes it possible to select all columns but a set of excluded columns.

It makes it easier to define record types that do not select all columns. For example:

```swift
try db.create(table: "player") { t in
    t.autoIncrementedPrimaryKey("id")
    t.column("score", .integer).notNull()
    t.column("bonus", .integer).notNull()
    t.column("totalScore", .integer).generatedAs(sql: "score + bonus")
}

struct Player: Codable {
    // No property for `totalScore`
    var id: Int64
    var score: Int
    var bonus: Int
}

extension Player: FetchableRecord, PersistableRecord {
    // Don't select totalScore
    static var databaseSelection: [any SQLSelectable] {
        [.allColumns(excluding: ["totalScore"])] // NEW!
    }
}

// SELECT id, score, bonus FROM player
let players = try dbQueue.read { db in
    try Player.fetchAll(db)
}
```
