### PR TITLE
Transaction observers are not impacted by Task Cancellation

### DIFF
--- a/GRDB/Core/Database+Statements.swift
+++ b/GRDB/Core/Database+Statements.swift
@@ -494,11 +494,9 @@ extension Database {
         
         switch ResultCode(rawValue: resultCode) {
         case .SQLITE_INTERRUPT, .SQLITE_ABORT:
-            if suspensionMutex.load().isCancelled {
-                // The only error that a user sees when a Task is cancelled
-                // is CancellationError.
-                throw CancellationError()
-            }
+            // The only error that a user sees when a Task is cancelled
+            // is CancellationError.
+            try suspensionMutex.load().checkCancellation()
         default:
             break
         }


### PR DESCRIPTION
Since the release of GRBD 7, `Task` cancellation interrupts asynchronous database accesses.

This has created a problem with transaction observers. If a `Task` is cancelled after a transaction was successfully committed to disk, observers could fail processing the transaction. `ValueObservation`, in particular, could not fetch fresh values, and report an error:

1. A task is started and performs an asynchronous write.
2. The task is cancelled after the write was committed to disk, but before observations could handle the change.
3. Observations attempts to fetch a fresh value, fail, and report an error (that's a bug).

This pull request restores the independence of transaction observers, and makes sure they can access the database even from a cancelled `Task`.

Thank you @tgrapperon for reporting this issue in https://github.com/groue/GRDB.swift/discussions/1746