### PR TITLE
Fix doubled word in doc comment

### DIFF
--- a/GRDB/Core/DatabaseBackupProgress.swift
+++ b/GRDB/Core/DatabaseBackupProgress.swift
@@ -12,7 +12,7 @@ public struct DatabaseBackupProgress: Sendable {
     /// It is the result of the `sqlite3_backup_pagecount` function.
     public let totalPageCount: Int
     
-    /// The number of of backed up pages.
+    /// The number of backed up pages.
     ///
     /// It is equal to `totalPageCount - remainingPageCount`.
     public var completedPageCount: Int {


### PR DESCRIPTION
Small doubled-word typo in the doc comment in `GRDB/Core/DatabaseBackupProgress.swift`: "The number of of backed up pages." -> "The number of backed up pages."
