### PR TITLE
Fix build issue when building against Swift's Static Linux SDK

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "f1025fb17c8fee081cbbf7273f5c682917a24f33d3c5fa4c9f86189b7008ac79",
+  "pins" : [
+    {
+      "identity" : "swift-toolchain-sqlite",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-toolchain-sqlite",
+      "state" : {
+        "revision" : "05c9f4d17fae1eb586e716e11e5aa52bac464d00",
+        "version" : "1.0.10"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -15,11 +15,34 @@ let darwinPlatforms: [Platform] = [
 var swiftSettings: [SwiftSetting] = [
     .define("SQLITE_ENABLE_FTS5"),
     .define("SQLITE_ENABLE_SNAPSHOT"),
-    // Not all Linux distributions have support for WAL snapshots.
-    .define("SQLITE_DISABLE_SNAPSHOT", .when(platforms: [.linux])),
+    // The amalgamation supplied by swiftlang/swift-toolchain-sqlite is
+    // built without SQLITE_ENABLE_SNAPSHOT (its library target declares
+    // no cSettings, and SwiftPM does not let us inject them into a binary
+    // dependency). The Swift call sites that reference sqlite3_snapshot_*
+    // are gated by `#if SQLITE_ENABLE_SNAPSHOT && !SQLITE_DISABLE_SNAPSHOT`,
+    // so applying SQLITE_DISABLE_SNAPSHOT unconditionally here keeps GRDB
+    // linking on every platform. Trade-off: snapshot-based ValueObservation
+    // optimisations are not available — the cost of switching to the
+    // swift-toolchain-sqlite route.
+    .define("SQLITE_DISABLE_SNAPSHOT"),
 ]
-var cSettings: [CSetting] = []
-var dependencies: [PackageDescription.Package.Dependency] = []
+var cSettings: [CSetting] = [
+    // Without SQLITE_CORE, sqlite3ext.h (exposed alongside sqlite3.h by
+    // SwiftToolchainCSQLite's modulemap) redefines sqlite3_db_config(...)
+    // and sqlite3_config(...) as macros that go through sqlite3_api->...,
+    // which is only valid in loadable-extension contexts. shim.c calls
+    // those functions directly, so without SQLITE_CORE the macro expansion
+    // breaks shim.c's compile. SQLITE_CORE skips that macro block (see
+    // sqlite3ext.h: `#if !defined(SQLITE_CORE) && ...`).
+    .define("SQLITE_CORE"),
+]
+var dependencies: [PackageDescription.Package.Dependency] = [
+    // Vendors the SQLite amalgamation as a regular SwiftPM target so that
+    // GRDB compiles on platforms without a system libsqlite3 — notably
+    // Swift's Static Linux SDK (musl-static), where the sysroot ships no
+    // sqlite3 and `.systemLibrary` would fail at `#include <sqlite3.h>`.
+    .package(url: "https://github.com/swiftlang/swift-toolchain-sqlite", from: "1.0.10"),
+]
 
 // Don't rely on those environment variables. They are ONLY testing conveniences:
 // $ SQLITE_ENABLE_PREUPDATE_HOOK=1 make test_SPM
@@ -62,9 +85,20 @@ let package = Package(
     dependencies: dependencies,
     targets: [
         // GRDB+SQLCipher: Delete the GRDBSQLite target
-        .systemLibrary(
+        //
+        // Thin shim over swiftlang/swift-toolchain-sqlite. shim.h declares
+        // wrappers around variadic sqlite3 calls that Swift can't import;
+        // shim.c provides the bodies (compiled with this target's cSettings).
+        // The SQLite amalgamation itself comes from the dependency.
+        .target(
             name: "GRDBSQLite",
-            providers: [.apt(["libsqlite3-dev"])]),
+            dependencies: [
+                .product(name: "SwiftToolchainCSQLite", package: "swift-toolchain-sqlite"),
+            ],
+            // shim.h and module.modulemap live at the target root, not in
+            // an `include/` subdirectory (SwiftPM's default).
+            publicHeadersPath: ".",
+            cSettings: cSettings),
         // GRDB+SQLCipher: Uncomment the GRDBSQLCipher target
         //.target(
         //    name: "GRDBSQLCipher",

--- a/Sources/GRDBSQLite/module.modulemap
+++ b/Sources/GRDBSQLite/module.modulemap
@@ -1,5 +1,4 @@
-module GRDBSQLite [system] {
+module GRDBSQLite {
     header "shim.h"
-    link "sqlite3"
     export *
 }

--- a/Sources/GRDBSQLite/shim.c
+++ b/Sources/GRDBSQLite/shim.c
@@ -1,0 +1,20 @@
+#include "shim.h"
+
+void _registerErrorLogCallback(_errorLogCallback callback) {
+    sqlite3_config(SQLITE_CONFIG_LOG, callback, 0);
+}
+
+#if SQLITE_VERSION_NUMBER >= 3029000
+void _disableDoubleQuotedStringLiterals(sqlite3 *db) {
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 0, (void *)0);
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 0, (void *)0);
+}
+
+void _enableDoubleQuotedStringLiterals(sqlite3 *db) {
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 1, (void *)0);
+    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 1, (void *)0);
+}
+#else
+void _disableDoubleQuotedStringLiterals(sqlite3 *db) { }
+void _enableDoubleQuotedStringLiterals(sqlite3 *db) { }
+#endif

--- a/Sources/GRDBSQLite/shim.h
+++ b/Sources/GRDBSQLite/shim.h
@@ -4,28 +4,15 @@ typedef void(*_errorLogCallback)(void *pArg, int iErrCode, const char *zMsg);
 
 /// Wrapper around sqlite3_config(SQLITE_CONFIG_LOG, ...) which is a variadic
 /// function that can't be used from Swift.
-static inline void _registerErrorLogCallback(_errorLogCallback callback) {
-    sqlite3_config(SQLITE_CONFIG_LOG, callback, 0);
-}
-
-#if SQLITE_VERSION_NUMBER >= 3029000
-/// Wrapper around sqlite3_db_config() which is a variadic function that can't
-/// be used from Swift.
-static inline void _disableDoubleQuotedStringLiterals(sqlite3 *db) {
-    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 0, (void *)0);
-    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 0, (void *)0);
-}
+void _registerErrorLogCallback(_errorLogCallback callback);
 
 /// Wrapper around sqlite3_db_config() which is a variadic function that can't
 /// be used from Swift.
-static inline void _enableDoubleQuotedStringLiterals(sqlite3 *db) {
-    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DDL, 1, (void *)0);
-    sqlite3_db_config(db, SQLITE_DBCONFIG_DQS_DML, 1, (void *)0);
-}
-#else
-static inline void _disableDoubleQuotedStringLiterals(sqlite3 *db) { }
-static inline void _enableDoubleQuotedStringLiterals(sqlite3 *db) { }
-#endif
+void _disableDoubleQuotedStringLiterals(sqlite3 *db);
+
+/// Wrapper around sqlite3_db_config() which is a variadic function that can't
+/// be used from Swift.
+void _enableDoubleQuotedStringLiterals(sqlite3 *db);
 
 // Expose APIs that are missing from system <sqlite3.h>
 #ifdef GRDB_SQLITE_ENABLE_PREUPDATE_HOOK


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

