### PR TITLE
Merged Migrations

### DIFF
--- a/GRDB/Migration/Migration.swift
+++ b/GRDB/Migration/Migration.swift
@@ -6,22 +6,27 @@ struct Migration: Sendable {
         case disabled
     }
     
+    typealias Migrate = @Sendable (_ db: Database, _ mergedIdentifiers: Set<String>) throws -> Void
+    
     let identifier: String
+    let mergedIdentifiers: Set<String>
     var foreignKeyChecks: ForeignKeyChecks
     // Private so that the guarantees of `run(_:)` are enforced.
-    private let migrate: @Sendable (Database) throws -> Void
+    private let migrate: Migrate
     
     init(
         identifier: String,
+        mergedIdentifiers: Set<String>,
         foreignKeyChecks: ForeignKeyChecks,
-        migrate: @escaping @Sendable (Database) throws -> Void
+        migrate: @escaping Migrate
     ) {
         self.identifier = identifier
+        self.mergedIdentifiers = mergedIdentifiers
         self.foreignKeyChecks = foreignKeyChecks
         self.migrate = migrate
     }
     
-    func run(_ db: Database) throws {
+    func run(_ db: Database, mergedIdentifiers: Set<String>) throws {
         // Migrations access the raw SQLite schema, without alteration due
         // to the schemaSource. The goal is to ensure that migrations are
         // immutable, immune from spooky actions at a distance.
@@ -29,33 +34,40 @@ struct Migration: Sendable {
             if try Bool.fetchOne(db, sql: "PRAGMA foreign_keys") ?? false {
                 switch foreignKeyChecks {
                 case .deferred:
-                    try runWithDeferredForeignKeysChecks(db)
+                    try runWithDeferredForeignKeysChecks(db, mergedIdentifiers: mergedIdentifiers)
                 case .immediate:
-                    try runWithImmediateForeignKeysChecks(db)
+                    try runWithImmediateForeignKeysChecks(db, mergedIdentifiers: mergedIdentifiers)
                 case .disabled:
-                    try runWithDisabledForeignKeysChecks(db)
+                    try runWithDisabledForeignKeysChecks(db, mergedIdentifiers: mergedIdentifiers)
                 }
             } else {
-                try runWithImmediateForeignKeysChecks(db)
+                try runWithImmediateForeignKeysChecks(db, mergedIdentifiers: mergedIdentifiers)
             }
         }
     }
     
-    private func runWithImmediateForeignKeysChecks(_ db: Database) throws {
+    
+    func deleteMergedIdentifiers(_ db: Database) throws {
+        if mergedIdentifiers.isEmpty == false {
+            try db.execute(literal: "DELETE FROM grdb_migrations WHERE identifier IN \(mergedIdentifiers)")
+        }
+    }
+    
+    private func runWithImmediateForeignKeysChecks(_ db: Database, mergedIdentifiers: Set<String>) throws {
         try db.inTransaction(.immediate) {
-            try migrate(db)
-            try insertAppliedIdentifier(db)
+            try migrate(db, mergedIdentifiers)
+            try updateAppliedIdentifier(db)
             return .commit
         }
     }
     
-    private func runWithDisabledForeignKeysChecks(_ db: Database) throws {
+    private func runWithDisabledForeignKeysChecks(_ db: Database, mergedIdentifiers: Set<String>) throws {
         try db.execute(sql: "PRAGMA foreign_keys = OFF")
         try throwingFirstError(
             execute: {
                 try db.inTransaction(.immediate) {
-                    try migrate(db)
-                    try insertAppliedIdentifier(db)
+                    try migrate(db, mergedIdentifiers)
+                    try updateAppliedIdentifier(db)
                     return .commit
                 }
             },
@@ -64,7 +76,7 @@ struct Migration: Sendable {
             })
     }
 
-    private func runWithDeferredForeignKeysChecks(_ db: Database) throws {
+    private func runWithDeferredForeignKeysChecks(_ db: Database, mergedIdentifiers: Set<String>) throws {
         // Support for database alterations described at
         // https://www.sqlite.org/lang_altertable.html#otheralter
         //
@@ -76,8 +88,8 @@ struct Migration: Sendable {
             execute: {
                 // > 2. Start a transaction.
                 try db.inTransaction(.immediate) {
-                    try migrate(db)
-                    try insertAppliedIdentifier(db)
+                    try migrate(db, mergedIdentifiers)
+                    try updateAppliedIdentifier(db)
                     
                     // > 10. If foreign key constraints were originally enabled
                     // > then run PRAGMA foreign_key_check to verify that the
@@ -96,7 +108,8 @@ struct Migration: Sendable {
             })
     }
     
-    private func insertAppliedIdentifier(_ db: Database) throws {
-        try db.execute(sql: "INSERT INTO grdb_migrations (identifier) VALUES (?)", arguments: [identifier])
+    private func updateAppliedIdentifier(_ db: Database) throws {
+        try deleteMergedIdentifiers(db)
+        try db.execute(literal: "INSERT INTO grdb_migrations (identifier) VALUES (\(identifier))")
     }
 }


### PR DESCRIPTION
The new `registerMigration(_:foreignKeyChecks:merging:migrate)` method registers a migration that **merges and replaces** a set of migrations defined in a previous version of the application. For example, to merge the migrations "v1", "v2" and "v3", redefine the "v3" migration so that it merges "v1" and "v2", as in the example below.

The second argument of the migration closure is the set of merged migrations that has been applied when the merged migration runs.

```swift
// Old code
migrator.registerMigration("v1") { db in
    // Apply schema version 1
}
migrator.registerMigration("v2") { db in
    // Apply schema version 2
}
migrator.registerMigration("v3") { db in
    // Apply schema version 3
}

// New code:
// - Migrations v1 and v2 are deleted.
// - Migration v3 is redefined and merges v1 and v2:
migrator.registerMigration("v3", merging: ["v1", "v2"]) { db, appliedIDs in
    if !appliedIDs.contains("v1") {
        // Apply schema version 1
    }
    if !appliedIDs.contains("v2") {
        // Apply schema version 2
    }
    // Apply schema version 3
}
```

See https://github.com/groue/GRDB.swift/discussions/1817 for a longer discussion.
