### PR TITLE
Rework import order for SQLCipher; add test conditionals for Android

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,6 +73,23 @@ jobs:
       - uses: actions/checkout@v4
       - name: ${{ matrix.name }}
         run: make test_SPM test_install_SPM
+  SPMSQLCipher:
+    name: SPM
+    runs-on: ${{ matrix.runsOn }}
+    env:
+      DEVELOPER_DIR: "/Applications/${{ matrix.xcode }}/Contents/Developer"
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - xcode: "Xcode_16.1.app"
+            runsOn: macOS-14
+            name: "Xcode 16.1"
+    steps:
+      - uses: actions/checkout@v4
+      - name: ${{ matrix.name }}
+        run: GRDBCIPHER="https://github.com/skiptools/swift-sqlcipher.git#1.2.1" swift test
   SQLCipher3:
     name: SQLCipher3
     runs-on: ${{ matrix.runsOn }}

--- a/GRDB/Core/Configuration.swift
+++ b/GRDB/Core/Configuration.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Database+Schema.swift
+++ b/GRDB/Core/Database+Schema.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/DatabaseCollation.swift
+++ b/GRDB/Core/DatabaseCollation.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/DatabaseError.swift
+++ b/GRDB/Core/DatabaseError.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/DatabaseFunction.swift
+++ b/GRDB/Core/DatabaseFunction.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/DatabaseSnapshotPool.swift
+++ b/GRDB/Core/DatabaseSnapshotPool.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_SNAPSHOT || (!GRDBCUSTOMSQLITE && !GRDBCIPHER)
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/DatabaseValue.swift
+++ b/GRDB/Core/DatabaseValue.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/RowDecodingError.swift
+++ b/GRDB/Core/RowDecodingError.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif
@@ -11,6 +11,8 @@ import SQLite3
 import string_h
 #elseif os(Linux)
 import Glibc
+#elseif canImport(Android)
+import Android
 #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #elseif os(Windows)

