### PR TITLE
Add the MIN and MAX multi-argument SQL functions to the query interface

### DIFF
--- a/GRDB/QueryInterface/SQL/SQLExpression.swift
+++ b/GRDB/QueryInterface/SQL/SQLExpression.swift
@@ -2209,8 +2209,10 @@ extension SQLExpressible where Self == Column {
 /// - ``localizedLowercased``
 /// - ``localizedUppercased``
 /// - ``lowercased``
+/// - ``min(_:_:_:)``
 /// - ``min(_:)``
 /// - ``min(_:filter:)``
+/// - ``max(_:_:_:)``
 /// - ``max(_:)``
 /// - ``max(_:filter:)``
 /// - ``sum(_:)``

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -147,6 +147,22 @@ public func length(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .function("LENGTH", [value.sqlExpression])
 }
 
+/// The `MAX` SQL multi-argument function.
+///
+/// For example:
+///
+/// ```swift
+/// // MAX(score, 1000)
+/// max(Column("score"), 1000)
+/// ```
+public func max(
+    _ value1: any SQLSpecificExpressible,
+    _ value2: any SQLExpressible,
+    _ values: any SQLExpressible...
+) -> SQLExpression {
+    .simpleFunction("MAX", [value1.sqlExpression, value2.sqlExpression] + values.map(\.sqlExpression))
+}
+
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
 /// The `MAX` SQL aggregate function.
 ///
@@ -191,6 +207,22 @@ public func max(_ value: some SQLSpecificExpressible) -> SQLExpression {
     .aggregateFunction("MAX", [value.sqlExpression])
 }
 #endif
+
+/// The `MIN` SQL multi-argument function.
+///
+/// For example:
+///
+/// ```swift
+/// // MIN(score, 1000)
+/// min(Column("score"), 1000)
+/// ```
+public func min(
+    _ value1: any SQLSpecificExpressible,
+    _ value2: any SQLExpressible,
+    _ values: any SQLExpressible...
+) -> SQLExpression {
+    .simpleFunction("MIN", [value1.sqlExpression, value2.sqlExpression] + values.map(\.sqlExpression))
+}
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
 /// The `MIN` SQL aggregate function.

--- a/GRDB/QueryInterface/SQL/SQLFunctions.swift
+++ b/GRDB/QueryInterface/SQL/SQLFunctions.swift
@@ -11,7 +11,7 @@ public func abs(_ value: some SQLSpecificExpressible) -> SQLExpression {
 }
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-/// The `AVG` SQL function.
+/// The `AVG` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -26,7 +26,7 @@ public func average(
     .aggregateFunction("AVG", [value.sqlExpression], filter: filter?.sqlExpression)
 }
 #else
-/// The `AVG` SQL function.
+/// The `AVG` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -44,7 +44,7 @@ public func average(
         filter: filter.sqlExpression)
 }
 
-/// The `AVG` SQL function.
+/// The `AVG` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -148,7 +148,7 @@ public func length(_ value: some SQLSpecificExpressible) -> SQLExpression {
 }
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-/// The `MAX` SQL function.
+/// The `MAX` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -163,7 +163,7 @@ public func max(
     .aggregateFunction("MAX", [value.sqlExpression], filter: filter?.sqlExpression)
 }
 #else
-/// The `MAX` SQL function.
+/// The `MAX` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -179,7 +179,7 @@ public func max(
     .aggregateFunction("MAX", [value.sqlExpression], filter: filter.sqlExpression)
 }
 
-/// The `MAX` SQL function.
+/// The `MAX` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -193,7 +193,7 @@ public func max(_ value: some SQLSpecificExpressible) -> SQLExpression {
 #endif
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-/// The `MIN` SQL function.
+/// The `MIN` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -208,7 +208,7 @@ public func min(
     .aggregateFunction("MIN", [value.sqlExpression], filter: filter?.sqlExpression)
 }
 #else
-/// The `MIN` SQL function.
+/// The `MIN` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -224,7 +224,7 @@ public func min(
     .aggregateFunction("MIN", [value.sqlExpression], filter: filter.sqlExpression)
 }
 
