### PR TITLE
Expose `sqlite3_libversion_number` as `Database.sqliteLibVersionNumber`

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -121,6 +121,7 @@ let SQLITE_TRANSIENT = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_
 /// - ``clearSchemaCache()``
 /// - ``logError``
 /// - ``releaseMemory()``
+/// - ``sqliteLibVersionNumber``
 /// - ``trace(options:_:)``
 ///
 /// ### Supporting Types
@@ -300,6 +301,21 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
         try DatabaseQueue().inDatabase {
             try Set(String.fetchCursor($0, sql: "PRAGMA COMPILE_OPTIONS"))
         }
+    }
+    
+    
+    /// An integer equal to [`SQLITE_VERSION_NUMBER`](https://www.sqlite.org/c3ref/c_source_id.html).
+    ///
+    /// This property returns the result of `sqlite3_libversion_number()`.
+    ///
+    /// ```swift
+    /// // Prints, for example, "3048000"
+    /// print(Database.sqliteLibVersionNumber)
+    /// ```
+    @inline(__always)
+    @inlinable
+    public static var sqliteLibVersionNumber: CInt {
+        sqlite3_libversion_number()
     }
     
     /// Whether the database region selected by statement execution is

--- a/GRDB/Dump/Database+Dump.swift
+++ b/GRDB/Dump/Database+Dump.swift
@@ -326,7 +326,7 @@ extension Database {
     private func isShadowTable(_ tableName: String) throws -> Bool {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Maybe SQLCipher is too old: check actual version
-        if sqlite3_libversion_number() >= 3037000 {
+        if Database.sqliteLibVersionNumber >= 3037000 {
             guard let table = try table(tableName) else {
                 // Not a table
                 return false

--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -1,12 +1,3 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 /// An SQL expression.
 ///
 /// `SQLExpression` is an opaque representation of an SQL expression.
@@ -2129,7 +2120,7 @@ extension SQLExpression {
         case .jsonValue:
             if isJSONValue {
                 return self
-            } else if sqlite3_libversion_number() >= 3045000 {
+            } else if Database.sqliteLibVersionNumber >= 3045000 {
                 return .function("JSONB", [self])
             } else {
                 return .function("JSON", [self])
@@ -2147,7 +2138,7 @@ extension SQLExpression {
         case .jsonValue:
             if isJSONValue {
                 return self
-            } else if sqlite3_libversion_number() >= 3045000 {
+            } else if Database.sqliteLibVersionNumber >= 3045000 {
                 return .function("JSONB", [self])
             } else {
                 return .function("JSON", [self])

--- a/Tests/GRDBTests/DatabaseConfigurationTests.swift
+++ b/Tests/GRDBTests/DatabaseConfigurationTests.swift
@@ -1,12 +1,3 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 import GRDB
 
@@ -139,7 +130,7 @@ class DatabaseConfigurationTests: GRDBTestCase {
             let foo = try dbQueue.inDatabase { db in
                 try String.fetchOne(db, sql: "SELECT \"foo\" FROM player")
             }
-            if sqlite3_libversion_number() >= 3029000 {
+            if Database.sqliteLibVersionNumber >= 3029000 {
                 XCTFail("Expected error")
             } else {
                 XCTAssertEqual(foo, "foo")
@@ -154,7 +145,7 @@ class DatabaseConfigurationTests: GRDBTestCase {
             try dbQueue.inDatabase { db in
                 try db.execute(sql: "CREATE INDEX i ON player(\"foo\")")
             }
-            if sqlite3_libversion_number() >= 3029000 {
+            if Database.sqliteLibVersionNumber >= 3029000 {
                 XCTFail("Expected error")
             }
         } catch let error as DatabaseError {

--- a/Tests/GRDBTests/DatabaseDumpTests.swift
+++ b/Tests/GRDBTests/DatabaseDumpTests.swift
@@ -1,12 +1,3 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 import GRDB
 
@@ -1282,7 +1273,7 @@ final class DatabaseDumpTests: GRDBTestCase {
     }
     
     func test_dumpSchema_ignores_shadow_tables() throws {
-        guard sqlite3_libversion_number() >= 3037000 else {
+        guard Database.sqliteLibVersionNumber >= 3037000 else {
             throw XCTSkip("Can't detect shadow tables")
         }
         
@@ -1486,7 +1477,7 @@ final class DatabaseDumpTests: GRDBTestCase {
     }
     
     func test_dumpContent_ignores_shadow_tables() throws {
-        guard sqlite3_libversion_number() >= 3037000 else {
+        guard Database.sqliteLibVersionNumber >= 3037000 else {
             throw XCTSkip("Can't detect shadow tables")
         }
         

--- a/Tests/GRDBTests/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/DatabaseRegionTests.swift
@@ -1,12 +1,3 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 @testable import GRDB
 
@@ -565,7 +556,7 @@ class DatabaseRegionTests : GRDBTestCase {
         //
         // See also testRowIdNameInUpdateStatement
         
-        guard sqlite3_libversion_number() < 3019003 else {
+        guard Database.sqliteLibVersionNumber < 3019003 else {
             // This test fails on SQLite 3.19.3 (iOS 11.2) and SQLite 3.21.0 (custom build),
             // but succeeds on SQLite 3.16.0 (iOS 10.3.1).
             // TODO: evaluate the consequences

--- a/Tests/GRDBTests/DatabaseWriterTests.swift
+++ b/Tests/GRDBTests/DatabaseWriterTests.swift
@@ -1,12 +1,3 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 import GRDB
 
@@ -208,7 +199,7 @@ class DatabaseWriterTests : GRDBTestCase {
             throw XCTSkip("VACUUM INTO is not available")
         }
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3027000 else {
+        guard Database.sqliteLibVersionNumber >= 3027000 else {
             throw XCTSkip("VACUUM INTO is not available")
         }
         
@@ -373,7 +364,7 @@ class DatabaseWriterTests : GRDBTestCase {
     @available(iOS 14, macOS 10.16, tvOS 14, *) // async + vacuum into
     func testAsyncAwait_vacuumInto() async throws {
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3027000 else {
+        guard Database.sqliteLibVersionNumber >= 3027000 else {
             throw XCTSkip("VACUUM INTO is not available")
         }
         

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -338,7 +338,7 @@ class FTS5TableBuilderTests: GRDBTestCase {
     // Regression test for <https://github.com/groue/GRDB.swift/issues/1390>
     func testIssue1390() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else

--- a/Tests/GRDBTests/FTS5TokenizerTests.swift
+++ b/Tests/GRDBTests/FTS5TokenizerTests.swift
@@ -1,13 +1,4 @@
 #if SQLITE_ENABLE_FTS5
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 import GRDB
 
@@ -212,7 +203,7 @@ class FTS5TokenizerTests: GRDBTestCase {
         // They were introduced on 2018-07-13 in https://sqlite.org/src/info/80d2b9e635e3100f
         // Next version is 3.25.0.
         // So we assume support for categories was introduced in SQLite 3.25.0.
-        guard sqlite3_libversion_number() >= 3025000 else {
+        guard Database.sqliteLibVersionNumber >= 3025000 else {
             throw XCTSkip("FTS5 unicode61 tokenizer categories are not available")
         }
         
@@ -372,7 +363,7 @@ class FTS5TokenizerTests: GRDBTestCase {
         // They were introduced on 2018-07-13 in https://sqlite.org/src/info/80d2b9e635e3100f
         // Next version is 3.25.0.
         // So we assume support for categories was introduced in SQLite 3.25.0.
-        guard sqlite3_libversion_number() >= 3025000 else {
+        guard Database.sqliteLibVersionNumber >= 3025000 else {
             throw XCTSkip("FTS5 unicode61 tokenizer categories are not available")
         }
         

--- a/Tests/GRDBTests/JSONColumnTests.swift
+++ b/Tests/GRDBTests/JSONColumnTests.swift
@@ -5,7 +5,7 @@ final class JSONColumnTests: GRDBTestCase {
     func test_JSONColumn_derived_from_CodingKey() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -47,7 +47,7 @@ final class JSONColumnTests: GRDBTestCase {
     func test_JSON_EXTRACT() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON_EXTRACT is not available")
         }
 #else
@@ -79,7 +79,7 @@ final class JSONColumnTests: GRDBTestCase {
     func test_extraction_operators() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON operators are not available")
         }
 #else

--- a/Tests/GRDBTests/JSONExpressionsTests.swift
+++ b/Tests/GRDBTests/JSONExpressionsTests.swift
@@ -1,23 +1,14 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 import GRDB
 
 final class JSONExpressionsTests: GRDBTestCase {
     /// The SQL function used to build JSON expressions
-    private let jsonFunction = (sqlite3_libversion_number() >= 3045000) ? "JSONB" : "JSON"
+    private let jsonFunction = (Database.sqliteLibVersionNumber >= 3045000) ? "JSONB" : "JSON"
     
     func test_Database_json() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -52,7 +43,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonb() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -85,7 +76,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_asJSON() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -146,7 +137,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonArray() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -201,7 +192,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonArray_from_SQLJSONExpressible() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -322,7 +313,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbArray() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -375,7 +366,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbArray_from_SQLJSONExpressible() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -494,7 +485,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonArrayLength() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -529,7 +520,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonArrayLength_atPath() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -572,7 +563,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonErrorPosition() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3042000 else {
+        guard Database.sqliteLibVersionNumber >= 3042000 else {
             throw XCTSkip("JSON_ERROR_JSON is not available")
         }
         
@@ -605,7 +596,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonExtract_atPath() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -648,7 +639,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonExtract_atPaths() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -683,7 +674,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbExtract_atPath() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -724,7 +715,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbExtract_atPaths() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -757,7 +748,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonInsert() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -812,7 +803,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbInsert() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -873,7 +864,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonReplace() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -928,7 +919,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbReplace() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -989,7 +980,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonSet() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1044,7 +1035,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbSet() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1105,7 +1096,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonObject_from_Dictionary() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1208,7 +1199,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonObject_from_Array() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1291,7 +1282,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonObject_from_KeyValuePairs() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1374,7 +1365,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbObject_from_Dictionary() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1511,7 +1502,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbObject_from_Array() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1621,7 +1612,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbObject_from_KeyValuePairs() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1731,7 +1722,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonPatch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1774,7 +1765,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbPatch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1815,7 +1806,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonRemove_atPath() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1858,7 +1849,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonRemove_atPaths() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -1893,7 +1884,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbRemove_atPath() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1934,7 +1925,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbRemove_atPaths() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -1967,7 +1958,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonType() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2002,7 +1993,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonType_atPath() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2045,7 +2036,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonIsValid() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2080,7 +2071,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonIsValid_options() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSON_VALID options are not available")
         }
         
@@ -2114,7 +2105,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonQuote() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2161,7 +2152,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupArray() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2192,7 +2183,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupArray_from_JSON() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2220,7 +2211,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupArray_from_JSONB() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
 
@@ -2246,7 +2237,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupArray_filter() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2277,7 +2268,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupArray_order() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3044000 else {
+        guard Database.sqliteLibVersionNumber >= 3044000 else {
             throw XCTSkip("JSON support is not available")
         }
         
@@ -2314,7 +2305,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbGroupArray() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -2343,7 +2334,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbGroupArray_filter() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -2372,7 +2363,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbGroupArray_order() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -2409,7 +2400,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupObject() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2436,7 +2427,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonGroupObject_filter() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2463,7 +2454,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbGroupObject() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -2488,7 +2479,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_Database_jsonbGroupObject_filter() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -2513,7 +2504,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_JSON_index_and_generated_columns() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3038000 else {
+        guard Database.sqliteLibVersionNumber >= 3038000 else {
             throw XCTSkip("JSON support is not available")
         }
 #else
@@ -2573,7 +2564,7 @@ final class JSONExpressionsTests: GRDBTestCase {
     func test_JSONB_index_and_generated_columns() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3045000 else {
+        guard Database.sqliteLibVersionNumber >= 3045000 else {
             throw XCTSkip("JSONB is not available")
         }
         
@@ -2631,7 +2622,7 @@ final class JSONExpressionsTests: GRDBTestCase {
 //     func test_ColumnAssignment() throws {
 // #if GRDBCUSTOMSQLITE || GRDBCIPHER
 //         // Prevent SQLCipher failures
-//         guard sqlite3_libversion_number() >= 3038000 else {
+//         guard Database.sqliteLibVersionNumber >= 3038000 else {
 //             throw XCTSkip("JSON support is not available")
 //         }
 // #else

--- a/Tests/GRDBTests/MutablePersistableRecordTests.swift
+++ b/Tests/GRDBTests/MutablePersistableRecordTests.swift
@@ -1249,7 +1249,7 @@ class MutablePersistableRecordTests: GRDBTestCase {
 extension MutablePersistableRecordTests {
     func test_insertAndFetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1270,7 +1270,7 @@ extension MutablePersistableRecordTests {
     
     func test_insertAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1320,7 +1320,7 @@ extension MutablePersistableRecordTests {
     
     func test_insertAndFetch_selection_fetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1411,7 +1411,7 @@ extension MutablePersistableRecordTests {
 extension MutablePersistableRecordTests {
     func test_saveAndFetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1432,7 +1432,7 @@ extension MutablePersistableRecordTests {
     
     func test_saveAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1558,7 +1558,7 @@ extension MutablePersistableRecordTests {
     
     func test_saveAndFetch_selection_fetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1688,7 +1688,7 @@ extension MutablePersistableRecordTests {
 extension MutablePersistableRecordTests {
     func test_updateAndFetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1739,7 +1739,7 @@ extension MutablePersistableRecordTests {
     
     func test_updateAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1789,7 +1789,7 @@ extension MutablePersistableRecordTests {
     
     func test_updateAndFetch_selection_fetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1843,7 +1843,7 @@ extension MutablePersistableRecordTests {
     
     func test_updateAndFetch_columns_selection_fetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1897,7 +1897,7 @@ extension MutablePersistableRecordTests {
     
     func test_updateChangesAndFetch_modify() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1958,7 +1958,7 @@ extension MutablePersistableRecordTests {
     
     func test_updateChangesAndFetch_as_modify() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -2018,7 +2018,7 @@ extension MutablePersistableRecordTests {
     
     func test_updateChangesAndFetch_selection_fetch_modify() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -2088,7 +2088,7 @@ extension MutablePersistableRecordTests {
 extension MutablePersistableRecordTests {
     func test_upsert() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -2237,7 +2237,7 @@ extension MutablePersistableRecordTests {
 
     func test_upsertAndFetch_do_update_set_where() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -2393,7 +2393,7 @@ extension MutablePersistableRecordTests {
     
     func test_upsertAndFetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -2496,7 +2496,7 @@ extension MutablePersistableRecordTests {
 
     func test_upsertAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else

--- a/Tests/GRDBTests/PersistableRecordTests.swift
+++ b/Tests/GRDBTests/PersistableRecordTests.swift
@@ -1328,7 +1328,7 @@ extension PersistableRecordTests {
 extension PersistableRecordTests {
     func test_insertAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1377,7 +1377,7 @@ extension PersistableRecordTests {
     
     func test_insertAndFetch_selection_fetch_column() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1426,7 +1426,7 @@ extension PersistableRecordTests {
     
     func test_insertAndFetch_selection_fetch_allColumns() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1475,7 +1475,7 @@ extension PersistableRecordTests {
     
     func test_insertAndFetch_selection_fetch_allColumns_excluding() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1528,7 +1528,7 @@ extension PersistableRecordTests {
 extension PersistableRecordTests {
     func test_saveAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1651,7 +1651,7 @@ extension PersistableRecordTests {
     
     func test_saveAndFetch_selection_fetch_column() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1774,7 +1774,7 @@ extension PersistableRecordTests {
     
     func test_saveAndFetch_selection_fetch_allColumns() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -1899,7 +1899,7 @@ extension PersistableRecordTests {
     
     func test_saveAndFetch_selection_fetch_allColumns_excluding() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -2028,7 +2028,7 @@ extension PersistableRecordTests {
 extension PersistableRecordTests {
     func test_upsert() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -2165,7 +2165,7 @@ extension PersistableRecordTests {
 
     func test_upsertAndFetch_do_update_set_where() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -2310,7 +2310,7 @@ extension PersistableRecordTests {
     
     func test_upsertAndFetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -2413,7 +2413,7 @@ extension PersistableRecordTests {
 
     func test_upsertAndFetch_as() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1508,7 +1508,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testAvgExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3030000 else {
+        guard Database.sqliteLibVersionNumber >= 3030000 else {
             throw XCTSkip("FILTER clause on aggregate functions is not available")
         }
         #else
@@ -1573,7 +1573,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testMinExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3030000 else {
+        guard Database.sqliteLibVersionNumber >= 3030000 else {
             throw XCTSkip("FILTER clause on aggregate functions is not available")
         }
         #else
@@ -1606,7 +1606,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testMaxExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3030000 else {
+        guard Database.sqliteLibVersionNumber >= 3030000 else {
             throw XCTSkip("FILTER clause on aggregate functions is not available")
         }
         #else
@@ -1639,7 +1639,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testSumExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3030000 else {
+        guard Database.sqliteLibVersionNumber >= 3030000 else {
             throw XCTSkip("FILTER clause on aggregate functions is not available")
         }
         #else
@@ -1661,7 +1661,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
     func testSumExpression_order() throws {
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3044000 else {
+        guard Database.sqliteLibVersionNumber >= 3044000 else {
             throw XCTSkip("ORDER BY clause on aggregate functions is not available")
         }
         
@@ -1696,7 +1696,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
     func testTotalExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3030000 else {
+        guard Database.sqliteLibVersionNumber >= 3030000 else {
             throw XCTSkip("FILTER clause on aggregate functions is not available")
         }
         #else
@@ -1718,7 +1718,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
     func testTotalExpression_order() throws {
         // Prevent SQLCipher failures
-        guard sqlite3_libversion_number() >= 3044000 else {
+        guard Database.sqliteLibVersionNumber >= 3044000 else {
             throw XCTSkip("ORDER BY clause on aggregate functions is not available")
         }
         

--- a/Tests/GRDBTests/SingletonRecordTest.swift
+++ b/Tests/GRDBTests/SingletonRecordTest.swift
@@ -188,7 +188,7 @@ class SingletonRecordTest: GRDBTestCase {
     
     func test_upsert_in_empty_database() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else
@@ -211,7 +211,7 @@ class SingletonRecordTest: GRDBTestCase {
     
     func test_upsert_in_populated_database() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("UPSERT is not available")
         }
 #else

--- a/Tests/GRDBTests/TableDefinitionTests.swift
+++ b/Tests/GRDBTests/TableDefinitionTests.swift
@@ -1,12 +1,3 @@
-// Import C SQLite functions
-#if SWIFT_PACKAGE
-import GRDBSQLite
-#elseif GRDBCIPHER
-import SQLCipher
-#elseif !GRDBCUSTOMSQLITE && !GRDBCIPHER
-import SQLite3
-#endif
-
 import XCTest
 import GRDB
 
@@ -56,7 +47,7 @@ class TableDefinitionTests: GRDBTestCase {
     }
 
     func testStrictTableCreationOption() throws {
-        guard sqlite3_libversion_number() >= 3037000 else {
+        guard Database.sqliteLibVersionNumber >= 3037000 else {
             throw XCTSkip("STRICT tables are not available")
         }
         #if !GRDBCUSTOMSQLITE && !GRDBCIPHER
@@ -367,7 +358,7 @@ class TableDefinitionTests: GRDBTestCase {
     
     func testColumnGeneratedAs() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3031000 else {
+        guard Database.sqliteLibVersionNumber >= 3031000 else {
             throw XCTSkip("Generated columns are not available")
         }
 #else
@@ -802,7 +793,7 @@ class TableDefinitionTests: GRDBTestCase {
     }
 
     func testAlterTableRenameColumn() throws {
-        guard sqlite3_libversion_number() >= 3025000 else {
+        guard Database.sqliteLibVersionNumber >= 3025000 else {
             throw XCTSkip("ALTER TABLE RENAME COLUMN is not available")
         }
         let dbQueue = try makeDatabaseQueue()
@@ -825,7 +816,7 @@ class TableDefinitionTests: GRDBTestCase {
     }
 
     func testAlterTableRenameColumnInvalidatesSchemaCache() throws {
-        guard sqlite3_libversion_number() >= 3025000 else {
+        guard Database.sqliteLibVersionNumber >= 3025000 else {
             throw XCTSkip("ALTER TABLE RENAME COLUMN is not available")
         }
         let dbQueue = try makeDatabaseQueue()
@@ -844,7 +835,7 @@ class TableDefinitionTests: GRDBTestCase {
     
     func testAlterTableAddGeneratedVirtualColumn() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3031000 else {
+        guard Database.sqliteLibVersionNumber >= 3031000 else {
             throw XCTSkip("Generated columns are not available")
         }
 #else
@@ -879,7 +870,7 @@ class TableDefinitionTests: GRDBTestCase {
     }
     
     func testAlterTableDropColumn() throws {
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("ALTER TABLE DROP COLUMN is not available")
         }
         #if !GRDBCUSTOMSQLITE && !GRDBCIPHER
@@ -903,7 +894,7 @@ class TableDefinitionTests: GRDBTestCase {
     }
     
     func testAlterTableDropColumnInvalidatesSchemaCache() throws {
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("ALTER TABLE DROP COLUMN is not available")
         }
         #if !GRDBCUSTOMSQLITE && !GRDBCIPHER

--- a/Tests/GRDBTests/TableRecordDeleteTests.swift
+++ b/Tests/GRDBTests/TableRecordDeleteTests.swift
@@ -227,7 +227,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testRequestDeleteAndFetchStatement() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -261,7 +261,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testRequestDeleteAndFetchCursor() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -320,7 +320,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testRequestDeleteAndFetchArray() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -348,7 +348,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testRequestDeleteAndFetchSet() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -374,7 +374,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testRequestDeleteAndFetchIds() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -457,7 +457,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testJoinedRequestDeleteAndFetch() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -624,7 +624,7 @@ class TableRecordDeleteTests: GRDBTestCase {
     
     func testGroupedRequestDeleteAndFetchCursor() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else

--- a/Tests/GRDBTests/TableRecordUpdateTests.swift
+++ b/Tests/GRDBTests/TableRecordUpdateTests.swift
@@ -116,7 +116,7 @@ class TableRecordUpdateTests: GRDBTestCase {
     
     func testRequestUpdateAndFetchStatement() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -155,7 +155,7 @@ class TableRecordUpdateTests: GRDBTestCase {
     
     func testRequestUpdateAndFetchCursor() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -182,7 +182,7 @@ class TableRecordUpdateTests: GRDBTestCase {
     
     func testRequestUpdateAndFetchAll() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else
@@ -210,7 +210,7 @@ class TableRecordUpdateTests: GRDBTestCase {
     
     func testRequestUpdateAndFetchSet() throws {
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-        guard sqlite3_libversion_number() >= 3035000 else {
+        guard Database.sqliteLibVersionNumber >= 3035000 else {
             throw XCTSkip("RETURNING clause is not available")
         }
 #else

--- a/Tests/GRDBTests/ValueObservationTests.swift
+++ b/Tests/GRDBTests/ValueObservationTests.swift
@@ -1059,7 +1059,7 @@ class ValueObservationTests: GRDBTestCase {
     func testManyObservations() throws {
         // TODO: Fix flaky test with SQLCipher 3
         #if GRDBCIPHER
-        if sqlite3_libversion_number() <= 3020001 {
+        if Database.sqliteLibVersionNumber <= 3020001 {
             throw XCTSkip("Skip flaky test with SQLCipher 3")
         }
         #endif


### PR DESCRIPTION
This makes it easier to write tests that depend on SQLite version, because we do not need to import the SQLite C apis.