### PR TITLE
Select ids with selectID()

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
             name: "macOS"
           - xcode: "Xcode_16.1.app"
             runsOn: macOS-14
-            destination: "OS=18.1,name=iPhone 15 Pro"
+            destination: "OS=18.1,name=iPhone 16 Pro"
             name: "iOS"
           - xcode: "Xcode_16.1.app"
             runsOn: macOS-14

--- a/GRDB/Documentation.docc/RecordRecommendedPractices.md
+++ b/GRDB/Documentation.docc/RecordRecommendedPractices.md
@@ -393,16 +393,16 @@ Extensions to the `DerivableRequest` protocol can not change the type of request
 
 ```swift
 extension QueryInterfaceRequest<Author> {
-    // Selects author ids
-    func selectId() -> QueryInterfaceRequest<Int64> {
-        selectPrimaryKey(as: Int64.self)
+    // Selects authors' name
+    func selectName() -> QueryInterfaceRequest<String> {
+        select(Author.Columns.name)
     }
 }
 
-// The ids of Japanese authors
-let ids: Set<Int64> = try Author.all()
+// The names of Japanese authors
+let names: Set<String> = try Author.all()
     .filter(countryCode: "JP")
-    .selectId()
+    .selectName()
     .fetchSet(db)
 ```
 

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -56,6 +56,7 @@
 /// - ``select(_:as:)-3o8qw``
 /// - ``select(literal:as:)``
 /// - ``select(sql:arguments:as:)``
+/// - ``selectID()``
 /// - ``selectPrimaryKey(as:)``
 ///
 /// ### Batch Delete
@@ -237,7 +238,7 @@ extension QueryInterfaceRequest: SelectionRequest {
         select(sqlLiteral, as: type)
     }
     
-    /// Selects the primary key.
+    /// Returns a request that selects the primary key.
     ///
     /// All primary keys are supported:
     ///
@@ -279,6 +280,26 @@ extension QueryInterfaceRequest: SelectionRequest {
             }
         }
         .asRequest(of: PrimaryKey.self)
