### PR TITLE
Adds SQLCipher Custom Fork documentation

### DIFF
--- a/Documentation/CustomSQLCipherBuilds.md
+++ b/Documentation/CustomSQLCipherBuilds.md
@@ -1,7 +1,7 @@
 Custom SQLCipher Builds
 =====================
 
-To use the official SQLCipher package in conjunction with GRDB, you must fork GRDB, and modify `Package.swift`. Instructions are in the file itself, in comments that contain "GRDB+SQLCipher".
+To use the official SQLCipher.swift package in conjunction with GRDB, you can use the official [fork of GRDB w/SQLCipher](https://github.com/sqlcipher/GRDB.swift). This fork is maintained by the SQLCipher team in collaboration with GRDB and is the recommended fork to use to enable SQLCipher encryption for GRDB.
 
 If you have requirements that the official SQLCipher package doesn't support, you can fork GRDB yourself and include a custom copy of SQLCipher. This guide provides instructions for what is minimally required to get up and running with your fork:
 

--- a/Documentation/CustomSQLCipherBuilds.md
+++ b/Documentation/CustomSQLCipherBuilds.md
@@ -1,10 +1,9 @@
-Custom SQLCipher Fork
+Custom SQLCipher Builds
 =====================
 
-The officially supported fork of GRDB w/SQLCipher is available here: `<url to official fork coming soon>`
-This fork is maintained by GRDB in collaboration with the SQLCipher team and is the recommended fork to use to enable SQLCipher encryption for GRDB.
+To use the official SQLCipher package in conjunction with GRDB, you must fork GRDB, and modify `Package.swift`. Instructions are in the file itself, in comments that contain "GRDB+SQLCipher".
 
-If you have requirements that the official fork doesn't support, you're can fork GRDB yourself and include a custom copy of SQLCipher. This guide provides instructions for what is minimally required to get up and running with your fork:
+If you have requirements that the official SQLCipher package doesn't support, you can fork GRDB yourself and include a custom copy of SQLCipher. This guide provides instructions for what is minimally required to get up and running with your fork:
 
 1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) GRDB
 2. Clone the repository on your machine

