### PR TITLE
Throwing row accessors

### DIFF
--- a/Documentation/AssociationsBasics.md
+++ b/Documentation/AssociationsBasics.md
@@ -2186,26 +2186,25 @@ struct BookInfo: FetchableRecord {
     
     init(row: Row) throws {
         book = try Book(row: row)
-        author = row["author"]
-        country = row["country"]
-        coverImage = row["coverImage"]
+        author = try row.decode(forKey: "author")
+        country = try row.decodeIfPresent(forKey: "country")
+        coverImage = try row.decodeIfPresent(forKey: "coverImage")
     }
 }
 
 let bookInfos: [BookInfo] = try BookInfo.fetchAll(db, request)
 ```
 
-You are already familiar with row subscripts to decode [database values](../README.md#column-values):
+When you extract a record from a row, GRDB looks up the tree of **association keys**:
 
 ```swift
-let name: String = row["name"]
+let author = try row.decode(Author.self, forKey: "author")
 ```
 
-When you extract a record instead of a value from a row, GRDB looks up the tree of **association keys**. If the key is not found, or only associated with columns that all contain NULL values, an optional record is decoded as nil:
+If the key is not found, or only associated with columns that are all NULL, an optional record is decoded as nil:
 
 ```swift
-let author: Author = row["author"]
-let country: Country? = row["country"]
+let country = try row.decodeIfPresent(Country.self, forKey: "country")
 ```
 
 You can also perform custom navigation in the tree by using *row scopes*. See [Row Adapters] for more information.
@@ -2221,7 +2220,7 @@ struct AuthorInfo: FetchableRecord {
     
     init(row: Row) throws {
         author = try Author(row: row)
-        books = row["books"]
+        books = try row.decode(forKey: "books")
     }
 }
 

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -129,6 +129,10 @@ import Foundation
 ///
 /// - ``RowAdapter``
 ///
+/// ### Errors
+///
+/// - ``RowDecodingError``
+///
 /// ### Supporting Types
 ///
 /// - ``RowCursor``

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -1546,6 +1546,7 @@ extension Row {
         Collection: RangeReplaceableCollection,
         Collection.Element: FetchableRecord
     {
+        // TODO: test independently
         guard let rows = prefetchedRows[key] else {
             let availableKeys = prefetchedRows.keys
             if availableKeys.isEmpty {
@@ -1608,6 +1609,7 @@ extension Row {
         forKey key: String)
     throws -> Set<Record>
     {
+        // TODO: test independently
         guard let rows = prefetchedRows[key] else {
             let availableKeys = prefetchedRows.keys
             if availableKeys.isEmpty {

--- a/GRDB/Core/Row.swift
+++ b/GRDB/Core/Row.swift
@@ -52,6 +52,8 @@ import Foundation
 /// - ``subscript(_:)-9c1fw``
 /// - ``subscript(_:)-3jhwm``
 /// - ``subscript(_:)-7krrg``
+/// - ``decode(_:atIndex:)-33ykh``
+/// - ``decode(_:atIndex:)-3btwn``
 /// - ``withUnsafeData(atIndex:_:)``
 /// - ``dataNoCopy(atIndex:)``
 ///
@@ -61,7 +63,8 @@ import Foundation
 /// - ``subscript(_:)-4k8od``
 /// - ``subscript(_:)-9rbo7``
 /// - ``coalesce(_:)-359k7``
-/// - ``coalesce(_:)-6nbah``
+/// - ``decode(_:forColumn:)-4i1o4``
+/// - ``decode(_:forColumn:)-4rhs4``
 /// - ``withUnsafeData(named:_:)``
 /// - ``dataNoCopy(named:)``
 ///
@@ -70,6 +73,9 @@ import Foundation
 /// - ``subscript(_:)-9txgm``
 /// - ``subscript(_:)-2esg7``
 /// - ``subscript(_:)-wl9a``
+/// - ``coalesce(_:)-6nbah``
+/// - ``decode(_:forColumn:)-1ljuo``
+/// - ``decode(_:forColumn:)-47qeg``
 /// - ``withUnsafeData(at:_:)``
 /// - ``dataNoCopy(_:)``
 ///
@@ -84,6 +90,10 @@ import Foundation
 /// - ``subscript(_:)-8god3``
 /// - ``subscript(_:)-jwnx``
 /// - ``subscript(_:)-6ge6t``
+/// - ``decode(_:forKey:)-9bbd3``
+/// - ``decode(_:forKey:)-2w6lc``
+/// - ``decode(_:forKey:)-2soc2``
+/// - ``decodeIfPresent(_:forKey:)``
 /// - ``PrefetchedRowsView``
 /// - ``ScopesTreeView``
 /// - ``ScopesView``
@@ -739,12 +749,13 @@ extension Row {
     
     // MARK: - Extracting Records
     
-    /// The record associated to the given scope.
+    /// Returns the record associated to the given key.
     ///
-    /// Row scopes can be defined manually, with ``ScopeAdapter``.
-    /// The ``JoinableRequest/including(required:)`` and
-    /// ``JoinableRequest/including(optional:)`` request methods define scopes
-    /// named after the key of included associations between record types.
+    /// The key is a row scope that was either defined manually, with
+    /// ``ScopeAdapter``, or with the ``JoinableRequest/including(required:)``
+    /// and ``JoinableRequest/including(optional:)`` request methods. The
+    /// latter define row scopes named after the key of included
+    /// associations between record types.
     ///
     /// A breadth-first search is performed in all available scopes in the row,
     /// recursively.
@@ -769,26 +780,28 @@ extension Row {
     /// let request = Book
     ///     .including(required: Book.author
     ///         .including(required: Author.country))
-    /// let bookRow = try Row.fetchOne(db, request)!
+    /// let row = try Row.fetchOne(db, request)!
     ///
-    /// let book = try Book(row: bookRow)
-    /// let author: Author = bookRow["author"]
-    /// let country: Country = bookRow["country"]
+    /// let book = try Book(row: row)
+    /// let author: Author = row["author"]
+    /// let country: Country = row["country"]
     /// ```
     ///
-    /// See also: ``scopesTree``
+    /// For more details about row scopes, see ``ScopeAdapter``,
+    /// ``splittingRowAdapters(columnCounts:)`` and ``scopesTree``.
     ///
     /// - parameter scope: A scope identifier.
     public subscript<Record: FetchableRecord>(_ scope: String) -> Record {
         try! decode(Record.self, forKey: scope)
     }
     
-    /// The eventual record associated to the given scope.
+    /// Returns the eventual record associated to the given key.
     ///
-    /// Row scopes can be defined manually, with ``ScopeAdapter``.
-    /// The ``JoinableRequest/including(required:)`` and
-    /// ``JoinableRequest/including(optional:)`` request methods define scopes
-    /// named after the key of included associations between record types.
+    /// The key is a row scope that was either defined manually, with
+    /// ``ScopeAdapter``, or with the ``JoinableRequest/including(required:)``
+    /// and ``JoinableRequest/including(optional:)`` request methods. The
+    /// latter define row scopes named after the key of included
+    /// associations between record types.
     ///
     /// A breadth-first search is performed in all available scopes in the row,
     /// recursively.
