### PR TITLE
Fix race condition regarding Task cancellation

### DIFF
--- a/GRDB/Core/DatabasePool.swift
+++ b/GRDB/Core/DatabasePool.swift
@@ -803,6 +803,7 @@ extension DatabasePool: DatabaseWriter {
                 try Task.checkCancellation()
                 return try writer.sync { db in
                     defer {
+                        cancelMutex.store(nil)
                         db.uncancel()
                     }
                     cancelMutex.store(db.cancel)

--- a/GRDB/Core/SerializedDatabase.swift
+++ b/GRDB/Core/SerializedDatabase.swift
@@ -256,6 +256,7 @@ final class SerializedDatabase {
         return try await withTaskCancellationHandler {
             try await actor.execute {
                 defer {
+                    cancelMutex.store(nil)
                     db.uncancel()
                     preconditionNoUnsafeTransactionLeft(db)
                 }


### PR DESCRIPTION
This PR fixes a race condition introduced in v7.6.0 that could cancel a database access when an unrelated task is cancelled.