### PR TITLE
Support for temporary virtual tables

### DIFF
--- a/Documentation/FullTextSearch.md
+++ b/Documentation/FullTextSearch.md
@@ -91,7 +91,7 @@ Generally speaking, FTS5 is better than FTS4 which improves on FTS3. But this do
 
 **FTS3 and FTS4 full-text tables store and index textual content.**
 
-Create tables with the `create(virtualTable:using:)` method:
+Create tables with the `create(virtualTable:options:using:_:)` method:
 
 ```swift
 // CREATE VIRTUAL TABLE document USING fts3(content)
@@ -326,7 +326,7 @@ let documents = try Document.filter(Column("content").match(pattern)).fetchAll(d
 
 To use FTS5, you'll need a [custom SQLite build] that activates the `SQLITE_ENABLE_FTS5` compilation option.
 
-Create FTS5 tables with the `create(virtualTable:using:)` method:
+Create FTS5 tables with the `create(virtualTable:options:using:_:)` method:
 
 ```swift
 // CREATE VIRTUAL TABLE document USING fts5(content)

--- a/GRDB/Documentation.docc/DatabaseSchemaModifications.md
+++ b/GRDB/Documentation.docc/DatabaseSchemaModifications.md
@@ -252,8 +252,8 @@ Unique constraints and unique indexes are somewhat different: don't miss the tip
 
 - ``Database/alter(table:body:)``
 - ``Database/create(table:options:body:)``
-- ``Database/create(virtualTable:ifNotExists:using:)``
-- ``Database/create(virtualTable:ifNotExists:using:_:)``
+- ``Database/create(virtualTable:options:using:)``
+- ``Database/create(virtualTable:options:using:_:)``
 - ``Database/drop(table:)``
 - ``Database/dropFTS4SynchronizationTriggers(forTable:)``
 - ``Database/dropFTS5SynchronizationTriggers(forTable:)``
@@ -265,6 +265,7 @@ Unique constraints and unique indexes are somewhat different: don't miss the tip
 - ``TableDefinition``
 - ``TableOptions``
 - ``VirtualTableModule``
+- ``VirtualTableOptions``
 
 ### Database Views
 
@@ -288,3 +289,5 @@ Those are legacy interfaces that are preserved for backwards compatibility. Thei
 
 - ``Database/create(index:on:columns:unique:ifNotExists:condition:)``
 - ``Database/create(table:temporary:ifNotExists:withoutRowID:body:)``
+- ``Database/create(virtualTable:ifNotExists:using:)``
+- ``Database/create(virtualTable:ifNotExists:using:_:)``

--- a/GRDB/FTS/FTS3.swift
+++ b/GRDB/FTS/FTS3.swift
@@ -1,7 +1,7 @@
 /// The virtual table module for the FTS3 full-text engine.
 ///
 /// To create FTS3 tables, use the ``Database`` method
-/// ``Database/create(virtualTable:ifNotExists:using:_:)``:
+/// ``Database/create(virtualTable:options:using:_:)``:
 ///
 /// ```swift
 /// // CREATE VIRTUAL TABLE document USING fts3(content)
