### PR TITLE
Async database accesses no longer require Sendable closures.

### DIFF
--- a/GRDB/Core/DatabaseQueue.swift
+++ b/GRDB/Core/DatabaseQueue.swift
@@ -234,7 +234,7 @@ extension DatabaseQueue: DatabaseReader {
     }
     
     public func read<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await writer.execute { db in
             try db.isolated(readOnly: true) {
@@ -244,7 +244,7 @@ extension DatabaseQueue: DatabaseReader {
     }
     
     public func asyncRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         writer.async { db in
             defer {
@@ -272,13 +272,13 @@ extension DatabaseQueue: DatabaseReader {
     }
     
     public func unsafeRead<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await writer.execute(value)
     }
     
     public func asyncUnsafeRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         writer.async { value(.success($0)) }
     }
@@ -288,7 +288,7 @@ extension DatabaseQueue: DatabaseReader {
     }
     
     public func spawnConcurrentRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         // Check that we're on the writer queue...
         writer.execute { db in
@@ -385,7 +385,7 @@ extension DatabaseQueue: DatabaseWriter {
     }
     
     public func writeWithoutTransaction<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await writer.execute(updates)
     }
@@ -396,13 +396,13 @@ extension DatabaseQueue: DatabaseWriter {
     }
     
     public func barrierWriteWithoutTransaction<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await writer.execute(updates)
     }
     
     public func asyncBarrierWriteWithoutTransaction(
-        _ updates: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ updates: sending @escaping (Result<Database, Error>) -> Void
     ) {
         writer.async { updates(.success($0)) }
     }
@@ -450,7 +450,7 @@ extension DatabaseQueue: DatabaseWriter {
     }
     
     public func asyncWriteWithoutTransaction(
-        _ updates: @escaping @Sendable (Database) -> Void
+        _ updates: sending @escaping (Database) -> Void
     ) {
         writer.async(updates)
     }

--- a/GRDB/Core/DatabaseReader.swift
+++ b/GRDB/Core/DatabaseReader.swift
@@ -22,14 +22,14 @@ import Dispatch
 /// ### Reading from the Database
 ///
 /// - ``read(_:)-3806d``
-/// - ``read(_:)-4d1da``
+/// - ``read(_:)-4zff3``
 /// - ``readPublisher(receiveOn:value:)``
 /// - ``asyncRead(_:)``
 ///
 /// ### Unsafe Methods
 ///
 /// - ``unsafeRead(_:)-5i7tf``
-/// - ``unsafeRead(_:)-5gsav``
+/// - ``unsafeRead(_:)-5b76n``
 /// - ``unsafeReentrantRead(_:)``
 /// - ``asyncUnsafeRead(_:)``
 ///
@@ -215,7 +215,7 @@ public protocol DatabaseReader: AnyObject, Sendable {
     ///   database access, or the error thrown by `value`, or
     ///   `CancellationError` if the task is cancelled.
     func read<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T
     
     /// Schedules read-only database operations for execution, and
@@ -245,7 +245,7 @@ public protocol DatabaseReader: AnyObject, Sendable {
     ///   is a `Result` that provides the database connection, or the failure
     ///   that would prevent establishing the read access to the database.
     func asyncRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     )
     
     /// Executes database operations, and returns their result after they have
@@ -319,7 +319,7 @@ public protocol DatabaseReader: AnyObject, Sendable {
     ///   database access, or the error thrown by `value`, or
     ///   `CancellationError` if the task is cancelled.
     func unsafeRead<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T
     
     /// Schedules database operations for execution, and returns immediately.
@@ -354,7 +354,7 @@ public protocol DatabaseReader: AnyObject, Sendable {
     ///   is a `Result` that provides the database connection, or the failure
     ///   that would prevent establishing the read access to the database.
     func asyncUnsafeRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     )
     
     /// Executes database operations, and returns their result after they have
@@ -652,13 +652,13 @@ extension AnyDatabaseReader: DatabaseReader {
     }
     
     public func read<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await base.read(value)
     }
     
     public func asyncRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         base.asyncRead(value)
     }
@@ -669,13 +669,13 @@ extension AnyDatabaseReader: DatabaseReader {
     }
     
     public func unsafeRead<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await base.unsafeRead(value)
     }
     
     public func asyncUnsafeRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         base.asyncUnsafeRead(value)
     }
@@ -748,7 +748,7 @@ extension DatabaseSnapshotReader {
     
     // There is no such thing as an unsafe access to a snapshot.
     public func asyncUnsafeRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         asyncRead(value)
     }

