### PR TITLE
Up to 3.4× faster statement preparation via in-place authorizer region accumulation

### DIFF
--- a/GRDB/Core/DatabaseRegion.swift
+++ b/GRDB/Core/DatabaseRegion.swift
@@ -41,7 +41,7 @@
 /// - ``isModified(byEventsOfKind:)``
 /// - ``isModified(by:)``
 public struct DatabaseRegion: Sendable {
-    private let tableRegions: [CaseInsensitiveIdentifier: TableRegion]?
+    private var tableRegions: [CaseInsensitiveIdentifier: TableRegion]?
     
     private init(tableRegions: [CaseInsensitiveIdentifier: TableRegion]?) {
         self.tableRegions = tableRegions
@@ -160,6 +160,24 @@ public struct DatabaseRegion: Sendable {
     /// Inserts the given region into this region
     public mutating func formUnion(_ other: DatabaseRegion) {
         self = union(other)
+    }
+    
+    /// Adds one table-column read reported by the SQLite authorizer.
+    ///
+    /// This operation is O(1) amortized, so statement compilation does not
+    /// merge the accumulated region for each authorizer callback.
+    ///
+    /// - parameter table: A table name.
+    /// - parameter column: A column name, or nil or empty for all columns.
+    mutating func formUnion(table: String, column: String?) {
+        guard tableRegions != nil else { return }
+        
+        let table = CaseInsensitiveIdentifier(rawValue: table)
+        let column = column.flatMap {
+            $0.isEmpty ? nil : CaseInsensitiveIdentifier(rawValue: $0)
+        }
+        tableRegions?[table, default: TableRegion(columns: [], rowIds: nil)]
+            .formUnion(column: column)
     }
     
     /// Returns a region suitable for database observation
@@ -368,6 +386,17 @@ private struct TableRegion: Equatable {
         }
         
         return TableRegion(columns: columnsUnion, rowIds: rowIdsUnion)
+    }
+    
+    /// Inserts a column read across all rows. A nil column means all
+    /// columns.
+    mutating func formUnion(column: CaseInsensitiveIdentifier?) {
+        rowIds = nil
+        guard let column else {
+            columns = nil
+            return
+        }
+        columns?.insert(column)
     }
     
     func contains(rowID: Int64) -> Bool {

--- a/GRDB/Core/StatementAuthorizer.swift
+++ b/GRDB/Core/StatementAuthorizer.swift
@@ -115,13 +115,7 @@ final class StatementAuthorizer {
         case SQLITE_READ:
             guard let tableName = cString1.map(String.init) else { return SQLITE_OK }
             guard let columnName = cString2.map(String.init) else { return SQLITE_OK }
-            if columnName.isEmpty {
-                // SELECT COUNT(*) FROM table
-                selectedRegion.formUnion(DatabaseRegion(table: tableName))
-            } else {
-                // SELECT column FROM table
-                selectedRegion.formUnion(DatabaseRegion(table: tableName, columns: [columnName]))
-            }
+            selectedRegion.formUnion(table: tableName, column: columnName)
             return SQLITE_OK
             
         case SQLITE_INSERT:

--- a/Tests/GRDBTests/Private/DatabaseRegionTests.swift
+++ b/Tests/GRDBTests/Private/DatabaseRegionTests.swift
@@ -142,6 +142,120 @@ class DatabaseRegionTests : GRDBTestCase {
         XCTAssertEqual(unions.map(\.description), ["foo(a)[1]", "foo(a,b)[1,2]", "foo(a,b)[1,2]", "foo(b)[2]"])
     }
     
+    func testRegionFormUnionTableColumn() {
+        var region = DatabaseRegion()
+        region.formUnion(table: "foo", column: "name")
+        
+        var expectedRegion = DatabaseRegion()
+        expectedRegion.formUnion(DatabaseRegion(table: "foo", columns: ["name"]))
+        XCTAssertEqual(region, expectedRegion)
+    }
+    
+    func testRegionFormUnionTableColumnWholeTable() {
+        do {
+            var region = DatabaseRegion(table: "foo", columns: ["name"])
+            region.formUnion(table: "foo", column: nil)
+            
+            var expectedRegion = DatabaseRegion(table: "foo", columns: ["name"])
+            expectedRegion.formUnion(DatabaseRegion(table: "foo"))
+            XCTAssertEqual(region, expectedRegion)
+        }
+        do {
+            var region = DatabaseRegion(table: "foo")
+            region.formUnion(table: "foo", column: "name")
+            
+            var expectedRegion = DatabaseRegion(table: "foo")
+            expectedRegion.formUnion(DatabaseRegion(table: "foo", columns: ["name"]))
+            XCTAssertEqual(region, expectedRegion)
+        }
+        do {
+            var region = DatabaseRegion(table: "foo", columns: ["name"])
+            region.formUnion(table: "foo", column: "")
+            
+            var expectedRegion = DatabaseRegion(table: "foo", columns: ["name"])
+            expectedRegion.formUnion(DatabaseRegion(table: "foo"))
+            XCTAssertEqual(region, expectedRegion)
+        }
+    }
+    
+    func testRegionFormUnionTableColumnRepeatedColumn() {
+        var region = DatabaseRegion()
+        region.formUnion(table: "foo", column: "name")
+        let expectedRegion = region
+        region.formUnion(table: "foo", column: "name")
+        
+        XCTAssertEqual(region, expectedRegion)
+    }
+    
+    func testRegionFormUnionTableColumnMultipleTables() {
+        var region = DatabaseRegion()
+        region.formUnion(table: "foo", column: "name")
+        region.formUnion(table: "bar", column: "score")
+        
+        var expectedRegion = DatabaseRegion()
+        expectedRegion.formUnion(DatabaseRegion(table: "foo", columns: ["name"]))
+        expectedRegion.formUnion(DatabaseRegion(table: "bar", columns: ["score"]))
+        XCTAssertEqual(region, expectedRegion)
+    }
+    
+    func testRegionFormUnionTableColumnCaseInsensitiveTable() {
+        var region = DatabaseRegion()
+        region.formUnion(table: "foo", column: "name")
+        region.formUnion(table: "FOO", column: "SCORE")
+        
+        var expectedRegion = DatabaseRegion()
+        expectedRegion.formUnion(DatabaseRegion(table: "foo", columns: ["name"]))
+        expectedRegion.formUnion(DatabaseRegion(table: "FOO", columns: ["SCORE"]))
+        XCTAssertEqual(region, expectedRegion)
+    }
+    
+    func testRegionFormUnionTableColumnAndRowIds() {
+        var region = DatabaseRegion(table: "foo", columns: ["name"])
+            .intersection(DatabaseRegion(table: "foo", rowIds: [1, 2]))
+        region.formUnion(table: "foo", column: "score")
+        
+        var expectedRegion = DatabaseRegion(table: "foo", columns: ["name"])
+            .intersection(DatabaseRegion(table: "foo", rowIds: [1, 2]))
+        expectedRegion.formUnion(DatabaseRegion(table: "foo", columns: ["score"]))
+        XCTAssertEqual(region, expectedRegion)
+        XCTAssertEqual(region.description, "foo(name,score)")
+    }
+    
+    func testRegionFormUnionTableColumnFullDatabase() {
+        var region = DatabaseRegion.fullDatabase
+        region.formUnion(table: "foo", column: "name")
+        
+        XCTAssertEqual(region, .fullDatabase)
+    }
+    
+    func testRegionFormUnionTableColumnSequenceEquivalence() {
+        let eventSequences: [[(table: String, column: String?)]] = [
+            [],
+            [("foo", "name")],
+            [("foo", "name"), ("foo", "name"), ("foo", "score")],
+            [("foo", "name"), ("bar", "score"), ("FOO", "email")],
+            [("foo", "name"), ("foo", nil), ("foo", "score")],
+            [("foo", nil), ("foo", "name")],
+            [("foo", "name"), ("foo", ""), ("bar", "score")],
+        ]
+        
+        for events in eventSequences {
+            var region = DatabaseRegion()
+            var expectedRegion = DatabaseRegion()
+            for event in events {
+                region.formUnion(table: event.table, column: event.column)
+                if let column = event.column, !column.isEmpty {
+                    expectedRegion.formUnion(DatabaseRegion(
+                        table: event.table,
+                        columns: [column]))
+                } else {
+                    expectedRegion.formUnion(DatabaseRegion(table: event.table))
+                }
+            }
+            XCTAssertEqual(region, expectedRegion)
+        }
+    }
+    
     func testRegionIntersection() {
         let regions = [
             DatabaseRegion.fullDatabase,

--- a/Tests/GRDBTests/Private/StatementPreparationPerformanceTests.swift
+++ b/Tests/GRDBTests/Private/StatementPreparationPerformanceTests.swift
@@ -1,0 +1,101 @@
+import Dispatch
+import XCTest
+@testable import GRDB
+
+/// Measures statement preparation performance in optimized builds.
+///
+/// Run with:
+///
+/// ```sh
+/// swift test -c release --filter StatementPreparationPerformanceTests
+/// ```
+class StatementPreparationPerformanceTests: XCTestCase {
+    private let iterationCount = 1_000
+    private let sampleCount = 5
+    
+    func testStatementPreparationPerformance() throws {
+#if DEBUG
+        throw XCTSkip(
+            "Run with: swift test -c release --filter StatementPreparationPerformanceTests")
+#else
+        let dbQueue = try DatabaseQueue()
+        try dbQueue.write { db in
+            try db.execute(sql: createTableSQL(
+                table: "wide",
+                columns: ["id INTEGER PRIMARY KEY"] + integerColumns(count: 119)))
+            try db.execute(sql: createTableSQL(
+                table: "author",
+                columns: ["id INTEGER PRIMARY KEY"] + integerColumns(count: 39)))
+            try db.execute(sql: createTableSQL(
+                table: "book",
+                columns: ["id INTEGER PRIMARY KEY", "authorId INTEGER"]
+                    + integerColumns(count: 38)))
+            try db.execute(sql: createTableSQL(
+                table: "review",
+                columns: ["id INTEGER PRIMARY KEY", "bookId INTEGER"]
+                    + integerColumns(count: 38)))
+            
+            let benchmarks = [
+                ("wide", "SELECT * FROM wide"),
+                ("join", """
+                    SELECT author.*, book.*, review.*
+                    FROM author
+                    JOIN book ON book.authorId = author.id
+                    JOIN review ON review.bookId = book.id
+                    """),
+                ("narrow", "SELECT id FROM wide"),
+            ]
+            
+            let sqliteVersion = try String.fetchOne(
+                db,
+                sql: "SELECT sqlite_version()")!
+            print("Statement preparation benchmark")
+            print("SQLite: \(sqliteVersion)")
+            print("Iterations: \(iterationCount); samples: \(sampleCount)")
+            
+            for (name, sql) in benchmarks {
+                let result = try benchmark(db, sql: sql)
+                print(String(
+                    format: "%@: %.3f ms total, %.3f us/prepare",
+                    name,
+                    result.totalMilliseconds,
+                    result.microsecondsPerPrepare))
+            }
+        }
+#endif
+    }
+    
+    private func benchmark(
+        _ db: Database,
+        sql: String)
+    throws -> (totalMilliseconds: Double, microsecondsPerPrepare: Double) {
+        for _ in 0..<100 {
+            _ = try db.makeStatement(sql: sql)
+        }
+        
+        var samples: [UInt64] = []
+        samples.reserveCapacity(sampleCount)
+        for _ in 0..<sampleCount {
+            let start = DispatchTime.now().uptimeNanoseconds
+            for _ in 0..<iterationCount {
+                _ = try db.makeStatement(sql: sql)
+            }
+            samples.append(DispatchTime.now().uptimeNanoseconds - start)
+        }
+        
+        let medianNanoseconds = samples.sorted()[sampleCount / 2]
+        let totalMilliseconds = Double(medianNanoseconds) / 1_000_000
+        let microsecondsPerPrepare = Double(medianNanoseconds)
+            / Double(iterationCount)
+            / 1_000
+        return (totalMilliseconds, microsecondsPerPrepare)
+    }
+    
+    private func createTableSQL(table: String, columns: [String]) -> String {
+        "CREATE TABLE \(table) (\(columns.joined(separator: ", ")))"
+    }
+    
+    private func integerColumns(count: Int) -> [String] {
+        (1...count).map { "column\($0) INTEGER" }
+    }
+}


### PR DESCRIPTION
SQLite invokes the statement authorizer once for every column read while compiling a statement. `StatementAuthorizer` handled each `SQLITE_READ` event by building a one-column `DatabaseRegion` and merging it with `DatabaseRegion.formUnion`, which rebuilds the table dictionary and column sets on every call. Compiling a statement that reads C columns therefore performs O(C²) region work, with temporary allocations on every callback. In a production app querying an 80-column table, this accounted for 1.73 seconds of main-thread time in a three-minute profile, from only a couple hundred statement preparations.

The authorizer now records each read through an internal `DatabaseRegion` operation that mutates one dictionary slot in place, making each callback O(1) amortized. Whole-table reads still promote a table region to all columns, a full-database region still absorbs every read, and the general `union`/`formUnion` operations are untouched. No public API or observable behavior changes.

### Performance

Median of five release-build samples, each compiling 1,000 fresh statements after 100 warm-ups (`Database.makeStatement(sql:)`, in-memory database):

| Statement | Before | After | Time reduction | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `SELECT *` from a 120-column table | 173.878 µs/prepare | 50.790 µs/prepare | −70.8% | 3.42× |
| Three-table, 120-column join | 190.086 µs/prepare | 68.897 µs/prepare | −63.8% | 2.76× |
| `SELECT id` narrow control | 2.124 µs/prepare | 1.129 µs/prepare | −46.8% | 1.88× |

Small statements improve as well, since the per-callback region construction and merge are gone regardless of statement width.

MacBook Pro (Apple M3 Max), macOS 26.5.1, Swift 6.3.2, system SQLite 3.51.0, default SPM configuration. Reproduce from the repository root:

```sh
swift test -c release --filter StatementPreparationPerformanceTests
```

The benchmark skips itself in debug builds, so plain `swift test` run time is unaffected.

As a broader check, five alternated release runs of the identical pre-existing test suite completed with a 1.6% lower median on this branch (76.2 s → 75.0 s). The effect is small, as expected: the suite's statements are mostly narrow and statement preparation is a minor share of its total time, so it exercises the affected path far less than the benchmark above.

### Correctness

The new operation produces regions equal (`==`) to the `formUnion` fold it replaces. `DatabaseRegionTests` covers:

| Case | Test |
| --- | --- |
| Single column into an empty region | `testRegionFormUnionTableColumn` |
| Whole-table promotion, both orders, empty column name | `testRegionFormUnionTableColumnWholeTable` |
| Repeated columns | `testRegionFormUnionTableColumnRepeatedColumn` |
| Multiple tables | `testRegionFormUnionTableColumnMultipleTables` |
| Case-insensitive table identity | `testRegionFormUnionTableColumnCaseInsensitiveTable` |
| Row IDs and all-rows promotion | `testRegionFormUnionTableColumnAndRowIds` |
| Full-database absorption | `testRegionFormUnionTableColumnFullDatabase` |
| Event-sequence folds | `testRegionFormUnionTableColumnSequenceEquivalence` |
| End-to-end statement regions, including rowid | `testSelectStatement`, `testSelectStatement_rowid` |

No existing expectation changed. On this branch:

- Full SwiftPM suite: 2,886 tests, 31 skipped, 0 failures.
- `make smokeTest`: 0 failures across system SQLite (max and min targets), SQLCipher 3, SQLCipher 4 encrypted, custom SQLite, and SPM.

### Pull Request Checklist

- [x] CONTRIBUTING: You have read https://github.com/groue/GRDB.swift/blob/master/CONTRIBUTING.md
- [x] BRANCH: This pull request is submitted against the `development` branch.
- [x] DOCUMENTATION: Inline documentation has been updated.
- [x] DOCUMENTATION: README.md or another dedicated guide has been updated. (Not applicable: internal change, no public API.)
- [x] TESTS: Changes are tested.
- [x] TESTS: The `make smokeTest` terminal command runs without failure.