+    }
+    
+    /// Returns a request that selects the primary key.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT id FROM player WHERE ...
+    /// let request = try Player.filter(...).selectID()
+    /// ```
+    public func selectID() -> QueryInterfaceRequest<RowDecoder.ID>
+    where RowDecoder: Identifiable
+    {
+        selectWhenConnected { db in
+            let primaryKey = try db.primaryKey(self.databaseTableName)
+            GRDBPrecondition(
+                primaryKey.columns.count == 1,
+                "selectID requires a single-column primary key in the table \(self.databaseTableName)")
+            return [Column(primaryKey.columns[0])]
+        }.asRequest(of: RowDecoder.ID.self)
     }
     
     public func annotatedWhenConnected(

--- a/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/Request/QueryInterfaceRequest.swift
@@ -290,6 +290,26 @@ extension QueryInterfaceRequest: SelectionRequest {
     /// // SELECT id FROM player WHERE ...
     /// let request = try Player.filter(...).selectID()
     /// ```
+    ///
+    /// **Important**: if the record type has an `ID` type that is an
+    /// optional, such as `Int64?`, it is recommended to prefer
+    /// ``selectPrimaryKey(as:)`` instead:
+    ///
+    /// ```swift
+    /// struct Player: Identifiable {
+    ///     var id: Int64?
+    /// }
+    ///
+    /// // NOT RECOMMENDED: Set<Int64?>
+    /// let ids = try Player.filter(...)
+    ///     .selectID()
+    ///     .fetchSet(db)
+    ///
+    /// // BETTER: Set<Int64>
+    /// let ids = try Player.filter(...)
+    ///     .selectPrimaryKey(as: Int64.self)
+    ///     .fetchSet(db)
+    /// ```
     public func selectID() -> QueryInterfaceRequest<RowDecoder.ID>
     where RowDecoder: Identifiable
     {

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -94,6 +94,7 @@
 /// - ``select(literal:as:)``
 /// - ``select(sql:arguments:)``
 /// - ``select(sql:arguments:as:)``
+/// - ``selectID()``
 /// - ``selectPrimaryKey(as:)``
 /// - ``with(_:)``
 ///
@@ -422,6 +423,22 @@ extension Table {
     -> QueryInterfaceRequest<PrimaryKey>
     {
         all().selectPrimaryKey(as: type)
+    }
+    
+    /// Returns a request that selects the primary key.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let table = Table<Player>("player")
+    ///
+    /// // SELECT id FROM player
+    /// let request = try table.selectID()
+    /// ```
+    public func selectID() -> QueryInterfaceRequest<RowDecoder.ID>
+    where RowDecoder: Identifiable
+    {
+        all().selectID()
     }
     
     /// Returns a request with the provided result columns appended to the

--- a/GRDB/QueryInterface/SQL/Table.swift
+++ b/GRDB/QueryInterface/SQL/Table.swift
@@ -435,6 +435,24 @@ extension Table {
     /// // SELECT id FROM player
     /// let request = try table.selectID()
     /// ```
+    ///
+    /// **Important**: if the record type has an `ID` type that is an
+    /// optional, such as `Int64?`, it is recommended to prefer
+    /// ``selectPrimaryKey(as:)`` instead:
+    ///
+    /// ```swift
+    /// struct Player: Identifiable {
+    ///     var id: Int64?
+    /// }
+    ///
+    /// let table = Table<Player>("player")
+    ///
+    /// // NOT RECOMMENDED: Set<Int64?>
+    /// let ids = try table.selectID().fetchSet(db)
+    ///
+    /// // BETTER: Set<Int64>
+    /// let ids = try table.selectPrimaryKey(as: Int64.self).fetchSet(db)
+    /// ```
     public func selectID() -> QueryInterfaceRequest<RowDecoder.ID>
     where RowDecoder: Identifiable
     {

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -251,6 +251,20 @@ extension TableRecord {
         all().selectPrimaryKey(as: type)
     }
     
+    /// Returns a request that selects the primary key.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // SELECT id FROM player
+    /// let request = try Player.selectID()
+    /// ```
+    public static func selectID() -> QueryInterfaceRequest<Self.ID>
+    where Self: Identifiable
+    {
+        all().selectID()
+    }
+    
     /// Returns a request with the provided result columns appended to the
     /// record selection.
     ///

--- a/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
+++ b/GRDB/QueryInterface/TableRecord+QueryInterfaceRequest.swift
@@ -259,6 +259,22 @@ extension TableRecord {
     /// // SELECT id FROM player
     /// let request = try Player.selectID()
     /// ```
+    ///
+    /// **Important**: if the record type has an `ID` type that is an
+    /// optional, such as `Int64?`, it is recommended to prefer
+    /// ``selectPrimaryKey(as:)`` instead:
+    ///
+    /// ```swift
+    /// struct Player: Identifiable {
+    ///     var id: Int64?
+    /// }
+    ///
+    /// // NOT RECOMMENDED: Set<Int64?>
+    /// let ids = try Player.selectID().fetchSet(db)
+    ///
+    /// // BETTER: Set<Int64>
+    /// let ids = try Player.selectPrimaryKey(as: Int64.self).fetchSet(db)
+    /// ```
     public static func selectID() -> QueryInterfaceRequest<Self.ID>
     where Self: Identifiable
     {

--- a/GRDB/Record/TableRecord.swift
+++ b/GRDB/Record/TableRecord.swift
@@ -98,6 +98,7 @@ import Foundation
 /// - ``select(literal:as:)``
 /// - ``select(sql:arguments:)``
 /// - ``select(sql:arguments:as:)``
+/// - ``selectID()``
 /// - ``selectPrimaryKey(as:)``
 /// - ``with(_:)``
 ///

--- a/README.md
+++ b/README.md
@@ -3341,6 +3341,16 @@ You can now build requests with the following methods: `all`, `none`, `select`, 
     Player.select(nameColumn, as: String.self)
     ```
 
+- [`selectID()`](https://swiftpackageindex.com/groue/GRDB.swift/documentation/grdb/queryinterfacerequest/selectID()) is available on [Identifiable Records]. It supports all tables that have a single-column primary key:
+
+    ```swift
+    // SELECT id FROM player
+    Player.selectID()
+    
+    // SELECT id FROM player WHERE name IS NOT NULL
+    Player.filter(nameColumn != nil).selectID()
+    ```
+
 - [`annotated(with: expression...)`](https://swiftpackageindex.com/groue/GRDB.swift/documentation/grdb/selectionrequest/annotated(with:)-6ehs4) extends the selection.
 
     ```swift

--- a/Tests/GRDBTests/RecordMinimalNonOptionalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalNonOptionalPrimaryKeySingleTests.swift
@@ -800,6 +800,16 @@ class RecordMinimalNonOptionalPrimaryKeySingleTests: GRDBTestCase {
         }
     }
     
+    func test_static_selectID() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalNonOptionalPrimaryKeySingle(id: "theUUID")
+            try record.insert(db)
+            let ids: [String] = try MinimalSingle.selectID().fetchAll(db)
+            XCTAssertEqual(ids, ["theUUID"])
+        }
+    }
+    
     func test_request_selectPrimaryKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -809,6 +819,16 @@ class RecordMinimalNonOptionalPrimaryKeySingleTests: GRDBTestCase {
             XCTAssertEqual(ids, ["theUUID"])
             let rows = try MinimalSingle.all().selectPrimaryKey(as: Row.self).fetchAll(db)
             XCTAssertEqual(rows, [["id": "theUUID"]])
+        }
+    }
+    
+    func test_request_selectID() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalNonOptionalPrimaryKeySingle(id: "theUUID")
+            try record.insert(db)
+            let ids: [String] = try MinimalSingle.all().selectID().fetchAll(db)
+            XCTAssertEqual(ids, ["theUUID"])
         }
     }
 }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeyRowIDTests.swift
@@ -844,6 +844,16 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
         }
     }
     