--- a/GRDB/Core/DatabaseSnapshot.swift
+++ b/GRDB/Core/DatabaseSnapshot.swift
@@ -152,13 +152,13 @@ extension DatabaseSnapshot: DatabaseSnapshotReader {
     }
     
     public func read<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await reader.execute(value)
     }
     
     public func asyncRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         reader.async { value(.success($0)) }
     }
@@ -173,13 +173,13 @@ extension DatabaseSnapshot: DatabaseSnapshotReader {
     // `DatabaseSnapshotReader`,  because of
     // <https://github.com/apple/swift/issues/74469>.
     public func unsafeRead<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await read(value)
     }
     
     public func asyncUnsafeRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         reader.async { value(.success($0)) }
     }

--- a/GRDB/Core/DatabaseWriter.swift
+++ b/GRDB/Core/DatabaseWriter.swift
@@ -22,18 +22,18 @@ import Dispatch
 /// ### Writing into the Database
 ///
 /// - ``write(_:)-76inz``
-/// - ``write(_:)-3db50``
+/// - ``write(_:)-5u4m3``
 /// - ``writePublisher(receiveOn:updates:)``
 /// - ``writePublisher(receiveOn:updates:thenRead:)``
 /// - ``writeWithoutTransaction(_:)-4qh1w``
-/// - ``writeWithoutTransaction(_:)-67mri``
+/// - ``writeWithoutTransaction(_:)-93qim``
 /// - ``asyncWrite(_:completion:)``
 /// - ``asyncWriteWithoutTransaction(_:)``
 ///
 /// ### Exclusive Access to the Database
 ///
 /// - ``barrierWriteWithoutTransaction(_:)-280j1``
-/// - ``barrierWriteWithoutTransaction(_:)-48d63``
+/// - ``barrierWriteWithoutTransaction(_:)-2xdrw``
 /// - ``asyncBarrierWriteWithoutTransaction(_:)``
 ///
 /// ### Reading from the Latest Committed Database State