@@ -63,7 +63,7 @@ public struct FTS3 {
     /// }
     /// ```
     ///
-    /// See ``Database/create(virtualTable:ifNotExists:using:_:)``
+    /// See ``Database/create(virtualTable:options:using:_:)``
     public init() { }
     
     /// Returns an array of tokens found in the string argument.
@@ -143,7 +143,7 @@ extension FTS3: VirtualTableModule {
 /// virtual table.
 ///
 /// You don't create instances of this class. Instead, you use the `Database`
-/// ``Database/create(virtualTable:ifNotExists:using:_:)`` method:
+/// ``Database/create(virtualTable:options:using:_:)`` method:
 ///
 /// ```swift
 /// try db.create(virtualTable: "document", using: FTS3()) { t in // t is FTS3TableDefinition

--- a/GRDB/FTS/FTS3TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS3TokenizerDescriptor.swift
@@ -106,13 +106,13 @@ public struct FTS3TokenizerDescriptor: Sendable {
         if !separators.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as separators, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
-            // and Database.create(virtualTable:using:)
+            // and Database.create(virtualTable:options:using:_:)
             arguments.append("separators=" + separators.sorted().map { String($0) }.joined())
         }
         if !tokenCharacters.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as tokenCharacters, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
-            // and Database.create(virtualTable:using:)
+            // and Database.create(virtualTable:options:using:_:)
             arguments.append("tokenchars=" + tokenCharacters.sorted().map { String($0) }.joined())
         }
         return FTS3TokenizerDescriptor("unicode61", arguments: arguments)

--- a/GRDB/FTS/FTS5TokenizerDescriptor.swift
+++ b/GRDB/FTS/FTS5TokenizerDescriptor.swift
@@ -112,14 +112,14 @@ public struct FTS5TokenizerDescriptor: Sendable {
         if !separators.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as separators, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
-            // and Database.create(virtualTable:using:)
+            // and Database.create(virtualTable:options:using:_:)
             components.append("separators")
             components.append(separators.sorted().map { String($0) }.joined())
         }
         if !tokenCharacters.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as tokenCharacters, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
-            // and Database.create(virtualTable:using:)
+            // and Database.create(virtualTable:options:using:_:)
             components.append("tokenchars")
             components.append(tokenCharacters.sorted().map { String($0) }.joined())
         }
@@ -197,14 +197,14 @@ public struct FTS5TokenizerDescriptor: Sendable {
         if !separators.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as separators, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
-            // and Database.create(virtualTable:using:)
+            // and Database.create(virtualTable:options:using:_:)
             components.append("separators")
             components.append(separators.sorted().map { String($0) }.joined())
         }
         if !tokenCharacters.isEmpty {
             // TODO: test "=" and "\"", "(" and ")" as tokenCharacters, with
             // both FTS3Pattern(matchingAnyTokenIn:tokenizer:)
-            // and Database.create(virtualTable:using:)
+            // and Database.create(virtualTable:options:using:_:)
             components.append("tokenchars")
             components.append(tokenCharacters.sorted().map { String($0) }.joined())
         }

--- a/GRDB/QueryInterface/Schema/VirtualTableModule.swift
+++ b/GRDB/QueryInterface/Schema/VirtualTableModule.swift
@@ -1,7 +1,7 @@
 /// The protocol for SQLite virtual table modules.
 ///
 /// The protocol can define a DSL for the
-/// ``Database/create(virtualTable:ifNotExists:using:_:)`` `Database` method:
+/// ``Database/create(virtualTable:options:using:_:)`` `Database` method:
 ///
 /// ```swift
 /// let module = ...
