### PR TITLE
fix: add `Sendable` conformance to `DispatchQueueExecutor` on Linux

### DIFF
--- a/GRDB/Core/DispatchQueueActor.swift
+++ b/GRDB/Core/DispatchQueueActor.swift
@@ -43,3 +43,7 @@ private final class DispatchQueueExecutor: SerialExecutor {
         dispatchPrecondition(condition: .onQueue(queue))
     }
 }
+
+#if os(Linux)
+    extension DispatchQueueExecutor: @unchecked Sendable {}
+#endif


### PR DESCRIPTION
I've been using GRDB for a while on Linux, but recently I started getting build failures due to `DispatchQueueExecutor` not conforming to `Sendable`. This change fixes it by conditionally setting `@unchecked Sendable` when on Linux.

https://github.com/swiftlang/swift-corelibs-libdispatch/blob/0bb6c10fa556722654917b4a18ba2dc39b18392a/src/swift/Block.swift#L16

<!--
Please check the boxes that apply to your pull request:
-->

- [X] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [X] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [X] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [X] TESTS: Changes are tested.
- [X] TESTS: The `make smokeTest` terminal command runs without failure.
