### PR TITLE
Deprecate Date coding strategies based on DateFormatter

### DIFF
--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -524,7 +524,12 @@ public enum DatabaseDataEncodingStrategy: Sendable {
 ///     var creationDate: Date
 /// }
 /// ```
-public enum DatabaseDateEncodingStrategy: Sendable {
+public enum DatabaseDateEncodingStrategy: @unchecked Sendable {
+    // @unchecked Sendable because of `DateFormatter`, which lost its
+    // `Sendable` conformance with Xcode 16.3. See
+    // <https://github.com/swiftlang/swift/issues/78635>.
+    // TODO GRDB8: remove @unchecked when the .formatted case has been removed.
+    
     /// The strategy that uses formatting from the Date structure.
     ///
     /// It encodes dates using the format "YYYY-MM-DD HH:MM:SS.SSS" in the
@@ -551,6 +556,7 @@ public enum DatabaseDateEncodingStrategy: Sendable {
     case iso8601
     
     /// Encodes a String, according to the provided formatter
+    @available(*, deprecated, message: "Use .custom and a Date.FormatStyle instead.")
     case formatted(DateFormatter)
     
     /// Encodes the result of the user-provided function

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -929,7 +929,12 @@ public enum DatabaseDataDecodingStrategy: Sendable {
 ///         var name: String
 ///         var registrationDate: Date // decoded from epoch timestamp
 ///     }
-public enum DatabaseDateDecodingStrategy: Sendable {
+public enum DatabaseDateDecodingStrategy: @unchecked Sendable {
+    // @unchecked Sendable because of `DateFormatter`, which lost its
+    // `Sendable` conformance with Xcode 16.3. See
+    // <https://github.com/swiftlang/swift/issues/78635>.
+    // TODO GRDB8: remove @unchecked when the .formatted case has been removed.
+    
     /// The strategy that uses formatting from the Date structure.
     ///
     /// It decodes numeric values as a number of seconds since Epoch
@@ -963,6 +968,7 @@ public enum DatabaseDateDecodingStrategy: Sendable {
     case iso8601
     
     /// Decodes a String, according to the provided formatter
+    @available(*, deprecated, message: "Use .custom and a Date.FormatStyle instead.")
     case formatted(DateFormatter)
     
     /// Decodes according to the user-provided function.

--- a/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
@@ -26,6 +26,7 @@ private enum StrategyIso8601: StrategyProvider {
     static let strategy: DatabaseDateDecodingStrategy = .iso8601
 }
 
+@available(*, deprecated)
 private enum StrategyFormatted: StrategyProvider {
     static let strategy: DatabaseDateDecodingStrategy = .formatted({
         let formatter = DateFormatter()
@@ -418,6 +419,7 @@ extension DatabaseDateDecodingStrategyTests {
 // MARK: - formatted(DateFormatter)
 
 extension DatabaseDateDecodingStrategyTests {
+    @available(*, deprecated)
     func testFormatted() throws {
         try makeDatabaseQueue().read { db in
             var calendar = Calendar(identifier: .gregorian)

--- a/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
@@ -30,6 +30,7 @@ private enum StrategyIso8601: StrategyProvider {
     static let strategy: DatabaseDateEncodingStrategy = .iso8601
 }
 
+@available(*, deprecated)
 private enum StrategyFormatted: StrategyProvider {
     static let strategy: DatabaseDateEncodingStrategy = .formatted({
         let formatter = DateFormatter()
@@ -197,6 +198,7 @@ extension DatabaseDateEncodingStrategyTests {
 // MARK: - formatted(DateFormatter)
 
 extension DatabaseDateEncodingStrategyTests {
+    @available(*, deprecated)
     func testFormatted() throws {
         try testNullEncoding(strategy: StrategyFormatted.self)
         


### PR DESCRIPTION
`DateFormatter` lost its Sendable conformance in Xcode 16.3, a conformance that [should never have shipped in Foundation](https://github.com/swiftlang/swift/issues/78635#issuecomment-2675918183). This creates compiler errors in GRDB regarding the Date coding strategies.

This pull requests deprecates the strategies based on `DateFormatter`. They will be removed in GRDB 8.

Instead, use `custom` strategies:

```swift
static func databaseDateDecodingStrategy(for column: String) -> DatabaseDateDecodingStrategy {
    DatabaseDateDecodingStrategy.custom { dbValue in
        guard let string = String.fromDatabaseValue(dbValue) else { return nil }
        let format: Date.FormatStyle = ...
        return try? format.parse(string)
    }
}

static func databaseDateEncodingStrategy(for column: String) -> DatabaseDateEncodingStrategy {
    DatabaseDateEncodingStrategy.custom { date in
        let format: Date.FormatStyle = ...
        return return date.formatted(format)
    }
}
```

---

Fix #1728