### PR TITLE
Fix: DatabaseQueue restores its read/write abilities when an async read-only database access is cancelled.

### DIFF
--- a/GRDB/Core/Database.swift
+++ b/GRDB/Core/Database.swift
@@ -1288,6 +1288,12 @@ public final class Database: CustomStringConvertible, CustomDebugStringConvertib
             return
         }
         
+        // Suspension should not prevent adjusting the read-only mode.
+        // See <https://github.com/groue/GRDB.swift/issues/1715>.
+        if statement.isQueryOnlyPragma {
+            return
+        }
+        
         // How should we interrupt the statement?
         enum Interrupt {
             case abort  // Rollback and throw SQLITE_ABORT

--- a/GRDB/Core/Statement.swift
+++ b/GRDB/Core/Statement.swift
@@ -92,6 +92,9 @@ public final class Statement {
     /// The effects on the database (reported by `sqlite3_set_authorizer`).
     private(set) var authorizerEventKinds: [DatabaseEventKind] = []
     
+    /// If true, the statement executes is a `PRAGMA QUERY_ONLY` statement.
+    private(set) var isQueryOnlyPragma = false
+    
     /// A boolean value indicating if the prepared statement makes no direct
     /// changes to the content of the database file.
     ///
@@ -160,6 +163,7 @@ public final class Statement {
         self.invalidatesDatabaseSchemaCache = authorizer.invalidatesDatabaseSchemaCache
         self.transactionEffect = authorizer.transactionEffect
         self.authorizerEventKinds = authorizer.databaseEventKinds
+        self.isQueryOnlyPragma = authorizer.isQueryOnlyPragma
     }
     
     deinit {

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -41,6 +41,9 @@ final class StatementAuthorizer {
     /// savepoint statement.
     var transactionEffect: Statement.TransactionEffect?
     
+    /// If true, the statement executes is a `PRAGMA QUERY_ONLY` statement.
+    var isQueryOnlyPragma = false
+    
     private var isDropStatement = false
     
     init(_ database: Database) {
@@ -67,6 +70,7 @@ final class StatementAuthorizer {
         databaseEventKinds = []
         invalidatesDatabaseSchemaCache = false
         transactionEffect = nil
+        isQueryOnlyPragma = false
         isDropStatement = false
     }
     
@@ -192,6 +196,11 @@ final class StatementAuthorizer {
             }
             return SQLITE_OK
             
+        case SQLITE_PRAGMA:
+            if let cString1 {
+                isQueryOnlyPragma = sqlite3_stricmp(cString1, "query_only") == 0
+            }
+            return SQLITE_OK
         default:
             return SQLITE_OK
         }


### PR DESCRIPTION
This pull request fixes the bug reported in #1715. Thank you @rcarver!