### PR TITLE
Undeprecate Date coding strategies based on DateFormatter

### DIFF
--- a/GRDB/Record/EncodableRecord.swift
+++ b/GRDB/Record/EncodableRecord.swift
@@ -526,9 +526,9 @@ public enum DatabaseDataEncodingStrategy: Sendable {
 /// ```
 public enum DatabaseDateEncodingStrategy: @unchecked Sendable {
     // @unchecked Sendable because of `DateFormatter`, which lost its
-    // `Sendable` conformance with Xcode 16.3. See
+    // `Sendable` conformance with Xcode 16.3 beta. See
     // <https://github.com/swiftlang/swift/issues/78635>.
-    // TODO GRDB8: remove @unchecked when the .formatted case has been removed.
+    // TODO: remove @unchecked when the compiler issue is fixed.
     
     /// The strategy that uses formatting from the Date structure.
     ///
@@ -556,7 +556,6 @@ public enum DatabaseDateEncodingStrategy: @unchecked Sendable {
     case iso8601
     
     /// Encodes a String, according to the provided formatter
-    @available(*, deprecated, message: "Use .custom and a Date.FormatStyle instead.")
     case formatted(DateFormatter)
     
     /// Encodes the result of the user-provided function

--- a/GRDB/Record/FetchableRecord.swift
+++ b/GRDB/Record/FetchableRecord.swift
@@ -931,9 +931,9 @@ public enum DatabaseDataDecodingStrategy: Sendable {
 ///     }
 public enum DatabaseDateDecodingStrategy: @unchecked Sendable {
     // @unchecked Sendable because of `DateFormatter`, which lost its
-    // `Sendable` conformance with Xcode 16.3. See
+    // `Sendable` conformance with Xcode 16.3 beta. See
     // <https://github.com/swiftlang/swift/issues/78635>.
-    // TODO GRDB8: remove @unchecked when the .formatted case has been removed.
+    // TODO: remove @unchecked when the compiler issue is fixed.
     
     /// The strategy that uses formatting from the Date structure.
     ///
@@ -968,7 +968,6 @@ public enum DatabaseDateDecodingStrategy: @unchecked Sendable {
     case iso8601
     
     /// Decodes a String, according to the provided formatter
-    @available(*, deprecated, message: "Use .custom and a Date.FormatStyle instead.")
     case formatted(DateFormatter)
     
     /// Decodes according to the user-provided function.

--- a/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
@@ -26,7 +26,6 @@ private enum StrategyIso8601: StrategyProvider {
     static let strategy: DatabaseDateDecodingStrategy = .iso8601
 }
 
-@available(*, deprecated)
 private enum StrategyFormatted: StrategyProvider {
     static let strategy: DatabaseDateDecodingStrategy = .formatted({
         let formatter = DateFormatter()
@@ -419,7 +418,6 @@ extension DatabaseDateDecodingStrategyTests {
 // MARK: - formatted(DateFormatter)
 
 extension DatabaseDateDecodingStrategyTests {
-    @available(*, deprecated)
     func testFormatted() throws {
         try makeDatabaseQueue().read { db in
             var calendar = Calendar(identifier: .gregorian)

--- a/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateEncodingStrategyTests.swift
@@ -30,7 +30,6 @@ private enum StrategyIso8601: StrategyProvider {
     static let strategy: DatabaseDateEncodingStrategy = .iso8601
 }
 
-@available(*, deprecated)
 private enum StrategyFormatted: StrategyProvider {
     static let strategy: DatabaseDateEncodingStrategy = .formatted({
         let formatter = DateFormatter()
@@ -198,7 +197,6 @@ extension DatabaseDateEncodingStrategyTests {
 // MARK: - formatted(DateFormatter)
 
 extension DatabaseDateEncodingStrategyTests {
-    @available(*, deprecated)
     func testFormatted() throws {
         try testNullEncoding(strategy: StrategyFormatted.self)
         


### PR DESCRIPTION
This pull request restores the Date coding strategies based on DateFormatter that were deprecated in #1729 due to a misunderstanding of a Xcode 16.3 beta compiler issue:

https://github.com/swiftlang/swift/issues/78635#issuecomment-2676324549

> `DateFormatter` is indeed thread safe and its conformance to `Sendable` is correct.
