### PR TITLE
Android and Windows platform import/conditional accommodation

### DIFF
--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -14,6 +14,8 @@ import GRDBSQLite
 import string_h
 #elseif os(Linux)
 import Glibc
+#elseif os(Android)
+import Android
 #elseif os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
 import Darwin
 #elseif os(Windows)

--- a/GRDB/Core/Support/Foundation/NSNumber.swift
+++ b/GRDB/Core/Support/Foundation/NSNumber.swift
@@ -1,4 +1,3 @@
-#if !os(Windows)
 import Foundation
 
 private let integerRoundingBehavior = NSDecimalNumberHandler(
@@ -104,4 +103,3 @@ extension NSNumber: DatabaseValueConvertible {
 }
 
 private let posixLocale = Locale(identifier: "en_US_POSIX")
-#endif

--- a/GRDB/Core/Support/Foundation/URL.swift
+++ b/GRDB/Core/Support/Foundation/URL.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-#if !os(Windows)
 /// NSURL stores its absoluteString in the database.
 extension NSURL: DatabaseValueConvertible {
     
@@ -20,7 +19,6 @@ extension NSURL: DatabaseValueConvertible {
         return cast(URL(string: string))
     }
 }
-#endif
 
 /// URL stores its absoluteString in the database.
 extension URL: DatabaseValueConvertible { }

--- a/GRDB/Core/Support/Foundation/UUID.swift
+++ b/GRDB/Core/Support/Foundation/UUID.swift
@@ -12,7 +12,6 @@ import GRDBSQLite
 
 import Foundation
 
-#if !os(Windows)
 /// NSUUID adopts DatabaseValueConvertible
 extension NSUUID: DatabaseValueConvertible {
     /// Returns a BLOB database value containing the uuid bytes.
@@ -52,7 +51,6 @@ extension NSUUID: DatabaseValueConvertible {
         }
     }
 }
-#endif
 
 /// UUID adopts DatabaseValueConvertible
 extension UUID: DatabaseValueConvertible {

--- a/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
+++ b/Tests/GRDBTests/AssociationTableAliasTestsSQLTests.swift
@@ -148,7 +148,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                     """
                 
                 do {
-                    let request = A
+                    let request: QueryInterfaceRequest<A> = A
                         .aliased(alias)
                         .select(\.name)
                         .filter(key: 1)
@@ -159,7 +159,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                     try assertEqualSQL(db, request, expectedSQL)
                 }
                 do {
-                    let request = A
+                    let request: QueryInterfaceRequest<A> = A
                         .select(\.name)
                         .filter(key: 1)
                         .filter { $0.name != nil && alias.name == "foo" }
@@ -183,7 +183,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                     """
                 
                 do {
-                    let request = A
+                    let request: QueryInterfaceRequest<A> = A
                         .aliased(alias)
                         .select(\.name)
                         .filter(key: 1)
@@ -194,7 +194,7 @@ class AssociationTableAliasTestsSQLTests : GRDBTestCase {
                     try assertEqualSQL(db, request, expectedSQL)
                 }
                 do {
-                    let request = A
+                    let request: QueryInterfaceRequest<A> = A
                         .select(\.name)
                         .filter(key: 1)
                         .filter { $0.name != nil && alias.name == "foo" }

--- a/Tests/GRDBTests/EncryptionTests.swift
+++ b/Tests/GRDBTests/EncryptionTests.swift
@@ -758,7 +758,8 @@ let testBundle = Bundle(for: GRDBTestCase.self)
         }
         let dbQueue = try makeDatabaseQueue(configuration: config)
         try dbQueue.inDatabase { db in
-            XCTAssertEqual("commoncrypto", try db.cipherProvider)
+            let provider = try db.cipherProvider
+            XCTAssertTrue(["commoncrypto", "libtomcrypt"].contains(provider), "unrecognized cipherProvider: \(provider ?? "")")
         }
     }
 


### PR DESCRIPTION
This PR contains a few miscellaneous fixes for non-Darwin platforms:

1. Remove the `#if !os(Windows)` conditional for some of the type extensions. I'm not sure when/why they were added, but they seem to work fine in my other branch that builds/tests this against Windows: https://github.com/swift-everywhere/grdb-sqlcipher/actions/runs/21649487847
2. Add a conditional `import Android` that is needed for standard C functions like `strcmp`
3. Add a type annotation to `AssociationTableAliasTestsSQLTests` that was causing some "statement to complex" evaluation errors when building on other platforms.
4. Handle both "commoncrypto" and "libtomcrypt" cipher names in `EncryptionTests.testCipherProvider`


### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [ ] DOCUMENTATION: Inline documentation has been updated.
- [ ] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