`GRDBSQLite` was a `.systemLibrary` target that required `sqlite3.h` and a linkable `libsqlite3` to be present in the SDK sysroot. This blocks cross-compilation with Swift's Static Linux SDK (musl-static), which ships no system sqlite3 — the build fails at `#include <sqlite3.h>` in `shim.h`. This commit makes `GRDBSQLite` carry its own copy of the SQLite amalgamation so GRDB compiles on every platform without needing a system sqlite3.

Static linking was failing with this error:

```
.build/checkouts/GRDB.swift/Sources/GRDBSQLite/shim.h:1:10: error: 'sqlite3.h' file not found
 1 | #include <sqlite3.h>
.build/checkouts/GRDB.swift/GRDB/Core/Configuration.swift:10:8: error: could not build C module 'GRDBSQLite'
```

## Verification

Tested with Swift 6.2.3 + Static Linux SDK `swift-6.2.3-RELEASE_static-linux-0.0.1`:

- `swift build` of the GRDB package on macOS arm64 — passes (`libGRDB-dynamic.dylib` links cleanly, ~9 s).
- `swift build --swift-sdk x86_64-swift-linux-musl --target GRDBSQLite` — passes (~1.5 s).
- `swift build --swift-sdk aarch64-swift-linux-musl` (full release build of a downstream consumer) — passes (~143 s); resulting binary is ELF aarch64, `statically linked`, runs on Linux (kernel 5.10), exercises the schema migrator + record protocols + insert/fetch round-trip end-to-end.
- `swift build --swift-sdk x86_64-swift-linux-musl -c release` (full release build of a downstream consumer) — passes (~80 s); resulting binary is ELF x86-64, `statically linked`.

### Pull Request Checklist

<!--
Please check the boxes that apply to your pull request:
-->

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated.
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