--- a/Documentation/SQLCipherCustomFork.md
+++ b/Documentation/SQLCipherCustomFork.md
@@ -1,0 +1,87 @@
+Custom SQLCipher Fork
+=====================
+
+The officially supported fork of GRDB w/SQLCipher is available here: `<url to official fork coming soon>`
+This fork is maintained by GRDB in collaboration with the SQLCipher team and is the recommended fork to use to enable SQLCipher encryption for GRDB.
+
+If you have requirements that the official fork doesn't support, you're can fork GRDB yourself and include a custom copy of SQLCipher. This guide provides instructions for what is minimally required to get up and running with your fork:
+
+1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) GRDB
+2. Clone the repository on your machine
+
+```sh
+git clone <url to your fork>
+```
+3. Build the sqlite amalgamation w/SQLCipher (for example using the SQLCipher documentation for [Apple Source Integration](https://www.zetetic.net/sqlcipher/sqlcipher-apple-community/#source-integration)) to generate `sqlite3.c`/`sqlite3.h` files
+4. Open the GRDB Package.swift project in Xcode. Create a new Directory named SQLCipher in the Sources directory and move the `sqlite3.c`/`sqlite3.h` files in the directory structure like so
+
+```sh
+SQLCipher
+├── include
+│   ├── module.modulemap
+│   ├── SQLCipher
+│   │   └── sqlite3.h
+│   └── SQLCipher.h
+└── sqlite3.c
+```
+
+Add a `module.modulemap` file in the `include` directory with these contents
+
+```swift
+module SQLCipher {
+    umbrella header "SQLCipher.h"
+    export *
+}
+```
+
+Add a `SQLCipher.h` umbrella header file in the `include` directory with these contents
+
+```objc
+#ifndef SQLCipher_h
+#define SQLCipher_h
+
+#import <SQLCipher/sqlite3.h>
+#endif /* SQLCipher_h */
+```
+
+6. Modify the `Package.swift` to include the new SQLCipher target and add it as a depdency for GRDB
+
+```swift
+        .target(
+            name: "GRDB",
+            dependencies: [
+                // GRDB+SQLCipher: Uncomment the SQLCipher and GRDBSQLCipher dependencies
+                .target(name: "SQLCipher"),
+                .target(name: "GRDBSQLCipher"),
+            ],
+            path: "GRDB",
+            resources: [.copy("PrivacyInfo.xcprivacy")],
+            cSettings: cSettings,
+            swiftSettings: swiftSettings),
+        .target(
+            name: "SQLCipher",
+            publicHeadersPath: "include",
+            cSettings: cSettings
+        ),
+```
+
+7. Add these swiftSettings and cSettings to `Package.swift` (and whatever other flags desired)
+
+```swift
+swiftSettings.append(.define("SQLITE_HAS_CODEC"))
+swiftSettings.append(.define("SQLCipher"))
+```
+
+```swift
+cSettings.append(contentsOf: [
+    .define("NDEBUG", to: nil),
+    .define("SQLCIPHER_CRYPTO_CC", to: nil),
+    .define("SQLITE_HAS_CODEC", to: nil),
+    .define("SQLITE_TEMP_STORE", to: "2"),
+    .define("SQLITE_THREADSAFE", to: "1"),
+    .define("SQLITE_EXTRA_INIT", to: "sqlcipher_extra_init"),
+    .define("SQLITE_EXTRA_SHUTDOWN", to: "sqlcipher_extra_shutdown"),
+    .define("SQLITE_ENABLE_FTS5", to: nil),
+    .define("SQLITE_ENABLE_SNAPSHOT", to: nil)
+])
+```

--- a/README.md
+++ b/README.md
@@ -4589,9 +4589,9 @@ Encryption
 
 **GRDB can encrypt your database with [SQLCipher](http://sqlcipher.net) v3.4+.**
 
-To use SQLCipher with [Swift Package Manager](https://swift.org/package-manager/), you can use the officially supported fork of GRDB w/SQLCipher here: `<url to official fork coming soon>` This fork is maintained by GRDB in collaboration with the SQLCipher team and is the recommended fork to use to enable SQLCipher encryption for GRDB.
+To use SQLCipher with [Swift Package Manager](https://swift.org/package-manager/), you must fork GRDB, and modify `Package.swift`. Instructions are in the file itself, in comments that contain "GRDB+SQLCipher".
 
-If you have requirements that the official fork doesn't support, you're can fork GRDB yourself and include a custom copy of SQLCipher using these [instructions](Documentation/SQLCipherCustomFork.md)
+If you have requirements that the official SQLCipher package doesn't support, you can fork GRDB yourself and include a custom copy of SQLCipher using these [instructions](Documentation/CustomSQLCipherBuilds.md)
 
 To use SQLCipher with [CocoaPods](http://cocoapods.org/), specify in your `Podfile`:
 

--- a/README.md
+++ b/README.md
@@ -4589,7 +4589,7 @@ Encryption
 
 **GRDB can encrypt your database with [SQLCipher](http://sqlcipher.net) v3.4+.**
 
-To use SQLCipher with [Swift Package Manager](https://swift.org/package-manager/), you must fork GRDB, and modify `Package.swift`. Instructions are in the file itself, in comments that contain "GRDB+SQLCipher".
+To use SQLCipher with [Swift Package Manager](https://swift.org/package-manager/), you can use the officially supported [fork of GRDB w/SQLCipher](https://github.com/sqlcipher/GRDB.swift). This fork is maintained by the SQLCipher team in collaboration with GRDB and is the recommended fork to use to enable SQLCipher encryption for GRDB.
 
 If you have requirements that the official SQLCipher package doesn't support, you can fork GRDB yourself and include a custom copy of SQLCipher using these [instructions](Documentation/CustomSQLCipherBuilds.md)
 

--- a/README.md
+++ b/README.md
@@ -4589,7 +4589,9 @@ Encryption
 
 **GRDB can encrypt your database with [SQLCipher](http://sqlcipher.net) v3.4+.**
 
-To use SQLCipher with the [Swift Package Manager](https://swift.org/package-manager/), you must fork GRDB, and modify `Package.swift`. Instructions are in the file itself, in comments that contain "GRDB+SQLCipher".
+To use SQLCipher with [Swift Package Manager](https://swift.org/package-manager/), you can use the officially supported fork of GRDB w/SQLCipher here: `<url to official fork coming soon>` This fork is maintained by GRDB in collaboration with the SQLCipher team and is the recommended fork to use to enable SQLCipher encryption for GRDB.
+
+If you have requirements that the official fork doesn't support, you're can fork GRDB yourself and include a custom copy of SQLCipher using these [instructions](Documentation/SQLCipherCustomFork.md)
 
 To use SQLCipher with [CocoaPods](http://cocoapods.org/), specify in your `Podfile`:
 


### PR DESCRIPTION
Adds SQLCipherCustomFork.md documentation. Adjusts README.md Encryption section to reference officially supported GRDB + SQLCipher fork and link SQLCipherCustomFork.md documentation.

This is a documentation update which includes instructions for creating a custom fork of GRDB w/SQLCipher to support requirements outside of the scope of the official fork.

Official Fork link has a placeholder of `<url to official fork coming soon>`

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