@@ -130,7 +130,7 @@ public protocol DatabaseWriter: DatabaseReader {
     ///   database access, or the error thrown by `updates`, or
     ///   `CancellationError` if the task is cancelled.
     func writeWithoutTransaction<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T
     
     /// Executes database operations, and returns their result after they have
@@ -213,7 +213,7 @@ public protocol DatabaseWriter: DatabaseReader {
     ///   database access, or the error thrown by `updates`, or
     ///   `CancellationError` if the task is cancelled.
     func barrierWriteWithoutTransaction<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T
     
     /// Schedules database operations for execution, and returns immediately.
@@ -256,7 +256,7 @@ public protocol DatabaseWriter: DatabaseReader {
     ///   is a `Result` that provides the database connection, or the failure
     ///   that would prevent establishing the barrier access to the database.
     func asyncBarrierWriteWithoutTransaction(
-        _ updates: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ updates: sending @escaping (Result<Database, Error>) -> Void
     )
     
     /// Schedules database operations for execution, and returns immediately.
@@ -290,7 +290,7 @@ public protocol DatabaseWriter: DatabaseReader {
     ///
     /// - parameter updates: A closure which accesses the database.
     func asyncWriteWithoutTransaction(
-        _ updates: @escaping @Sendable (Database) -> Void
+        _ updates: sending @escaping (Database) -> Void
     )
     
     /// Executes database operations, and returns their result after they have
@@ -374,7 +374,7 @@ public protocol DatabaseWriter: DatabaseReader {
     ///   is a `Result` that provides the database connection, or the failure
     ///   that would prevent establishing the read access to the database.
     func spawnConcurrentRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     )
 }
 
@@ -461,8 +461,8 @@ extension DatabaseWriter {
     /// - parameter updates: A closure which accesses the database.
     /// - parameter completion: A closure called with the transaction result.
     public func asyncWrite<T>(
-        _ updates: @escaping @Sendable (Database) throws -> T,
-        completion: @escaping @Sendable (Database, Result<T, Error>) -> Void
+        _ updates: sending @escaping (Database) throws -> T,
+        completion: sending @escaping (Database, Result<T, Error>) -> Void
     ) {
         asyncWriteWithoutTransaction { db in
             do {
@@ -640,7 +640,7 @@ extension DatabaseWriter {
     ///   database access, or the error thrown by `updates`, or
     ///   `CancellationError` if the task is cancelled.
     public func write<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await writeWithoutTransaction { db in
             var result: T?
@@ -885,13 +885,13 @@ extension AnyDatabaseWriter: DatabaseReader {
     }
     
     public func read<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await base.read(value)
     }
     
     public func asyncRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         base.asyncRead(value)
     }
@@ -902,13 +902,13 @@ extension AnyDatabaseWriter: DatabaseReader {
     }
     
     public func unsafeRead<T: Sendable>(
-        _ value: @escaping @Sendable (Database) throws -> T
+        _ value: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await base.unsafeRead(value)
     }
     
     public func asyncUnsafeRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         base.asyncUnsafeRead(value)
     }
@@ -936,7 +936,7 @@ extension AnyDatabaseWriter: DatabaseWriter {
     }
     
     public func writeWithoutTransaction<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await base.writeWithoutTransaction(updates)
     }
@@ -947,19 +947,19 @@ extension AnyDatabaseWriter: DatabaseWriter {
     }
     
     public func barrierWriteWithoutTransaction<T: Sendable>(
-        _ updates: @escaping @Sendable (Database) throws -> T
+        _ updates: sending @escaping (Database) throws -> T
     ) async throws -> T {
         try await base.barrierWriteWithoutTransaction(updates)
     }
     
     public func asyncBarrierWriteWithoutTransaction(
-        _ updates: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ updates: sending @escaping (Result<Database, Error>) -> Void
     ) {
         base.asyncBarrierWriteWithoutTransaction(updates)
     }
     
     public func asyncWriteWithoutTransaction(
-        _ updates: @escaping @Sendable (Database) -> Void
+        _ updates: sending @escaping (Database) -> Void
     ) {
         base.asyncWriteWithoutTransaction(updates)
     }
@@ -969,7 +969,7 @@ extension AnyDatabaseWriter: DatabaseWriter {
     }
     
     public func spawnConcurrentRead(
-        _ value: @escaping @Sendable (Result<Database, Error>) -> Void
+        _ value: sending @escaping (Result<Database, Error>) -> Void
     ) {
         base.spawnConcurrentRead(value)
     }

--- a/GRDB/Documentation.docc/Concurrency.md
+++ b/GRDB/Documentation.docc/Concurrency.md
@@ -97,7 +97,7 @@ try dbQueue.write { db in
     }
     ```
 
-    See ``DatabaseReader/read(_:)-4d1da`` and ``DatabaseWriter/write(_:)-3db50``.
+    See ``DatabaseReader/read(_:)-4zff3`` and ``DatabaseWriter/write(_:)-5u4m3``.
     
     Note the identical method names: `read`, `write`. The async version is only available in async Swift functions.
     

--- a/GRDB/Utils/Pool.swift
+++ b/GRDB/Utils/Pool.swift
@@ -121,7 +121,11 @@ final class Pool<T: Sendable>: Sendable {
     ///
     /// - important: The `execute` argument is executed in a serial dispatch
     ///   queue, so make sure you use the element asynchronously.
-    func asyncGet(_ execute: @escaping @Sendable (Result<ElementAndRelease, Error>) -> Void) {
+    func asyncGet(_ execute: sending @escaping (Result<ElementAndRelease, Error>) -> Void) {
+        // Avoid compiler warning. There is no data race because `execute` is invoked once.
+        typealias SendableClosure = @Sendable (Result<ElementAndRelease, Error>) -> Void
+        let execute = unsafeBitCast(execute, to: SendableClosure.self)
+        
         // Inspired by https://khanlou.com/2016/04/the-GCD-handbook/
         // > We wait on the semaphore in the serial queue, which means that
         // > we’ll have at most one blocked thread when we reach maximum
@@ -186,7 +190,11 @@ final class Pool<T: Sendable>: Sendable {
     
     /// Asynchronously runs the `barrier` function when no element is used, and
     /// before any other element is dequeued.
-    func asyncBarrier(execute barrier: @escaping @Sendable () -> Void) {
+    func asyncBarrier(execute barrier: sending @escaping () -> Void) {
+        // Avoid compiler warning. There is no data race because `barrier` is invoked once.
+        typealias SendableClosure = @Sendable () -> Void
+        let barrier = unsafeBitCast(barrier, to: SendableClosure.self)
+        
         barrierQueue.async(flags: [.barrier]) {
             self.itemsGroup.wait()
             barrier()


### PR DESCRIPTION
This pull request enhances asynchronous APIs by allowing some non-sendable value to be captured by database access closures without compiler error or warning.

It addresses the feature request by @layoutSubviews expressed at https://mastodon.social/@layoutSubviews/114032891799577133.

Applications that use the Swift 5 language mode may have to enable the `RegionBasedIsolation` [upcoming feature](https://www.swift.org/blog/using-upcoming-feature-flags/) in order to profit from the enhancement.