+    func test_static_selectID() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalRowID()
+            try record.insert(db)
+            let ids: [Int64?] = try MinimalRowID.selectID().fetchAll(db)
+            XCTAssertEqual(ids, [1])
+        }
+    }
+    
     func test_request_selectPrimaryKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -853,6 +863,16 @@ class RecordMinimalPrimaryKeyRowIDTests : GRDBTestCase {
             XCTAssertEqual(ids, [1])
             let rows = try MinimalRowID.all().selectPrimaryKey(as: Row.self).fetchAll(db)
             XCTAssertEqual(rows, [["id": 1]])
+        }
+    }
+    
+    func test_request_selectID() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalRowID()
+            try record.insert(db)
+            let ids: [Int64?] = try MinimalRowID.all().selectID().fetchAll(db)
+            XCTAssertEqual(ids, [1])
         }
     }
 }

--- a/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
+++ b/Tests/GRDBTests/RecordMinimalPrimaryKeySingleTests.swift
@@ -375,7 +375,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             XCTAssertEqual(lastSQLQuery, "SELECT * FROM \"minimalSingles\" WHERE \"UUID\" = '\(record.UUID!)'")
         }
     }
-
+    
     
     // MARK: - Fetch With Key Request
     
@@ -661,7 +661,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
                 _ = try MinimalSingle.find(db, key: id)
                 XCTFail("Expected RecordError")
             } catch RecordError.recordNotFound(databaseTableName: "minimalSingles", key: ["UUID": .null]) { }
-
+            
             do {
                 let fetchedRecord = try MinimalSingle.find(db, key: record.UUID)
                 XCTAssertTrue(fetchedRecord.UUID == record.UUID)
@@ -680,7 +680,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             }
         }
     }