--- a/GRDB/Core/StatementColumnConvertible.swift
+++ b/GRDB/Core/StatementColumnConvertible.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Support/Foundation/Data.swift
+++ b/GRDB/Core/Support/Foundation/Data.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
+++ b/GRDB/Core/Support/Foundation/DatabaseDateComponents.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Support/Foundation/Date.swift
+++ b/GRDB/Core/Support/Foundation/Date.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Support/Foundation/Decimal.swift
+++ b/GRDB/Core/Support/Foundation/Decimal.swift
@@ -1,9 +1,9 @@
 #if !os(Linux)
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Support/Foundation/NSNumber.swift
+++ b/GRDB/Core/Support/Foundation/NSNumber.swift
@@ -1,4 +1,4 @@
-#if !os(Linux) && !os(Windows)
+#if !os(Linux) && !os(Windows) && !os(Android)
 import Foundation
 
 private let integerRoundingBehavior = NSDecimalNumberHandler(

--- a/GRDB/Core/Support/Foundation/URL.swift
+++ b/GRDB/Core/Support/Foundation/URL.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-#if !os(Linux) && !os(Windows)
+#if !os(Linux) && !os(Windows) && !os(Android)
 /// NSURL stores its absoluteString in the database.
 extension NSURL: DatabaseValueConvertible {
     

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -1,15 +1,15 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif
 
 import Foundation
 
-#if !os(Linux) && !os(Windows)
+#if !os(Linux) && !os(Windows) && !os(Android)
 /// NSUUID adopts DatabaseValueConvertible
 extension NSUUID: DatabaseValueConvertible {
     /// Returns a BLOB database value containing the uuid bytes.

--- a/GRDB/Core/Support/StandardLibrary/Optional.swift
+++ b/GRDB/Core/Support/StandardLibrary/Optional.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
+++ b/GRDB/Core/Support/StandardLibrary/StandardLibrary.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/TransactionObserver.swift
+++ b/GRDB/Core/TransactionObserver.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Core/WALSnapshot.swift
+++ b/GRDB/Core/WALSnapshot.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_SNAPSHOT || (!GRDBCUSTOMSQLITE && !GRDBCIPHER)
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Dump/Database+Dump.swift
+++ b/GRDB/Dump/Database+Dump.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 // MARK: - Dump
 

--- a/GRDB/Dump/DumpFormats/DebugDumpFormat.swift
+++ b/GRDB/Dump/DumpFormats/DebugDumpFormat.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Dump/DumpFormats/JSONDumpFormat.swift
+++ b/GRDB/Dump/DumpFormats/JSONDumpFormat.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Dump/DumpFormats/LineDumpFormat.swift
+++ b/GRDB/Dump/DumpFormats/LineDumpFormat.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Dump/DumpFormats/ListDumpFormat.swift
+++ b/GRDB/Dump/DumpFormats/ListDumpFormat.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Dump/DumpFormats/QuoteDumpFormat.swift
+++ b/GRDB/Dump/DumpFormats/QuoteDumpFormat.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/FTS/FTS5.swift
+++ b/GRDB/FTS/FTS5.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_FTS5
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/FTS/FTS5CustomTokenizer.swift
+++ b/GRDB/FTS/FTS5CustomTokenizer.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_FTS5
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/FTS/FTS5Tokenizer.swift
+++ b/GRDB/FTS/FTS5Tokenizer.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_FTS5
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/FTS/FTS5WrapperTokenizer.swift
+++ b/GRDB/FTS/FTS5WrapperTokenizer.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_FTS5
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,24 @@ if ProcessInfo.processInfo.environment["SPI_BUILDER"] == "1" {
     dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
 
+var targetDependencies: [Target.Dependency] = ["GRDBSQLite"]
+
+
+var GRDBCIPHER = ProcessInfo.processInfo.environment["GRDBCIPHER"]
+// e.g.:
+//GRDBCIPHER="https://github.com/skiptools/swift-sqlcipher.git#1.2.1"
+if let SQLCipherRepo = GRDBCIPHER?.split(separator: "#").first,
+    let SQLCipherVersion = GRDBCIPHER?.split(separator: "#").last,
+    let SQLCipherRepoURL = URL(string: SQLCipherRepo.description) {
+    swiftSettings.append(.define("GRDBCIPHER"))
+    targetDependencies = [.product(name: "SQLCipher", package: SQLCipherRepoURL.deletingPathExtension().lastPathComponent)]
+    if let version = Version(SQLCipherVersion.description) { // numeric version
+        dependencies.append(.package(url: SQLCipherRepoURL.absoluteString, from: version))
+    } else { // branch
+        dependencies.append(.package(url: SQLCipherRepoURL.absoluteString, branch: SQLCipherVersion.description))
+    }
+}
+
 let package = Package(
     name: "GRDB",
     defaultLocalization: "en", // for tests
@@ -48,7 +66,7 @@ let package = Package(
             providers: [.apt(["libsqlite3-dev"])]),
         .target(
             name: "GRDB",
-            dependencies: ["GRDBSQLite"],
+            dependencies: targetDependencies,
             path: "GRDB",
             resources: [.copy("PrivacyInfo.xcprivacy")],
             cSettings: cSettings,

--- a/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
+++ b/Tests/GRDBTests/AssociationPrefetchingRowTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/CGFloatTests.swift
+++ b/Tests/GRDBTests/CGFloatTests.swift
@@ -1,3 +1,4 @@
+#if canImport(CoreGraphics)
 import XCTest
 import CoreGraphics
 import GRDB
@@ -21,3 +22,4 @@ class CGFloatTests: GRDBTestCase {
         }
     }
 }
+#endif

--- a/Tests/GRDBTests/DataMemoryTests.swift
+++ b/Tests/GRDBTests/DataMemoryTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/DatabaseDumpTests.swift
+++ b/Tests/GRDBTests/DatabaseDumpTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/DatabaseMigratorTests.swift
+++ b/Tests/GRDBTests/DatabaseMigratorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import GRDB
 
+#if !os(Android)
 class DatabaseMigratorTests : GRDBTestCase {
     // Test passes if it compiles.
     // See <https://github.com/groue/GRDB.swift/issues/1541>
@@ -1110,3 +1111,4 @@ class DatabaseMigratorTests : GRDBTestCase {
         } catch DatabaseError.SQLITE_CONSTRAINT_FOREIGNKEY { }
     }
 }
+#endif

--- a/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
+++ b/Tests/GRDBTests/DatabasePoolConcurrencyTests.swift
@@ -3,6 +3,7 @@ import Dispatch
 import Foundation
 @testable import GRDB
 
+#if canImport(Darwin) // needs NSFileCoordinator
 class DatabasePoolConcurrencyTests: GRDBTestCase {
     
     func testDatabasePoolFundamental1() throws {
@@ -1348,3 +1349,4 @@ class DatabasePoolConcurrencyTests: GRDBTestCase {
         }
     }
 }
+#endif

--- a/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
+++ b/Tests/GRDBTests/DatabasePoolReleaseMemoryTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/DatabasePoolTests.swift
+++ b/Tests/GRDBTests/DatabasePoolTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/DatabaseQueueTests.swift
+++ b/Tests/GRDBTests/DatabaseQueueTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Dispatch
 import GRDB
 
+#if canImport(Darwin) // needed for __dispatch_get_global_queue
 class DatabaseQueueTests: GRDBTestCase {
     func testJournalModeConfiguration() throws {
         do {
@@ -473,3 +474,4 @@ class DatabaseQueueTests: GRDBTestCase {
         dbQueue.releaseMemory()
     }
 }
+#endif

--- a/Tests/GRDBTests/DatabaseRegionObservationTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionObservationTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import GRDB
 
 class DatabaseRegionObservationTests: GRDBTestCase {
+    #if canImport(Combine)
     // Test passes if it compiles.
     // See <https://github.com/groue/GRDB.swift/issues/1541>
     func testAnyDatabaseWriter(writer: any DatabaseWriter) throws {
@@ -10,7 +11,8 @@ class DatabaseRegionObservationTests: GRDBTestCase {
         _ = observation.start(in: writer, onError: { _ in }, onChange: { _ in })
         _ = observation.publisher(in: writer)
     }
-    
+    #endif
+
     func testDatabaseRegionObservation_FullDatabase() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.write {

--- a/Tests/GRDBTests/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/DatabaseSnapshotTests.swift
+++ b/Tests/GRDBTests/DatabaseSnapshotTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import GRDB
 
+#if !os(Android)
 class DatabaseSnapshotTests: GRDBTestCase {
     /// A helper type
     private struct Counter {
@@ -432,3 +433,4 @@ class DatabaseSnapshotTests: GRDBTestCase {
         }
     }
 }
+#endif

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -1,6 +1,9 @@
 #if SQLITE_ENABLE_FTS5
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 class FTS5TableBuilderTests: GRDBTestCase {
     func testWithoutBody() throws {

--- a/Tests/GRDBTests/FTS5TokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5TokenizerTests.swift
@@ -1,9 +1,9 @@
 #if SQLITE_ENABLE_FTS5
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/FailureTestCase.swift
+++ b/Tests/GRDBTests/FailureTestCase.swift
@@ -1,6 +1,7 @@
 // Inspired by https://github.com/groue/CombineExpectations
 import XCTest
 
+#if canImport(Darwin) // needed for XCTIssue
 /// A XCTestCase subclass that can test its own failures.
 class FailureTestCase: XCTestCase {
     private struct Failure: Hashable {
@@ -207,3 +208,4 @@ class FailureTestCaseTests: FailureTestCase {
         }
     }
 }
+#endif

--- a/Tests/GRDBTests/FoundationNSDecimalNumberTests.swift
+++ b/Tests/GRDBTests/FoundationNSDecimalNumberTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import GRDB
 
+#if canImport(Darwin) // needed for NSDecimalNumber
 class FoundationNSDecimalNumberTests: GRDBTestCase {
 
     func testNSDecimalNumberPreservesIntegerValues() {
@@ -157,3 +158,4 @@ class FoundationNSDecimalNumberTests: GRDBTestCase {
         try test("18446744073709551615", isDecodedAs: NSDecimalNumber(string: "18446744073709551615"))
     }
 }
+#endif

--- a/Tests/GRDBTests/FoundationNSNumberTests.swift
+++ b/Tests/GRDBTests/FoundationNSNumberTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import GRDB
 
+#if canImport(Darwin) // needed for NSDecimalNumber
 class FoundationNSNumberTests: GRDBTestCase {
     
     func testNSNumberDatabaseValueToSwiftType() {
@@ -192,3 +193,4 @@ class FoundationNSNumberTests: GRDBTestCase {
         try test("18446744073709551615", isDecodedAs: NSDecimalNumber(value: UInt64(18446744073709551615)))
     }
 }
+#endif

--- a/Tests/GRDBTests/FoundationNSURLTests.swift
+++ b/Tests/GRDBTests/FoundationNSURLTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import GRDB
 
+#if canImport(Darwin) // needed for NSURL
 class FoundationNSURLTests: GRDBTestCase {
     
     func testNSURLDatabaseRoundTrip() throws {
@@ -46,3 +47,4 @@ class FoundationNSURLTests: GRDBTestCase {
     }
     
 }
+#endif

--- a/Tests/GRDBTests/FoundationNSUUIDTests.swift
+++ b/Tests/GRDBTests/FoundationNSUUIDTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import GRDB
 
+#if canImport(Darwin) // needed for NSUUID
 class FoundationNSUUIDTests: GRDBTestCase {
     private func assert(_ value: (any DatabaseValueConvertible)?, isDecodedAs expectedUUID: NSUUID?) throws {
         try makeDatabaseQueue().read { db in
@@ -50,3 +51,4 @@ class FoundationNSUUIDTests: GRDBTestCase {
         try assert("abcdefghijklmnopq".data(using: .utf8)!, isDecodedAs: nil)
     }
 }
+#endif

--- a/Tests/GRDBTests/FoundationUUIDTests.swift
+++ b/Tests/GRDBTests/FoundationUUIDTests.swift
@@ -28,7 +28,9 @@ class FoundationUUIDTests: GRDBTestCase {
         try assert(string.lowercased(), isDecodedAs: uuid)
         try assert(string.uppercased(), isDecodedAs: uuid)
         try assert(uuid, isDecodedAs: uuid)
+        #if canImport(Darwin) // needed for NSUUID
         try assert(uuid as NSUUID, isDecodedAs: uuid)
+        #endif
         try assert(data, isDecodedAs: uuid)
     }
     

--- a/Tests/GRDBTests/GRDBTestCase.swift
+++ b/Tests/GRDBTests/GRDBTestCase.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/JSONColumnTests.swift
+++ b/Tests/GRDBTests/JSONColumnTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 final class JSONColumnTests: GRDBTestCase {
     func test_JSONColumn_derived_from_CodingKey() throws {

--- a/Tests/GRDBTests/JSONExpressionsTests.swift
+++ b/Tests/GRDBTests/JSONExpressionsTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_json() throws {

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 private struct MutablePersistableRecordPerson : MutablePersistableRecord {
     var id: Int64?

--- a/Tests/GRDBTests/PersistableRecordTests.swift
+++ b/Tests/GRDBTests/PersistableRecordTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 private struct PersistableRecordPerson : PersistableRecord {
     var name: String?

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 @testable import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 private struct Col {
     static let id = Column("id")

--- a/Tests/GRDBTests/SingletonRecordTest.swift
+++ b/Tests/GRDBTests/SingletonRecordTest.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 private struct AppConfiguration: Codable {
     // Support for the single row guarantee

--- a/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
+++ b/Tests/GRDBTests/StatementColumnConvertibleFetchTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/TableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/TableRecordDeleteTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 private struct Hacker : TableRecord {
     static let databaseTableName = "hackers"

--- a/Tests/GRDBTests/TableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/TableRecordUpdateTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
 private struct Player: Codable, PersistableRecord, FetchableRecord, Hashable {
     var id: Int64

--- a/Tests/GRDBTests/UpdateStatementTests.swift
+++ b/Tests/GRDBTests/UpdateStatementTests.swift
@@ -1,8 +1,8 @@
 // Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
+#if GRDBCIPHER
 import SQLCipher
+#elseif SWIFT_PACKAGE
+import GRDBSQLite
 #elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
 import SQLite3
 #endif

--- a/Tests/GRDBTests/ValueObservationRecorderTests.swift
+++ b/Tests/GRDBTests/ValueObservationRecorderTests.swift
@@ -1,6 +1,7 @@
 import Dispatch
 import XCTest
 
+#if canImport(Darwin) // needed for FailureTestCase
 class ValueObservationRecorderTests: FailureTestCase {
     // MARK: - NextOne
     
@@ -781,3 +782,4 @@ class ValueObservationRecorderTests: FailureTestCase {
         }
     }
 }
+#endif

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -1,7 +1,11 @@
 import XCTest
 import Dispatch
 @testable import GRDB
+#if GRDBCIPHER
+import SQLCipher
+#endif
 
+#if canImport(Darwin)
 class ValueObservationTests: GRDBTestCase {
     // Test passes if it compiles.
     // See <https://github.com/groue/GRDB.swift/issues/1541>
@@ -1353,3 +1357,4 @@ class ValueObservationTests: GRDBTestCase {
                 })
     }
 }
+#endif


### PR DESCRIPTION
This is a less ambitious alternative to https://github.com/groue/GRDB.swift/pull/1701 that enables adding a SQLCipher source dependency to the Package.swift based on the `GRDBCIPHER` environment variable. Tests can be run with the dependency with a command like:

```
GRDBCIPHER="https://github.com/skiptools/swift-sqlcipher.git#1.2.1" swift test
```

Running it without the environment variable will leave things exactly as they are. The majority of changes in this PR are simply re-ordering the import header checks for `GRDBCIPHER` and `SWIFT_PACKAGE`, since we would need the former to take precedence of the latter.

An advantage of doing it this way is that it facilitates creating a `GRDB-SQLCipher` fork that can follow the releases of the upstream. The only change in such a fork would be to hardwire the `GRDBCIPHER` setting in Package.swift to some SQLCipher source repository (either mine, or one that you maintain). When a client package wants to switch between GRDB and GRDB-SQLCipher, they would just need to swap their dependency URL.

This PR also adds in support building and testing against Android, mostly by stubbing out the unit tests that can't compile due to missing `NSFileCoordinator`, `Combine`, and the like. Android tests can be run with [skip](https://skip.tools/docs/native/):

```
GRDBCIPHER="https://github.com/skiptools/swift-sqlcipher.git#1.2.1" skip android test
```

Most of the tests pass, but there are a few that need to be investigated. I'll look into them next.

Closes https://github.com/groue/GRDB.swift/pull/1701