@@ -20,7 +20,7 @@
 /// - ``VirtualTableConfiguration``
 public protocol VirtualTableModule {
     /// The type of the argument in the
-    /// ``Database/create(virtualTable:ifNotExists:using:_:)`` closure.
+    /// ``Database/create(virtualTable:options:using:_:)`` closure.
     ///
     /// For example:
     ///
@@ -35,7 +35,7 @@ public protocol VirtualTableModule {
     var moduleName: String { get }
     
     /// Returns a table definition that is passed as the argument in the
-    /// ``Database/create(virtualTable:ifNotExists:using:_:)`` closure.
+    /// ``Database/create(virtualTable:options:using:_:)`` closure.
     ///
     /// For example:
     ///
@@ -54,10 +54,29 @@ public protocol VirtualTableModule {
     func database(_ db: Database, didCreate tableName: String, using definition: TableDefinition) throws
 }
 
+// TODO: Question the existence of this API. VirtualTableConfiguration was
+// never able to be used by user-defined VirtualTableModule types, because
+// `ifNotExists` has never been public.
 public struct VirtualTableConfiguration {
     /// If true, existing objects must not be replaced, or generate any error
     /// (even if they do not match the objects that would be created otherwise.)
     var ifNotExists: Bool
+    
+    /// If true, new objects must be created in the temp schema.
+    var temporary: Bool
+}
+
+/// Virtual table creation options.
+public struct VirtualTableOptions: OptionSet, Sendable {
+    public let rawValue: Int
+    
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    
+    /// Only creates the table if it does not already exist.
+    public static let ifNotExists = VirtualTableOptions(rawValue: 1 << 0)
+    
+    /// Creates a temporary table.
+    public static let temporary = VirtualTableOptions(rawValue: 1 << 1)
 }
 
 extension Database {
@@ -77,18 +96,24 @@ extension Database {
     ///
     /// - parameters:
     ///     - name: The table name.
-    ///     - ifNotExists: If false (the default), an error is thrown if the
-    ///       table already exists. Otherwise, the table is created unless it
-    ///       already exists.
+    ///     - options: Table creation options.
     ///     - module: The name of an SQLite virtual table module.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
-    public func create(virtualTable name: String, ifNotExists: Bool = false, using module: String) throws {
+    public func create(
+        virtualTable name: String,
+        options: VirtualTableOptions = [],
+        using module: String
+    ) throws {
         var chunks: [String] = []
         chunks.append("CREATE VIRTUAL TABLE")
-        if ifNotExists {
+        if options.contains(.ifNotExists) {
             chunks.append("IF NOT EXISTS")
         }
-        chunks.append(name.quotedDatabaseIdentifier)
+        if options.contains(.temporary) {
+            chunks.append("temp.\(name.quotedDatabaseIdentifier)")
+        } else {
+            chunks.append(name.quotedDatabaseIdentifier)
+        }
         chunks.append("USING")
         chunks.append(module)
         let sql = chunks.joined(separator: " ")
@@ -114,21 +139,21 @@ extension Database {
     ///
     /// - parameters:
     ///     - tableName: The table name.
-    ///     - ifNotExists: If false (the default), an error is thrown if the
-    ///       table already exists. Otherwise, the table is created unless it
-    ///       already exists.
+    ///     - options: Table creation options.
     ///     - module: a virtual module.
     ///     - body: An optional closure that defines the virtual table.
     /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
     public func create<Module: VirtualTableModule>(
         virtualTable tableName: String,
-        ifNotExists: Bool = false,
+        options: VirtualTableOptions = [],
         using module: Module,
         _ body: ((Module.TableDefinition) throws -> Void)? = nil)
     throws
     {
         // Define virtual table
-        let configuration = VirtualTableConfiguration(ifNotExists: ifNotExists)
+        let configuration = VirtualTableConfiguration(
+            ifNotExists: options.contains(.ifNotExists),
+            temporary: options.contains(.temporary))
         let definition = module.makeTableDefinition(configuration: configuration)
         if let body {
             try body(definition)
@@ -137,10 +162,14 @@ extension Database {
         // Create virtual table
         var chunks: [String] = []
         chunks.append("CREATE VIRTUAL TABLE")
-        if ifNotExists {
+        if options.contains(.ifNotExists) {
             chunks.append("IF NOT EXISTS")
         }
-        chunks.append(tableName.quotedDatabaseIdentifier)
+        if options.contains(.temporary) {
+            chunks.append("temp.\(tableName.quotedDatabaseIdentifier)")
+        } else {
+            chunks.append(tableName.quotedDatabaseIdentifier)
+        }
         chunks.append("USING")
         let arguments = try module.moduleArguments(for: definition, in: self)
         if arguments.isEmpty {
@@ -155,5 +184,79 @@ extension Database {
             try module.database(self, didCreate: tableName, using: definition)
             return .commit
         }
+    }
+    
+    /// Creates a virtual database table.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// // CREATE VIRTUAL TABLE vocabulary USING spellfix1
+    /// try db.create(virtualTable: "vocabulary", using: "spellfix1")
+    /// ```
+    ///
+    /// Related SQLite documentation: <https://www.sqlite.org/lang_createtable.html>
+    ///
+    /// - warning: This is a legacy interface that is preserved for backwards
+    ///   compatibility. Use of this interface is not recommended: prefer
+    ///   ``create(virtualTable:options:using:)`` instead.
+    ///
+    /// - parameters:
+    ///     - name: The table name.
+    ///     - ifNotExists: If false (the default), an error is thrown if the
+    ///       table already exists. Otherwise, the table is created unless it
+    ///       already exists.
+    ///     - module: The name of an SQLite virtual table module.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    @_disfavoredOverload
+    public func create(virtualTable name: String, ifNotExists: Bool = false, using module: String) throws {
+        try create(
+            virtualTable: name,
+            options: ifNotExists ? .ifNotExists : [],
+            using: module)
+    }
+    
+    /// Creates a virtual database table.
+    ///
+    /// The type of the argument of the `body` function depends on the type of
+    /// the `module` argument: refer to this module's documentation.
+    ///
+    /// You can use this method to create full-text virtual tables:
+    ///
+    /// ```swift
+    /// try db.create(virtualTable: "book", using: FTS4()) { t in
+    ///     t.column("title")
+    ///     t.column("author")
+    ///     t.column("body")
+    /// }
+    /// ```
+    ///
+    /// Related SQLite documentation: <https://www.sqlite.org/lang_createtable.html>
+    ///
+    /// - warning: This is a legacy interface that is preserved for backwards
+    ///   compatibility. Use of this interface is not recommended: prefer
+    ///   ``create(virtualTable:options:using:_:)`` instead.
+    ///
+    /// - parameters:
+    ///     - tableName: The table name.
+    ///     - ifNotExists: If false (the default), an error is thrown if the
+    ///       table already exists. Otherwise, the table is created unless it
+    ///       already exists.
+    ///     - module: a virtual module.
+    ///     - body: An optional closure that defines the virtual table.
+    /// - throws: A ``DatabaseError`` whenever an SQLite error occurs.
+    @_disfavoredOverload
+    public func create<Module: VirtualTableModule>(
+        virtualTable tableName: String,
+        ifNotExists: Bool = false,
+        using module: Module,
+        _ body: ((Module.TableDefinition) throws -> Void)? = nil)
+    throws
+    {
+        try create(
+            virtualTable: tableName,
+            options: ifNotExists ? .ifNotExists : [],
+            using: module,
+            body)
     }
 }

--- a/Tests/GRDBTests/FTS3TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS3TableBuilderTests.swift
@@ -13,7 +13,29 @@ class FTS3TableBuilderTests: GRDBTestCase {
         }
     }
 
-    func testOptions() throws {
+    func test_option_ifNotExists() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", options: .ifNotExists, using: FTS3())
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE IF NOT EXISTS \"documents\" USING fts3")
+            
+            try db.execute(sql: "INSERT INTO documents VALUES (?)", arguments: ["abc"])
+            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM documents WHERE documents MATCH ?", arguments: ["abc"])!, 1)
+        }
+    }
+
+    func test_option_temporary() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", options: .temporary, using: FTS3())
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE temp.\"documents\" USING fts3")
+            
+            try db.execute(sql: "INSERT INTO documents VALUES (?)", arguments: ["abc"])
+            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM documents WHERE documents MATCH ?", arguments: ["abc"])!, 1)
+        }
+    }
+
+    func testLegacyOptions() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.create(virtualTable: "documents", ifNotExists: true, using: FTS3())

--- a/Tests/GRDBTests/FTS4TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS4TableBuilderTests.swift
@@ -13,7 +13,29 @@ class FTS4TableBuilderTests: GRDBTestCase {
         }
     }
 
-    func testOptions() throws {
+    func test_option_ifNotExists() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", options: .ifNotExists, using: FTS4())
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE IF NOT EXISTS \"documents\" USING fts4")
+            
+            try db.execute(sql: "INSERT INTO documents VALUES (?)", arguments: ["abc"])
+            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM documents WHERE documents MATCH ?", arguments: ["abc"])!, 1)
+        }
+    }
+
+    func test_option_temporary() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", options: .temporary, using: FTS4())
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE temp.\"documents\" USING fts4")
+            
+            try db.execute(sql: "INSERT INTO documents VALUES (?)", arguments: ["abc"])
+            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM documents WHERE documents MATCH ?", arguments: ["abc"])!, 1)
+        }
+    }
+
+    func testLegacyOptions() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.create(virtualTable: "documents", ifNotExists: true, using: FTS4())
@@ -193,8 +215,8 @@ class FTS4TableBuilderTests: GRDBTestCase {
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ft_documents WHERE ft_documents MATCH ?", arguments: ["bar"])!, 1)
         }
     }