-
+    
     
     // MARK: - Fetch With Primary Key Request
     
@@ -861,7 +861,7 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
     }
     
     // MARK: Select PrimaryKey
-
+    
     func test_static_selectPrimaryKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -875,6 +875,17 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
         }
     }
     
+    func test_static_selectID() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalSingle()
+            record.UUID = "theUUID"
+            try record.insert(db)
+            let ids: [String] = try MinimalSingle.selectID().fetchAll(db)
+            XCTAssertEqual(ids, ["theUUID"])
+        }
+    }
+    
     func test_request_selectPrimaryKey() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
@@ -885,6 +896,17 @@ class RecordMinimalPrimaryKeySingleTests: GRDBTestCase {
             XCTAssertEqual(ids, ["theUUID"])
             let rows = try MinimalSingle.all().selectPrimaryKey(as: Row.self).fetchAll(db)
             XCTAssertEqual(rows, [["UUID": "theUUID"]])
+        }
+    }
+    
+    func test_request_selectID() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            let record = MinimalSingle()
+            record.UUID = "theUUID"
+            try record.insert(db)
+            let ids: [String] = try MinimalSingle.all().selectID().fetchAll(db)
+            XCTAssertEqual(ids, ["theUUID"])
         }
     }
 }

--- a/Tests/GRDBTests/TableTests.swift
+++ b/Tests/GRDBTests/TableTests.swift
@@ -133,6 +133,8 @@ class TableTests: GRDBTestCase {
                 try assertEqualSQL(db, t.filter(ids: [1, 2, 3]), """
                     SELECT * FROM "player" WHERE "id" IN (1, 2, 3)
                     """)
+                
+                try XCTAssertEqual(t.selectID().fetchOne(db), 1)
             }
             
             do {
@@ -148,6 +150,8 @@ class TableTests: GRDBTestCase {
                 try assertEqualSQL(db, t.filter(ids: [1, 2, 3]), """
                     SELECT * FROM "player" WHERE "id" IN (1, 2, 3)
                     """)
+                
+                try XCTAssertEqual(t.selectID().fetchOne(db), 1)
             }
         }
     }


### PR DESCRIPTION
For `Identifiable` record types, the new `selectID` method is easier to use than `selectPrimaryKey(as:)`:

```swift
struct Player: Identifiable, TableRecord {
    var id: Int64
}

// Before
let ids = try Player.selectPrimaryKey(as: Int64.self).fetchSet(db)

// After
let ids = try Player.selectID().fetchSet(db)
```

This pull request reverts 7ffc332327d6ebe1a61d139de24e413e83d80cd9.

At the time, `selectID` was replaced with `selectPrimaryKey(as:)` because:

> Since `Optional` is a database value like others, `selectID` would be a request of optionals for records with an optional ID type:
>
> ```swift
> struct Player: Identifiable, MutablePersistableRecord {
>     var id: Int64?
> }
>
> Player.selectID() // QueryInterface<Int64?>
> ```
>
> This is not good, because primary keys are not null. And those requests would fetch impractical types such as `[Int64?]`, `Set<Int64?>`, `Int64??`.

This problem is reintroduced, but we now recommend against `Identifiable` types with optional ids in [Recommended Practices for Designing Record Types](https://swiftpackageindex.com/groue/grdb.swift/documentation/grdb/recordrecommendedpractices).

Records with optional ids can use `selectPrimaryKey(as:)` in order to remove the undesired optional:

```swift
// NOT RECOMMENDED: Identifiable type with optional ID 
struct Player: Identifiable, MutablePersistableRecord {
    var id: Int64? 
}

// NOT RECOMMENDED: QueryInterface<Int64?>
Player.selectID() 

// OK: QueryInterface<Int64>
Player.selectPrimaryKey(as: Int64.self) 
```
