### PR TITLE
Add Sendable conformance to DispatchQueueExecutor for Android and Windows

### DIFF
--- a/GRDB/Core/DispatchQueueActor.swift
+++ b/GRDB/Core/DispatchQueueActor.swift
@@ -48,6 +48,6 @@ private final class DispatchQueueExecutor: SerialExecutor {
     }
 }
 
-#if os(Linux)
+#if os(Linux) || os(Android) || os(Windows)
     extension DispatchQueueExecutor: @unchecked Sendable {}
 #endif


### PR DESCRIPTION
As with Linux, Android and Windows need DispatchQueueExecutor to add a retroactive conformance to Sendable.