-
-    func testFTS4SynchronizationIfNotExists() throws {
+    
+    func testFTS4Synchronization_with_ifNotExists_option() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.writeWithoutTransaction { db in
             try db.create(table: "documents") { t in
@@ -202,7 +224,7 @@ class FTS4TableBuilderTests: GRDBTestCase {
                 t.column("content", .text)
             }
             assertDidExecute(sql: "CREATE TABLE \"documents\" (\"id\" INTEGER PRIMARY KEY, \"content\" TEXT)")
-            try db.create(virtualTable: "ft_documents", ifNotExists: true, using: FTS4()) { t in
+            try db.create(virtualTable: "ft_documents", options: .ifNotExists, using: FTS4()) { t in
                 t.synchronize(withTable: "documents")
                 t.column("content")
             }
@@ -210,7 +232,7 @@ class FTS4TableBuilderTests: GRDBTestCase {
             assertDidExecute(sql: "CREATE TRIGGER IF NOT EXISTS \"__ft_documents_bu\" BEFORE UPDATE ON \"documents\" BEGIN\n    DELETE FROM \"ft_documents\" WHERE docid=old.\"id\";\nEND")
         }
     }
-
+    
     func testFTS4SynchronizationCleanup() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in

--- a/Tests/GRDBTests/FTS5TableBuilderTests.swift
+++ b/Tests/GRDBTests/FTS5TableBuilderTests.swift
@@ -16,7 +16,33 @@ class FTS5TableBuilderTests: GRDBTestCase {
         }
     }
 
-    func testOptions() throws {
+    func test_option_ifNotExists() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", options: .ifNotExists, using: FTS5()) { t in
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE IF NOT EXISTS \"documents\" USING fts5(content)")
+            
+            try db.execute(sql: "INSERT INTO documents VALUES (?)", arguments: ["abc"])
+            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM documents WHERE documents MATCH ?", arguments: ["abc"])!, 1)
+        }
+    }
+
+    func test_option_temporary() throws {
+        let dbQueue = try makeDatabaseQueue()
+        try dbQueue.inDatabase { db in
+            try db.create(virtualTable: "documents", options: .temporary, using: FTS5()) { t in
+                t.column("content")
+            }
+            assertDidExecute(sql: "CREATE VIRTUAL TABLE temp.\"documents\" USING fts5(content)")
+            
+            try db.execute(sql: "INSERT INTO documents VALUES (?)", arguments: ["abc"])
+            XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM documents WHERE documents MATCH ?", arguments: ["abc"])!, 1)
+        }
+    }
+
+    func testLegacyOptions() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.inDatabase { db in
             try db.create(virtualTable: "documents", ifNotExists: true, using: FTS5()) { t in
@@ -251,8 +277,8 @@ class FTS5TableBuilderTests: GRDBTestCase {
             XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM ft_documents WHERE ft_documents MATCH ?", arguments: ["bar"])!, 1)
         }
     }
-
-    func testFTS5SynchronizationIfNotExists() throws {
+    
+    func testFTS5Synchronization_with_ifNotExists_option() throws {
         let dbQueue = try makeDatabaseQueue()
         try dbQueue.writeWithoutTransaction { db in
             try db.create(table: "documents") { t in
@@ -260,7 +286,7 @@ class FTS5TableBuilderTests: GRDBTestCase {
                 t.column("content", .text)
             }
             assertDidExecute(sql: "CREATE TABLE \"documents\" (\"id\" INTEGER PRIMARY KEY, \"content\" TEXT)")
-            try db.create(virtualTable: "ft_documents", ifNotExists: true, using: FTS5()) { t in
+            try db.create(virtualTable: "ft_documents", options: .ifNotExists, using: FTS5()) { t in
                 t.synchronize(withTable: "documents")
                 t.column("content")
             }


### PR DESCRIPTION
This pull request fixes #1724 by allowing the creation of temporary virtual tables:

```swift
try database.create(virtualTable: "ft", options: .temporary, using: FTS5()) { t in
  ...
}
```

Note that temporary external-content FTS4 and FTS5 tables are not supported, and trigger a fatal error:

```swift
// fatal error: Temporary external content FTS5 tables are not supported.
try database.create(virtualTable: "documents_ft", options: .temporary, using: FTS5()) { t in
  t.synchronize(withTable: "documents")
  t.column("content")
}
```

This limitation comes from SQLite itself, which can't rebuild temporary indexes:

```sql
CREATE TABLE t(id INTEGER PRIMARY KEY, a, b, c);
CREATE VIRTUAL TABLE temp.ft USING fts4(content="t", b, c);
INSERT INTO ft(ft) VALUES('rebuild'); -- SQL logic error
```