-/// The `MIN` SQL function.
+/// The `MIN` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -238,7 +238,7 @@ public func min(_ value: some SQLSpecificExpressible) -> SQLExpression {
 #endif
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-/// The `SUM` SQL function.
+/// The `SUM` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -262,7 +262,7 @@ public func sum(
         filter: filter?.sqlExpression)
 }
 #else
-/// The `SUM` SQL function.
+/// The `SUM` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -284,7 +284,7 @@ public func sum(
         filter: filter.sqlExpression)
 }
 
-/// The `SUM` SQL function.
+/// The `SUM` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -302,7 +302,7 @@ public func sum(_ value: some SQLSpecificExpressible) -> SQLExpression {
 #endif
 
 #if GRDBCUSTOMSQLITE || GRDBCIPHER
-/// The `TOTAL` SQL function.
+/// The `TOTAL` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -326,7 +326,7 @@ public func total(
         filter: filter?.sqlExpression)
 }
 #else
-/// The `TOTAL` SQL function.
+/// The `TOTAL` SQL aggregate function.
 ///
 /// For example:
 ///
@@ -348,7 +348,7 @@ public func total(
         filter: filter.sqlExpression)
 }
 
-/// The `TOTAL` SQL function.
+/// The `TOTAL` SQL aggregate function.
 ///
 /// For example:
 ///

--- a/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
+++ b/Tests/GRDBTests/QueryInterfaceExpressionsTests.swift
@@ -1559,7 +1559,18 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT LENGTH(\"name\") FROM \"readers\"")
     }
     
-    func testMinExpression() throws {
+    func testMultiArgumentMinExpression() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(min(Col.age, 1000))),
+            "SELECT MIN(\"age\", 1000) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(min(Col.age, 1000, Col.id))),
+            "SELECT MIN(\"age\", 1000, \"id\") FROM \"readers\"")
+    }
+    
+    func testAggregateMinExpression() throws {
         let dbQueue = try makeDatabaseQueue()
         
         XCTAssertEqual(
@@ -1570,7 +1581,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT MIN(\"age\" / 2) FROM \"readers\"")
     }
     
-    func testMinExpression_filter() throws {
+    func testAggregateMinExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
         guard Database.sqliteLibVersionNumber >= 3030000 else {
@@ -1592,7 +1603,18 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT MIN(\"age\" / 2) FILTER (WHERE \"age\" > 0) FROM \"readers\"")
     }
     
-    func testMaxExpression() throws {
+    func testMultiArgumentMaxExpression() throws {
+        let dbQueue = try makeDatabaseQueue()
+        
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(max(Col.age, 1000))),
+            "SELECT MAX(\"age\", 1000) FROM \"readers\"")
+        XCTAssertEqual(
+            sql(dbQueue, tableRequest.select(max(Col.age, 1000, Col.id))),
+            "SELECT MAX(\"age\", 1000, \"id\") FROM \"readers\"")
+    }
+    
+    func testAggregateMaxExpression() throws {
         let dbQueue = try makeDatabaseQueue()
         
         XCTAssertEqual(
@@ -1603,7 +1625,7 @@ class QueryInterfaceExpressionsTests: GRDBTestCase {
             "SELECT MAX(\"age\" / 2) FROM \"readers\"")
     }
     
-    func testMaxExpression_filter() throws {
+    func testAggregateMaxExpression_filter() throws {
         #if GRDBCUSTOMSQLITE || GRDBCIPHER
         // Prevent SQLCipher failures
         guard Database.sqliteLibVersionNumber >= 3030000 else {


### PR DESCRIPTION
This pull request fixes #1743 by adding support for the [`MIN(X,Y,...)`](https://www.sqlite.org/lang_corefunc.html#min_scalar) and [`MAX(X,Y,...)`](https://www.sqlite.org/lang_corefunc.html#max_scalar) multi-argument SQL functions (distinct from the aggregate functions of the same name):

```swift
// SELECT MAX(score, 1000) FROM player
Player.select(max(Column("score"), 1000))
```