@@ -809,25 +822,26 @@ extension Row {
     ///
     /// struct Country: TableRecord, FetchableRecord { }
     ///
-    /// // Fetch a book, with its author, and the country of its author.
+    /// // Fetch a book, with its eventual author, and the country of its author.
     /// let request = Book
     ///     .including(optional: Book.author
     ///         .including(optional: Author.country))
-    /// let bookRow = try Row.fetchOne(db, request)!
+    /// let row = try Row.fetchOne(db, request)!
     ///
-    /// let book = try Book(row: bookRow)
-    /// let author: Author? = bookRow["author"]
-    /// let country: Country? = bookRow["country"]
+    /// let book = try Book(row: row)
+    /// let author: Author? = row["author"]
+    /// let country: Country? = row["country"]
     /// ```
     ///
-    /// See also: ``scopesTree``
+    /// For more details about row scopes, see ``ScopeAdapter``,
+    /// ``splittingRowAdapters(columnCounts:)`` and ``scopesTree``.
     ///
     /// - parameter scope: A scope identifier.
     public subscript<Record: FetchableRecord>(_ scope: String) -> Record? {
         try! decodeIfPresent(Record.self, forKey: scope)
     }
     
-    /// A collection of prefetched records associated to the given
+    /// Returns a collection of prefetched records associated to the given
     /// association key.
     ///
     /// Prefetched rows are defined by the ``JoinableRequest/including(all:)``
@@ -843,10 +857,10 @@ extension Row {
     /// struct Book: TableRecord, FetchableRecord { }
     ///
     /// let request = Author.including(all: Author.books)
-    /// let authorRow = try Row.fetchOne(db, request)!
+    /// let row = try Row.fetchOne(db, request)!
     ///
-    /// let author = try Author(row: authorRow)
-    /// let books: [Book] = author["books"]
+    /// let author = try Author(row: row)
+    /// let books: [Book] = row["books"]
     /// ```
     ///
     /// See also: ``prefetchedRows``
@@ -861,7 +875,8 @@ extension Row {
         try! decode(Records.self, forKey: key)
     }
     
-    /// A set prefetched records associated to the given association key.
+    /// Returns the set of prefetched records associated to the given
+    /// association key.
     ///
     /// Prefetched rows are defined by the ``JoinableRequest/including(all:)``
     /// request method.
@@ -876,10 +891,10 @@ extension Row {
     /// struct Book: TableRecord, FetchableRecord, Hashable { }
     ///
     /// let request = Author.including(all: Author.books)
-    /// let authorRow = try Row.fetchOne(db, request)!
+    /// let row = try Row.fetchOne(db, request)!
     ///
-    /// let author = try Author(row: authorRow)
-    /// let books: Set<Book> = author["books"]
+    /// let author = try Author(row: row)
+    /// let books: Set<Book> = row["books"]
     /// ```
     ///
     /// See also: ``prefetchedRows``
@@ -935,7 +950,8 @@ extension Row {
     /// // Prints [code:"US" name:"United States of America"]
     /// ```
     ///
-    /// See also ``scopesTree``.
+    /// For more details about row scopes, see ``ScopeAdapter``,
+    /// ``splittingRowAdapters(columnCounts:)`` and ``scopesTree``.
     public var scopes: ScopesView {
         impl.scopes(prefetchedRows: prefetchedRows)
     }
@@ -1065,8 +1081,26 @@ extension Row {
     /// Indexes span from `0` for the leftmost column to `row.count - 1` for the
     /// rightmost column.
     ///
-    /// If the SQLite value is NULL, or if the conversion fails, a
-    /// `RowDecodingError` is thrown.
+    /// For example:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 42")!
+    /// let score = try row.decode(Int.self, atIndex: 0) // 42
+    /// let score: Int = try row.decode(atIndex: 0)      // 42
+    ///
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice'")!
+    /// let name = try row.decode(String.self, atIndex: 0) // "Alice"
+    /// let name: String = try row.decode(atIndex: 0)      // "Alice"
+    /// ```
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT NULL")!
+    /// let name: String? = try row.decode(atIndex: 0) // nil
+    /// ```
+    ///
+    /// - throws: Any error that happens during the decoding.
     @inlinable
     public func decode<Value: DatabaseValueConvertible>(
         _ type: Value.Type = Value.self,
@@ -1082,9 +1116,33 @@ extension Row {
     /// Column name lookup is case-insensitive. When several columns exist with
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, or if the SQLite value is NULL,
-    /// or if the SQLite value can not be converted to `Value`, a
-    /// `RowDecodingError` is thrown.
+    /// For example:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    /// let score = try row.decode(Int.self, forColumn: "score") // 42
+    /// let score: Int = try row.decode(forColumn: "score")      // 42
+    ///
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name = try row.decode(String.self, forColumn: "name") // "Alice"
+    /// let name: String = try row.decode(forColumn: "name")      // "Alice"
+    /// ```
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    /// let name: String? = try row.decode(forColumn: "name") // nil
+    /// ```
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name: String? = try row.decode(forColumn: "missing") // nil
+    /// ```
+    ///
+    /// - throws: Any error that happens during the decoding.
     @inlinable
     public func decode<Value: DatabaseValueConvertible>(
         _ type: Value.Type = Value.self,
@@ -1106,9 +1164,33 @@ extension Row {
     /// Column name lookup is case-insensitive. When several columns exist with
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, or if the SQLite value is NULL,
-    /// or if the SQLite value can not be converted to `Value`, a
-    /// `RowDecodingError` is thrown.
+    /// For example:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    /// let score = try row.decode(Int.self, forColumn: Column("score")) // 42
+    /// let score: Int = try row.decode(forColumn: Column("score"))      // 42
+    ///
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name = try row.decode(String.self, forColumn: Column("name")) // "Alice"
+    /// let name: String = try row.decode(forColumn: Column("name"))      // "Alice"
+    /// ```
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    /// let name: String? = try row.decode(forColumn: Column("name")) // nil
+    /// ```
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name: String? = try row.decode(forColumn: Column("missing")) // nil
+    /// ```
+    ///
+    /// - throws: Any error that happens during the decoding.
     @inlinable
     public func decode<Value: DatabaseValueConvertible>(
         _ type: Value.Type = Value.self,
@@ -1131,8 +1213,26 @@ extension Row {
     /// Indexes span from `0` for the leftmost column to `row.count - 1` for the
     /// rightmost column.
     ///
-    /// If the SQLite value is NULL, or if the conversion fails, a
-    /// `RowDecodingError` is thrown.
+    /// For example:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 42")!
+    /// let score = try row.decode(Int.self, atIndex: 0) // 42
+    /// let score: Int = try row.decode(atIndex: 0)      // 42
+    ///
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice'")!
+    /// let name = try row.decode(String.self, atIndex: 0) // "Alice"
+    /// let name: String = try row.decode(atIndex: 0)      // "Alice"
+    /// ```
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT NULL")!
+    /// let name: String? = try row.decode(atIndex: 0) // nil
+    /// ```
+    ///
+    /// - throws: Any error that happens during the decoding.
     @inline(__always)
     @inlinable
     public func decode<Value: DatabaseValueConvertible & StatementColumnConvertible>(
@@ -1153,9 +1253,33 @@ extension Row {
     /// Column name lookup is case-insensitive. When several columns exist with
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, or if the SQLite value is NULL,
-    /// or if the SQLite value can not be converted to `Value`, a
-    /// `RowDecodingError` is thrown.
+    /// For example:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    /// let score = try row.decode(Int.self, forColumn: "score") // 42
+    /// let score: Int = try row.decode(forColumn: "score")      // 42
+    ///
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name = try row.decode(String.self, forColumn: "name") // "Alice"
+    /// let name: String = try row.decode(forColumn: "name")      // "Alice"
+    /// ```
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    /// let name: String? = try row.decode(forColumn: "name") // nil
+    /// ```
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name: String? = try row.decode(forColumn: "missing") // nil
+    /// ```
+    ///
+    /// - throws: Any error that happens during the decoding.
     @inlinable
     public func decode<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -1181,9 +1305,33 @@ extension Row {
     /// Column name lookup is case-insensitive. When several columns exist with
     /// the same name, the leftmost column is considered.
     ///
-    /// If the row does not contain the column, or if the SQLite value is NULL,
-    /// or if the SQLite value can not be converted to `Value`, a
-    /// `RowDecodingError` is thrown.
+    /// For example:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 42 AS score")!
+    /// let score = try row.decode(Int.self, forColumn: Column("score")) // 42
+    /// let score: Int = try row.decode(forColumn: Column("score"))      // 42
+    ///
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name = try row.decode(String.self, forColumn: Column("name")) // "Alice"
+    /// let name: String = try row.decode(forColumn: Column("name"))      // "Alice"
+    /// ```
+    ///
+    /// When the database value may be nil, ask for an optional:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+    /// let name: String? = try row.decode(forColumn: Column("name")) // nil
+    /// ```
+    ///
+    /// When the column does not exist, nil is returned:
+    ///
+    /// ```swift
+    /// let row = try Row.fetchOne(db, sql: "SELECT 'Alice' AS name")!
+    /// let name: String? = try row.decode(forColumn: Column("missing")) // nil
+    /// ```
+    ///
+    /// - throws: Any error that happens during the decoding.
     @inlinable
     public func decode<Value: DatabaseValueConvertible & StatementColumnConvertible>(
         _ type: Value.Type = Value.self,
@@ -1225,36 +1373,50 @@ extension Row {
 // MARK: - Throwing Record Decoding Methods
 
 extension Row {
-    /// Returns the eventual record associated with the given scope.
+    /// Returns the eventual record associated to the given key.
+    ///
+    /// The key is a row scope that was either defined manually, with
+    /// ``ScopeAdapter``, or with the ``JoinableRequest/including(required:)``
+    /// and ``JoinableRequest/including(optional:)`` request methods. The
+    /// latter define row scopes named after the key of included
+    /// associations between record types.
+    ///
+    /// A breadth-first search is performed in all available scopes in the row,
+    /// recursively.
+    ///
+    /// The result is nil if the scope is not available, or contains only
+    /// `NULL` values.
     ///
     /// For example:
     ///
-    ///     let request = Book.including(optional: Book.author)
-    ///     let row = try Row.fetchOne(db, request)!
+    /// ```swift
+    /// struct Book: TableRecord, FetchableRecord {
+    ///     static let author = belongsTo(Author.self)
+    /// }
     ///
-    ///     try print(Book(row: row).title)
-    ///     // Prints "Moby-Dick"
+    /// struct Author: TableRecord, FetchableRecord {
+    ///     static let country = belongsTo(Country.self)
+    /// }
     ///
-    ///     let author: Author? = row["author"]
-    ///     print(author.name)
-    ///     // Prints "Herman Melville"
+    /// struct Country: TableRecord, FetchableRecord { }
     ///
-    /// Associated records stored in nested associations are available, too:
+    /// // Fetch a book, with its eventual author, and the country of its author.
+    /// let request = Book
+    ///     .including(optional: Book.author
+    ///         .including(optional: Author.country))
+    /// let row = try Row.fetchOne(db, request)!
     ///
-    ///     let request = Book.including(optional: Book.author.including(optional: Author.country))
-    ///     let row = try Row.fetchOne(db, request)!
+    /// let book = try Book(row: row)
+    /// let author: Author? = try row.decode(forKey: "author")
+    /// let country: Country? = try row.decode(forKey: "country")
+    /// ```
     ///
-    ///     try print(Book(row: row).title)
-    ///     // Prints "Moby-Dick"
+    /// For more details about row scopes, see ``ScopeAdapter``,
+    /// ``splittingRowAdapters(columnCounts:)`` and ``scopesTree``.
     ///
-    ///     let country: Country? = row["country"]
-    ///     print(country.name)
-    ///     // Prints "United States"
-    ///
-    /// Nil is returned if the scope is not available, or contains only
-    /// null values.
-    ///
-    /// See ``splittingRowAdapters(columnCounts:)`` for a sample code.
+    /// - parameter type: The decoded type.
+    /// - parameter scope: A scope identifier.
+    /// - throws: Any error that happens during the decoding.
     public func decodeIfPresent<Record: FetchableRecord>(
         _ type: Record.Type = Record.self,
         forKey scope: String)
@@ -1266,36 +1428,47 @@ extension Row {
         return try Record(row: scopedRow)
     }
     
-    /// Returns the record associated with the given scope.
+    /// Returns the record associated to the given key.
+    ///
+    /// The key is a row scope that was either defined manually, with
+    /// ``ScopeAdapter``, or with the ``JoinableRequest/including(required:)``
+    /// and ``JoinableRequest/including(optional:)`` request methods. The
+    /// latter define row scopes named after the key of included
+    /// associations between record types.
+    ///
+    /// A breadth-first search is performed in all available scopes in the row,
+    /// recursively.
     ///
     /// For example:
     ///
-    ///     let request = Book.including(required: Book.author)
-    ///     let row = try Row.fetchOne(db, request)!
+    /// ```swift
+    /// struct Book: TableRecord, FetchableRecord {
+    ///     static let author = belongsTo(Author.self)
+    /// }
     ///
-    ///     try print(Book(row: row).title)
-    ///     // Prints "Moby-Dick"
+    /// struct Author: TableRecord, FetchableRecord {
+    ///     static let country = belongsTo(Country.self)
+    /// }
     ///
-    ///     let author: Author = row["author"]
-    ///     print(author.name)
-    ///     // Prints "Herman Melville"
+    /// struct Country: TableRecord, FetchableRecord { }
     ///
-    /// Associated records stored in nested associations are available, too:
+    /// // Fetch a book, with its author, and the country of its author.
+    /// let request = Book
+    ///     .including(required: Book.author
+    ///         .including(required: Author.country))
+    /// let row = try Row.fetchOne(db, request)!
     ///
-    ///     let request = Book.including(required: Book.author.including(required: Author.country))
-    ///     let row = try Row.fetchOne(db, request)!
+    /// let book = try Book(row: row)
+    /// let author: Author = try row.decode(forKey: "author")
+    /// let country: Country = try row.decode(forKey: "country")
+    /// ```
     ///
-    ///     try print(Book(row: row).title)
-    ///     // Prints "Moby-Dick"
+    /// For more details about row scopes, see ``ScopeAdapter``,
+    /// ``splittingRowAdapters(columnCounts:)`` and ``scopesTree``.
     ///
-    ///     let country: Country = row["country"]
-    ///     print(country.name)
-    ///     // Prints "United States"
-    ///
-    /// A fatal error is raised if the scope is not available, or contains only
-    /// null values.
-    ///
-    /// See ``splittingRowAdapters(columnCounts:)`` for a sample code.
+    /// - parameter type: The decoded type.
+    /// - parameter scope: A scope identifier.
+    /// - throws: Any error that happens during the decoding.
     public func decode<Record: FetchableRecord>(
         _ type: Record.Type = Record.self,
         forKey scope: String)
@@ -1338,19 +1511,33 @@ extension Row {
 // MARK: - Throwing Record RangeReplaceableCollection and Set Methods
 
 extension Row {
-    /// Returns the records encoded in the given prefetched rows.
+    /// Returns a collection of prefetched records associated to the given
+    /// association key.
+    ///
+    /// Prefetched rows are defined by the ``JoinableRequest/including(all:)``
+    /// request method.
     ///
     /// For example:
     ///
-    ///     let request = Author.including(all: Author.books)
-    ///     let row = try Row.fetchOne(db, request)!
+    /// ```swift
+    /// struct Author: TableRecord, FetchableRecord {
+    ///     static let books = hasMany(Book.self)
+    /// }
     ///
-    ///     try print(Author(row: row).name)
-    ///     // Prints "Herman Melville"
+    /// struct Book: TableRecord, FetchableRecord { }
     ///
-    ///     let books: [Book] = row["books"]
-    ///     print(books[0].title)
-    ///     // Prints "Moby-Dick"
+    /// let request = Author.including(all: Author.books)
+    /// let row = try Row.fetchOne(db, request)!
+    ///
+    /// let author = try Author(row: row)
+    /// let books: [Book] = try row.decode(forKey: "books")
+    /// ```
+    ///
+    /// See also: ``prefetchedRows``
+    ///
+    /// - parameter type: The type of the decoded collection.
+    /// - parameter key: An association key.
+    /// - throws: Any error that happens during the decoding.
     public func decode<Collection>(
         _ type: Collection.Type = Collection.self,
         forKey key: String)
@@ -1389,19 +1576,33 @@ extension Row {
         return collection
     }
     
-    /// Returns the set of records encoded in the given prefetched rows.
+    /// Returns the set of prefetched records associated to the given
+    /// association key.
+    ///
+    /// Prefetched rows are defined by the ``JoinableRequest/including(all:)``
+    /// request method.
     ///
     /// For example:
     ///
-    ///     let request = Author.including(all: Author.books)
-    ///     let row = try Row.fetchOne(db, request)!
+    /// ```swift
+    /// struct Author: TableRecord, FetchableRecord {
+    ///     static let books = hasMany(Book.self)
+    /// }
     ///
-    ///     try print(Author(row: row).name)
-    ///     // Prints "Herman Melville"
+    /// struct Book: TableRecord, FetchableRecord, Hashable { }
     ///
-    ///     let books: Set<Book> = row["books"]
-    ///     print(books.first!.title)
-    ///     // Prints "Moby-Dick"
+    /// let request = Author.including(all: Author.books)
+    /// let row = try Row.fetchOne(db, request)!
+    ///
+    /// let author = try Author(row: row)
+    /// let books: Set<Book> = try row.decode(forKey: "books")
+    /// ```
+    ///
+    /// See also: ``prefetchedRows``
+    ///
+    /// - parameter type: The type of the decoded set.
+    /// - parameter key: An association key.
+    /// - throws: Any error that happens during the decoding.
     public func decode<Record: FetchableRecord & Hashable>(
         _ type: Set<Record>.Type = Set<Record>.self,
         forKey key: String)

--- a/GRDB/Core/RowDecodingError.swift
+++ b/GRDB/Core/RowDecodingError.swift
@@ -23,9 +23,8 @@ enum RowKey: Hashable, Sendable {
     case prefetchKey(String)
 }
 
-/// A decoding error
-@usableFromInline
-struct RowDecodingError: Error {
+/// A decoding error thrown when decoding a database row.
+public struct RowDecodingError: Error {
     enum Impl {
         case keyNotFound(RowKey, Context)
         case valueMismatch(Any.Type, Context)
@@ -177,8 +176,7 @@ struct RowDecodingContext {
 }
 
 extension RowDecodingError: CustomStringConvertible {
-    @usableFromInline
-    var description: String {
+    public var description: String {
         let context = self.context
         let row = context.row
         var chunks: [String] = []

--- a/GRDB/Core/RowDecodingError.swift
+++ b/GRDB/Core/RowDecodingError.swift
@@ -24,6 +24,14 @@ enum RowKey: Hashable, Sendable {
 }
 
 /// A decoding error thrown when decoding a database row.
+///
+/// For example:
+///
+/// ```swift
+/// let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+/// // RowDecodingError: could not decode String from database value NULL.
+/// let name = try row.decode(String.self, forColumn: "name")
+/// ```
 public struct RowDecodingError: Error {
     enum Impl {
         case keyNotFound(RowKey, Context)

--- a/GRDB/QueryInterface/SQLGeneration/TableAlias.swift
+++ b/GRDB/QueryInterface/SQLGeneration/TableAlias.swift
@@ -290,6 +290,12 @@ extension TableAliasBase {
 /// See <https://github.com/groue/GRDB.swift/blob/master/Documentation/AssociationsBasics.md#table-aliases> for more information and examples.
 ///
 /// - note: [**🔥 EXPERIMENTAL**](https://github.com/groue/GRDB.swift/blob/master/README.md#what-are-experimental-features)
+///
+/// ## Topics
+///
+/// ## Supporting Types
+///
+/// - ``TableAliasBase``
 @dynamicMemberLookup
 public final class TableAlias<RowDecoder>: TableAliasBase, @unchecked Sendable {
     init(tableName: String, userName: String? = nil)

--- a/GRDB/Record/FetchableRecord+Decodable.swift
+++ b/GRDB/Record/FetchableRecord+Decodable.swift
@@ -212,20 +212,20 @@ private struct _RowDecoder<R: FetchableRecord>: Decoder {
         
         // swiftlint:disable comma
         // swiftlint:disable line_length
-        func decode(_ type: Bool.Type,   forKey key: Key) throws -> Bool   { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Int.Type,    forKey key: Key) throws -> Int    { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Int8.Type,   forKey key: Key) throws -> Int8   { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Int16.Type,  forKey key: Key) throws -> Int16  { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Int32.Type,  forKey key: Key) throws -> Int32  { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Int64.Type,  forKey key: Key) throws -> Int64  { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: UInt.Type,   forKey key: Key) throws -> UInt   { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: UInt8.Type,  forKey key: Key) throws -> UInt8  { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Float.Type,  forKey key: Key) throws -> Float  { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: Double.Type, forKey key: Key) throws -> Double { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
-        func decode(_ type: String.Type, forKey key: Key) throws -> String { try decoder.row.decode(forKey: decodeColumn(forKey: key)) }
+        func decode(_ type: Bool.Type,   forKey key: Key) throws -> Bool   { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Int.Type,    forKey key: Key) throws -> Int    { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Int8.Type,   forKey key: Key) throws -> Int8   { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Int16.Type,  forKey key: Key) throws -> Int16  { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Int32.Type,  forKey key: Key) throws -> Int32  { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Int64.Type,  forKey key: Key) throws -> Int64  { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: UInt.Type,   forKey key: Key) throws -> UInt   { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: UInt8.Type,  forKey key: Key) throws -> UInt8  { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Float.Type,  forKey key: Key) throws -> Float  { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: Double.Type, forKey key: Key) throws -> Double { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
+        func decode(_ type: String.Type, forKey key: Key) throws -> String { try decoder.row.decode(forColumn: decodeColumn(forKey: key)) }
         // swiftlint:enable line_length
         // swiftlint:enable comma
         

--- a/README.md
+++ b/README.md
@@ -843,6 +843,13 @@ row[...] as Int
 row[...] as Int?
 ```
 
+Throwing accessors exist as well. Their use is not encouraged, because a database decoding error is a programming error. If an application stores invalid data in the database file, that is a bug that needs to be fixed:
+
+```swift
+let name = try row.decode(String.self, atIndex: 0)
+let bookCount = try row.decode(Int.self, forColumn: "bookCount")
+```
+
 > **Warning**: avoid the `as!` and `as?` operators:
 > 
 > ```swift

--- a/README.md
+++ b/README.md
@@ -4984,12 +4984,13 @@ try dbQueue.write { db in
 
 ## Error Handling
 
-GRDB can throw [DatabaseError](#databaseerror), [RecordError], or crash your program with a [fatal error](#fatal-errors).
+GRDB can throw [DatabaseError](#databaseerror), [RecordError], [RowDecodingError], or crash your program with a [fatal error](#fatal-errors).
 
 Considering that a local database is not some JSON loaded from a remote server, GRDB focuses on **trusted databases**. Dealing with [untrusted databases](#how-to-deal-with-untrusted-inputs) requires extra care.
 
 - [DatabaseError](#databaseerror)
 - [RecordError]
+- [RowDecodingError]
 - [Fatal Errors](#fatal-errors)
 - [How to Deal with Untrusted Inputs](#how-to-deal-with-untrusted-inputs)
 - [Error Log](#error-log)
@@ -5093,6 +5094,18 @@ do {
 }
 ```
 
+
+### RowDecodingError
+
+📖 [`RowDecodingError`](https://swiftpackageindex.com/groue/GRDB.swift/documentation/grdb/rowdecodingerror)
+
+**RowDecodingError** is thrown when the application can not decode a value from a database row. For example:
+
+```swift
+let row = try Row.fetchOne(db, sql: "SELECT NULL AS name")!
+// RowDecodingError: could not decode String from database value NULL.
+let name = try row.decode(String.self, forColumn: "name")
+```
 
 ### Fatal Errors
 
@@ -6111,6 +6124,7 @@ This chapter has been superseded by [ValueObservation] and [DatabaseRegionObserv
 [persistence methods]: #persistence-methods
 [Persistence Methods and the `RETURNING` clause]: #persistence-methods-and-the-returning-clause
 [RecordError]: #recorderror
+[RowDecodingError]: #rowdecodingerror
 [Transactions and Savepoints]: https://swiftpackageindex.com/groue/GRDB.swift/documentation/grdb/transactions
 [`DatabaseQueue`]: https://swiftpackageindex.com/groue/GRDB.swift/documentation/grdb/databasequeue
 [Database queues]: https://swiftpackageindex.com/groue/GRDB.swift/documentation/grdb/databasequeue

--- a/Tests/GRDBTests/AssociationBelongsToFetchableRecordTests.swift
+++ b/Tests/GRDBTests/AssociationBelongsToFetchableRecordTests.swift
@@ -22,7 +22,10 @@ private struct PlayerWithRequiredTeam: FetchableRecord {
     
     init(row: Row) throws {
         player = try Player(row: row)
-        team = row[Player.teamScope]
+        let subscriptTeam: Team = row[Player.teamScope]
+        let decodedTeam: Team = try row.decode(forKey: Player.teamScope)
+        XCTAssertEqual(subscriptTeam.id, decodedTeam.id)
+        team = subscriptTeam
     }
 }
 
@@ -32,7 +35,10 @@ private struct PlayerWithOptionalTeam: FetchableRecord {
     
     init(row: Row) throws {
         player = try Player(row: row)
-        team = row[Player.teamScope]
+        let subscriptTeam: Team? = row[Player.teamScope]
+        let decodedTeam: Team? = try row.decodeIfPresent(forKey: Player.teamScope)
+        XCTAssertEqual(subscriptTeam?.id, decodedTeam?.id)
+        team = subscriptTeam
     }
 }
 

--- a/Tests/GRDBTests/DatabaseDataDecodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDataDecodingStrategyTests.swift
@@ -126,7 +126,7 @@ extension DatabaseDataDecodingStrategyTests {
                     XCTFail("Unexpected Data")
                 }
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Data from database value "invalid" - \

--- a/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
+++ b/Tests/GRDBTests/DatabaseDateDecodingStrategyTests.swift
@@ -208,7 +208,7 @@ extension DatabaseDateDecodingStrategyTests {
                     XCTFail("Unexpected Date")
                 }
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Date from database value "Yesterday" - \
@@ -254,7 +254,7 @@ extension DatabaseDateDecodingStrategyTests {
             } catch let error as RowDecodingError {
                 // Decoding from DatabaseValue does not work:
                 // "Yesterday" is not decoded as 0.
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Date from database value "Yesterday" - \
@@ -298,7 +298,7 @@ extension DatabaseDateDecodingStrategyTests {
             } catch let error as RowDecodingError {
                 // Decoding from DatabaseValue does not work:
                 // "Yesterday" is not decoded as 0.
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Date from database value "Yesterday" - \
@@ -352,7 +352,7 @@ extension DatabaseDateDecodingStrategyTests {
             } catch let error as RowDecodingError {
                 // Decoding from DatabaseValue does not work:
                 // "Yesterday" is not decoded as 0.
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Date from database value "Yesterday" - \
@@ -397,7 +397,7 @@ extension DatabaseDateDecodingStrategyTests {
                     XCTFail("Unexpected Date")
                 }
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
             could not decode Date from database value "Yesterday" - \
@@ -443,7 +443,7 @@ extension DatabaseDateDecodingStrategyTests {
                     XCTFail("Unexpected Date")
                 }
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Date from database value "Yesterday" - \
@@ -480,7 +480,7 @@ extension DatabaseDateDecodingStrategyTests {
                     XCTFail("Unexpected Date")
                 }
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                         could not decode Date from database value "invalid" - \

--- a/Tests/GRDBTests/DatabaseValueConversionErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConversionErrorTests.swift
@@ -23,7 +23,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil])
@@ -44,7 +44,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil])
@@ -74,7 +74,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("name"))
                     XCTAssertEqual(context.key, nil)
@@ -94,7 +94,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("name"))
                     XCTAssertEqual(context.key, nil)
@@ -139,7 +139,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(1))
                     XCTAssertEqual(context.row, ["1": 1, "value": "invalid"])
@@ -160,7 +160,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(1))
                     XCTAssertEqual(context.row, ["1": 1, "value": "invalid"])
@@ -190,7 +190,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("value"))
                     XCTAssertEqual(context.key, nil)
@@ -210,7 +210,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("value"))
                     XCTAssertEqual(context.key, nil)
@@ -248,7 +248,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -269,7 +269,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -299,7 +299,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("name"))
                     XCTAssertEqual(context.key, nil)
@@ -319,7 +319,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("name"))
                     XCTAssertEqual(context.key, nil)
@@ -360,7 +360,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(1))
                     XCTAssertEqual(context.row, ["name": nil, "value": "invalid"])
@@ -381,7 +381,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(1))
                     XCTAssertEqual(context.row, ["name": nil, "value": "invalid"])
@@ -411,7 +411,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("value"))
                     XCTAssertEqual(context.key, nil)
@@ -431,7 +431,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("value"))
                     XCTAssertEqual(context.key, nil)
@@ -484,7 +484,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -521,7 +521,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record(row: row)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("value"))
                     XCTAssertEqual(context.key, nil)
@@ -541,7 +541,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Record.fetchOne(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("value"))
                     XCTAssertEqual(context.key, nil)
@@ -571,7 +571,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try String.fetchAll(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -595,7 +595,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(String.self, forKey: "name")
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -617,7 +617,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(String.self, atIndex: 0)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -648,7 +648,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                     .next()
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .keyNotFound(key, context):
                     XCTAssertEqual(key, .columnName("missing"))
                     XCTAssertEqual(context.key, nil)
@@ -670,7 +670,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Int8.fetchAll(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["foo": 1000])
@@ -694,7 +694,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(Int8.self, forKey: "foo")
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["foo": 1000])
@@ -716,7 +716,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(Int8.self, atIndex: 0)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["foo": 1000])
@@ -749,7 +749,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Value.fetchAll(statement)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -772,7 +772,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try Value.fetchOne(statement, adapter: SuffixRowAdapter(fromIndex: 1))
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(1))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -796,7 +796,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(Value.self, forKey: "name")
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -818,7 +818,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(Value.self, atIndex: 0)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["name": nil, "team": "invalid"])
@@ -840,7 +840,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
                 _ = try row.decode(Value.self, atIndex: 0)
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case let .valueMismatch(_, context):
                     XCTAssertEqual(context.key, .columnIndex(0))
                     XCTAssertEqual(context.row, ["team": "invalid"])

--- a/Tests/GRDBTests/DatabaseValueConversionErrorTests.swift
+++ b/Tests/GRDBTests/DatabaseValueConversionErrorTests.swift
@@ -7,7 +7,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
             var name: String
 
             init(row: Row) throws {
-                name = try row.decode(forKey: "name")
+                name = try row.decode(forColumn: "name")
             }
         }
         
@@ -123,7 +123,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
             var value: Value
 
             init(row: Row) throws {
-                value = try row.decode(forKey: "value")
+                value = try row.decode(forColumn: "value")
             }
         }
         
@@ -592,7 +592,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
             
             do {
                 let row = try Row.fetchOne(statement)!
-                _ = try row.decode(String.self, forKey: "name")
+                _ = try row.decode(String.self, forColumn: "name")
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
                 switch error.impl {
@@ -644,7 +644,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
             
             do {
                 _ = try Row.fetchCursor(statement)
-                    .map { try $0.decode(Int8.self, forKey: "missing") }
+                    .map { try $0.decode(Int8.self, forColumn: "missing") }
                     .next()
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
@@ -691,7 +691,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
             
             do {
                 let row = try Row.fetchOne(statement)!
-                _ = try row.decode(Int8.self, forKey: "foo")
+                _ = try row.decode(Int8.self, forColumn: "foo")
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
                 switch error.impl {
@@ -793,7 +793,7 @@ class DatabaseValueConversionErrorTests: GRDBTestCase {
             
             do {
                 let row = try Row.fetchOne(statement)!
-                _ = try row.decode(Value.self, forKey: "name")
+                _ = try row.decode(Value.self, forColumn: "name")
                 XCTFail("Expected error")
             } catch let error as RowDecodingError {
                 switch error.impl {

--- a/Tests/GRDBTests/FetchableRecordDecodableTests.swift
+++ b/Tests/GRDBTests/FetchableRecordDecodableTests.swift
@@ -376,7 +376,7 @@ extension FetchableRecordDecodableTests {
                 _ = try StructWithData(row: ["data": nil])
                 XCTFail("Expected Error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                     could not decode Data from database value NULL - \
@@ -395,7 +395,7 @@ extension FetchableRecordDecodableTests {
                 }
                 XCTFail("Expected Error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                     could not decode Data from database value NULL - \
@@ -439,7 +439,7 @@ extension FetchableRecordDecodableTests {
                 _ = try StructWithDate(row: ["date": nil])
                 XCTFail("Expected Error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                     could not decode Date from database value NULL - \
@@ -458,7 +458,7 @@ extension FetchableRecordDecodableTests {
                 }
                 XCTFail("Expected Error")
             } catch let error as RowDecodingError {
-                switch error {
+                switch error.impl {
                 case .valueMismatch:
                     XCTAssertEqual(error.description, """
                     could not decode Date from database value NULL - \
@@ -1050,9 +1050,13 @@ extension FetchableRecordDecodableTests {
                 "optionalDates2": "[128000]",
             ])
             XCTFail("Expected error")
-        } catch let RowDecodingError.keyNotFound(.columnName(column), context) {
-            XCTAssertEqual(column, "requiredId")
-            XCTAssertEqual(context.debugDescription, "column not found: \"requiredId\"")
+        } catch let error as RowDecodingError {
+            if case let .keyNotFound(.columnName(column), context) = error.impl {
+                XCTAssertEqual(column, "requiredId")
+                XCTAssertEqual(context.debugDescription, "column not found: \"requiredId\"")
+            } else {
+                XCTFail("Unexpected error")
+            }
         }
     }
     
@@ -1163,12 +1167,16 @@ extension FetchableRecordDecodableTests {
                 "optional_dates2": "[128000]",
             ])
             XCTFail("Expected error")
-        } catch let RowDecodingError.keyNotFound(.columnName(column), context) {
-            XCTAssertEqual(column, "requiredId")
-            XCTAssertEqual(context.debugDescription, """
-                key not found: CodingKeys(stringValue: "requiredId", intValue: nil) ("requiredId"), \
-                converted to required_id
-                """)
+        } catch let error as RowDecodingError {
+            if case let .keyNotFound(.columnName(column), context) = error.impl {
+                XCTAssertEqual(column, "requiredId")
+                XCTAssertEqual(context.debugDescription, """
+                    key not found: CodingKeys(stringValue: "requiredId", intValue: nil) ("requiredId"), \
+                    converted to required_id
+                    """)
+            } else {
+                XCTFail("Unexpected error")
+            }
         }
         
         do {
@@ -1180,13 +1188,17 @@ extension FetchableRecordDecodableTests {
                 "optional_dates2": "[128000]",
             ])
             XCTFail("Expected error")
-        } catch let RowDecodingError.keyNotFound(.columnName(column), context) {
-            XCTAssertEqual(column, "requiredID")
-            XCTAssertEqual(context.debugDescription, """
-                key not found: CodingKeys(stringValue: "requiredID", intValue: nil) ("requiredID"), \
-                with divergent representation requiredId, \
-                converted to required_id
-                """)
+        } catch let error as RowDecodingError {
+            if case let .keyNotFound(.columnName(column), context) = error.impl {
+                XCTAssertEqual(column, "requiredID")
+                XCTAssertEqual(context.debugDescription, """
+                    key not found: CodingKeys(stringValue: "requiredID", intValue: nil) ("requiredID"), \
+                    with divergent representation requiredId, \
+                    converted to required_id
+                    """)
+            } else {
+                XCTFail("Unexpected error")
+            }
         }
     }
     
@@ -1264,11 +1276,15 @@ extension FetchableRecordDecodableTests {
                 "_optionalDates2": "[128000]",
             ])
             XCTFail("Expected error")
-        } catch let RowDecodingError.keyNotFound(.columnName(column), context) {
-            XCTAssertEqual(column, "requiredId")
-            XCTAssertEqual(context.debugDescription, """
-                key not found: CodingKeys(stringValue: "requiredId", intValue: nil) ("requiredId")
-                """)
+        } catch let error as RowDecodingError {
+            if case let .keyNotFound(.columnName(column), context) = error.impl {
+                XCTAssertEqual(column, "requiredId")
+                XCTAssertEqual(context.debugDescription, """
+                    key not found: CodingKeys(stringValue: "requiredId", intValue: nil) ("requiredId")
+                    """)
+            } else {
+                XCTFail("Unexpected error")
+            }
         }
     }
 }

--- a/Tests/GRDBTests/RowAdapterTests.swift
+++ b/Tests/GRDBTests/RowAdapterTests.swift
@@ -42,14 +42,14 @@ class AdapterRowTests : RowTestCase {
             assertRowRawValueEqual(row, index: 2, value: 2 as Int64)
             
             // DatabaseValueConvertible & StatementColumnConvertible
-            assertRowConvertedValueEqual(row, index: 0, value: 0 as Int)
-            assertRowConvertedValueEqual(row, index: 1, value: 1 as Int)
-            assertRowConvertedValueEqual(row, index: 2, value: 2 as Int)
+            try assertRowConvertedValueEqual(row, index: 0, value: 0 as Int)
+            try assertRowConvertedValueEqual(row, index: 1, value: 1 as Int)
+            try assertRowConvertedValueEqual(row, index: 2, value: 2 as Int)
             
             // DatabaseValueConvertible
-            assertRowConvertedValueEqual(row, index: 0, value: CustomValue.a)
-            assertRowConvertedValueEqual(row, index: 1, value: CustomValue.b)
-            assertRowConvertedValueEqual(row, index: 2, value: CustomValue.c)
+            try assertRowConvertedValueEqual(row, index: 0, value: CustomValue.a)
+            try assertRowConvertedValueEqual(row, index: 1, value: CustomValue.b)
+            try assertRowConvertedValueEqual(row, index: 2, value: CustomValue.c)
             
             // Expect fatal error:
             //
@@ -70,14 +70,14 @@ class AdapterRowTests : RowTestCase {
             assertRowRawValueEqual(row, name: "c", value: 2 as Int64)
             
             // DatabaseValueConvertible & StatementColumnConvertible
-            assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
-            assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
-            assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
+            try assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
+            try assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
+            try assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
             
             // DatabaseValueConvertible
-            assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
-            assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
-            assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
+            try assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
+            try assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
+            try assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
         }
     }
     
@@ -93,14 +93,14 @@ class AdapterRowTests : RowTestCase {
             assertRowRawValueEqual(row, column: Column("c"), value: 2 as Int64)
             
             // DatabaseValueConvertible & StatementColumnConvertible
-            assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
-            assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
-            assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
+            try assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
+            try assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
+            try assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
             
             // DatabaseValueConvertible
-            assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
-            assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
-            assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
+            try assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
+            try assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
+            try assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
         }
     }
     

--- a/Tests/GRDBTests/RowCopiedFromStatementTests.swift
+++ b/Tests/GRDBTests/RowCopiedFromStatementTests.swift
@@ -44,14 +44,14 @@ class RowCopiedFromStatementTests: RowTestCase {
             assertRowRawValueEqual(row, index: 2, value: 2 as Int64)
             
             // DatabaseValueConvertible & StatementColumnConvertible
-            assertRowConvertedValueEqual(row, index: 0, value: 0 as Int)
-            assertRowConvertedValueEqual(row, index: 1, value: 1 as Int)
-            assertRowConvertedValueEqual(row, index: 2, value: 2 as Int)
+            try assertRowConvertedValueEqual(row, index: 0, value: 0 as Int)
+            try assertRowConvertedValueEqual(row, index: 1, value: 1 as Int)
+            try assertRowConvertedValueEqual(row, index: 2, value: 2 as Int)
             
             // DatabaseValueConvertible
-            assertRowConvertedValueEqual(row, index: 0, value: CustomValue.a)
-            assertRowConvertedValueEqual(row, index: 1, value: CustomValue.b)
-            assertRowConvertedValueEqual(row, index: 2, value: CustomValue.c)
+            try assertRowConvertedValueEqual(row, index: 0, value: CustomValue.a)
+            try assertRowConvertedValueEqual(row, index: 1, value: CustomValue.b)
+            try assertRowConvertedValueEqual(row, index: 2, value: CustomValue.c)
             
             // Expect fatal error:
             //
@@ -73,14 +73,14 @@ class RowCopiedFromStatementTests: RowTestCase {
             assertRowRawValueEqual(row, name: "c", value: 2 as Int64)
             
             // DatabaseValueConvertible & StatementColumnConvertible
-            assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
-            assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
-            assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
+            try assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
+            try assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
+            try assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
             
             // DatabaseValueConvertible
-            assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
-            assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
-            assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
+            try assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
+            try assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
+            try assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
         }
     }
 
@@ -97,14 +97,14 @@ class RowCopiedFromStatementTests: RowTestCase {
             assertRowRawValueEqual(row, column: Column("c"), value: 2 as Int64)
             
             // DatabaseValueConvertible & StatementColumnConvertible
-            assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
-            assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
-            assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
+            try assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
+            try assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
+            try assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
             
             // DatabaseValueConvertible
-            assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
-            assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
-            assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
+            try assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
+            try assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
+            try assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
         }
     }
 

--- a/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryLiteralTests.swift
@@ -39,7 +39,7 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         XCTAssertEqual(row["a"] as Int, 0)
     }
     
-    func testRowValueAtIndex() {
+    func testRowValueAtIndex() throws {
         let row: Row = ["a": 0, "b": 1, "c": 2]
         
         let aIndex = row.distance(from: row.startIndex, to: row.firstIndex(where: { (column, value) in column == "a" })!)
@@ -52,14 +52,14 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         assertRowRawValueEqual(row, index: cIndex, value: 2 as Int64)
         
         // DatabaseValueConvertible & StatementColumnConvertible
-        assertRowConvertedValueEqual(row, index: aIndex, value: 0 as Int)
-        assertRowConvertedValueEqual(row, index: bIndex, value: 1 as Int)
-        assertRowConvertedValueEqual(row, index: cIndex, value: 2 as Int)
+        try assertRowConvertedValueEqual(row, index: aIndex, value: 0 as Int)
+        try assertRowConvertedValueEqual(row, index: bIndex, value: 1 as Int)
+        try assertRowConvertedValueEqual(row, index: cIndex, value: 2 as Int)
         
         // DatabaseValueConvertible
-        assertRowConvertedValueEqual(row, index: aIndex, value: CustomValue.a)
-        assertRowConvertedValueEqual(row, index: bIndex, value: CustomValue.b)
-        assertRowConvertedValueEqual(row, index: cIndex, value: CustomValue.c)
+        try assertRowConvertedValueEqual(row, index: aIndex, value: CustomValue.a)
+        try assertRowConvertedValueEqual(row, index: bIndex, value: CustomValue.b)
+        try assertRowConvertedValueEqual(row, index: cIndex, value: CustomValue.c)
         
         // Expect fatal error:
         //
@@ -67,7 +67,7 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         // row[3]
     }
     
-    func testRowValueNamed() {
+    func testRowValueNamed() throws {
         let row: Row = ["a": 0, "b": 1, "c": 2]
         
         // Raw extraction
@@ -76,17 +76,17 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         assertRowRawValueEqual(row, name: "c", value: 2 as Int64)
         
         // DatabaseValueConvertible & StatementColumnConvertible
-        assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
-        assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
-        assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
+        try assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
+        try assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
+        try assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
         
         // DatabaseValueConvertible
-        assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
-        assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
-        assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
+        try assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
+        try assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
+        try assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
     }
     
-    func testRowValueFromColumn() {
+    func testRowValueFromColumn() throws {
         let row: Row = ["a": 0, "b": 1, "c": 2]
         
         // Raw extraction
@@ -95,14 +95,14 @@ class RowFromDictionaryLiteralTests : RowTestCase {
         assertRowRawValueEqual(row, column: Column("c"), value: 2 as Int64)
         
         // DatabaseValueConvertible & StatementColumnConvertible
-        assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
-        assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
-        assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
+        try assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
+        try assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
+        try assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
         
         // DatabaseValueConvertible
-        assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
-        assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
-        assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
+        try assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
+        try assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
+        try assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
     }
     
     func testWithUnsafeData() throws {

--- a/Tests/GRDBTests/RowFromDictionaryTests.swift
+++ b/Tests/GRDBTests/RowFromDictionaryTests.swift
@@ -26,7 +26,7 @@ class RowFromDictionaryTests : RowTestCase {
         XCTAssertEqual(bools, [false, true, true])
     }
     
-    func testRowValueAtIndex() {
+    func testRowValueAtIndex() throws {
         let dictionary: [String: (any DatabaseValueConvertible)?] = ["a": 0, "b": 1, "c": 2]
         let row = Row(dictionary)
         
@@ -40,14 +40,14 @@ class RowFromDictionaryTests : RowTestCase {
         assertRowRawValueEqual(row, index: cIndex, value: 2 as Int64)
         
         // DatabaseValueConvertible & StatementColumnConvertible
-        assertRowConvertedValueEqual(row, index: aIndex, value: 0 as Int)
-        assertRowConvertedValueEqual(row, index: bIndex, value: 1 as Int)
-        assertRowConvertedValueEqual(row, index: cIndex, value: 2 as Int)
+        try assertRowConvertedValueEqual(row, index: aIndex, value: 0 as Int)
+        try assertRowConvertedValueEqual(row, index: bIndex, value: 1 as Int)
+        try assertRowConvertedValueEqual(row, index: cIndex, value: 2 as Int)
         
         // DatabaseValueConvertible
-        assertRowConvertedValueEqual(row, index: aIndex, value: CustomValue.a)
-        assertRowConvertedValueEqual(row, index: bIndex, value: CustomValue.b)
-        assertRowConvertedValueEqual(row, index: cIndex, value: CustomValue.c)
+        try assertRowConvertedValueEqual(row, index: aIndex, value: CustomValue.a)
+        try assertRowConvertedValueEqual(row, index: bIndex, value: CustomValue.b)
+        try assertRowConvertedValueEqual(row, index: cIndex, value: CustomValue.c)
         
         // Expect fatal error:
         //
@@ -55,7 +55,7 @@ class RowFromDictionaryTests : RowTestCase {
         // row[3]
     }
     
-    func testRowValueNamed() {
+    func testRowValueNamed() throws {
         let row = Row(["a": 0, "b": 1, "c": 2])
         
         // Raw extraction
@@ -64,17 +64,17 @@ class RowFromDictionaryTests : RowTestCase {
         assertRowRawValueEqual(row, name: "c", value: 2 as Int64)
         
         // DatabaseValueConvertible & StatementColumnConvertible
-        assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
-        assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
-        assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
+        try assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
+        try assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
+        try assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
         
         // DatabaseValueConvertible
-        assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
-        assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
-        assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
+        try assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
+        try assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
+        try assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
     }
     
-    func testRowValueFromColumn() {
+    func testRowValueFromColumn() throws {
         let row = Row(["a": 0, "b": 1, "c": 2])
         
         // Raw extraction
@@ -83,14 +83,14 @@ class RowFromDictionaryTests : RowTestCase {
         assertRowRawValueEqual(row, column: Column("c"), value: 2 as Int64)
         
         // DatabaseValueConvertible & StatementColumnConvertible
-        assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
-        assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
-        assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
+        try assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
+        try assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
+        try assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
         
         // DatabaseValueConvertible
-        assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
-        assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
-        assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
+        try assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
+        try assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
+        try assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
     }
     
     func testWithUnsafeData() throws {

--- a/Tests/GRDBTests/RowFromStatementTests.swift
+++ b/Tests/GRDBTests/RowFromStatementTests.swift
@@ -51,14 +51,14 @@ class RowFromStatementTests : RowTestCase {
                 assertRowRawValueEqual(row, index: 2, value: 2 as Int64)
                 
                 // DatabaseValueConvertible & StatementColumnConvertible
-                assertRowConvertedValueEqual(row, index: 0, value: 0 as Int)
-                assertRowConvertedValueEqual(row, index: 1, value: 1 as Int)
-                assertRowConvertedValueEqual(row, index: 2, value: 2 as Int)
+                try assertRowConvertedValueEqual(row, index: 0, value: 0 as Int)
+                try assertRowConvertedValueEqual(row, index: 1, value: 1 as Int)
+                try assertRowConvertedValueEqual(row, index: 2, value: 2 as Int)
                 
                 // DatabaseValueConvertible
-                assertRowConvertedValueEqual(row, index: 0, value: CustomValue.a)
-                assertRowConvertedValueEqual(row, index: 1, value: CustomValue.b)
-                assertRowConvertedValueEqual(row, index: 2, value: CustomValue.c)
+                try assertRowConvertedValueEqual(row, index: 0, value: CustomValue.a)
+                try assertRowConvertedValueEqual(row, index: 1, value: CustomValue.b)
+                try assertRowConvertedValueEqual(row, index: 2, value: CustomValue.c)
                 
                 // Expect fatal error:
                 //
@@ -85,14 +85,14 @@ class RowFromStatementTests : RowTestCase {
                 assertRowRawValueEqual(row, name: "c", value: 2 as Int64)
                 
                 // DatabaseValueConvertible & StatementColumnConvertible
-                assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
-                assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
-                assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
+                try assertRowConvertedValueEqual(row, name: "a", value: 0 as Int)
+                try assertRowConvertedValueEqual(row, name: "b", value: 1 as Int)
+                try assertRowConvertedValueEqual(row, name: "c", value: 2 as Int)
                 
                 // DatabaseValueConvertible
-                assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
-                assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
-                assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
+                try assertRowConvertedValueEqual(row, name: "a", value: CustomValue.a)
+                try assertRowConvertedValueEqual(row, name: "b", value: CustomValue.b)
+                try assertRowConvertedValueEqual(row, name: "c", value: CustomValue.c)
             }
             XCTAssertTrue(rowFetched)
         }
@@ -114,14 +114,14 @@ class RowFromStatementTests : RowTestCase {
                 assertRowRawValueEqual(row, column: Column("c"), value: 2 as Int64)
                 
                 // DatabaseValueConvertible & StatementColumnConvertible
-                assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
-                assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
-                assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
+                try assertRowConvertedValueEqual(row, column: Column("a"), value: 0 as Int)
+                try assertRowConvertedValueEqual(row, column: Column("b"), value: 1 as Int)
+                try assertRowConvertedValueEqual(row, column: Column("c"), value: 2 as Int)
                 
                 // DatabaseValueConvertible
-                assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
-                assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
-                assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
+                try assertRowConvertedValueEqual(row, column: Column("a"), value: CustomValue.a)
+                try assertRowConvertedValueEqual(row, column: Column("b"), value: CustomValue.b)
+                try assertRowConvertedValueEqual(row, column: Column("c"), value: CustomValue.c)
             }
             XCTAssertTrue(rowFetched)
         }

--- a/Tests/GRDBTests/RowTestCase.swift
+++ b/Tests/GRDBTests/RowTestCase.swift
@@ -5,8 +5,10 @@ class RowTestCase: GRDBTestCase {
     
     func assertRowRawValueEqual<T: Equatable>(_ row: Row, index: Int, value: T) {
         // form 1
-        let v = row[index]
-        XCTAssertEqual(v as! T, value)
+        do {
+            let v = row[index]
+            XCTAssertEqual(v as! T, value)
+        }
         
         // form 2
         XCTAssertEqual(row[index] as! T, value)
@@ -51,7 +53,7 @@ class RowTestCase: GRDBTestCase {
         }
     }
     
-    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible>(_ row: Row, index: Int, value: T) {
+    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible>(_ row: Row, index: Int, value: T) throws {
         // form 1
         XCTAssertEqual(row[index] as T, value)
         
@@ -67,9 +69,15 @@ class RowTestCase: GRDBTestCase {
         } else {
             XCTFail("expected successful extraction")
         }
+        
+        // form 5
+        try XCTAssertEqual(row.decode(T.self, atIndex: index), value)
+        
+        // form 6
+        try XCTAssertEqual(row.decode(atIndex: index) as T, value)
     }
     
-    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible>(_ row: Row, name: String, value: T) {
+    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible>(_ row: Row, name: String, value: T) throws {
         // form 1
         XCTAssertEqual(row[name] as T, value)
         
@@ -85,9 +93,15 @@ class RowTestCase: GRDBTestCase {
         } else {
             XCTFail("expected successful extraction")
         }
+        
+        // form 5
+        try XCTAssertEqual(row.decode(T.self, forColumn: name), value)
+        
+        // form 6
+        try XCTAssertEqual(row.decode(forColumn: name) as T, value)
     }
     
-    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible>(_ row: Row, column: Column, value: T) {
+    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible>(_ row: Row, column: Column, value: T) throws {
         // form 1
         XCTAssertEqual(row[column] as T, value)
         
@@ -103,9 +117,15 @@ class RowTestCase: GRDBTestCase {
         } else {
             XCTFail("expected successful extraction")
         }
+        
+        // form 5
+        try XCTAssertEqual(row.decode(T.self, forColumn: column), value)
+        
+        // form 6
+        try XCTAssertEqual(row.decode(forColumn: column) as T, value)
     }
     
-    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible & StatementColumnConvertible>(_ row: Row, index: Int, value: T) {
+    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible & StatementColumnConvertible>(_ row: Row, index: Int, value: T) throws {
         // form 1
         XCTAssertEqual(row[index] as T, value)
         
@@ -121,9 +141,15 @@ class RowTestCase: GRDBTestCase {
         } else {
             XCTFail("expected successful extraction")
         }
+        
+        // form 5
+        try XCTAssertEqual(row.decode(T.self, atIndex: index), value)
+        
+        // form 6
+        try XCTAssertEqual(row.decode(atIndex: index) as T, value)
     }
     
-    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible & StatementColumnConvertible>(_ row: Row, name: String, value: T) {
+    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible & StatementColumnConvertible>(_ row: Row, name: String, value: T) throws {
         // form 1
         XCTAssertEqual(row[name] as T, value)
         
@@ -139,9 +165,15 @@ class RowTestCase: GRDBTestCase {
         } else {
             XCTFail("expected successful extraction")
         }
+        
+        // form 5
+        try XCTAssertEqual(row.decode(T.self, forColumn: name), value)
+        
+        // form 6
+        try XCTAssertEqual(row.decode(forColumn: name) as T, value)
     }
     
-    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible & StatementColumnConvertible>(_ row: Row, column: Column, value: T) {
+    func assertRowConvertedValueEqual<T: Equatable & DatabaseValueConvertible & StatementColumnConvertible>(_ row: Row, column: Column, value: T) throws {
         // form 1
         XCTAssertEqual(row[column] as T, value)
         
@@ -157,5 +189,11 @@ class RowTestCase: GRDBTestCase {
         } else {
             XCTFail("expected successful extraction")
         }
+        
+        // form 5
+        try XCTAssertEqual(row.decode(T.self, forColumn: column), value)
+        
+        // form 6
+        try XCTAssertEqual(row.decode(forColumn: column) as T, value)
     }
 }


### PR DESCRIPTION
This pull requests add a way to catch row decoding errors:

```swift
self.name = try row.decode(String.self, atIndex: 0)
self.bookCount = try row.decode(Int.self, forColumn: "bookCount")
```

**The use of those throwing accessors is not encouraged**, because a database decoding error is a programming error. If an application stores invalid data in the database file, that is a bug that needs to be fixed.

Throwing accessors can be useful while debugging such an application, as described in #1786.

Other users can profit from the much shorter subscripts:

```swift
self.name = row[0]
self.bookCount = row["bookCount"]
```
